### PR TITLE
feat(indexer): preload reserve snapshot effects

### DIFF
--- a/indexer-envio/src/handlers/steth.ts
+++ b/indexer-envio/src/handlers/steth.ts
@@ -14,6 +14,7 @@ import {
   STETH_DAILY_SNAPSHOT_BLOCK_INTERVAL,
   TRACKED_STETH_WALLETS,
   V3_REVENUE_LAUNCH_BLOCK,
+  V3_REVENUE_LAUNCH_TIMESTAMP,
   isTrackedWallet,
   type EventMeta,
 } from "./steth/shared.js";
@@ -71,9 +72,13 @@ export async function handleStethTransfer({
   if (from === to) return;
   if (!isTrackedWallet(from) && !isTrackedWallet(to)) return;
   const meta = eventMeta(event);
-  const balanceResults = await readAllTrackedStethBalanceResults(context, meta);
-  // preload-handler-note: tracked-transfer filters are event-derived; both
-  // wallet keys are awaited in preload before ordered movement reads and writes.
+  const balanceResults =
+    meta.blockTimestamp >= V3_REVENUE_LAUNCH_TIMESTAMP
+      ? await readAllTrackedStethBalanceResults(context, meta)
+      : undefined;
+  // preload-handler-note: tracked-transfer and launch-time filters are
+  // event-derived; both wallet keys are awaited in preload before ordered
+  // movement reads and writes.
   // preload-effect-helpers: readAllTrackedStethBalanceResults, recordStethYieldEventDailySnapshots
   if (context.isPreload) return;
   const id = eventId(meta.chainId, Number(meta.blockNumber), meta.logIndex);

--- a/indexer-envio/src/handlers/steth.ts
+++ b/indexer-envio/src/handlers/steth.ts
@@ -4,6 +4,7 @@ import { indexer } from "../indexer.js";
 import {
   handleStethLaunchBaseline,
   handleStethYieldDailySnapshotHeartbeat,
+  readAllTrackedStethBalanceResults,
   recordStethYieldEventDailySnapshots,
 } from "./steth/dailySnapshots.js";
 import { recordTransfer, shouldProcess } from "./steth/movements.js";
@@ -49,6 +50,38 @@ function eventMeta(event: {
     logIndex: event.logIndex,
     txHash: event.transaction.hash,
   };
+}
+
+export async function handleStethTransfer({
+  event,
+  context,
+}: {
+  event: {
+    chainId: number;
+    params: { from: string; to: string; value: bigint };
+    block: { number: number; timestamp: number };
+    logIndex: number;
+    transaction: { hash: string };
+  };
+  context: import("./steth/shared.js").StethContext;
+}): Promise<void> {
+  const from = asAddress(event.params.from);
+  const to = asAddress(event.params.to);
+  if (from === ZERO_ADDRESS && to === ZERO_ADDRESS) return;
+  if (from === to) return;
+  if (!isTrackedWallet(from) && !isTrackedWallet(to)) return;
+  const meta = eventMeta(event);
+  const balanceResults = await readAllTrackedStethBalanceResults(context, meta);
+  // preload-handler-note: tracked-transfer filters are event-derived; both
+  // wallet keys are awaited in preload before ordered movement reads and writes.
+  // preload-effect-helpers: readAllTrackedStethBalanceResults, recordStethYieldEventDailySnapshots
+  if (context.isPreload) return;
+  const id = eventId(meta.chainId, Number(meta.blockNumber), meta.logIndex);
+  if (!(await shouldProcess(context, id))) return;
+  if (await recordTransfer(context, meta, from, to, event.params.value)) {
+    await updateSummary(context, meta);
+    await recordStethYieldEventDailySnapshots(context, meta, balanceResults);
+  }
 }
 
 if (!stethRegistrationState.__mentoStethYieldEventHandlersRegistered) {
@@ -109,22 +142,7 @@ if (!stethRegistrationState.__mentoStethYieldEventHandlersRegistered) {
       where: () => ({ params: transferWhereParams }),
     },
     async ({ event, context }) => {
-      const from = asAddress(event.params.from);
-      const to = asAddress(event.params.to);
-      if (from === ZERO_ADDRESS && to === ZERO_ADDRESS) return;
-      if (from === to) return;
-      if (!isTrackedWallet(from) && !isTrackedWallet(to)) return;
-      const meta = eventMeta(event);
-      const id = eventId(meta.chainId, Number(meta.blockNumber), meta.logIndex);
-      // preload-handler-note: snapshot writes follow ordered movements; preload-safe
-      // balance collection is tracked in #1396.
-      // preload-effect-helpers: recordStethYieldEventDailySnapshots
-      if (context.isPreload) return;
-      if (!(await shouldProcess(context, id))) return;
-      if (await recordTransfer(context, meta, from, to, event.params.value)) {
-        await updateSummary(context, meta);
-        await recordStethYieldEventDailySnapshots(context, meta);
-      }
+      await handleStethTransfer({ event, context });
     },
   );
 }

--- a/indexer-envio/src/handlers/steth/dailySnapshots.ts
+++ b/indexer-envio/src/handlers/steth/dailySnapshots.ts
@@ -37,6 +37,13 @@ type StethDailySnapshotOptions = {
   requirePreviousDay?: boolean;
 };
 
+type StethBalanceResults = readonly (bigint | null)[];
+
+type StethHeartbeatEffectResults = {
+  blockTimestamp: bigint | null;
+  balances: StethBalanceResults;
+};
+
 function stethWalletLaunchBaselineId(chainId: number, wallet: string): string {
   return `${chainId}-steth-${wallet}-launch`;
 }
@@ -136,7 +143,7 @@ async function findPreviousDailySnapshot(
   return undefined;
 }
 
-async function readStethBalance(
+function readStethBalance(
   context: StethContext,
   meta: Pick<BlockMeta, "chainId" | "blockNumber">,
   wallet: string,
@@ -149,14 +156,29 @@ async function readStethBalance(
   });
 }
 
+export function readAllTrackedStethBalanceResults(
+  context: StethContext,
+  meta: Pick<BlockMeta, "chainId" | "blockNumber">,
+): Promise<StethBalanceResults> {
+  return Promise.all(
+    TRACKED_STETH_WALLETS.map((wallet) =>
+      readStethBalance(context, meta, wallet),
+    ),
+  );
+}
+
 async function readAllTrackedBalances(
   context: StethContext,
   meta: BlockMeta,
+  balanceResults?: StethBalanceResults,
 ): Promise<Map<string, bigint> | null> {
+  const results =
+    balanceResults ?? (await readAllTrackedStethBalanceResults(context, meta));
   const balances = new Map<string, bigint>();
-  for (const wallet of TRACKED_STETH_WALLETS) {
-    const balance = await readStethBalance(context, meta, wallet);
+  for (const [index, wallet] of TRACKED_STETH_WALLETS.entries()) {
+    const balance = results[index];
     if (balance === null) return null;
+    if (balance === undefined) return null;
     balances.set(wallet, balance);
   }
   return balances;
@@ -254,10 +276,11 @@ export async function recordStethYieldDailySnapshots(
   context: StethContext,
   meta: BlockMeta,
   options: StethDailySnapshotOptions = {},
+  balanceResults?: StethBalanceResults,
 ): Promise<boolean> {
   if (meta.blockTimestamp < V3_REVENUE_LAUNCH_TIMESTAMP) return false;
 
-  const balances = await readAllTrackedBalances(context, meta);
+  const balances = await readAllTrackedBalances(context, meta, balanceResults);
   if (balances === null) return false;
 
   const totalsByWallet = new Map<string, StethWalletYieldTotals>();
@@ -292,10 +315,16 @@ export async function recordStethYieldDailySnapshots(
 export async function recordStethYieldEventDailySnapshots(
   context: StethContext,
   meta: EventMeta,
+  balanceResults?: StethBalanceResults,
 ): Promise<boolean> {
-  return recordStethYieldDailySnapshots(context, meta, {
-    requirePreviousDay: true,
-  });
+  return recordStethYieldDailySnapshots(
+    context,
+    meta,
+    {
+      requirePreviousDay: true,
+    },
+    balanceResults,
+  );
 }
 
 function launchBaselineMeta(sampledAtTimestamp: bigint): EventMeta {
@@ -431,11 +460,12 @@ export async function recordStethWalletLaunchBaselines(
 export async function recordStethYieldHeartbeatSnapshots(
   context: StethContext,
   blockNumber: bigint,
+  effectResults?: StethHeartbeatEffectResults,
 ): Promise<boolean> {
-  const blockTimestamp = await context.effect(blockTimestampEffect, {
-    chainId: ETHEREUM_CHAIN_ID,
-    blockNumber,
-  });
+  const effects =
+    effectResults ??
+    (await readStethHeartbeatEffectResults(context, blockNumber));
+  const { blockTimestamp } = effects;
   if (blockTimestamp === null || blockTimestamp <= ZERO) return false;
 
   const meta: BlockMeta = {
@@ -446,7 +476,22 @@ export async function recordStethYieldHeartbeatSnapshots(
   if (meta.blockTimestamp < V3_REVENUE_LAUNCH_TIMESTAMP) return false;
   if (!(await ensureStethWalletLaunchBaselines(context))) return false;
 
-  return recordStethYieldDailySnapshots(context, meta);
+  return recordStethYieldDailySnapshots(context, meta, {}, effects.balances);
+}
+
+async function readStethHeartbeatEffectResults(
+  context: StethContext,
+  blockNumber: bigint,
+): Promise<StethHeartbeatEffectResults> {
+  const meta = {
+    chainId: ETHEREUM_CHAIN_ID,
+    blockNumber,
+  };
+  const [blockTimestamp, balances] = await Promise.all([
+    context.effect(blockTimestampEffect, meta),
+    readAllTrackedStethBalanceResults(context, meta),
+  ]);
+  return { blockTimestamp, balances };
 }
 
 export async function handleStethLaunchBaseline({
@@ -479,9 +524,17 @@ export async function handleStethYieldDailySnapshotHeartbeat({
   block: { number: number | bigint };
   context: StethContext;
 }): Promise<boolean> {
-  // preload-handler-note: heartbeat writes need ordered daily state; preload-safe
-  // block and balance reads are tracked in #1396.
+  const effectResults = await readStethHeartbeatEffectResults(
+    context,
+    BigInt(block.number),
+  );
+  // preload-handler-note: raw block and wallet results are awaited before this
+  // guard; ordered processing alone reads baselines and writes snapshots.
   // preload-effect-helpers: recordStethYieldHeartbeatSnapshots
   if (context.isPreload) return false;
-  return recordStethYieldHeartbeatSnapshots(context, BigInt(block.number));
+  return recordStethYieldHeartbeatSnapshots(
+    context,
+    BigInt(block.number),
+    effectResults,
+  );
 }

--- a/indexer-envio/src/handlers/susds/dailySnapshots.ts
+++ b/indexer-envio/src/handlers/susds/dailySnapshots.ts
@@ -28,6 +28,11 @@ type SusdsYieldDailySnapshotOptions = {
   requirePreviousDay?: boolean;
 };
 
+type SusdsHeartbeatEffectResults = {
+  blockTimestamp: bigint | null;
+  sharePriceUsdWei: bigint | null;
+};
+
 function baselineFromSameDaySnapshot(
   snapshot: SusdsYieldDailySnapshot,
 ): SusdsYieldDeltaBaseline {
@@ -196,11 +201,12 @@ export async function readSharePrice(
 export async function recordSusdsYieldHeartbeatSnapshot(
   context: SusdsContext,
   blockNumber: bigint,
+  effectResults?: SusdsHeartbeatEffectResults,
 ): Promise<boolean> {
-  const blockTimestamp = await context.effect(blockTimestampEffect, {
-    chainId: ETHEREUM_CHAIN_ID,
-    blockNumber,
-  });
+  const effects =
+    effectResults ??
+    (await readSusdsHeartbeatEffectResults(context, blockNumber));
+  const { blockTimestamp } = effects;
   if (blockTimestamp === null || blockTimestamp <= 0n) return false;
 
   const meta: BlockMeta = {
@@ -210,8 +216,31 @@ export async function recordSusdsYieldHeartbeatSnapshot(
   };
   if (meta.blockTimestamp < V3_REVENUE_LAUNCH_TIMESTAMP) return false;
 
-  const sharePriceUsdWei = await readSharePrice(context, meta);
+  const { sharePriceUsdWei } = effects;
+  if (sharePriceUsdWei === null) {
+    throw new Error(
+      `[sUSDS] convertToAssets(1e18) unavailable at block ${meta.blockNumber}`,
+    );
+  }
   return recordSusdsYieldDailySnapshot(context, meta, sharePriceUsdWei);
+}
+
+async function readSusdsHeartbeatEffectResults(
+  context: SusdsContext,
+  blockNumber: bigint,
+): Promise<SusdsHeartbeatEffectResults> {
+  const meta = {
+    chainId: ETHEREUM_CHAIN_ID,
+    blockNumber,
+  };
+  const [blockTimestamp, sharePriceUsdWei] = await Promise.all([
+    context.effect(blockTimestampEffect, meta),
+    context.effect(susdsSharePriceEffect, {
+      ...meta,
+      tokenAddress: SUSDS_ADDRESS,
+    }),
+  ]);
+  return { blockTimestamp, sharePriceUsdWei };
 }
 
 export async function handleSusdsYieldDailySnapshotHeartbeat({
@@ -221,9 +250,17 @@ export async function handleSusdsYieldDailySnapshotHeartbeat({
   block: { number: number | bigint };
   context: SusdsContext;
 }): Promise<boolean> {
-  // preload-handler-note: this dormant heartbeat needs ordered snapshot writes;
-  // preload-safe block/share-price reads are tracked in #1396 before activation.
+  const effectResults = await readSusdsHeartbeatEffectResults(
+    context,
+    BigInt(block.number),
+  );
+  // preload-handler-note: raw block and share-price results are awaited before
+  // this guard; the dormant heartbeat still keeps snapshot work ordered.
   // preload-effect-helpers: recordSusdsYieldHeartbeatSnapshot
   if (context.isPreload) return false;
-  return recordSusdsYieldHeartbeatSnapshot(context, BigInt(block.number));
+  return recordSusdsYieldHeartbeatSnapshot(
+    context,
+    BigInt(block.number),
+    effectResults,
+  );
 }

--- a/indexer-envio/test/steth.test.ts
+++ b/indexer-envio/test/steth.test.ts
@@ -294,19 +294,15 @@ describeReserveYield("stETH reserve-yield ledger", () => {
     );
   });
 
-  it("preloads tracked transfer balances before ordered movement state", async () => {
+  it("skips pre-launch balance effects but preserves tracked movement state", async () => {
     const mockDb = MockDb.createMockDb();
-    const calls: unknown[] = [];
     const context = {
       ...stethSnapshotContext(mockDb, {
         [RESERVE_SAFE]: steth(10),
         [OPS_SAFE]: 0n,
       }),
-      effect: async (effect: unknown, input: unknown) => {
-        assert.equal(effect, stethBalanceOfEffect);
-        calls.push(input);
-        const account = (input as { account: string }).account;
-        return account === RESERVE_SAFE ? steth(10) : 0n;
+      effect: async () => {
+        throw new Error("pre-launch transfer must not read balance effects");
       },
       isPreload: true,
     } as Parameters<typeof handleStethTransfer>[0]["context"];
@@ -314,24 +310,106 @@ describeReserveYield("stETH reserve-yield ledger", () => {
       chainId: ETHEREUM_CHAIN_ID,
       params: { from: EXTERNAL, to: RESERVE_SAFE, value: steth(10) },
       block: {
-        number: V3_REVENUE_LAUNCH_BLOCK + 600,
-        timestamp: Number(V3_REVENUE_LAUNCH_TIMESTAMP + 1n),
+        number: V3_REVENUE_LAUNCH_BLOCK - 1,
+        timestamp: Number(V3_REVENUE_LAUNCH_TIMESTAMP - 1n),
       },
       logIndex: 1,
       transaction: { hash: txHash(1) },
     };
 
     await handleStethTransfer({ event, context });
-    const preloadCalls = [...calls];
     assert.equal(mockDb.entities.StethYieldMovement.getAll().length, 0);
 
-    calls.length = 0;
     await handleStethTransfer({
       event,
       context: { ...context, isPreload: false },
     });
-    assert.deepEqual(calls, preloadCalls);
     assert.equal(mockDb.entities.StethYieldMovement.getAll().length, 1);
+    assert.equal(summary(mockDb).currentBalance, steth(10));
+    assert.equal(mockDb.entities.StethYieldDailySnapshot.getAll().length, 0);
+  });
+
+  it("preloads exact-launch and post-launch transfer balances before ordered state", async () => {
+    const mockDb = MockDb.createMockDb();
+    await recordStethWalletLaunchBaselines(
+      stethSnapshotContext(mockDb, {
+        [RESERVE_SAFE]: 0n,
+        [OPS_SAFE]: 0n,
+      }),
+      V3_REVENUE_LAUNCH_TIMESTAMP - 1n,
+    );
+
+    const cases = [
+      {
+        blockNumber: V3_REVENUE_LAUNCH_BLOCK,
+        blockTimestamp: V3_REVENUE_LAUNCH_TIMESTAMP,
+        balance: steth(10),
+        value: steth(10),
+      },
+      {
+        blockNumber: V3_REVENUE_LAUNCH_BLOCK + 7_200,
+        blockTimestamp: dayAfterLaunch(1) + 3_600n,
+        balance: steth(15),
+        value: steth(5),
+      },
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      const calls: Array<{ effect: unknown; input: unknown }> = [];
+      const context = {
+        ...stethSnapshotContext(mockDb, {
+          [RESERVE_SAFE]: testCase.balance,
+          [OPS_SAFE]: 0n,
+        }),
+        effect: async (effect: unknown, input: unknown) => {
+          assert.equal(effect, stethBalanceOfEffect);
+          calls.push({ effect, input });
+          const account = (input as { account: string }).account;
+          return account === RESERVE_SAFE ? testCase.balance : 0n;
+        },
+        isPreload: true,
+      } as Parameters<typeof handleStethTransfer>[0]["context"];
+      const event = {
+        chainId: ETHEREUM_CHAIN_ID,
+        params: {
+          from: EXTERNAL,
+          to: RESERVE_SAFE,
+          value: testCase.value,
+        },
+        block: {
+          number: testCase.blockNumber,
+          timestamp: Number(testCase.blockTimestamp),
+        },
+        logIndex: index + 1,
+        transaction: { hash: txHash(index + 1) },
+      };
+
+      await handleStethTransfer({ event, context });
+      const preloadCalls = [...calls];
+      assert.equal(preloadCalls.length, TRACKED_STETH_WALLETS.length);
+      assert.equal(mockDb.entities.StethYieldMovement.getAll().length, index);
+
+      calls.length = 0;
+      await handleStethTransfer({
+        event,
+        context: { ...context, isPreload: false },
+      });
+      assert.deepEqual(calls, preloadCalls);
+      assert.equal(
+        mockDb.entities.StethYieldMovement.getAll().length,
+        index + 1,
+      );
+      assert.equal(
+        walletSnapshot(
+          mockDb,
+          RESERVE_SAFE,
+          index === 0 ? V3_REVENUE_LAUNCH_TIMESTAMP : dayAfterLaunch(1),
+        ).balanceAmount,
+        testCase.balance,
+      );
+    }
+
+    assert.equal(summary(mockDb).currentBalance, steth(15));
   });
 
   it("writes ordered tracked-transfer snapshots and keeps movement writes when a later balance is null", async () => {

--- a/indexer-envio/test/steth.test.ts
+++ b/indexer-envio/test/steth.test.ts
@@ -18,11 +18,13 @@ import {
   V3_REVENUE_LAUNCH_TIMESTAMP,
 } from "../src/handlers/steth/shared.ts";
 import {
+  handleStethYieldDailySnapshotHeartbeat,
   recordStethWalletLaunchBaselines,
   recordStethYieldDailySnapshots,
   recordStethYieldEventDailySnapshots,
   recordStethYieldHeartbeatSnapshots,
 } from "../src/handlers/steth/dailySnapshots.ts";
+import { handleStethTransfer } from "../src/handlers/steth.ts";
 import {
   _clearMockStethBalanceOf,
   _setMockStethBalanceOf,
@@ -136,6 +138,18 @@ function stethSnapshotContext(
         mockDb.entities.StethYieldDailySnapshot.set(entity);
       },
     },
+    StethYieldMovement: {
+      get: async (id: string) => mockDb.entities.StethYieldMovement.get(id),
+      set: (entity: { id: string }) => {
+        mockDb.entities.StethYieldMovement.set(entity);
+      },
+    },
+    StethYieldSummary: {
+      get: async (id: string) => mockDb.entities.StethYieldSummary.get(id),
+      set: (entity: { id: string }) => {
+        mockDb.entities.StethYieldSummary.set(entity);
+      },
+    },
     effect: async (effect, input) => {
       if (effect === stethBalanceOfEffect) {
         const account = input.account.toLowerCase();
@@ -193,6 +207,222 @@ describeReserveYield("stETH reserve-yield ledger", () => {
 
   it("samples stETH sub-daily so missed slots cannot skip UTC buckets", () => {
     assert.equal(STETH_DAILY_SNAPSHOT_BLOCK_INTERVAL, 600);
+  });
+
+  it("preloads the same stETH heartbeat effects that ordered processing uses", async () => {
+    const mockDb = MockDb.createMockDb();
+    const calls: Array<{ name: string; input: unknown }> = [];
+    const context = {
+      ...stethSnapshotContext(
+        mockDb,
+        { [RESERVE_SAFE]: steth(1), [OPS_SAFE]: steth(2) },
+        V3_REVENUE_LAUNCH_TIMESTAMP + 1n,
+      ),
+      effect: async (effect: unknown, input: unknown) => {
+        calls.push({
+          name: effect === blockTimestampEffect ? "timestamp" : "stethBalance",
+          input,
+        });
+        if (effect === blockTimestampEffect) {
+          return V3_REVENUE_LAUNCH_TIMESTAMP + 1n;
+        }
+        if (effect === stethBalanceOfEffect) {
+          const account = (input as { account: string }).account;
+          return account === RESERVE_SAFE ? steth(1) : steth(2);
+        }
+        throw new Error("unexpected effect");
+      },
+      isPreload: true,
+    } as Parameters<
+      typeof handleStethYieldDailySnapshotHeartbeat
+    >[0]["context"];
+
+    assert.equal(
+      await handleStethYieldDailySnapshotHeartbeat({
+        block: { number: V3_REVENUE_LAUNCH_BLOCK + 600 },
+        context,
+      }),
+      false,
+    );
+    const preloadCalls = [...calls];
+    assert.equal(mockDb.entities.StethYieldDailySnapshot.getAll().length, 0);
+
+    calls.length = 0;
+    assert.equal(
+      await handleStethYieldDailySnapshotHeartbeat({
+        block: { number: V3_REVENUE_LAUNCH_BLOCK + 600 },
+        context: { ...context, isPreload: false },
+      }),
+      false,
+    );
+    assert.deepEqual(calls, preloadCalls);
+  });
+
+  it("writes stETH heartbeat snapshots from preloaded balances after launch baselines", async () => {
+    const mockDb = MockDb.createMockDb();
+    const day1 = dayAfterLaunch(1);
+    const heartbeatBlock = V3_REVENUE_LAUNCH_BLOCK + 7_200;
+
+    await recordStethWalletLaunchBaselines(
+      stethSnapshotContext(mockDb, {
+        [RESERVE_SAFE]: 0n,
+        [OPS_SAFE]: 0n,
+      }),
+      V3_REVENUE_LAUNCH_TIMESTAMP - 1n,
+    );
+
+    const didWrite = await handleStethYieldDailySnapshotHeartbeat({
+      block: { number: heartbeatBlock },
+      context: stethSnapshotContext(
+        mockDb,
+        {
+          [RESERVE_SAFE]: steth(10),
+          [OPS_SAFE]: steth(2),
+        },
+        day1 + 3_600n,
+      ),
+    });
+
+    assert.equal(didWrite, true);
+    assert.equal(
+      walletSnapshot(mockDb, RESERVE_SAFE, day1).balanceAmount,
+      steth(10),
+    );
+    assert.equal(
+      walletSnapshot(mockDb, OPS_SAFE, day1).balanceAmount,
+      steth(2),
+    );
+  });
+
+  it("preloads tracked transfer balances before ordered movement state", async () => {
+    const mockDb = MockDb.createMockDb();
+    const calls: unknown[] = [];
+    const context = {
+      ...stethSnapshotContext(mockDb, {
+        [RESERVE_SAFE]: steth(10),
+        [OPS_SAFE]: 0n,
+      }),
+      effect: async (effect: unknown, input: unknown) => {
+        assert.equal(effect, stethBalanceOfEffect);
+        calls.push(input);
+        const account = (input as { account: string }).account;
+        return account === RESERVE_SAFE ? steth(10) : 0n;
+      },
+      isPreload: true,
+    } as Parameters<typeof handleStethTransfer>[0]["context"];
+    const event = {
+      chainId: ETHEREUM_CHAIN_ID,
+      params: { from: EXTERNAL, to: RESERVE_SAFE, value: steth(10) },
+      block: {
+        number: V3_REVENUE_LAUNCH_BLOCK + 600,
+        timestamp: Number(V3_REVENUE_LAUNCH_TIMESTAMP + 1n),
+      },
+      logIndex: 1,
+      transaction: { hash: txHash(1) },
+    };
+
+    await handleStethTransfer({ event, context });
+    const preloadCalls = [...calls];
+    assert.equal(mockDb.entities.StethYieldMovement.getAll().length, 0);
+
+    calls.length = 0;
+    await handleStethTransfer({
+      event,
+      context: { ...context, isPreload: false },
+    });
+    assert.deepEqual(calls, preloadCalls);
+    assert.equal(mockDb.entities.StethYieldMovement.getAll().length, 1);
+  });
+
+  it("writes ordered tracked-transfer snapshots and keeps movement writes when a later balance is null", async () => {
+    const mockDb = MockDb.createMockDb();
+    const day1 = dayAfterLaunch(1);
+    const day2 = dayAfterLaunch(2);
+
+    await recordStethWalletLaunchBaselines(
+      stethSnapshotContext(mockDb, {
+        [RESERVE_SAFE]: 0n,
+        [OPS_SAFE]: 0n,
+      }),
+      V3_REVENUE_LAUNCH_TIMESTAMP - 1n,
+    );
+
+    const firstContext = stethSnapshotContext(mockDb, {
+      [RESERVE_SAFE]: steth(10),
+      [OPS_SAFE]: 0n,
+    }) as Parameters<typeof handleStethTransfer>[0]["context"];
+    await handleStethTransfer({
+      event: {
+        chainId: ETHEREUM_CHAIN_ID,
+        params: { from: EXTERNAL, to: RESERVE_SAFE, value: steth(10) },
+        block: {
+          number: V3_REVENUE_LAUNCH_BLOCK + 7_200,
+          timestamp: Number(day1 + 3_600n),
+        },
+        logIndex: 1,
+        transaction: { hash: txHash(1) },
+      },
+      context: firstContext,
+    });
+
+    assert.equal(
+      walletSnapshot(mockDb, RESERVE_SAFE, day1).balanceAmount,
+      steth(10),
+    );
+    assert.equal(walletSnapshot(mockDb, OPS_SAFE, day1).balanceAmount, 0n);
+    const snapshotsBeforeNullBalance = dailySnapshots(mockDb).length;
+
+    const nullBalanceContext = stethSnapshotContext(mockDb, {
+      [RESERVE_SAFE]: steth(10),
+      [OPS_SAFE]: null,
+    }) as Parameters<typeof handleStethTransfer>[0]["context"];
+    await handleStethTransfer({
+      event: {
+        chainId: ETHEREUM_CHAIN_ID,
+        params: { from: EXTERNAL, to: OPS_SAFE, value: steth(5) },
+        block: {
+          number: V3_REVENUE_LAUNCH_BLOCK + 14_400,
+          timestamp: Number(day2 + 3_600n),
+        },
+        logIndex: 2,
+        transaction: { hash: txHash(2) },
+      },
+      context: nullBalanceContext,
+    });
+
+    assert.equal(mockDb.entities.StethYieldMovement.getAll().length, 2);
+    assert.equal(summary(mockDb).currentBalance, steth(15));
+    assert.equal(dailySnapshots(mockDb).length, snapshotsBeforeNullBalance);
+    assert.equal(
+      mockDb.entities.StethYieldDailySnapshot.get(
+        `1-steth-${OPS_SAFE}-${day2}`,
+      ),
+      undefined,
+    );
+  });
+
+  it("does not start stETH balance effects for a filtered transfer", async () => {
+    const context = {
+      isPreload: true,
+      effect: async () => {
+        throw new Error("filtered transfer must not read effects");
+      },
+    } as Parameters<typeof handleStethTransfer>[0]["context"];
+
+    await handleStethTransfer({
+      event: {
+        chainId: ETHEREUM_CHAIN_ID,
+        params: {
+          from: EXTERNAL,
+          to: "0x0000000000000000000000000000000000000def",
+          value: steth(1),
+        },
+        block: { number: V3_REVENUE_LAUNCH_BLOCK + 600, timestamp: 1 },
+        logIndex: 1,
+        transaction: { hash: txHash(1) },
+      },
+      context,
+    });
   });
 
   it("records the first tracked stETH mint as FIFO principal", async () => {

--- a/indexer-envio/test/susds.test.ts
+++ b/indexer-envio/test/susds.test.ts
@@ -175,7 +175,7 @@ function dailySnapshotContext(
 function heartbeatContext(
   mockDb: MockDb,
   blockTimestamp: bigint | null,
-  sharePriceUsdWei: bigint,
+  sharePriceUsdWei: bigint | null,
   expectedBlockNumber = 300n,
 ): Parameters<typeof recordSusdsYieldHeartbeatSnapshot>[0] {
   return {
@@ -571,27 +571,102 @@ describeReserveYield("sUSDS reserve yield accounting", () => {
     assert.equal(rows[1]?.sampledAtBlock, 300n);
   });
 
-  it("skips the sUSDS heartbeat onBlock handler path while preloading", async () => {
+  it("preloads raw sUSDS heartbeat effects without writing snapshots", async () => {
     const mockDb = MockDb.createMockDb();
-    const context = heartbeatContext(
-      mockDb,
-      V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n + 1n,
-      WAD,
-      300n,
-    );
+    const calls: Array<{ effect: unknown; input: unknown }> = [];
+    const context = {
+      ...heartbeatContext(
+        mockDb,
+        V3_REVENUE_LAUNCH_TIMESTAMP + 86_400n + 1n,
+        WAD,
+        300n,
+      ),
+      isPreload: true,
+      effect: async (effect: unknown, input: unknown) => {
+        calls.push({ effect, input });
+        if (effect === blockTimestampEffect) return null;
+        if (effect === susdsSharePriceEffect) return null;
+        throw new Error("unexpected effect");
+      },
+    } as Parameters<
+      typeof handleSusdsYieldDailySnapshotHeartbeat
+    >[0]["context"];
 
     const didWrite = await handleSusdsYieldDailySnapshotHeartbeat({
       block: { number: 300 },
-      context: {
-        ...context,
-        isPreload: true,
-        effect: async () => {
-          throw new Error("preload heartbeat must not read effects");
-        },
-      },
+      context,
     });
 
     assert.equal(didWrite, false);
+    assert.equal(calls.length, 2);
+    assert.equal(dailySnapshots(mockDb).length, 0);
+  });
+
+  it("keeps sUSDS timestamp-null skip ahead of a hydrated share-price failure", async () => {
+    const mockDb = MockDb.createMockDb();
+    const calls: Array<{ effect: unknown; input: unknown }> = [];
+    const context = {
+      ...heartbeatContext(mockDb, null, WAD, 300n),
+      effect: async (effect: unknown, input: unknown) => {
+        calls.push({ effect, input });
+        if (effect === blockTimestampEffect) return null;
+        if (effect === susdsSharePriceEffect) return null;
+        throw new Error("unexpected effect");
+      },
+    } as Parameters<
+      typeof handleSusdsYieldDailySnapshotHeartbeat
+    >[0]["context"];
+
+    assert.equal(
+      await handleSusdsYieldDailySnapshotHeartbeat({
+        block: { number: 300 },
+        context: { ...context, isPreload: true },
+      }),
+      false,
+    );
+    const preloadCalls = [...calls];
+    calls.length = 0;
+    assert.equal(
+      await handleSusdsYieldDailySnapshotHeartbeat({
+        block: { number: 300 },
+        context: { ...context, isPreload: false },
+      }),
+      false,
+    );
+    assert.deepEqual(calls, preloadCalls);
+  });
+
+  it("fails the sUSDS heartbeat when a valid timestamp has no share price", async () => {
+    const mockDb = MockDb.createMockDb();
+
+    await assert.rejects(
+      handleSusdsYieldDailySnapshotHeartbeat({
+        block: { number: 300 },
+        context: heartbeatContext(
+          mockDb,
+          V3_REVENUE_LAUNCH_TIMESTAMP + 1n,
+          null,
+        ),
+      }),
+      /convertToAssets\(1e18\) unavailable at block 300/,
+    );
+    assert.equal(dailySnapshots(mockDb).length, 0);
+  });
+
+  it("skips the sUSDS heartbeat before launch when the share price is null", async () => {
+    const mockDb = MockDb.createMockDb();
+
+    assert.equal(
+      await handleSusdsYieldDailySnapshotHeartbeat({
+        block: { number: 300 },
+        context: heartbeatContext(
+          mockDb,
+          V3_REVENUE_LAUNCH_TIMESTAMP - 1n,
+          null,
+        ),
+      }),
+      false,
+    );
     assert.equal(dailySnapshots(mockDb).length, 0);
   });
 


### PR DESCRIPTION
## The Problem

- Reserve snapshot handlers start required RPC reads during ordered processing, so Envio cannot overlap those reads with preload work.
- Moving calls across phases can change null handling, launch behavior, or entity write order if the effect keys and processing checks drift.

## The Solution

- Start eligible timestamp, share-price, and balance effects during preload after event-derived filters are stable.
- Invoke the same effect keys during processing, then keep all existing null, launch, entity, and write-order semantics in processing.

## Details

- Preload raw sUSDS timestamp and share-price effects without interpreting null values or reading entities.
- Keep sUSDS event-only. This PR does not register the dormant heartbeat handler.
- Preserve sUSDS ordering: timestamp-null and prelaunch checks run before a null share price can fail processing.
- Preload the two fixed stETH wallet balances for heartbeat snapshots.
- For tracked transfers, apply event-derived wallet and launch-time filters first. Pre-launch transfers keep movement and summary processing but start no balance effects.
- At and after launch, preload the same stETH balance effect keys that processing uses.
- Preserve stETH ordered writes. Movement and summary writes complete before later snapshot handling.
- Keep later null balances snapshot-local. Keep launch-balance null values fatal.
- Keep the bounded one-block launch path processing-only.
- Add handler-level tests for pre-launch zero-effect processing, exact-launch and post-launch phase parity, successful snapshots, ordered transfer snapshots, null-balance partial writes, and sUSDS prelaunch and failure ordering.
- No architecture decision is introduced. This applies the existing Envio preload contract, so no ADR is required.
- No UI code changed. Browser verification is not applicable.

## Validation

- Exact head: `affbb55bec5274bf336d7724402f661de49dddc5`.
- `CI=true pnpm agent:quality-gate --run` — all mapped commands passed after the review repair.
- The mapped gate included reserve-yield tests, code generation, install, Trunk, lint, typecheck, coverage, knip, dependency boundaries, and Terraform tests.
- Reserve-yield handler suites — sUSDS 16/16 and stETH 20/20 passed.
- Initial full-patch sealed review — no findings; patch correct at 0.94 confidence. Manifest `a31b8093b2516d4d3af72c0bc749673bb9b885ca905cd34f6fda2fef3c6dfa17` remained unchanged.
- Review-repair sealed review — no findings; patch correct at 0.97 confidence. Manifest `fa4d5855f234669129dbeeb6943c370e2fa21fd120040e135269b0fde61b9fc0` remained unchanged.
- Deterministic local autoreview — no findings.
- `git diff --check` — passed.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every known deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This applies the existing Envio preload contract.

Closes #1396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stETH and sUSDS yield snapshot processing by avoiding duplicate balance and pricing lookups.
  * Added reliable handling for transfers before, at, and after the revenue launch.
  * Improved behavior for missing balances, timestamps, and share prices.
  * Preserved filtering and deduplication of transfers.

* **Tests**
  * Expanded coverage for heartbeat snapshots, transfer timing, preload behavior, and invalid or missing data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->