### PR TITLE
feat(tooling): backfill cloud claim fields

### DIFF
--- a/.agents/skills/doc-garden/SKILL.md
+++ b/.agents/skills/doc-garden/SKILL.md
@@ -34,7 +34,10 @@ list for review.
    Claude cloud session without the capability gate use the MCP workboard
    fallback in
    [`docs/notes/github-tooling-surfaces.md`](../../../docs/notes/github-tooling-surfaces.md)
-   (label transition, claim comment, `issue:board sync` handoff). Do not
+   (label transition, claim comment, `issue:board backfill --issue <n>` and
+   `issue:board sync` handoff). Run the backfill helper first with `--dry-run`.
+   It fills empty ownership fields from a trusted claim comment and rejects
+   conflicting Project values. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/.claude/skills/doc-garden/SKILL.md
+++ b/.claude/skills/doc-garden/SKILL.md
@@ -34,7 +34,10 @@ list for review.
    Claude cloud session without the capability gate use the MCP workboard
    fallback in
    [`docs/notes/github-tooling-surfaces.md`](../../../docs/notes/github-tooling-surfaces.md)
-   (label transition, claim comment, `issue:board sync` handoff). Do not
+   (label transition, claim comment, `issue:board backfill --issue <n>` and
+   `issue:board sync` handoff). Run the backfill helper first with `--dry-run`.
+   It fills empty ownership fields from a trusted claim comment and rejects
+   conflicting Project values. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -3,7 +3,7 @@ title: Agent Issue Workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-21
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -124,10 +124,14 @@ Use `pnpm issue:board backfill --issue <n>` only to recover Project ownership
 fields after an eligible MCP claim. It requires one open issue with exactly one
 of `agent-active` or `in-pr`, a valid trusted claim comment, and Project fields
 with exact types: `Agent`, `Claim ID`, and `Branch` as text; `Claimed At` as a
-date. Start with `--dry-run`. The helper fills empty fields only. It rejects a
-non-empty mismatch and leaves Status unchanged. It re-reads the issue, claim,
-and fields before writing, then verifies the result. It cannot make the
-separate GitHub reads and writes atomic. It reads at most 100 comment pages or
+date. The claim comment may omit `Branch`; the helper then leaves the existing
+Project Branch value outside its fill and conflict checks. Start with
+`--dry-run`. The helper fills empty fields only. It rejects a non-empty mismatch
+and leaves Status unchanged. Before every field write, it re-reads the issue,
+exact trusted claim snapshot, Project field types, and Project field values.
+GitHub provides no compare-and-swap operation. A concurrent write can occur
+after a re-read and before its mutation. The helper does not roll back because a
+rollback could erase concurrent state. It reads at most 100 comment pages or
 10,000 comments and fails closed rather than use incomplete claim history.
 
 ## PR Body Rules

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -100,6 +100,7 @@ pnpm issue:review --pr 123 --issue 901
 pnpm issue:release --issue 901
 pnpm issue:release --issue 901 --needs-grooming
 pnpm issue:board sync
+pnpm issue:board backfill --issue 901 --dry-run
 pnpm issue:board:test
 ```
 
@@ -118,6 +119,16 @@ The helper requires a text Project field named `Claim ID` before it will claim
 issues; this field is the ownership token that prevents two agents from both
 winning the same issue. It also populates optional Project fields named `Agent`,
 `Branch`, `Claimed At`, and `PR` when those fields exist.
+
+Use `pnpm issue:board backfill --issue <n>` only to recover Project ownership
+fields after an eligible MCP claim. It requires one open issue with exactly one
+of `agent-active` or `in-pr`, a valid trusted claim comment, and Project fields
+with exact types: `Agent`, `Claim ID`, and `Branch` as text; `Claimed At` as a
+date. Start with `--dry-run`. The helper fills empty fields only. It rejects a
+non-empty mismatch and leaves Status unchanged. It re-reads the issue, claim,
+and fields before writing, then verifies the result. It cannot make the
+separate GitHub reads and writes atomic. It reads at most 100 comment pages or
+10,000 comments and fails closed rather than use incomplete claim history.
 
 ## PR Body Rules
 

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -3,7 +3,7 @@ title: GitHub Tooling Surfaces — gh CLI vs MCP
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-08-21
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -97,19 +97,25 @@ partial MCP emulation plus an explicit gh-capable handoff:
    label set, e.g. swap `agent-ready` for `agent-active` on claim, or
    `agent-active` for `in-pr` when the PR opens).
 2. Post the matching helper-format comment with `add_issue_comment` (claim
-   comments include the `Claim ID:` / `Branch:` / `Claimed at:` lines), and
-   state in it that Project #12 fields were not set from this session.
+   comments include the `Claim ID:` and `Claimed at:` lines, plus `Branch:`
+   when known), and state in it that Project #12 fields were not set from this
+   session.
 3. The Project Claim ID race guard is absent on this path, so the claim
    comment is the ownership record; check for a fresher competing claim
    comment before starting work.
 4. Hand off to a gh-capable surface. Run
    `pnpm issue:board backfill --issue <n> --dry-run`, then rerun it without
    `--dry-run` only when the proposed ownership-field writes are correct. The
-   helper reads the newest valid trusted claim comment and fills empty `Claim
-ID`, `Agent`, `Branch`, and `Claimed At` fields. It preserves Project Status,
-   rejects non-empty conflicts, re-reads before writing, and does not provide
-   atomic compare-and-swap semantics. Run `pnpm issue:board sync` separately
-   to reconcile status.
+   helper reads the newest valid trusted claim comment. It fills empty Project
+   fields as follows: `Claim ID`, `Agent`, and `Claimed At`. It fills `Branch`
+   only when the claim supplies it. It preserves Project Status and rejects
+   non-empty conflicts.
+   Before every field write, it re-reads the lifecycle, exact trusted claim
+   snapshot, Project field types, and current values. GitHub provides no
+   compare-and-swap operation. A concurrent write can still occur after that
+   read and before the mutation. The helper does not roll back because a
+   rollback could erase concurrent state. Run `pnpm issue:board sync`
+   separately to reconcile status.
 
 ## Known MCP gaps
 

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -102,11 +102,14 @@ partial MCP emulation plus an explicit gh-capable handoff:
 3. The Project Claim ID race guard is absent on this path, so the claim
    comment is the ownership record; check for a fresher competing claim
    comment before starting work.
-4. Hand off to a gh-capable surface: run `pnpm issue:board sync` afterward
-   to reconcile the Project #12 item's status. Sync writes status only — the
-   ownership fields (`Claim ID`, `Agent`, `Branch`, `Claimed At`) stay empty
-   until backfilled from the claim comment (a helper backfill path is
-   tracked in #1488), so the claim comment remains the ownership record.
+4. Hand off to a gh-capable surface. Run
+   `pnpm issue:board backfill --issue <n> --dry-run`, then rerun it without
+   `--dry-run` only when the proposed ownership-field writes are correct. The
+   helper reads the newest valid trusted claim comment and fills empty `Claim
+ID`, `Agent`, `Branch`, and `Claimed At` fields. It preserves Project Status,
+   rejects non-empty conflicts, re-reads before writing, and does not provide
+   atomic compare-and-swap semantics. Run `pnpm issue:board sync` separately
+   to reconcile status.
 
 ## Known MCP gaps
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -104,6 +104,7 @@ pnpm issue:claim --count 3 --agent codex       # Claim ready issues and move the
 pnpm issue:review --pr 123 --issue 901         # Move claimed issue to in-pr / review
 pnpm issue:release --issue 901                 # Release a mistaken claim back to agent-ready
 pnpm issue:board sync                          # Re-project labels and close merged in-pr board items
+pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 
 # Sentry triage pipeline (Stage A — deterministic ingest; Stage B — read-only triage + digest; ADR 0036)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3979,9 +3979,9 @@ while IFS= read -r path; do
         scripts/pr/review-materiality.mjs|scripts/pr/review-materiality-context.mjs|scripts/pr/review-materiality.test.mjs)
           add_command "pnpm agent:review-materiality:test" "agent review materiality helper changed"
           ;;
-        scripts/pr/agent-issue-board.mjs|scripts/pr/agent-issue-board.test.mjs|scripts/pr/issue-board-cli.mjs|scripts/pr/issue-board-commands.mjs|scripts/pr/issue-board-projects.mjs|scripts/pr/issue-board-state.mjs|scripts/pr/issue-board-transport.mjs)
-          # agent-issue-board.mjs is the entry point over five layers (cli,
-          # transport, state, projects, commands). The one suite covers the
+        scripts/pr/agent-issue-board.mjs|scripts/pr/agent-issue-board.test.mjs|scripts/pr/issue-board-backfill.mjs|scripts/pr/issue-board-cli.mjs|scripts/pr/issue-board-commands.mjs|scripts/pr/issue-board-projects.mjs|scripts/pr/issue-board-state.mjs|scripts/pr/issue-board-transport.mjs)
+          # agent-issue-board.mjs is the entry point over six layers (cli,
+          # transport, state, projects, backfill, commands). The one suite covers the
           # pure state machine through the entry's re-exports, so every layer
           # routes to it.
           add_command "pnpm issue:board:test" "agent issue board helper changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4663,6 +4663,9 @@ assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
 run_gate "scripts/pr/agent-issue-board.test.mjs"
 assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
 
+run_gate "scripts/pr/issue-board-backfill.mjs"
+assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
+
 run_gate "scripts/pr/issue-board-cli.mjs"
 assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
 

--- a/scripts/pr/agent-issue-board.mjs
+++ b/scripts/pr/agent-issue-board.mjs
@@ -4,12 +4,13 @@
  * the repo's GitHub Projects workboard.
  *
  * This file is the entry point and the public surface. The implementation
- * lives in five layers it composes:
+ * lives in six layers it composes:
  *   - `issue-board-state.mjs`     pure transitions and predicates
  *   - `issue-board-cli.mjs`       argv parsing and usage text
  *   - `issue-board-transport.mjs` the bounded `gh` runner and issue readers
  *   - `issue-board-projects.mjs`  Projects V2 field IO
- *   - `issue-board-commands.mjs`  claim, review, release, sync
+ *   - `issue-board-backfill.mjs`  trusted claim recovery and fill-only plans
+ *   - `issue-board-commands.mjs`  claim, review, release, sync, backfill
  */
 
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import { parseArgs, usage } from "./issue-board-cli.mjs";
 import {
   claim,
+  backfill,
   release,
   renderResults,
   review,
@@ -24,7 +26,12 @@ import {
 } from "./issue-board-commands.mjs";
 
 export { parseArgs, parseIssueNumbers } from "./issue-board-cli.mjs";
-export { buildClaimComment } from "./issue-board-commands.mjs";
+export { backfill, buildClaimComment } from "./issue-board-commands.mjs";
+export {
+  buildBackfillPlan,
+  parseClaimComment,
+  selectNewestTrustedClaim,
+} from "./issue-board-backfill.mjs";
 export { githubProjectScopeHint } from "./issue-board-transport.mjs";
 export {
   chooseUntriedCandidate,
@@ -32,6 +39,7 @@ export {
   DEFAULT_PROJECT_OWNER,
   DEFAULT_REPO,
   isClaimable,
+  isBackfillable,
   isRecoverableClaimRaceError,
   isReleasable,
   isReviewable,
@@ -55,6 +63,9 @@ async function main() {
   switch (options.command) {
     case "claim":
       results = await claim(options);
+      break;
+    case "backfill":
+      results = await backfill(options);
       break;
     case "review":
       results = await review(options);

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -547,6 +547,12 @@ function trustedComment({
   };
 }
 
+function commentWithHandoff(lines, options) {
+  const comment = trustedComment(options);
+  comment.body += `\n${lines.join("\n")}`;
+  return comment;
+}
+
 test("claim parser rejects conflicting newest-time claims and collapses identical ties", () => {
   assertThrows(
     () =>
@@ -600,6 +606,59 @@ test("claim parser ignores untrusted, wrong-issue, and malformed comments", () =
   const branchless = parseClaimComment(trustedComment({ branch: null }), 901);
   assertEqual(branchless.branch, null);
   assertEqual(Object.hasOwn(branchless.metadata, "Branch"), false);
+});
+
+test("claim parser accepts bounded cloud handoffs with trailing newlines", () => {
+  for (const trailingLines of [1, 2]) {
+    assert(
+      parseClaimComment(
+        commentWithHandoff([
+          "Project #12 fields were not set from this session.",
+          ...Array(trailingLines).fill(""),
+        ]),
+        901,
+      ),
+      "expected trailing newlines to be accepted",
+    );
+  }
+  assert(
+    parseClaimComment(
+      commentWithHandoff(["one", "two", "three", "four", "", ""]),
+      901,
+    ),
+    "expected four handoff lines plus trailing newlines to be accepted",
+  );
+  assert(
+    parseClaimComment(commentWithHandoff(["x".repeat(1000), "", ""]), 901),
+    "expected exactly 1000 handoff characters plus trailing newlines to be accepted",
+  );
+  const branchless = parseClaimComment(
+    commentWithHandoff(
+      ["Project #12 fields were not set from this session.", ""],
+      { branch: null },
+    ),
+    901,
+  );
+  assertEqual(branchless.branch, null);
+  assertEqual(Object.hasOwn(branchless.metadata, "Branch"), false);
+});
+
+test("claim parser rejects unsafe or oversized cloud handoffs", () => {
+  for (const lines of [
+    ["first line", "", "third line"],
+    ["first line", "Claim ID: second"],
+    ["first line", "Branch: second"],
+    ["first line", "Claimed at: 2026-08-20T10:00:00.000Z"],
+    ["handoff\u0000text"],
+    ["handoff\ttext"],
+    [" handoff"],
+    ["handoff "],
+    ["   "],
+    ["one", "two", "three", "four", "five"],
+    ["x".repeat(500), "x".repeat(500)],
+  ]) {
+    assertEqual(parseClaimComment(commentWithHandoff(lines), 901), null);
+  }
 });
 
 test("claim parser rejects unsafe text and invalid calendar dates", () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -496,7 +496,7 @@ test("claim queue treats stale claim races as recoverable", () => {
   );
 });
 
-test("claim comment records agent, issue, claim id, and branch", () => {
+test("claim comment records agent, issue, claim id, and an optional branch", () => {
   const comment = buildClaimComment(
     {
       agent: "codex",
@@ -510,6 +510,16 @@ test("claim comment records agent, issue, claim id, and branch", () => {
   assert(comment.includes("codex claimed #901"), "missing agent claim line");
   assert(comment.includes("Claim ID: codex-20260617T100000"), "missing claim");
   assert(comment.includes("Branch: agent/issue-901"), "missing branch");
+
+  const branchless = buildClaimComment(
+    {
+      agent: "codex",
+      claimId: "codex-20260617T100000",
+      claimedAt: "2026-06-17T10:00:00.000Z",
+    },
+    { number: 901 },
+  );
+  assert(!branchless.includes("Branch:"), "unexpected branch");
 });
 
 function trustedComment({
@@ -522,17 +532,18 @@ function trustedComment({
   branch = "agent/901",
   claimedAt = "2026-08-20T09:00:00.000Z",
 } = {}) {
+  const lines = [
+    `Agent claim: ${agent} claimed #${issue} for implementation.`,
+    "",
+    `Claim ID: ${claimId}`,
+  ];
+  if (branch !== null) lines.push(`Branch: ${branch}`);
+  lines.push(`Claimed at: ${claimedAt}`);
   return {
     id,
     createdAt,
     authorAssociation: association,
-    body: [
-      `Agent claim: ${agent} claimed #${issue} for implementation.`,
-      "",
-      `Claim ID: ${claimId}`,
-      `Branch: ${branch}`,
-      `Claimed at: ${claimedAt}`,
-    ].join("\n"),
+    body: lines.join("\n"),
   };
 }
 
