### PR TITLE
feat(sentry): surface refused stub inventory

### DIFF
--- a/.github/workflows/sentry-autofix.yml
+++ b/.github/workflows/sentry-autofix.yml
@@ -1412,6 +1412,12 @@ jobs:
             done < <(printf '%s' "${ENTRIES:-[]}" | jq -r '.[].issue')
           fi
 
+          # Operator inventory only. This is one bounded Search API read after
+          # selection; it is deliberately separate from the selector's
+          # ghCalls report and does not affect selection or retry behavior.
+          refused_inventory_json=$(node scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs \
+            --repo "${REPO}" 2>/dev/null || printf '%s\n' '{"state":"unknown"}')
+
           trigger="${TRIGGER}"
           if [ "${TRIGGER}" = "workflow_dispatch" ] && [ -n "${DISPATCH_ISSUE:-}" ]; then
             trigger="workflow_dispatch (issue #${DISPATCH_ISSUE})"
@@ -1440,7 +1446,9 @@ jobs:
             --rate-limited "${rate_limited}" \
             --handled-overflow "${handled_overflow}" \
             --reverse-truncated "${reverse_truncated}" \
-            --reverse-nonconvergent "${reverse_nonconvergent}")
+            --reverse-nonconvergent "${reverse_nonconvergent}" \
+            --refused-inventory "${refused_inventory_json}" \
+            --refused-inventory-repo "${REPO}")
 
           # Rolling comment: PATCH the existing marker-bearing comment if present,
           # else create it. Selection is author-fenced + prefix-anchored

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1015,6 +1015,21 @@ operator who sees a standing deferred count overrides it with the single-issue
 explicit human intent that beats a heuristic signal. Selection itself stays
 read-only and never re-queues anything.
 
+The same tracker record now carries a bounded operator inventory after each
+selection: `Refused stubs (all states): N` uses one GitHub Search API read for
+this repository, both `sentry-triage` and `sentry:fix-refused` labels, no state
+filter, and oldest-first ordering. It reports the REST `total_count`, up to ten
+issue links, and `+N more`; it never derives the count from the capped result
+list. A failed or incomplete read renders `unknown` and still permits the
+tracker upsert. This read is separate from the selector's `ghCalls` count.
+
+The historical refusal cluster needs operator attribution. Repeated refusals
+for #1304 and #1313 came from two `workflow_dispatch` runs after an operator
+manually removed the terminal labels. They were operator-induced retries, not
+selector lag. No stage performs automatic review, retry, or label removal for
+this cluster. The issue remains open until a human records dispositions for
+#1304, #1313, #1316, #1326, and #1328.
+
 **Cost bound** (PR #1810, re-sized when the window went to 200). Terminal,
 projected, archived, and external-project stubs are all excluded server-side
 before `--limit` applies, so the eligible window stays single-digit at steady

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1027,8 +1027,14 @@ The historical refusal cluster needs operator attribution. Repeated refusals
 for #1304 and #1313 came from two `workflow_dispatch` runs after an operator
 manually removed the terminal labels. They were operator-induced retries, not
 selector lag. No stage performs automatic review, retry, or label removal for
-this cluster. The issue remains open until a human records dispositions for
-#1304, #1313, #1316, #1326, and #1328.
+this cluster. The issue remains open until a human records dispositions for the
+following issues:
+
+- #1304
+- #1313
+- #1316
+- #1326
+- #1328
 
 **Cost bound** (PR #1810, re-sized when the window went to 200). Terminal,
 projected, archived, and external-project stubs are all excluded server-side

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -62,18 +62,20 @@ stay with their domain.
 same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
 
 - **Autoreview runtime materialization.** `agent-autoreview.sh` pins sibling
-  runtime through Perl copy lists and fixed `runtime_paths` arrays. Feedback
-  helpers resolve separately from `origin/main`. Move those feedback paths
-  across three merges: add new copies and a dual-path fallback; repoint every
-  consumer; remove old copies and fallback only after no pre-move wrapper
-  remains in use (ADR 0064).
-- **Gate routing pins.** `agent-quality-gate.sh` uses
-  `$script_source_dir == $repo_root/scripts` to exclude stub-repo tests. It pairs
-  `bootstrap/codex-cloud-setup.{sh,test.sh}` for offline installer tests.
-- **Gate runtime module pins.** `agent-quality-gate.sh` resolves
-  `docs/docs-navigation-eval-helpers.mjs` and `gate/lockfile-scope.mjs` from
-  `$script_source_dir`, not the stub `$repo_root`, and pins each in three
-  literals. Repoint all three; ADR 0064 lists them.
+  runtime in Perl lists and `runtime_paths`; feedback helpers use `origin/main`.
+  Move feedback paths in three merges: add copies and a dual-path fallback;
+  repoint consumers; remove old paths and fallback when no pre-move wrapper
+  remains (ADR 0064).
+- **Gate routing pins.** The gate excludes stub-repo tests with
+  `$script_source_dir == $repo_root/scripts`, and pairs
+  `bootstrap/codex-cloud-setup.{sh,test.sh}` for offline tests. It routes
+  `sentry/autofix/sentry-autofix-refused-inventory.mjs` alone to
+  `pnpm sentry:autofix:run-record:test` and
+  `pnpm sentry:autofix:finalize:test`.
+- **Gate runtime module pins.** `agent-quality-gate.sh` pins
+  `docs/docs-navigation-eval-helpers.mjs` and `gate/lockfile-scope.mjs` to
+  `$script_source_dir` in three literals, not stub `$repo_root`. Repoint all
+  three (ADR 0064).
 - **Evaluation fixture forbidden lists.** `forbidden_sources` in
   `docs/evals/documentation-navigation-fixtures.json` names the navigation
   eval's own implementation.

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4088,10 +4088,11 @@ while IFS= read -r path; do
         scripts/sentry/autofix/sentry-autofix-finalize.mjs|scripts/sentry/autofix/sentry-autofix-finalize.test.mjs)
           add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix finalize helper changed"
           ;;
-        scripts/sentry/autofix/sentry-autofix-run-record.mjs|scripts/sentry/autofix/sentry-autofix-run-record.test.mjs)
-          # The tracker run-record body builder, extracted from finalize.mjs.
-          # Run its own suite AND finalize's — finalize imports it for the
-          # `run-record` CLI subcommand, so its wiring rides on this module.
+        scripts/sentry/autofix/sentry-autofix-run-record.mjs|scripts/sentry/autofix/sentry-autofix-run-record.test.mjs|scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs)
+          # The tracker run-record body builder, extracted from finalize.mjs,
+          # and its bounded refused-stub Search API helper. Run the focused
+          # suite AND finalize's — finalize imports the builder for the
+          # `run-record` CLI subcommand, so their wiring rides on this route.
           add_command "pnpm sentry:autofix:run-record:test" "Sentry autofix run-record builder changed"
           add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix run-record builder changed"
           ;;

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4412,6 +4412,13 @@ run_gate "scripts/sentry/autofix/sentry-autofix-family-handled.mjs"
 assert_contains "- pnpm sentry:autofix:select:test (Sentry autofix handled-family lookup changed)"
 assert_contains "- pnpm sentry:autofix:finalize:test (Sentry autofix per-run cost cap changed)"
 
+# The record-run Search API inventory is not part of selector routing or its
+# gh-call budget. It shares the run-record suite and finalize wiring, so a
+# helper-only edit must still run both focused suites.
+run_gate "scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs"
+assert_contains "- pnpm sentry:autofix:run-record:test (Sentry autofix run-record builder changed)"
+assert_contains "- pnpm sentry:autofix:finalize:test (Sentry autofix run-record builder changed)"
+
 # The self-run Sentry-suite gate (#1779, ADR 0062) asserts, at runtime, that the
 # suites actually ran. A contributor who edits the gate script, its own suite, or
 # the manifest it reconciles against must run scripts/sentry/gate/sentry-suite-gate.test.mjs

--- a/scripts/sentry/autofix/sentry-autofix-finalize.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-finalize.mjs
@@ -56,6 +56,7 @@ import {
   AUTOFIX_RUN_RECORD_MARKER,
   buildAutofixRunRecordBody,
 } from "./sentry-autofix-run-record.mjs";
+import { parseRefusedStubInventoryResult } from "./sentry-autofix-refused-inventory.mjs";
 
 // The agent's diff may touch at most this many files. A real fix commonly spans
 // the change plus its tests and a couple of related call sites, so the ceiling
@@ -686,12 +687,14 @@ Commands:
              [--second-look-failed <bool>] [--gh-calls <n>] \\
              [--rate-limited <n>] \\
              [--handled-overflow <n>] [--reverse-truncated <bool>] \\
-             [--reverse-nonconvergent <bool>]
+             [--reverse-nonconvergent <bool>] \\
+             [--refused-inventory <json>] [--refused-inventory-repo <owner/name>]
       Print the tracker run-record comment body (rolling comment, marker-keyed).
       The Window line renders only when --window-total exceeds --window-evaluated;
       the Second look line only when the bounded second look actually ran; the
       DEGRADED line only when --rate-limited is nonzero; each truncation line
-      only when its budget was actually hit.
+      only when its budget was actually hit. The refused-stub inventory line is
+      known only when the separate bounded Search API read returned valid data.
   select-run-record-id --comments-file <path>
       Print the numeric id of the tracker issue's existing rolling run-record
       comment (trusted-author + prefix-anchored, selectMarkedComment),