@@ -567,9 +578,7 @@ test("claim parser rejects conflicting newest-time claims and collapses identica
   assertEqual(newest.metadata["Claim ID"], "same");
 });
 
-test("claim parser ignores untrusted, wrong-issue, malformed, and missing-field comments", () => {
-  const missing = trustedComment();
-  missing.body = missing.body.replace("Branch: agent/901\n", "");
+test("claim parser ignores untrusted, wrong-issue, and malformed comments", () => {
   const missingId = trustedComment();
   delete missingId.id;
   for (const comment of [
@@ -581,13 +590,16 @@ test("claim parser ignores untrusted, wrong-issue, malformed, and missing-field 
       ...trustedComment({ claimId: "bad" }),
       body: "Agent claim: codex claimed #901.",
     },
-    missing,
   ]) {
     assertEqual(parseClaimComment(comment, 901), null);
   }
   const handoff = trustedComment();
   handoff.body += "\nProject #12 fields were not set from this session.";
   assertEqual(parseClaimComment(handoff, 901).metadata.Branch, "agent/901");
+
+  const branchless = parseClaimComment(trustedComment({ branch: null }), 901);
+  assertEqual(branchless.branch, null);
+  assertEqual(Object.hasOwn(branchless.metadata, "Branch"), false);
 });
 
 test("claim parser rejects unsafe text and invalid calendar dates", () => {
@@ -648,6 +660,24 @@ test("backfill plan normalizes dates, fills only empties, and rejects conflicts"
     () => buildBackfillPlan({ ...metadata, Branch: "other" }, metadata),
     /conflicts/,
   );
+  const branchless = { ...metadata };
+  delete branchless.Branch;
+  assertDeepEqual(
+    buildBackfillPlan(
+      {
+        Agent: null,
+        "Claim ID": null,
+        Branch: "preserved-branch",
+        "Claimed At": null,
+      },
+      branchless,
+    ),
+    [
+      { field: "Claim ID", value: "claim-1" },
+      { field: "Agent", value: "codex" },
+      { field: "Claimed At", value: "2026-08-20" },
+    ],
+  );
 });
 
 function backfillFakes({
@@ -667,6 +697,7 @@ function backfillFakes({
     ],
   };
   const state = {
+    comments,
     issue: issue ?? {
       number: 901,
       title: "Backfill",
@@ -679,20 +710,39 @@ function backfillFakes({
       Branch: null,
       "Claimed At": null,
     },
+    project,
     writes: [],
+  };
+  const expectedFieldTypes = {
+    Agent: "TEXT",
+    "Claim ID": "TEXT",
+    Branch: "TEXT",
+    "Claimed At": "DATE",
   };
   return {
     state,
-    getProject: async () => project,
+    getProject: async () => state.project,
     getIssue: async () => ({ ...state.issue, labels: [...state.issue.labels] }),
     findIssueProjectItem: async () => "item",
-    listIssueComments: async () => comments,
-    requireBackfillFields: () => project.fields,
+    listIssueComments: async () => state.comments,
+    requireBackfillFields: (candidateProject) => {
+      const fields = {};
+      for (const [name, dataType] of Object.entries(expectedFieldTypes)) {
+        const field = candidateProject.fields.find(
+          (candidate) => candidate.name === name,
+        );
+        if (field?.dataType !== dataType) {
+          throw new Error(`Project must have a ${dataType} ${name} field`);
+        }
+        fields[name] = field;
+      }
+      return fields;
+    },
     readBackfillProjectFields: async () => ({ ...state.values }),
     writeBackfillProjectFields: async (_options, _project, _item, writes) => {
       state.writes.push(...writes);
       for (const write of writes) state.values[write.field] = write.value;
-      mutate?.(state);
+      mutate?.(state, writes);
     },
   };
 }
@@ -725,6 +775,28 @@ test("backfill writes claim ID first, fills partial matches, and is idempotent",
   assertEqual(fakes.state.writes.length, 3);
 });
 
+test("backfill preserves Branch when the trusted claim omits it", async () => {
+  const fakes = backfillFakes({
+    comments: [trustedComment({ branch: null })],
+    values: {
+      Agent: null,
+      "Claim ID": null,
+      Branch: "preserved-branch",
+      "Claimed At": null,
+    },
+  });
+  const [result] = await backfill({ issues: [901], dryRun: false }, fakes);
+  assertDeepEqual(
+    result.writes.map((write) => write.field),
+    ["Claim ID", "Agent", "Claimed At"],
+  );
+  assertEqual(fakes.state.values.Branch, "preserved-branch");
+  assertEqual(
+    fakes.state.writes.some((write) => write.field === "Branch"),
+    false,
+  );
+});
+
 test("backfill aborts conflicts before writes and detects post-write verification failure", async () => {
   const conflict = backfillFakes({
     values: {
@@ -742,7 +814,7 @@ test("backfill aborts conflicts before writes and detects post-write verificatio
 
   const broken = backfillFakes({
     mutate: (state) => {
-      state.values.Branch = "other";
+      if (state.writes.length === 4) state.values.Branch = "other";
     },
   });
   await assertRejects(
@@ -783,6 +855,101 @@ test("backfill aborts when one trusted comment ID changes metadata before write"
     /changed before backfill write/,
   );
   assertEqual(fakes.state.writes.length, 0);
+});
+
+test("backfill fingerprints an absent Branch before writing", async () => {
+  const fakes = backfillFakes({ comments: [trustedComment({ branch: null })] });
+  let commentReads = 0;
+  fakes.listIssueComments = async () => [
+    trustedComment({
+      branch: commentReads++ === 0 ? null : "agent/901",
+    }),
+  ];
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /changed before backfill write/,
+  );
+  assertEqual(fakes.state.writes.length, 0);
+});
+
+test("backfill stops before later writes when a newer claim arrives", async () => {
+  const fakes = backfillFakes({
+    mutate: (state) => {
+      if (state.writes.length === 1) {
+        state.comments = [
+          trustedComment({
+            id: "comment-2",
+            claimId: "claim-2",
+            createdAt: "2026-08-20T11:00:00.000Z",
+          }),
+        ];
+      }
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /changed before backfill write/,
+  );
+  assertDeepEqual(
+    fakes.state.writes.map((write) => write.field),
+    ["Claim ID"],
+  );
+});
+
+test("backfill stops before later writes when a target field drifts", async () => {
+  const fakes = backfillFakes({
+    mutate: (state) => {
+      if (state.writes.length === 1) state.values.Agent = "other";
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /changed before backfill write/,
+  );
+  assertDeepEqual(
+    fakes.state.writes.map((write) => write.field),
+    ["Claim ID"],
+  );
+});
+
+test("backfill stops before later writes when the lifecycle drifts", async () => {
+  const fakes = backfillFakes({
+    mutate: (state) => {
+      if (state.writes.length === 1) {
+        state.issue.labels = [{ name: "agent-ready" }];
+      }
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /is not backfillable/,
+  );
+  assertDeepEqual(
+    fakes.state.writes.map((write) => write.field),
+    ["Claim ID"],
+  );
+});
+
+test("backfill stops before later writes when an ownership field type drifts", async () => {
+  const fakes = backfillFakes({
+    mutate: (state) => {
+      if (state.writes.length !== 1) return;
+      state.project = {
+        ...state.project,
+        fields: state.project.fields.map((field) =>
+          field.name === "Agent" ? { ...field, dataType: "DATE" } : field,
+        ),
+      };
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /Project must have a TEXT Agent field/,
+  );
+  assertDeepEqual(
+    fakes.state.writes.map((write) => write.field),
+    ["Claim ID"],
+  );
 });
 
 function backfillProject() {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import {
   buildClaimComment,
+  buildBackfillPlan,
+  backfill,
   chooseUntriedCandidate,
   githubProjectScopeHint,
   isClaimable,
+  isBackfillable,
   isReleasable,
   isRecoverableClaimRaceError,
   isReviewable,
@@ -12,18 +15,42 @@ import {
   parseIssueNumbers,
   projectDateFieldValue,
   projectPrFieldValue,
+  parseClaimComment,
+  selectNewestTrustedClaim,
   selectStatusOption,
   shouldRollbackFailedTransition,
   stateFromLabels,
   validateOpenPr,
 } from "./agent-issue-board.mjs";
+import {
+  readBackfillProjectFields,
+  writeBackfillProjectFields,
+} from "./issue-board-projects.mjs";
+import { listIssueComments } from "./issue-board-transport.mjs";
 
 let passed = 0;
 let failed = 0;
+const pending = [];
 
 function test(name, fn) {
   try {
-    fn();
+    const result = fn();
+    if (result?.then) {
+      pending.push(
+        result.then(
+          () => {
+            process.stdout.write(`ok ${name}\n`);
+            passed += 1;
+          },
+          (err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`not ok ${name}\n  ${message}\n`);
+            failed += 1;
+          },
+        ),
+      );
+      return;
+    }
     process.stdout.write(`ok ${name}\n`);
     passed += 1;
   } catch (err) {
@@ -66,6 +93,21 @@ function assertThrows(fn, pattern) {
     return;
   }
   throw new Error("expected function to throw");
+}
+
+async function assertRejects(fn, pattern) {
+  try {
+    await fn();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!pattern.test(message)) {
+      throw new Error(`expected ${message} to match ${pattern}`, {
+        cause: err,
+      });
+    }
+    return;
+  }
+  throw new Error("expected function to reject");
 }
 
 test("parses repeated, comma-separated, and URL issue references", () => {
@@ -170,6 +212,24 @@ test("parses claim options for the monitoring workboard", () => {
   assertEqual(args.projectOwner, "mento-protocol");
   assertEqual(args.projectNumber, 12);
   assertEqual(args.dryRun, true);
+});
+
+test("backfill requires exactly one explicit issue", () => {
+  const options = parseArgs(["board", "backfill", "--issue", "901"]);
+  assertEqual(options.issues[0], 901);
+  assertEqual(options.backfillIssueFlags, undefined);
+  assertEqual(options.positionalIssueValues, undefined);
+  for (const argv of [
+    ["board", "backfill"],
+    ["board", "backfill", "901"],
+    ["board", "backfill", "--issue", "901", "--issue", "902"],
+    ["board", "backfill", "--issue", "901,902"],
+    ["board", "backfill", "--issue", "901,901"],
+    ["board", "backfill", "--issue", "0"],
+    ["board", "backfill", "--issues", "901"],
+  ]) {
+    assertThrows(() => parseArgs(argv), /exactly one explicit --issue/);
+  }
 });
 
 test("parses PR URLs only for the selected repository", () => {
@@ -451,6 +511,467 @@ test("claim comment records agent, issue, claim id, and branch", () => {
   assert(comment.includes("Claim ID: codex-20260617T100000"), "missing claim");
   assert(comment.includes("Branch: agent/issue-901"), "missing branch");
 });
+
+function trustedComment({
+  id = "comment-1",
+  createdAt = "2026-08-20T10:00:00.000Z",
+  association = "MEMBER",
+  issue = 901,
+  agent = "codex",
+  claimId = "claim-1",
+  branch = "agent/901",
+  claimedAt = "2026-08-20T09:00:00.000Z",
+} = {}) {
+  return {
+    id,
+    createdAt,
+    authorAssociation: association,
+    body: [
+      `Agent claim: ${agent} claimed #${issue} for implementation.`,
+      "",
+      `Claim ID: ${claimId}`,
+      `Branch: ${branch}`,
+      `Claimed at: ${claimedAt}`,
+    ].join("\n"),
+  };
+}
+
+test("claim parser rejects conflicting newest-time claims and collapses identical ties", () => {
+  assertThrows(
+    () =>
+      selectNewestTrustedClaim(
+        [
+          trustedComment({ id: "a", claimId: "first" }),
+          trustedComment({ id: "b", claimId: "second" }),
+        ],
+        901,
+      ),
+    /ambiguous trusted claims/,
+  );
+  const newest = selectNewestTrustedClaim(
+    [
+      trustedComment({
+        id: "b",
+        claimId: "same",
+        createdAt: "2026-08-21T10:00:00.000Z",
+      }),
+      trustedComment({
+        id: "a",
+        claimId: "same",
+        createdAt: "2026-08-21T10:00:00.000Z",
+      }),
+    ],
+    901,
+  );
+  assertEqual(newest.id, "a");
+  assertEqual(newest.metadata["Claim ID"], "same");
+});
+
+test("claim parser ignores untrusted, wrong-issue, malformed, and missing-field comments", () => {
+  const missing = trustedComment();
+  missing.body = missing.body.replace("Branch: agent/901\n", "");
+  const missingId = trustedComment();
+  delete missingId.id;
+  for (const comment of [
+    trustedComment({ association: "CONTRIBUTOR", claimId: "untrusted" }),
+    trustedComment({ issue: 902, claimId: "wrong" }),
+    trustedComment({ createdAt: "not-a-timestamp" }),
+    missingId,
+    {
+      ...trustedComment({ claimId: "bad" }),
+      body: "Agent claim: codex claimed #901.",
+    },
+    missing,
+  ]) {
+    assertEqual(parseClaimComment(comment, 901), null);
+  }
+  const handoff = trustedComment();
+  handoff.body += "\nProject #12 fields were not set from this session.";
+  assertEqual(parseClaimComment(handoff, 901).metadata.Branch, "agent/901");
+});
+
+test("claim parser rejects unsafe text and invalid calendar dates", () => {
+  for (const comment of [
+    trustedComment({ agent: `a${"x".repeat(120)}` }),
+    trustedComment({ claimId: `claim-${"x".repeat(160)}` }),
+    trustedComment({ branch: `branch-${"x".repeat(250)}` }),
+    trustedComment({ claimId: "claim\u0000id" }),
+    trustedComment({ agent: " codex " }),
+    trustedComment({ claimId: " claim-1 " }),
+    trustedComment({ branch: " agent/901 " }),
+    trustedComment({ claimedAt: "2026-02-30T09:00:00.000Z" }),
+    trustedComment({ claimedAt: "2026-13-01T09:00:00.000Z" }),
+  ]) {
+    assertEqual(parseClaimComment(comment, 901), null);
+  }
+});
+
+test("backfill state matrix accepts only open active or in-pr issues", () => {
+  assertEqual(
+    isBackfillable({ state: "OPEN", labels: [{ name: "agent-active" }] }),
+    true,
+  );
+  assertEqual(
+    isBackfillable({ state: "OPEN", labels: [{ name: "in-pr" }] }),
+    true,
+  );
+  for (const issue of [
+    { state: "CLOSED", labels: [{ name: "agent-active" }] },
+    { state: "OPEN", labels: [{ name: "agent-ready" }] },
+    { state: "OPEN", labels: [{ name: "agent-active" }, { name: "in-pr" }] },
+    { state: "OPEN", labels: [{ name: "in-pr" }, { name: "needs-grooming" }] },
+  ]) {
+    assertEqual(isBackfillable(issue), false);
+  }
+});
+
+test("backfill plan normalizes dates, fills only empties, and rejects conflicts", () => {
+  const metadata = {
+    Agent: "codex",
+    "Claim ID": "claim-1",
+    Branch: "agent/901",
+    "Claimed At": projectDateFieldValue("2026-08-20T09:00:00.000Z"),
+  };
+  assertDeepEqual(
+    buildBackfillPlan(
+      { Agent: "codex", "Claim ID": "", Branch: null, "Claimed At": null },
+      metadata,
+    ),
+    [
+      { field: "Claim ID", value: "claim-1" },
+      { field: "Branch", value: "agent/901" },
+      { field: "Claimed At", value: "2026-08-20" },
+    ],
+  );
+  assertDeepEqual(buildBackfillPlan(metadata, metadata), []);
+  assertThrows(
+    () => buildBackfillPlan({ ...metadata, Branch: "other" }, metadata),
+    /conflicts/,
+  );
+});
+
+function backfillFakes({
+  values,
+  comments = [trustedComment()],
+  issue,
+  mutate,
+} = {}) {
+  const project = {
+    id: "project",
+    title: "Workboard",
+    fields: [
+      { id: "agent", name: "Agent", dataType: "TEXT" },
+      { id: "claim", name: "Claim ID", dataType: "TEXT" },
+      { id: "branch", name: "Branch", dataType: "TEXT" },
+      { id: "date", name: "Claimed At", dataType: "DATE" },
+    ],
+  };
+  const state = {
+    issue: issue ?? {
+      number: 901,
+      title: "Backfill",
+      state: "OPEN",
+      labels: [{ name: "agent-active" }],
+    },
+    values: values ?? {
+      Agent: null,
+      "Claim ID": null,
+      Branch: null,
+      "Claimed At": null,
+    },
+    writes: [],
+  };
+  return {
+    state,
+    getProject: async () => project,
+    getIssue: async () => ({ ...state.issue, labels: [...state.issue.labels] }),
+    findIssueProjectItem: async () => "item",
+    listIssueComments: async () => comments,
+    requireBackfillFields: () => project.fields,
+    readBackfillProjectFields: async () => ({ ...state.values }),
+    writeBackfillProjectFields: async (_options, _project, _item, writes) => {
+      state.writes.push(...writes);
+      for (const write of writes) state.values[write.field] = write.value;
+      mutate?.(state);
+    },
+  };
+}
+
+test("backfill dry-run has no writes and returns exact writes", async () => {
+  const fakes = backfillFakes();
+  const [result] = await backfill({ issues: [901], dryRun: true }, fakes);
+  assertEqual(fakes.state.writes.length, 0);
+  assertDeepEqual(
+    result.writes.map((write) => write.field),
+    ["Claim ID", "Agent", "Branch", "Claimed At"],
+  );
+});
+
+test("backfill writes claim ID first, fills partial matches, and is idempotent", async () => {
+  const fakes = backfillFakes({
+    values: {
+      Agent: "codex",
+      "Claim ID": null,
+      Branch: null,
+      "Claimed At": null,
+    },
+  });
+  const options = { issues: [901], dryRun: false };
+  const [result] = await backfill(options, fakes);
+  assertEqual(result.state, "backfilled");
+  assertEqual(fakes.state.writes[0].field, "Claim ID");
+  const [again] = await backfill(options, fakes);
+  assertEqual(again.state, "backfill already matched");
+  assertEqual(fakes.state.writes.length, 3);
+});
+
+test("backfill aborts conflicts before writes and detects post-write verification failure", async () => {
+  const conflict = backfillFakes({
+    values: {
+      Agent: "other",
+      "Claim ID": null,
+      Branch: null,
+      "Claimed At": null,
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, conflict),
+    /conflicts/,
+  );
+  assertEqual(conflict.state.writes.length, 0);
+
+  const broken = backfillFakes({
+    mutate: (state) => {
+      state.values.Branch = "other";
+    },
+  });
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, broken),
+    /verification failed/,
+  );
+});
+
+test("backfill re-reads and aborts when project values drift before writing", async () => {
+  const fakes = backfillFakes();
+  const read = fakes.readBackfillProjectFields;
+  let reads = 0;
+  fakes.readBackfillProjectFields = async (...args) => {
+    reads += 1;
+    if (reads === 2) fakes.state.values.Agent = "other";
+    return read(...args);
+  };
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /changed before backfill write/,
+  );
+  assertEqual(fakes.state.writes.length, 0);
+});
+
+test("backfill aborts when one trusted comment ID changes metadata before write", async () => {
+  const fakes = backfillFakes();
+  let commentReads = 0;
+  fakes.listIssueComments = async () => [
+    trustedComment({
+      claimedAt:
+        commentReads++ === 0
+          ? "2026-08-20T09:00:00.000Z"
+          : "2026-08-20T10:00:00.000Z",
+    }),
+  ];
+  await assertRejects(
+    () => backfill({ issues: [901], dryRun: false }, fakes),
+    /changed before backfill write/,
+  );
+  assertEqual(fakes.state.writes.length, 0);
+});
+
+function backfillProject() {
+  return {
+    id: "project",
+    fields: [
+      { id: "agent", name: "Agent", dataType: "TEXT" },
+      { id: "claim", name: "Claim ID", dataType: "TEXT" },
+      { id: "branch", name: "Branch", dataType: "TEXT" },
+      { id: "date", name: "Claimed At", dataType: "DATE" },
+    ],
+  };
+}
+
+function commentPage(
+  nodes,
+  pageInfo = { hasNextPage: false, endCursor: null },
+) {
+  return { data: { repository: { issue: { comments: { nodes, pageInfo } } } } };
+}
+
+test("comment adapter reads every page and rejects bad cursor progress or caps", async () => {
+  const calls = [];
+  const comments = await listIssueComments(
+    { repo: "mento-protocol/monitoring-monorepo" },
+    901,
+    {
+      graphql: async (_query, variables) => {
+        calls.push(variables.cursor ?? null);
+        return variables.cursor
+          ? commentPage([trustedComment({ id: "two" })])
+          : commentPage([trustedComment({ id: "one" })], {
+              hasNextPage: true,
+              endCursor: "next",
+            });
+      },
+    },
+  );
+  assertDeepEqual(calls, [null, "next"]);
+  assertEqual(comments.length, 2);
+  await assertRejects(
+    () =>
+      listIssueComments({ repo: "mento-protocol/monitoring-monorepo" }, 901, {
+        graphql: async () =>
+          commentPage([], { hasNextPage: true, endCursor: null }),
+      }),
+    /did not advance cursor/,
+  );
+  await assertRejects(
+    () =>
+      listIssueComments({ repo: "mento-protocol/monitoring-monorepo" }, 901, {
+        graphql: async () =>
+          commentPage([], { hasNextPage: true, endCursor: "same" }),
+        maxPages: 3,
+      }),
+    /did not advance cursor/,
+  );
+  await assertRejects(
+    () =>
+      listIssueComments({ repo: "mento-protocol/monitoring-monorepo" }, 901, {
+        graphql: async () =>
+          commentPage([], { hasNextPage: true, endCursor: "next" }),
+        maxPages: 1,
+      }),
+    /exceeded 1 pages/,
+  );
+});
+
+test("project adapters paginate, decode values, order mutations, and reject bad cursors", async () => {
+  const project = backfillProject();
+  const readCalls = [];
+  const values = await readBackfillProjectFields({}, project, "item", {
+    graphql: async (_query, variables) => {
+      readCalls.push(variables.cursor ?? null);
+      return variables.cursor
+        ? {
+            data: {
+              node: {
+                fieldValues: {
+                  nodes: [
+                    { date: "2026-08-20", field: { id: "date" } },
+                    { text: "agent/901", field: { id: "branch" } },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          }
+        : {
+            data: {
+              node: {
+                fieldValues: {
+                  nodes: [
+                    { text: "codex", field: { id: "agent" } },
+                    { text: "claim-1", field: { id: "claim" } },
+                  ],
+                  pageInfo: { hasNextPage: true, endCursor: "next" },
+                },
+              },
+            },
+          };
+    },
+  });
+  assertDeepEqual(readCalls, [null, "next"]);
+  assertDeepEqual(values, {
+    Agent: "codex",
+    "Claim ID": "claim-1",
+    Branch: "agent/901",
+    "Claimed At": "2026-08-20",
+  });
+  await assertRejects(
+    () =>
+      readBackfillProjectFields({}, project, "item", {
+        graphql: async () => ({
+          data: {
+            node: {
+              fieldValues: {
+                nodes: [],
+                pageInfo: { hasNextPage: true, endCursor: "same" },
+              },
+            },
+          },
+        }),
+        maxPages: 3,
+      }),
+    /did not advance cursor/,
+  );
+  await assertRejects(
+    () =>
+      readBackfillProjectFields({}, project, "item", {
+        graphql: async () => ({
+          data: {
+            node: {
+              fieldValues: {
+                nodes: [],
+                pageInfo: { hasNextPage: true, endCursor: null },
+              },
+            },
+          },
+        }),
+      }),
+    /did not advance cursor/,
+  );
+  await assertRejects(
+    () =>
+      readBackfillProjectFields({}, project, "item", {
+        graphql: async () => ({
+          data: {
+            node: {
+              fieldValues: {
+                nodes: [],
+                pageInfo: { hasNextPage: true, endCursor: "next" },
+              },
+            },
+          },
+        }),
+        maxPages: 1,
+      }),
+    /exceeded 1 pages/,
+  );
+  const writes = [];
+  await writeBackfillProjectFields(
+    { dryRun: false },
+    project,
+    "item",
+    [
+      { field: "Claim ID", value: "claim-1" },
+      { field: "Agent", value: "codex" },
+      { field: "Branch", value: "agent/901" },
+      { field: "Claimed At", value: "2026-08-20" },
+    ],
+    {
+      graphql: async (query, variables) => {
+        writes.push({ query, variables });
+        return { data: {} };
+      },
+    },
+  );
+  assertDeepEqual(
+    writes.map((write) => write.variables.field),
+    ["claim", "agent", "branch", "date"],
+  );
+  assertEqual(writes[0].variables.text, "claim-1");
+  assertEqual(writes[3].variables.date, "2026-08-20");
+  assert(writes[0].query.includes("text: $text"), "missing text mutation");
+  assert(writes[3].query.includes("date: $date"), "missing date mutation");
+});
+
+await Promise.all(pending);
 
 if (failed > 0) {
   process.stderr.write(`${failed} failed, ${passed} passed\n`);

--- a/scripts/pr/issue-board-backfill.mjs
+++ b/scripts/pr/issue-board-backfill.mjs
@@ -24,6 +24,13 @@ const MAX_CLAIM_ID_LENGTH = 160;
 const MAX_BRANCH_LENGTH = 256;
 const MAX_COMMENT_ID_LENGTH = 512;
 
+function claimFields(metadata) {
+  return CLAIM_FIELDS.filter(
+    (field) =>
+      field !== OPTIONAL_PROJECT_FIELDS.branch || metadata[field] != null,
+  );
+}
+
 function hasControlCharacter(value) {
   for (const character of value) {
     const codePoint = character.codePointAt(0);
@@ -116,7 +123,8 @@ export function parseClaimComment(comment, issueNumber) {
   const claimedAt = values.get("Claimed at");
   if (
     !isSafeSingleLineText(claimId, MAX_CLAIM_ID_LENGTH) ||
-    !isSafeSingleLineText(branch, MAX_BRANCH_LENGTH) ||
+    (branch !== undefined &&
+      !isSafeSingleLineText(branch, MAX_BRANCH_LENGTH)) ||
     !isValidIsoTimestamp(claimedAt)
   ) {
     return null;
@@ -125,10 +133,13 @@ export function parseClaimComment(comment, issueNumber) {
     id: String(comment.id),
     createdAt: comment.createdAt,
     claimedAt,
+    branch: branch ?? null,
     metadata: {
       [OPTIONAL_PROJECT_FIELDS.agent]: match[1],
       [OPTIONAL_PROJECT_FIELDS.claimId]: claimId,
-      [OPTIONAL_PROJECT_FIELDS.branch]: branch,
+      ...(branch === undefined
+        ? {}
+        : { [OPTIONAL_PROJECT_FIELDS.branch]: branch }),
       [OPTIONAL_PROJECT_FIELDS.claimedAt]: projectDateFieldValue(claimedAt),
     },
   };
@@ -136,6 +147,7 @@ export function parseClaimComment(comment, issueNumber) {
 
 function claimMetadataFingerprint(claim) {
   return JSON.stringify({
+    branch: claim.branch,
     claimedAt: claim.claimedAt,
     metadata: claim.metadata,
   });
@@ -164,15 +176,11 @@ export function selectNewestTrustedClaim(comments, issueNumber) {
   return newest[0];
 }
 
-function valueFor(field, metadata) {
-  return metadata[field] ?? null;
-}
-
 export function buildBackfillPlan(values, metadata) {
   const writes = [];
-  for (const field of CLAIM_FIELDS) {
+  for (const field of claimFields(metadata)) {
     const current = values[field];
-    const expected = valueFor(field, metadata);
+    const expected = metadata[field];
     if (current == null || current === "") {
       writes.push({ field, value: expected });
     } else if (current !== expected) {
@@ -191,19 +199,75 @@ function issueFingerprint(issue) {
   });
 }
 
-function snapshotFingerprint(snapshot) {
-  return JSON.stringify({
+function backfillFieldFingerprint(fields) {
+  return Object.fromEntries(
+    Object.entries(fields)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, field]) => [
+        name,
+        { id: field.id, dataType: field.dataType },
+      ]),
+  );
+}
+
+function backfillValuesFingerprint(values) {
+  return JSON.stringify(
+    Object.fromEntries(
+      CLAIM_FIELDS.map((field) => [field, values[field] ?? null]),
+    ),
+  );
+}
+
+function snapshotIdentity(snapshot) {
+  return {
     issue: issueFingerprint(snapshot.issue),
+    project: {
+      id: snapshot.project.id,
+      fields: backfillFieldFingerprint(snapshot.fields),
+    },
+    itemId: snapshot.itemId,
     claim: snapshot.claim
       ? {
           id: snapshot.claim.id,
           createdAt: snapshot.claim.createdAt,
           claimedAt: snapshot.claim.claimedAt,
+          branch: snapshot.claim.branch,
           metadata: snapshot.claim.metadata,
         }
       : null,
-    values: snapshot.values,
+  };
+}
+
+function snapshotIdentityFingerprint(snapshot) {
+  return JSON.stringify(snapshotIdentity(snapshot));
+}
+
+function snapshotFingerprint(snapshot) {
+  return JSON.stringify({
+    ...snapshotIdentity(snapshot),
+    values: backfillValuesFingerprint(snapshot.values),
   });
+}
+
+function hasExpectedValues(snapshot, expectedValues) {
+  return (
+    backfillValuesFingerprint(snapshot.values) ===
+    backfillValuesFingerprint(expectedValues)
+  );
+}
+
+function assertSnapshotMatches(
+  expectedIdentity,
+  expectedValues,
+  snapshot,
+  issueNumber,
+) {
+  if (
+    snapshotIdentityFingerprint(snapshot) !== expectedIdentity ||
+    !hasExpectedValues(snapshot, expectedValues)
+  ) {
+    throw new Error(`Issue #${issueNumber} changed before backfill write`);
+  }
 }
 
 async function readSnapshot(options, dependencies) {
@@ -214,7 +278,7 @@ async function readSnapshot(options, dependencies) {
     );
   }
   const project = await dependencies.getProject(options);
-  dependencies.requireBackfillFields(project);
+  const fields = dependencies.requireBackfillFields(project);
   const itemId = await dependencies.findIssueProjectItem(
     options,
     issue,
@@ -235,7 +299,7 @@ async function readSnapshot(options, dependencies) {
       `Issue #${issue.number} has no valid trusted agent claim comment`,
     );
   }
-  return { issue, project, itemId, claim, values };
+  return { issue, project, fields, itemId, claim, values };
 }
 
 export async function backfillIssue(options, dependencies) {
@@ -260,21 +324,46 @@ export async function backfillIssue(options, dependencies) {
     beforeWrite.values,
     beforeWrite.claim.metadata,
   );
-  if (writes.length > 0) {
-    await dependencies.writeBackfillProjectFields(
-      options,
-      beforeWrite.project,
-      beforeWrite.itemId,
-      writes,
+  const expectedIdentity = snapshotIdentityFingerprint(beforeWrite);
+  const expectedValues = { ...beforeWrite.values };
+  for (const write of writes) {
+    const current = await readSnapshot(options, dependencies);
+    assertSnapshotMatches(
+      expectedIdentity,
+      expectedValues,
+      current,
+      beforeWrite.issue.number,
     );
-  }
-  const verified = await readSnapshot(options, dependencies);
-  for (const field of CLAIM_FIELDS) {
-    if (verified.values[field] !== verified.claim.metadata[field]) {
+    const currentPlan = buildBackfillPlan(
+      current.values,
+      current.claim.metadata,
+    );
+    if (
+      !currentPlan.some(
+        (candidate) =>
+          candidate.field === write.field && candidate.value === write.value,
+      )
+    ) {
       throw new Error(
-        `Issue #${verified.issue.number} backfill verification failed for ${field}`,
+        `Issue #${beforeWrite.issue.number} changed before backfill write`,
       );
     }
+    await dependencies.writeBackfillProjectFields(
+      options,
+      current.project,
+      current.itemId,
+      [write],
+    );
+    expectedValues[write.field] = write.value;
+  }
+  const verified = await readSnapshot(options, dependencies);
+  if (
+    snapshotIdentityFingerprint(verified) !== expectedIdentity ||
+    !hasExpectedValues(verified, expectedValues)
+  ) {
+    throw new Error(
+      `Issue #${beforeWrite.issue.number} backfill verification failed`,
+    );
   }
   return {
     number: verified.issue.number,

--- a/scripts/pr/issue-board-backfill.mjs
+++ b/scripts/pr/issue-board-backfill.mjs
@@ -73,11 +73,15 @@ function isValidIsoTimestamp(value) {
 }
 
 function isBoundedCloudHandoff(lines) {
+  const handoff = [...lines];
+  while (handoff[handoff.length - 1] === "") handoff.pop();
   return (
-    lines.length <= 4 &&
-    lines.join("\n").length <= 1000 &&
-    lines.every(
-      (line) => line.length > 0 && !/^(Claim ID|Branch|Claimed at):/.test(line),
+    handoff.length <= 4 &&
+    handoff.join("\n").length <= 1000 &&
+    handoff.every(
+      (line) =>
+        isSafeSingleLineText(line, 1000) &&
+        !/^(Claim ID|Branch|Claimed at):/.test(line),
     )
   );
 }

--- a/scripts/pr/issue-board-backfill.mjs
+++ b/scripts/pr/issue-board-backfill.mjs
@@ -1,0 +1,285 @@
+/**
+ * Fill missing Project ownership fields from trusted agent claim comments.
+ *
+ * This is deliberately a fill-only recovery path. It does not update Status
+ * and it does not offer compare-and-swap semantics across GitHub surfaces.
+ */
+
+import {
+  OPTIONAL_PROJECT_FIELDS,
+  isBackfillable,
+  labelNames,
+  projectDateFieldValue,
+} from "./issue-board-state.mjs";
+
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const CLAIM_FIELDS = [
+  OPTIONAL_PROJECT_FIELDS.claimId,
+  OPTIONAL_PROJECT_FIELDS.agent,
+  OPTIONAL_PROJECT_FIELDS.branch,
+  OPTIONAL_PROJECT_FIELDS.claimedAt,
+];
+const MAX_AGENT_LENGTH = 120;
+const MAX_CLAIM_ID_LENGTH = 160;
+const MAX_BRANCH_LENGTH = 256;
+const MAX_COMMENT_ID_LENGTH = 512;
+
+function hasControlCharacter(value) {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint <= 0x1f || codePoint === 0x7f) return true;
+  }
+  return false;
+}
+
+function isSafeSingleLineText(value, maxLength) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maxLength &&
+    value === value.trim() &&
+    !hasControlCharacter(value)
+  );
+}
+
+function isValidIsoTimestamp(value) {
+  const match = String(value).match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2}))$/,
+  );
+  if (!match) return false;
+  const [, year, month, day, hour, minute, second, , offsetHour, offsetMinute] =
+    match.map((part) => (part === undefined ? undefined : Number(part)));
+  if (
+    year < 1 ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    (offsetHour !== undefined && (offsetHour > 23 || offsetMinute > 59))
+  ) {
+    return false;
+  }
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day <= daysInMonth && Number.isFinite(Date.parse(value));
+}
+
+function isBoundedCloudHandoff(lines) {
+  return (
+    lines.length <= 4 &&
+    lines.join("\n").length <= 1000 &&
+    lines.every(
+      (line) => line.length > 0 && !/^(Claim ID|Branch|Claimed at):/.test(line),
+    )
+  );
+}
+
+export function parseClaimComment(comment, issueNumber) {
+  if (!TRUSTED_ASSOCIATIONS.has(comment?.authorAssociation)) return null;
+  if (
+    !isSafeSingleLineText(comment?.id, MAX_COMMENT_ID_LENGTH) ||
+    !isValidIsoTimestamp(comment?.createdAt)
+  ) {
+    return null;
+  }
+  const lines = String(comment.body ?? "")
+    .replace(/\r\n/g, "\n")
+    .split("\n");
+  const first = lines.shift();
+  const match = first?.match(
+    /^Agent claim: (.+) claimed #(\d+) for implementation\.$/,
+  );
+  if (
+    !match ||
+    Number(match[2]) !== issueNumber ||
+    !match[1].trim() ||
+    !isSafeSingleLineText(match[1], MAX_AGENT_LENGTH)
+  )
+    return null;
+
+  const values = new Map();
+  let index = 0;
+  while (index < lines.length && lines[index] === "") index += 1;
+  for (; index < lines.length; index += 1) {
+    const line = lines[index];
+    const field = line.match(/^(Claim ID|Branch|Claimed at):\s*(.*)$/);
+    if (!field) break;
+    if (values.has(field[1]) || !field[2]) return null;
+    values.set(field[1], field[2]);
+  }
+  while (index < lines.length && lines[index] === "") index += 1;
+  if (!isBoundedCloudHandoff(lines.slice(index))) return null;
+
+  const claimId = values.get("Claim ID");
+  const branch = values.get("Branch");
+  const claimedAt = values.get("Claimed at");
+  if (
+    !isSafeSingleLineText(claimId, MAX_CLAIM_ID_LENGTH) ||
+    !isSafeSingleLineText(branch, MAX_BRANCH_LENGTH) ||
+    !isValidIsoTimestamp(claimedAt)
+  ) {
+    return null;
+  }
+  return {
+    id: String(comment.id),
+    createdAt: comment.createdAt,
+    claimedAt,
+    metadata: {
+      [OPTIONAL_PROJECT_FIELDS.agent]: match[1],
+      [OPTIONAL_PROJECT_FIELDS.claimId]: claimId,
+      [OPTIONAL_PROJECT_FIELDS.branch]: branch,
+      [OPTIONAL_PROJECT_FIELDS.claimedAt]: projectDateFieldValue(claimedAt),
+    },
+  };
+}
+
+function claimMetadataFingerprint(claim) {
+  return JSON.stringify({
+    claimedAt: claim.claimedAt,
+    metadata: claim.metadata,
+  });
+}
+
+export function selectNewestTrustedClaim(comments, issueNumber) {
+  const valid = (comments ?? [])
+    .map((comment) => parseClaimComment(comment, issueNumber))
+    .filter(Boolean);
+  if (valid.length === 0) return null;
+  const newestTime = Math.max(
+    ...valid.map((claim) => Date.parse(claim.createdAt)),
+  );
+  const newest = valid.filter(
+    (claim) => Date.parse(claim.createdAt) === newestTime,
+  );
+  const metadata = claimMetadataFingerprint(newest[0]);
+  if (newest.some((claim) => claimMetadataFingerprint(claim) !== metadata)) {
+    throw new Error(
+      `Issue #${issueNumber} has ambiguous trusted claims at the newest timestamp`,
+    );
+  }
+  // IDs do not establish chronology. At one timestamp with identical metadata,
+  // use one ID only to make the collapsed representation stable across pages.
+  newest.sort((left, right) => left.id.localeCompare(right.id));
+  return newest[0];
+}
+
+function valueFor(field, metadata) {
+  return metadata[field] ?? null;
+}
+
+export function buildBackfillPlan(values, metadata) {
+  const writes = [];
+  for (const field of CLAIM_FIELDS) {
+    const current = values[field];
+    const expected = valueFor(field, metadata);
+    if (current == null || current === "") {
+      writes.push({ field, value: expected });
+    } else if (current !== expected) {
+      throw new Error(
+        `Project ${field} conflicts: ${current} does not match trusted claim ${expected}`,
+      );
+    }
+  }
+  return writes;
+}
+
+function issueFingerprint(issue) {
+  return JSON.stringify({
+    state: issue.state,
+    labels: [...labelNames(issue)].sort(),
+  });
+}
+
+function snapshotFingerprint(snapshot) {
+  return JSON.stringify({
+    issue: issueFingerprint(snapshot.issue),
+    claim: snapshot.claim
+      ? {
+          id: snapshot.claim.id,
+          createdAt: snapshot.claim.createdAt,
+          claimedAt: snapshot.claim.claimedAt,
+          metadata: snapshot.claim.metadata,
+        }
+      : null,
+    values: snapshot.values,
+  });
+}
+
+async function readSnapshot(options, dependencies) {
+  const issue = await dependencies.getIssue(options, options.issues[0]);
+  if (!isBackfillable(issue)) {
+    throw new Error(
+      `Issue #${issue.number} is not backfillable; expected open with exactly one of agent-active/in-pr`,
+    );
+  }
+  const project = await dependencies.getProject(options);
+  dependencies.requireBackfillFields(project);
+  const itemId = await dependencies.findIssueProjectItem(
+    options,
+    issue,
+    project,
+  );
+  if (!itemId) {
+    throw new Error(
+      `Issue #${issue.number} is not on Project ${project.title}`,
+    );
+  }
+  const [comments, values] = await Promise.all([
+    dependencies.listIssueComments(options, issue.number),
+    dependencies.readBackfillProjectFields(options, project, itemId),
+  ]);
+  const claim = selectNewestTrustedClaim(comments, issue.number);
+  if (!claim) {
+    throw new Error(
+      `Issue #${issue.number} has no valid trusted agent claim comment`,
+    );
+  }
+  return { issue, project, itemId, claim, values };
+}
+
+export async function backfillIssue(options, dependencies) {
+  const initial = await readSnapshot(options, dependencies);
+  if (options.dryRun) {
+    const writes = buildBackfillPlan(initial.values, initial.claim.metadata);
+    return {
+      number: initial.issue.number,
+      title: initial.issue.title,
+      state: "backfill dry-run",
+      writes,
+    };
+  }
+
+  const beforeWrite = await readSnapshot(options, dependencies);
+  if (snapshotFingerprint(initial) !== snapshotFingerprint(beforeWrite)) {
+    throw new Error(
+      `Issue #${initial.issue.number} changed before backfill write`,
+    );
+  }
+  const writes = buildBackfillPlan(
+    beforeWrite.values,
+    beforeWrite.claim.metadata,
+  );
+  if (writes.length > 0) {
+    await dependencies.writeBackfillProjectFields(
+      options,
+      beforeWrite.project,
+      beforeWrite.itemId,
+      writes,
+    );
+  }
+  const verified = await readSnapshot(options, dependencies);
+  for (const field of CLAIM_FIELDS) {
+    if (verified.values[field] !== verified.claim.metadata[field]) {
+      throw new Error(
+        `Issue #${verified.issue.number} backfill verification failed for ${field}`,
+      );
+    }
+  }
+  return {
+    number: verified.issue.number,
+    title: verified.issue.title,
+    state: writes.length === 0 ? "backfill already matched" : "backfilled",
+    writes,
+  };
+}

--- a/scripts/pr/issue-board-cli.mjs
+++ b/scripts/pr/issue-board-cli.mjs
@@ -19,6 +19,7 @@ export function usage() {
   pnpm issue:review --pr 123 --issue 901 [--issue 902]
   pnpm issue:release --issue 901 [--needs-grooming]
   pnpm issue:board sync [--dry-run]
+  pnpm issue:board backfill --issue 901 [--dry-run]
 
 Options:
   --repo <owner/name>              Repository to operate on (default: ${DEFAULT_REPO})
@@ -107,6 +108,8 @@ export function parseArgs(argv, env = process.env) {
     ),
     count: 1,
     issueValues: [],
+    backfillIssueFlags: 0,
+    positionalIssueValues: [],
     issues: [],
     agent: defaultAgent(env),
     branch: env.AGENT_BRANCH ?? "",
@@ -148,6 +151,9 @@ export function parseArgs(argv, env = process.env) {
         options.count = Number(readValue());
         break;
       case "--issue":
+        options.backfillIssueFlags += 1;
+        options.issueValues.push(readValue());
+        break;
       case "--issues":
         options.issueValues.push(readValue());
         break;
@@ -179,6 +185,7 @@ export function parseArgs(argv, env = process.env) {
       default:
         if (arg.startsWith("-")) throw new Error(`Unknown option: ${arg}`);
         options.issueValues.push(arg);
+        options.positionalIssueValues.push(arg);
     }
   }
 
@@ -194,5 +201,21 @@ export function parseArgs(argv, env = process.env) {
   }
   delete options.prValue;
   options.issues = parseIssueNumbers(options.issueValues, options.repo);
+  if (options.command === "backfill") {
+    const explicitIssue = options.issueValues[0]?.trim();
+    if (
+      options.backfillIssueFlags !== 1 ||
+      options.positionalIssueValues.length > 0 ||
+      options.issueValues.length !== 1 ||
+      !/^#?[1-9]\d*$/.test(explicitIssue ?? "") ||
+      options.issues.length !== 1
+    ) {
+      throw new Error(
+        "backfill requires exactly one explicit --issue <number>",
+      );
+    }
+  }
+  delete options.backfillIssueFlags;
+  delete options.positionalIssueValues;
   return options;
 }

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -1,5 +1,5 @@
 /**
- * Issue-board commands: claim, review, release, and sync.
+ * Issue-board commands: claim, review, release, sync, and backfill.
  *
  * Each command drives one label transition, projects it onto the workboard,
  * and posts the matching issue comment. Label edits happen first and roll back
@@ -22,20 +22,25 @@ import {
   findIssueProjectItem,
   getProject,
   hasDifferentClaimId,
+  readBackfillProjectFields,
+  requireBackfillFields,
   requireClaimIdField,
   updateProjectFields,
   verifyClaimOwnership,
+  writeBackfillProjectFields,
 } from "./issue-board-projects.mjs";
 import {
   ensurePrExists,
   getGitBranch,
   getIssue,
   getPrIssues,
+  listIssueComments,
   listIssuesByLabel,
   listReadyIssues,
   runGh,
   sleep,
 } from "./issue-board-transport.mjs";
+import { backfillIssue } from "./issue-board-backfill.mjs";
 
 const CLAIM_SETTLE_MS = 1500;
 
@@ -352,9 +357,35 @@ export async function sync(options) {
   return results;
 }
 
+export async function backfill(options, dependencies = {}) {
+  const project = dependencies.getProject
+    ? await dependencies.getProject(options)
+    : await getProject(options);
+  return [
+    await backfillIssue(options, {
+      getIssue: dependencies.getIssue ?? getIssue,
+      getProject: async () => project,
+      findIssueProjectItem:
+        dependencies.findIssueProjectItem ?? findIssueProjectItem,
+      listIssueComments: dependencies.listIssueComments ?? listIssueComments,
+      requireBackfillFields:
+        dependencies.requireBackfillFields ?? requireBackfillFields,
+      readBackfillProjectFields:
+        dependencies.readBackfillProjectFields ?? readBackfillProjectFields,
+      writeBackfillProjectFields:
+        dependencies.writeBackfillProjectFields ?? writeBackfillProjectFields,
+    }),
+  ];
+}
+
 export function renderResults(results) {
   if (results.length === 0) return "No issues changed.";
   return results
-    .map((issue) => `#${issue.number} ${issue.state}: ${issue.title}`)
+    .map((issue) => {
+      const writes = issue.writes
+        ?.map((write) => `${write.field}=${write.value}`)
+        .join(", ");
+      return `#${issue.number} ${issue.state}: ${issue.title}${writes ? ` (${writes})` : ""}`;
+    })
     .join("\n");
 }

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -358,13 +358,10 @@ export async function sync(options) {
 }
 
 export async function backfill(options, dependencies = {}) {
-  const project = dependencies.getProject
-    ? await dependencies.getProject(options)
-    : await getProject(options);
   return [
     await backfillIssue(options, {
       getIssue: dependencies.getIssue ?? getIssue,
-      getProject: async () => project,
+      getProject: dependencies.getProject ?? getProject,
       findIssueProjectItem:
         dependencies.findIssueProjectItem ?? findIssueProjectItem,
       listIssueComments: dependencies.listIssueComments ?? listIssueComments,

--- a/scripts/pr/issue-board-projects.mjs
+++ b/scripts/pr/issue-board-projects.mjs
@@ -15,6 +15,9 @@ import {
 } from "./issue-board-state.mjs";
 import { getIssue, ghGraphql } from "./issue-board-transport.mjs";
 
+export const MAX_PROJECT_FIELD_VALUE_PAGES = 100;
+export const MAX_PROJECT_FIELD_VALUE_NODES = 10_000;
+
 export async function getProject(options) {
   const response = await ghGraphql(
     `query($org:String!,$number:Int!){
@@ -69,6 +72,26 @@ export async function getProject(options) {
 
 function findField(project, name) {
   return project.fields.find((field) => field.name === name);
+}
+
+export function requireBackfillFields(project) {
+  const expected = {
+    [OPTIONAL_PROJECT_FIELDS.agent]: "TEXT",
+    [OPTIONAL_PROJECT_FIELDS.claimId]: "TEXT",
+    [OPTIONAL_PROJECT_FIELDS.branch]: "TEXT",
+    [OPTIONAL_PROJECT_FIELDS.claimedAt]: "DATE",
+  };
+  const fields = {};
+  for (const [name, dataType] of Object.entries(expected)) {
+    const field = findField(project, name);
+    if (field?.dataType !== dataType) {
+      throw new Error(
+        `Project must have a ${dataType} ${name} field for backfill`,
+      );
+    }
+    fields[name] = field;
+  }
+  return fields;
 }
 
 function findIssueProjectItemInNodes(nodes, project) {
@@ -133,6 +156,95 @@ async function readProjectTextField(options, itemId, fieldId) {
   const values = response?.data?.node?.fieldValues?.nodes ?? [];
   const match = values.find((value) => value?.field?.id === fieldId);
   return match?.text ?? null;
+}
+
+export async function readBackfillProjectFields(
+  options,
+  project,
+  itemId,
+  {
+    graphql = ghGraphql,
+    maxPages = MAX_PROJECT_FIELD_VALUE_PAGES,
+    maxNodes = MAX_PROJECT_FIELD_VALUE_NODES,
+  } = {},
+) {
+  const fields = requireBackfillFields(project);
+  const valuesById = new Map();
+  let cursor = null;
+  const seenCursors = new Set();
+  let pages = 0;
+  let nodesRead = 0;
+  while (true) {
+    if (pages >= maxPages) {
+      throw new Error(
+        `Project item ${itemId} field pagination exceeded ${maxPages} pages`,
+      );
+    }
+    const response = await graphql(
+      `
+        query ($item: ID!, $cursor: String) {
+          node(id: $item) {
+            ... on ProjectV2Item {
+              fieldValues(first: 100, after: $cursor) {
+                nodes {
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field {
+                      ... on ProjectV2FieldCommon {
+                        id
+                      }
+                    }
+                  }
+                  ... on ProjectV2ItemFieldDateValue {
+                    date
+                    field {
+                      ... on ProjectV2FieldCommon {
+                        id
+                      }
+                    }
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      `,
+      { item: itemId, cursor },
+    );
+    const connection = response?.data?.node?.fieldValues;
+    if (!connection) throw new Error(`Project item ${itemId} was not found`);
+    pages += 1;
+    const nodes = connection.nodes ?? [];
+    nodesRead += nodes.length;
+    if (nodesRead > maxNodes) {
+      throw new Error(
+        `Project item ${itemId} field pagination exceeded ${maxNodes} nodes`,
+      );
+    }
+    for (const value of nodes) {
+      if (value?.field?.id)
+        valuesById.set(value.field.id, value.text ?? value.date ?? null);
+    }
+    if (!connection.pageInfo?.hasNextPage) break;
+    const nextCursor = connection.pageInfo.endCursor;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error(
+        `Project item ${itemId} field pagination did not advance cursor`,
+      );
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return Object.fromEntries(
+    Object.entries(fields).map(([name, field]) => [
+      name,
+      valuesById.get(field.id) ?? null,
+    ]),
+  );
 }
 
 export async function verifyClaimOwnership(
@@ -246,48 +358,97 @@ async function clearProjectField(options, project, itemId, fieldId) {
   );
 }
 
-async function updateTextField(options, project, itemId, fieldId, text) {
+async function updateTextField(
+  options,
+  project,
+  itemId,
+  fieldId,
+  text,
+  { graphql = ghGraphql } = {},
+) {
   if (text === undefined || text === "") return;
   if (text === null) {
     await clearProjectField(options, project, itemId, fieldId);
     return;
   }
-  await ghGraphql(
-    `mutation($project:ID!,$item:ID!,$field:ID!,$text:String!){
-      updateProjectV2ItemFieldValue(input:{
-        projectId:$project
-        itemId:$item
-        fieldId:$field
-        value:{text:$text}
-      }) {
-        projectV2Item { id }
+  await graphql(
+    `
+      mutation ($project: ID!, $item: ID!, $field: ID!, $text: String!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $project
+            itemId: $item
+            fieldId: $field
+            value: { text: $text }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
       }
-    }`,
+    `,
     { project: project.id, item: itemId, field: fieldId, text },
     { dryRun: options.dryRun, mutates: true },
   );
 }
 
-async function updateDateField(options, project, itemId, fieldId, date) {
+async function updateDateField(
+  options,
+  project,
+  itemId,
+  fieldId,
+  date,
+  { graphql = ghGraphql } = {},
+) {
   if (date === undefined || date === "") return;
   if (date === null) {
     await clearProjectField(options, project, itemId, fieldId);
     return;
   }
-  await ghGraphql(
-    `mutation($project:ID!,$item:ID!,$field:ID!,$date:Date!){
-      updateProjectV2ItemFieldValue(input:{
-        projectId:$project
-        itemId:$item
-        fieldId:$field
-        value:{date:$date}
-      }) {
-        projectV2Item { id }
+  await graphql(
+    `
+      mutation ($project: ID!, $item: ID!, $field: ID!, $date: Date!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $project
+            itemId: $item
+            fieldId: $field
+            value: { date: $date }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
       }
-    }`,
+    `,
     { project: project.id, item: itemId, field: fieldId, date },
     { dryRun: options.dryRun, mutates: true },
   );
+}
+
+export async function writeBackfillProjectFields(
+  options,
+  project,
+  itemId,
+  writes,
+  { graphql = ghGraphql } = {},
+) {
+  const fields = requireBackfillFields(project);
+  for (const write of writes) {
+    const field = fields[write.field];
+    if (!field) throw new Error(`Unknown backfill field: ${write.field}`);
+    if (field.dataType === "DATE") {
+      await updateDateField(options, project, itemId, field.id, write.value, {
+        graphql,
+      });
+    } else {
+      await updateTextField(options, project, itemId, field.id, write.value, {
+        graphql,
+      });
+    }
+  }
 }
 
 export async function updateProjectFields(

--- a/scripts/pr/issue-board-state.mjs
+++ b/scripts/pr/issue-board-state.mjs
@@ -96,6 +96,18 @@ export function isClaimable(issue) {
   );
 }
 
+export function isBackfillable(issue) {
+  const labels = labelNames(issue);
+  const hasActive = labels.has("agent-active");
+  const hasReview = labels.has("in-pr");
+  return (
+    issue.state === "OPEN" &&
+    hasActive !== hasReview &&
+    !labels.has("agent-ready") &&
+    !labels.has("needs-grooming")
+  );
+}
+
 export function isReviewable(issue) {
   const labels = labelNames(issue);
   return (

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -11,6 +11,9 @@ import { spawn } from "node:child_process";
 import { splitRepo, validateOpenPr } from "./issue-board-state.mjs";
 
 const GH_OUTPUT_MAX_BYTES = 20 * 1024 * 1024;
+// A bounded traversal must fail rather than use an incomplete comment history.
+export const MAX_ISSUE_COMMENT_PAGES = 100;
+export const MAX_ISSUE_COMMENT_NODES = 10_000;
 
 function quoteArg(value) {
   if (/^[A-Za-z0-9_./:=@#-]+$/.test(value)) return value;
@@ -114,6 +117,7 @@ export async function ghJson(args, opts = {}) {
 export async function ghGraphql(query, variables = {}, opts = {}) {
   const args = ["api", "graphql", "-f", `query=${query}`];
   for (const [key, value] of Object.entries(variables)) {
+    if (value == null) continue;
     const flag = typeof value === "number" ? "-F" : "-f";
     args.push(flag, `${key}=${value}`);
   }
@@ -202,6 +206,84 @@ export async function getIssue(options, number) {
     "--json",
     "id,number,title,url,labels,state,projectItems",
   ]);
+}
+
+export async function listIssueComments(
+  options,
+  issueNumber,
+  {
+    graphql = ghGraphql,
+    maxPages = MAX_ISSUE_COMMENT_PAGES,
+    maxNodes = MAX_ISSUE_COMMENT_NODES,
+  } = {},
+) {
+  const repo = splitRepo(options.repo);
+  const comments = [];
+  let cursor = null;
+  const seenCursors = new Set();
+  let pages = 0;
+  while (true) {
+    if (pages >= maxPages) {
+      throw new Error(
+        `Issue #${issueNumber} comment pagination exceeded ${maxPages} pages`,
+      );
+    }
+    const response = await graphql(
+      `
+        query (
+          $owner: String!
+          $repo: String!
+          $number: Int!
+          $cursor: String
+        ) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              comments(first: 100, after: $cursor) {
+                nodes {
+                  id
+                  body
+                  createdAt
+                  authorAssociation
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner: repo.owner,
+        repo: repo.name,
+        number: issueNumber,
+        cursor,
+      },
+    );
+    const connection = response?.data?.repository?.issue?.comments;
+    if (!connection) {
+      throw new Error(`Issue #${issueNumber} was not found in ${options.repo}`);
+    }
+    pages += 1;
+    const nodes = (connection.nodes ?? []).filter(Boolean);
+    if (comments.length + nodes.length > maxNodes) {
+      throw new Error(
+        `Issue #${issueNumber} comment pagination exceeded ${maxNodes} nodes`,
+      );
+    }
+    comments.push(...nodes);
+    if (!connection.pageInfo?.hasNextPage) break;
+    const nextCursor = connection.pageInfo.endCursor;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error(
+        `Issue #${issueNumber} comment pagination did not advance cursor`,
+      );
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return comments;
 }
 
 export async function getPrIssues(options) {


### PR DESCRIPTION
## The Problem

- Cloud claim comments can leave Project #12 ownership fields empty because the MCP fallback cannot write Projects v2 fields.
- The existing board sync command updates status and cannot safely reconstruct or overwrite ownership metadata.

## The Solution

- Add an explicit fill-only `pnpm issue:board backfill --issue <number>` command that reconstructs ownership from the newest trusted helper claim.
- Recheck the issue, claim, Project schema, and ownership values before every write. Preserve Status and verify the final values.

## Details

- Require one positive issue number and exactly one active lifecycle label: `agent-active` or `in-pr`.
- Parse only the newest valid trusted helper claim. Bind each snapshot to the comment, lifecycle, Project item, field IDs and types, and ownership values.
- Accept helper claims without `Branch:`. In that case, leave the Project Branch value outside fill and conflict checks. Reject an unsafe Branch when it is present.
- Accept bounded handoff text with final newlines. Reject interior blanks, deferred metadata fields, control characters, padded lines, more than four lines, and more than 1,000 joined characters.
- Reject ambiguous equal-time claims unless their projected values are identical.
- Fill only empty `Claim ID`, `Agent`, `Branch`, and `Claimed At` fields. Reject every conflicting non-empty value.
- Write one field at a time. Before each write, re-read the lifecycle, exact claim snapshot, Project field schema, item ID, and all ownership values. Stop on drift.
- Keep `Status` unchanged. The backfill path does not call the status-sync writer.
- Do not roll back a completed write. GitHub provides no compare-and-swap operation, and a rollback could erase concurrent state.
- Bound comment and Project-field pagination to 100 pages and 10,000 nodes. Missing or repeated cursors fail closed.
- Route helper-only changes to `pnpm issue:board:test` in the quality gate.
- Update the board workflow, GitHub tooling, quick-command, and mirrored doc-garden guidance.
- No package script changed. The existing `issue:board` dispatcher owns the new subcommand.
- No architecture decision is introduced. This extends the existing issue-board recovery workflow, so no ADR is required.
- No UI code changed. Browser verification is not applicable.

## Validation

- Exact head: `25c4ed882df59c45b5fe16539fff31a79a80a073`.
- `CI=true pnpm agent:quality-gate --run` — all mapped commands passed, including 45 issue-board tests and the quality-gate routing regression suite.
- `CI=true pnpm issue:board backfill --issue 1488 --dry-run --json` — failed closed on the live `Agent` mismatch (`chapati` versus trusted claim `codex`); no Project write occurred.
- Deterministic local autoreview — no findings.
- Fresh feedback review for optional Branch and per-write drift — no findings; patch correct at 0.98 confidence.
- Sealed feedback bundle manifest before and after that review: `c9e9485df20d57e08dd2b25f537cff0b10df4a30f0931f7a60d7756dff5bc8a5`.
- Fresh no-history parser review — production fix correct at 0.99 confidence; its boundary-test suggestion was implemented.
- `git diff --check` — passed.

## Deferrals

- [#1488](https://github.com/mento-protocol/monitoring-monorepo/issues/1488) remains open until the command fills an eligible cloud claim in a live Project and verifies the result.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This extends the existing issue-board recovery workflow.

Refs #1488