@@ -818,6 +821,9 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
       return;
     }
     case "run-record": {
+      const refusedInventory = parseRefusedStubInventoryResult(
+        readFlag(args, "--refused-inventory"),
+      );
       stdout.write(
         `${buildAutofixRunRecordBody({
           timestampIso: readFlag(args, "--timestamp"),
@@ -843,6 +849,8 @@ export function runCli(argv, { stdout = process.stdout } = {}) {
           handledOverflow: readFlag(args, "--handled-overflow"),
           reverseTruncated: readFlag(args, "--reverse-truncated"),
           reverseNonconvergent: readFlag(args, "--reverse-nonconvergent"),
+          refusedInventory,
+          refusedInventoryRepo: readFlag(args, "--refused-inventory-repo"),
         })}\n`,
       );
       return;

--- a/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
@@ -609,12 +609,17 @@ await test("CLI autofix-comment / branch / label-def / refused-label-def / run-r
     "3",
     "--deferred-issues",
     "1313 1316 1326",
+    "--refused-inventory",
+    JSON.stringify({ state: "known", count: 1, issues: [1304] }),
   ]);
   assert(
     record.includes(AUTOFIX_RUN_RECORD_MARKER) &&
       record.includes("Fix PRs opened: 1") &&
       record.includes(
         "Deferred (duplicate_of family): 3 (#1313, #1316, #1326)",
+      ) &&
+      record.includes(
+        "https://github.com/mento-protocol/monitoring-monorepo/issues/1304",
       ),
     "CLI run-record assembles",
   );

--- a/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
@@ -1798,6 +1798,54 @@ await test("fork-fence negative control: the pre-fix bare jq TRUSTS the fork PR"
   }
 });
 
+await test("record-run inventory failure stays explicit and still reaches the upsert path", () => {
+  const code = workflowCode();
+  assert(
+    code.includes(
+      "refused_inventory_json=$(node scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs",
+    ),
+    "record-run invokes the bounded inventory helper",
+  );
+  assert(
+    code.includes("printf '%s\\n' '{\"state\":\"unknown\"}'"),
+    "helper failure degrades to an explicit unknown result",
+  );
+  const renderIndex = code.indexOf(
+    '--refused-inventory "${refused_inventory_json}"',
+  );
+  const upsertIndex = code.indexOf(
+    'gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}"',
+  );
+  assert(renderIndex >= 0, "unknown inventory reaches run-record rendering");
+  assert(
+    upsertIndex > renderIndex,
+    "run-record rendering precedes tracker upsert",
+  );
+  const body = captureCli([
+    "run-record",
+    "--timestamp",
+    "2026-08-21T00:00:00Z",
+    "--trigger",
+    "schedule",
+    "--disposition",
+    "active",
+    "--candidates",
+    "0",
+    "--opened",
+    "0",
+    "--refused",
+    "0",
+    "--incomplete",
+    "0",
+    "--refused-inventory",
+    '{"state":"unknown"}',
+  ]);
+  assert(
+    body.includes("- Refused stubs (all states): unknown"),
+    "unknown result renders explicitly",
+  );
+});
+
 await test("the select job's timeout-minutes is pinned to the selection caps it is sized against", () => {
   // The one change in the window/second-look work with no test at all: a bare
   // YAML scalar. `timeout-minutes` is the REAL binding constraint on this leg —

--- a/scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs
@@ -1,0 +1,260 @@
+/**
+ * Bounded, read-only inventory of refused Sentry queue stubs for the autofix
+ * tracker record. This is deliberately separate from selection: the Search
+ * API read is an operator report and is not part of the selector's gh-call
+ * budget or decision surface.
+ *
+ * The runner is injectable so tests can exercise both the exact request and
+ * every fail-closed parsing path without a GitHub token.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const REFUSED_INVENTORY_LIMIT = 10;
+export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
+export const REFUSED_INVENTORY_TIMEOUT_MS = 15_000;
+export const REFUSED_INVENTORY_KILL_GRACE_MS = 100;
+
+export function refusedInventoryArgs(repo) {
+  return [
+    "api",
+    "search/issues",
+    "--method",
+    "GET",
+    "-f",
+    `q=repo:${repo} is:issue label:sentry-triage label:sentry:fix-refused`,
+    "-f",
+    "sort=created",
+    "-f",
+    "order=asc",
+    "-f",
+    `per_page=${REFUSED_INVENTORY_LIMIT}`,
+  ];
+}
+
+function unknownInventory() {
+  return { state: "unknown" };
+}
+
+function isPositiveIssueNumber(value) {
+  return (
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    String(value) === String(Math.trunc(value))
+  );
+}
+
+function validIssueList(issues, count) {
+  if (
+    !Array.isArray(issues) ||
+    issues.length !== Math.min(count, REFUSED_INVENTORY_LIMIT)
+  ) {
+    return false;
+  }
+  const seen = new Set();
+  for (const number of issues) {
+    if (!isPositiveIssueNumber(number) || seen.has(number)) return false;
+    seen.add(number);
+  }
+  return true;
+}
+
+/** Parse and validate the raw Search API response. */
+export function parseRefusedStubInventory(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(String(stdout));
+  } catch {
+    return unknownInventory();
+  }
+
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    parsed.incomplete_results !== false ||
+    !Number.isSafeInteger(parsed.total_count) ||
+    parsed.total_count < 0 ||
+    !Array.isArray(parsed.items)
+  ) {
+    return unknownInventory();
+  }
+
+  const issues = [];
+  for (const item of parsed.items) {
+    if (
+      item === null ||
+      typeof item !== "object" ||
+      Array.isArray(item) ||
+      !isPositiveIssueNumber(item.number)
+    ) {
+      return unknownInventory();
+    }
+    issues.push(item.number);
+  }
+
+  if (!validIssueList(issues, parsed.total_count)) return unknownInventory();
+  return { state: "known", count: parsed.total_count, issues };
+}
+
+/** Parse the helper's JSON result before it reaches the public tracker body. */
+export function parseRefusedStubInventoryResult(value) {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return unknownInventory();
+    }
+  }
+  if (parsed?.state === "unknown") return unknownInventory();
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    parsed.state !== "known" ||
+    !Number.isSafeInteger(parsed.count) ||
+    parsed.count < 0 ||
+    !validIssueList(parsed.issues, parsed.count)
+  ) {
+    return unknownInventory();
+  }
+  return { state: "known", count: parsed.count, issues: [...parsed.issues] };
+}
+
+export function runGhWithTimeout(
+  args,
+  {
+    spawnFn = spawn,
+    timeoutMs = REFUSED_INVENTORY_TIMEOUT_MS,
+    killGraceMs = REFUSED_INVENTORY_KILL_GRACE_MS,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = {},
+) {
+  return new Promise((resolve, reject) => {
+    let child;
+    let settled = false;
+    let childDone = false;
+    let timer;
+    let killTimer;
+    let stdout = "";
+    let stderr = "";
+
+    const clearKillTimer = () => {
+      if (killTimer !== undefined) {
+        clearTimeoutFn(killTimer);
+        killTimer = undefined;
+      }
+    };
+
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeoutFn(timer);
+      clearKillTimer();
+      callback(value);
+    };
+
+    const markChildDone = () => {
+      childDone = true;
+      clearKillTimer();
+    };
+
+    try {
+      child = spawnFn("gh", args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      finish(reject, error);
+      return;
+    }
+
+    const failOnTimeout = () => {
+      const error = new Error(`gh search read timed out after ${timeoutMs}ms`);
+      // Settle before killing. Some child implementations emit `close`
+      // synchronously from kill(), and the timeout must remain the cause.
+      finish(reject, error);
+      let terminated = false;
+      try {
+        terminated = child.kill("SIGTERM");
+      } catch {
+        // Try the forced path below if SIGTERM was rejected.
+      }
+      if (terminated === false) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // The read is already settled as unknown. There is no safe recovery
+          // path if a child implementation rejects both termination requests.
+        }
+      } else if (!childDone) {
+        killTimer = setTimeoutFn(() => {
+          killTimer = undefined;
+          if (childDone) return;
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // The read is already settled as unknown.
+          }
+        }, killGraceMs);
+      }
+    };
+
+    timer = setTimeoutFn(failOnTimeout, timeoutMs);
+    try {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      child.on("error", (error) => {
+        markChildDone();
+        finish(reject, error);
+      });
+      child.on("close", (status) => {
+        markChildDone();
+        if (status === 0) {
+          finish(resolve, stdout);
+        } else {
+          finish(
+            reject,
+            new Error(`gh search read failed with exit ${status}: ${stderr}`),
+          );
+        }
+      });
+    } catch (error) {
+      finish(reject, error);
+    }
+  });
+}
+
+function defaultRunGh(args) {
+  return runGhWithTimeout(args);
+}
+
+/** Read once and fail closed for all command and response failures. */
+export async function readRefusedStubInventory(
+  { repo = DEFAULT_REPO } = {},
+  { runGh = defaultRunGh } = {},
+) {
+  try {
+    const stdout = await runGh(refusedInventoryArgs(repo));
+    return parseRefusedStubInventory(stdout);
+  } catch {
+    return unknownInventory();
+  }
+}
+
+async function main() {
+  const repoIndex = process.argv.indexOf("--repo");
+  const repo = repoIndex === -1 ? DEFAULT_REPO : process.argv[repoIndex + 1];
+  const result =
+    typeof repo === "string" && repo.length > 0
+      ? await readRefusedStubInventory({ repo })
+      : unknownInventory();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-refused-inventory.mjs
@@ -23,7 +23,7 @@ export function refusedInventoryArgs(repo) {
     "--method",
     "GET",
     "-f",
-    `q=repo:${repo} is:issue label:sentry-triage label:sentry:fix-refused`,
+    `q=repo:${repo} is:issue label:"sentry-triage" label:"sentry:fix-refused"`,
     "-f",
     "sort=created",
     "-f",

--- a/scripts/sentry/autofix/sentry-autofix-run-record.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-run-record.mjs
@@ -13,6 +13,10 @@
  * the body; the finalize CLI's `run-record` subcommand renders it and the
  * always-run record job does the best-effort rolling-comment upsert.
  */
+import {
+  DEFAULT_REPO as REFUSED_INVENTORY_DEFAULT_REPO,
+  parseRefusedStubInventoryResult,
+} from "./sentry-autofix-refused-inventory.mjs";
 
 export const AUTOFIX_RUN_RECORD_MARKER =
   "<!-- sentry-autofix:run-record:v1 -->";
@@ -55,6 +59,27 @@ function renderDeferredIssues(deferredIssues) {
     .slice(0, MAX_RECORDED_DEFERRED_ISSUES);
   if (numbers.length === 0) return "";
   return ` (${numbers.map((n) => `#${n}`).join(", ")})`;
+}
+
+/** Render the bounded Search API result without trusting API-provided URLs. */
+export function renderRefusedStubInventory(
+  refusedInventory,
+  repo = REFUSED_INVENTORY_DEFAULT_REPO,
+) {
+  const inventory = parseRefusedStubInventoryResult(refusedInventory);
+  if (inventory.state !== "known") {
+    return "- Refused stubs (all states): unknown";
+  }
+
+  const links = inventory.issues.map(
+    (number) => `[#${number}](https://github.com/${repo}/issues/${number})`,
+  );
+  const more = inventory.count - links.length;
+  const details =
+    links.length > 0 || more > 0
+      ? ` (${[...links, ...(more > 0 ? [`+${more} more`] : [])].join(", ")})`
+      : "";
+  return `- Refused stubs (all states): ${inventory.count}${details}`;
 }
 
 /**
@@ -106,6 +131,8 @@ export function buildAutofixRunRecordBody({
   handledOverflow,
   reverseTruncated,
   reverseNonconvergent,
+  refusedInventory,
+  refusedInventoryRepo,
 }) {
   const lines = [
     AUTOFIX_RUN_RECORD_MARKER,
@@ -120,6 +147,7 @@ export function buildAutofixRunRecordBody({
     `- Incomplete / errored: ${nonNegativeInt(incomplete)}`,
     `- Deferred (duplicate_of family): ${nonNegativeInt(deferred)}${renderDeferredIssues(deferredIssues)}`,
     `- Skipped (fix_scope: architectural): ${nonNegativeInt(skipped)}${renderDeferredIssues(skippedIssues)}`,
+    renderRefusedStubInventory(refusedInventory, refusedInventoryRepo),
   ];
   // Window tripwire (PR #1810): rendered ONLY when the list window exceeded the
   // evaluation cap (total > evaluated). Kept as a guard rather than deleted:

--- a/scripts/sentry/autofix/sentry-autofix-run-record.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-run-record.mjs
@@ -66,13 +66,15 @@ export function renderRefusedStubInventory(
   refusedInventory,
   repo = REFUSED_INVENTORY_DEFAULT_REPO,
 ) {
+  const targetRepo = repo ?? REFUSED_INVENTORY_DEFAULT_REPO;
   const inventory = parseRefusedStubInventoryResult(refusedInventory);
   if (inventory.state !== "known") {
     return "- Refused stubs (all states): unknown";
   }
 
   const links = inventory.issues.map(
-    (number) => `[#${number}](https://github.com/${repo}/issues/${number})`,
+    (number) =>
+      `[#${number}](https://github.com/${targetRepo}/issues/${number})`,
   );
   const more = inventory.count - links.length;
   const details =

--- a/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
@@ -1,8 +1,24 @@
 #!/usr/bin/env node
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { PassThrough } from "node:stream";
+
 import {
   AUTOFIX_RUN_RECORD_MARKER,
   buildAutofixRunRecordBody,
+  renderRefusedStubInventory,
 } from "./sentry-autofix-run-record.mjs";
+import {
+  parseRefusedStubInventory,
+  readRefusedStubInventory,
+  refusedInventoryArgs,
+  runGhWithTimeout,
+} from "./sentry-autofix-refused-inventory.mjs";
+
+const RUN_RECORD_MODULES = [
+  "sentry-autofix-run-record.mjs",
+  "sentry-autofix-refused-inventory.mjs",
+].map((name) => new URL(`./${name}`, import.meta.url));
 
 let passed = 0;
 let failed = 0;
@@ -50,6 +66,16 @@ await test("assertEqual reports the message its call site passed", () => {
   assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
 });
 
+await test("run-record modules stay under the 600-line soft cap", () => {
+  for (const moduleUrl of RUN_RECORD_MODULES) {
+    const lineCount = readFileSync(moduleUrl, "utf8").split(/\r?\n/).length;
+    assert(
+      lineCount <= 600,
+      `${moduleUrl.pathname} has ${lineCount} lines; the cap is 600`,
+    );
+  }
+});
+
 await test("run record body carries the marker, trigger, state, and tallies", () => {
   const body = buildAutofixRunRecordBody({
     timestampIso: "2026-07-19T08:30:00Z",
@@ -68,6 +94,226 @@ await test("run record body carries the marker, trigger, state, and tallies", ()
   assert(body.includes("Fix PRs opened: 1"), "opened count");
   assert(body.includes("Refused (no PR): 1"), "refused count");
   assert(body.includes("Incomplete / errored: 0"), "incomplete count");
+});
+
+await test("refused inventory reads the exact oldest-first all-state Search query", async () => {
+  let calls = 0;
+  const result = await readRefusedStubInventory(
+    { repo: "mento-protocol/monitoring-monorepo" },
+    {
+      runGh: async (args) => {
+        calls += 1;
+        assertEqual(
+          JSON.stringify(args),
+          JSON.stringify(
+            refusedInventoryArgs("mento-protocol/monitoring-monorepo"),
+          ),
+          "one bounded Search API request",
+        );
+        const query = args.find((arg) => arg.startsWith("q=repo:"));
+        assert(
+          query ===
+            "q=repo:mento-protocol/monitoring-monorepo is:issue label:sentry-triage label:sentry:fix-refused",
+          "query includes both labels and is:issue",
+        );
+        assert(
+          !args.some(
+            (arg) => arg.includes("is:open") || arg.includes("is:closed"),
+          ),
+          "no state filter",
+        );
+        return JSON.stringify({
+          total_count: 2,
+          incomplete_results: false,
+          items: [{ number: 1304 }, { number: 1313 }],
+        });
+      },
+    },
+  );
+  assertEqual(calls, 1, "single read");
+  assertEqual(
+    JSON.stringify(result),
+    JSON.stringify({ state: "known", count: 2, issues: [1304, 1313] }),
+  );
+});
+
+await test("refused inventory preserves ordered links and reports a capped remainder", () => {
+  const result = parseRefusedStubInventory(
+    JSON.stringify({
+      total_count: 13,
+      incomplete_results: false,
+      items: Array.from({ length: 10 }, (_, index) => ({
+        number: 1304 + index,
+      })),
+    }),
+  );
+  assertEqual(
+    renderRefusedStubInventory(result, "mento-protocol/monitoring-monorepo"),
+    "- Refused stubs (all states): 13 ([#1304](https://github.com/mento-protocol/monitoring-monorepo/issues/1304), [#1305](https://github.com/mento-protocol/monitoring-monorepo/issues/1305), [#1306](https://github.com/mento-protocol/monitoring-monorepo/issues/1306), [#1307](https://github.com/mento-protocol/monitoring-monorepo/issues/1307), [#1308](https://github.com/mento-protocol/monitoring-monorepo/issues/1308), [#1309](https://github.com/mento-protocol/monitoring-monorepo/issues/1309), [#1310](https://github.com/mento-protocol/monitoring-monorepo/issues/1310), [#1311](https://github.com/mento-protocol/monitoring-monorepo/issues/1311), [#1312](https://github.com/mento-protocol/monitoring-monorepo/issues/1312), [#1313](https://github.com/mento-protocol/monitoring-monorepo/issues/1313), +3 more)",
+  );
+});
+
+await test("refused inventory accepts a known empty result", () => {
+  assertEqual(
+    JSON.stringify(
+      parseRefusedStubInventory(
+        JSON.stringify({
+          total_count: 0,
+          incomplete_results: false,
+          items: [],
+        }),
+      ),
+    ),
+    JSON.stringify({ state: "known", count: 0, issues: [] }),
+  );
+});
+
+await test("refused inventory rejects duplicate issue numbers", () => {
+  assertEqual(
+    JSON.stringify(
+      parseRefusedStubInventory(
+        JSON.stringify({
+          total_count: 2,
+          incomplete_results: false,
+          items: [{ number: 1304 }, { number: 1304 }],
+        }),
+      ),
+    ),
+    JSON.stringify({ state: "unknown" }),
+  );
+});
+
+await test("refused inventory requires the Search API list to be exactly capped", () => {
+  assertEqual(
+    JSON.stringify(
+      parseRefusedStubInventory(
+        JSON.stringify({
+          total_count: 12,
+          incomplete_results: false,
+          items: [{ number: 1304 }],
+        }),
+      ),
+    ),
+    JSON.stringify({ state: "unknown" }),
+  );
+});
+
+await test("a non-terminating gh child times out, is terminated, and becomes unknown", async () => {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  const killSignals = [];
+  child.kill = (signal) => {
+    killSignals.push(signal);
+    return true;
+  };
+  const timers = [];
+  const resultPromise = readRefusedStubInventory(
+    { repo: "mento-protocol/monitoring-monorepo" },
+    {
+      runGh: (args) =>
+        runGhWithTimeout(args, {
+          spawnFn: () => child,
+          timeoutMs: 5,
+          killGraceMs: 10,
+          setTimeoutFn: (callback, delay) => {
+            const timer = { callback, delay, cleared: false };
+            timers.push(timer);
+            return timer;
+          },
+          clearTimeoutFn: (timer) => {
+            timer.cleared = true;
+          },
+        }),
+    },
+  );
+  assertEqual(timers.length, 1, "read arms one timeout");
+  timers[0].callback();
+  const result = await resultPromise;
+  assertEqual(JSON.stringify(result), JSON.stringify({ state: "unknown" }));
+  assertEqual(timers[0].cleared, true, "timeout is cleaned up on rejection");
+  assertEqual(
+    JSON.stringify(killSignals),
+    JSON.stringify(["SIGTERM"]),
+    "timed-out gh child first receives SIGTERM",
+  );
+  assertEqual(timers.length, 2, "SIGTERM arms one forced-kill grace timer");
+  timers[1].callback();
+  assertEqual(
+    JSON.stringify(killSignals),
+    JSON.stringify(["SIGTERM", "SIGKILL"]),
+    "a child that ignores SIGTERM receives SIGKILL",
+  );
+});
+
+await test("gh close and error paths clear the read deadline", async () => {
+  for (const event of ["close", "error"]) {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const timers = [];
+    const promise = runGhWithTimeout(["search/issues"], {
+      spawnFn: () => child,
+      setTimeoutFn: (callback) => {
+        const timer = { callback, cleared: false };
+        timers.push(timer);
+        return timer;
+      },
+      clearTimeoutFn: (timer) => {
+        timer.cleared = true;
+      },
+    });
+    if (event === "close") child.emit("close", 0);
+    else child.emit("error", new Error("spawn failed"));
+    if (event === "close") await promise;
+    else await promise.catch(() => {});
+    assertEqual(timers.length, 1, `${event} arms one deadline`);
+    assertEqual(timers[0].cleared, true, `${event} clears the deadline`);
+  }
+});
+
+await test("refused inventory fails closed for incomplete, command, JSON, shape, and count errors", async () => {
+  const cases = [
+    '{"total_count":1,"incomplete_results":true,"items":[{"number":1}]}',
+    "not json",
+    '{"total_count":1,"incomplete_results":false,"items":[{"number":"1"}]}',
+    '{"total_count":0,"incomplete_results":false,"items":[{"number":1}]}',
+  ];
+  for (const stdout of cases) {
+    assertEqual(
+      JSON.stringify(parseRefusedStubInventory(stdout)),
+      JSON.stringify({ state: "unknown" }),
+    );
+  }
+  assertEqual(
+    JSON.stringify(
+      await readRefusedStubInventory(
+        { repo: "mento-protocol/monitoring-monorepo" },
+        {
+          runGh: async () => {
+            throw new Error("Search API unavailable");
+          },
+        },
+      ),
+    ),
+    JSON.stringify({ state: "unknown" }),
+  );
+  const body = buildAutofixRunRecordBody({
+    timestampIso: "2026-07-19T08:30:00Z",
+    trigger: "schedule",
+    disposition: "active",
+    candidates: 0,
+    refused: 0,
+    refusedInventory: { state: "unknown" },
+  });
+  assert(
+    body.includes("- Refused stubs (all states): unknown"),
+    "degraded read remains explicit",
+  );
+  assert(
+    body.includes("- Refused (no PR): 0"),
+    "current-run refusal line is unchanged",
+  );
 });
 
 await test("run record body coerces missing/bad counters and labels safely", () => {

--- a/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-run-record.test.mjs
@@ -113,7 +113,7 @@ await test("refused inventory reads the exact oldest-first all-state Search quer
         const query = args.find((arg) => arg.startsWith("q=repo:"));
         assert(
           query ===
-            "q=repo:mento-protocol/monitoring-monorepo is:issue label:sentry-triage label:sentry:fix-refused",
+            'q=repo:mento-protocol/monitoring-monorepo is:issue label:"sentry-triage" label:"sentry:fix-refused"',
           "query includes both labels and is:issue",
         );
         assert(
@@ -150,6 +150,23 @@ await test("refused inventory preserves ordered links and reports a capped remai
   assertEqual(
     renderRefusedStubInventory(result, "mento-protocol/monitoring-monorepo"),
     "- Refused stubs (all states): 13 ([#1304](https://github.com/mento-protocol/monitoring-monorepo/issues/1304), [#1305](https://github.com/mento-protocol/monitoring-monorepo/issues/1305), [#1306](https://github.com/mento-protocol/monitoring-monorepo/issues/1306), [#1307](https://github.com/mento-protocol/monitoring-monorepo/issues/1307), [#1308](https://github.com/mento-protocol/monitoring-monorepo/issues/1308), [#1309](https://github.com/mento-protocol/monitoring-monorepo/issues/1309), [#1310](https://github.com/mento-protocol/monitoring-monorepo/issues/1310), [#1311](https://github.com/mento-protocol/monitoring-monorepo/issues/1311), [#1312](https://github.com/mento-protocol/monitoring-monorepo/issues/1312), [#1313](https://github.com/mento-protocol/monitoring-monorepo/issues/1313), +3 more)",
+  );
+});
+
+await test("refused inventory defaults only nullish repositories", () => {
+  const result = { state: "known", count: 1, issues: [1304] };
+  const defaultLine =
+    "- Refused stubs (all states): 1 ([#1304](https://github.com/mento-protocol/monitoring-monorepo/issues/1304))";
+  assertEqual(renderRefusedStubInventory(result), defaultLine, "omitted repo");
+  assertEqual(
+    renderRefusedStubInventory(result, null),
+    defaultLine,
+    "null repo from an omitted CLI flag",
+  );
+  assertEqual(
+    renderRefusedStubInventory(result, "example/custom-repo"),
+    "- Refused stubs (all states): 1 ([#1304](https://github.com/example/custom-repo/issues/1304))",
+    "explicit repo",
   );
 });
 


### PR DESCRIPTION
## The Problem

- Refused Sentry autofix stubs are terminal, but the periodic run record does not surface them for human review.
- A failed or malformed inventory read must not report a false zero.

## The Solution

- Add one bounded, oldest-first inventory read for issues that have both `sentry-triage` and `sentry:fix-refused` in any state.
- Record the total and up to ten issue links in the periodic tracker. Record the inventory as unknown when the read is incomplete or invalid.

## Details

- Run the exact GitHub Search API query once per record run. Keep this read outside the autofix selection budget and item cap.
- Require a complete response, exact result cardinality, unique positive issue numbers, and a valid total count.
- Apply a 15-second child-process deadline. Send `SIGTERM`, then `SIGKILL` after the bounded grace period.
- Preserve tracker rendering and upsert when the inventory degrades to unknown.
- Quote both label values in the Search API query.
- Apply the default repository to omitted and null CLI values. Preserve explicit repository values.
- Route helper-only changes to both the run-record and finalize test suites.
- Document the inventory as `Refused stubs (all states)`. The historical double refusals were operator retries, so this change does not add a selector-lag guard.
- This extends the existing Sentry run-record telemetry. It does not introduce an architecture decision, so no ADR is required.
- No UI code changed. Browser verification is not applicable.

## Validation

- Exact head: `e0f88c07b012bf180ea93b26ae490d4eaf8a68ef`.
- `pnpm sentry:autofix:run-record:test` — 24/24 tests passed.
- `pnpm sentry:autofix:finalize:test` — 65/65 tests passed.
- `CI=true pnpm agent:quality-gate --run` — all 18 mapped commands passed, including the quality-gate regression suite, Sentry suites, workflow trust checks, Terraform tests, documentation and context checks, script lint, and targeted Trunk checks.
- Initial no-history semantic review — no findings; patch correct at 0.98 confidence. Manifest `9e7ff063b89a018a8cac8644ead27409b74f6530c5ea0aa7f1a936a581c9c2cb` remained unchanged.
- Review-repair semantic review — no findings; patch correct at 0.97 confidence. Manifest `be0259364d8845ef910f0a44d8ad414c4c201d4f02ba40886787658052a621db` remained unchanged.
- `git diff --check origin/main...HEAD` — passed.

## Deferrals

- Human review records for the existing refused stubs remain tracked by [#1762](https://github.com/mento-protocol/monitoring-monorepo/issues/1762). This PR adds the required inventory but does not claim those reviews occurred.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every known deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This extends the existing run-record telemetry.

Refs #1762
