### PR TITLE
chore(indexer): upgrade Envio cloud CLI

### DIFF
--- a/.agents/skills/envio/SKILL.md
+++ b/.agents/skills/envio/SKILL.md
@@ -117,8 +117,8 @@ unscoped older deployment's logs; use the registration diagnostic and Envio UI.
 
 ## `envio-cloud` CLI
 
-Use the workspace-pinned CLI and its current `--help`; `envio-cloud` is still
-pre-1.0. Prefer the repo wrappers for deploy, verify, promote, rollback, logs,
+Use the workspace-pinned CLI and its current `--help`. Prefer the repo wrappers
+for deploy, verify, promote, rollback, logs,
 metrics, and info, and reach for raw subcommands (`indexer get`,
 `deployment status`, `deployment endpoint`, `indexer env list`) only for reads
 the wrappers do not cover — for example

--- a/.claude/skills/envio/SKILL.md
+++ b/.claude/skills/envio/SKILL.md
@@ -117,8 +117,8 @@ unscoped older deployment's logs; use the registration diagnostic and Envio UI.
 
 ## `envio-cloud` CLI
 
-Use the workspace-pinned CLI and its current `--help`; `envio-cloud` is still
-pre-1.0. Prefer the repo wrappers for deploy, verify, promote, rollback, logs,
+Use the workspace-pinned CLI and its current `--help`. Prefer the repo wrappers
+for deploy, verify, promote, rollback, logs,
 metrics, and info, and reach for raw subcommands (`indexer get`,
 `deployment status`, `deployment endpoint`, `indexer env list`) only for reads
 the wrappers do not cover — for example

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@prometheus-io/lezer-promql": "0.311.3",
     "@upstash/mcp-server": "0.2.4",
     "dependency-cruiser": "17.4.0",
-    "envio-cloud": "0.9.3",
+    "envio-cloud": "1.0.0",
     "eslint": "^10.0.2",
     "esbuild": "0.28.1",
     "globals": "^17.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: 17.4.0
         version: 17.4.0
       envio-cloud:
-        specifier: 0.9.3
-        version: 0.9.3
+        specifier: 1.0.0
+        version: 1.0.0
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -1228,28 +1228,28 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@envio-dev/envio-cloud-darwin-arm64@0.9.3':
-    resolution: {integrity: sha512-+7ESE2TGPnBmqJ6PILc89sQsbBNtJ2nN7YHN53QoYc3mYOD9zB9RiXE0CgP4X5bSjCmYLKc3e6W/Cue5+qwccA==}
+  '@envio-dev/envio-cloud-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-FVM51zsvyzpoUpqw4/dKdZDQRjcOVx0hYzk0ap1QOuZQYt31KNbM4dkgnon8KJnqzEhJNcLN5ev/4KsBCmFjjQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/envio-cloud-darwin-x64@0.9.3':
-    resolution: {integrity: sha512-CyXBcFuomcxoGyqMMAoF5bGVz2TO6f2aQVreJeXvNwidTctosi39omfWsB0TNUUR5QaRvsUcKcsnzvS/VGZiog==}
+  '@envio-dev/envio-cloud-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-LP5BHxcmjSeIwXO1A8nlZoEPYQ8rDM3ZUiSA9UWBz+D8zQa/r8bNSqppH19IBnuk3mm4xYynUmPqQHgnHLcKsg==}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/envio-cloud-linux-arm64@0.9.3':
-    resolution: {integrity: sha512-DsMM+IVXWqNpi0HwJ0hQ3O0si/xoUqlxgbrerEediuJ+hktXzH2EuRdSutxd7MNU2b//ds7bLjHIfSoGEVfRGQ==}
+  '@envio-dev/envio-cloud-linux-arm64@1.0.0':
+    resolution: {integrity: sha512-gnhpQQnlBny8xSueOnTK+g16ye9v8PC3opXbd6ZWHZaN+Yl0zV15Qj9OSQV1enffSZr8nf+fBeDpIamAuVMmbw==}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/envio-cloud-linux-x64@0.9.3':
-    resolution: {integrity: sha512-8bu7Eaq6Im7AvT+9RAeNCypFFS/vHM7nUBWR3u+ZsOb+HbTOXP0xQDBMA9wY94sw7emgkFm9aPc/eqmsvQ0pgQ==}
+  '@envio-dev/envio-cloud-linux-x64@1.0.0':
+    resolution: {integrity: sha512-whAxOwpOexpxIQJS76xSpNfwo2FBWtWTX7gtOWja8bsIO8ZnU7AMHyK/hfQaYuMMSrkvE8d+xqlL3LTO6tDZTw==}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/envio-cloud-win32-x64@0.9.3':
-    resolution: {integrity: sha512-vk7S4deFHuTCk6N7QZSo6GRIpcT3H7/Lik178ZOnKvfjBocJHo0DREA55v0PhjBqbDejWyc88AykEBiuIMJ2IQ==}
+  '@envio-dev/envio-cloud-win32-x64@1.0.0':
+    resolution: {integrity: sha512-1zDdMDd3KLc07bjEB66ib3Doo+wv2Y7K/xtxGlH/h/cz2ru4Jz2uXzT/w/2v+MLSMbapAwBLuAxlPmyDejC0Ow==}
     cpu: [x64]
     os: [win32]
 
@@ -6173,8 +6173,8 @@ packages:
   env-schema@7.0.0:
     resolution: {integrity: sha512-b8rdAwdFpekDxNAUNuT6KbV/QEX/pTBs0gjehEPmBUUteh9zBDm9zxFSQt55D29odo3rJt4feoWRqn4U/tzicw==}
 
-  envio-cloud@0.9.3:
-    resolution: {integrity: sha512-UPAOXU5dKj0BCFA6/bsgFEUPl5AeUlbz/0bwIIaBDiH9t8B7GvyX/RDtpdABJrrAM2GSmDEFDIpeatYLb+3K5g==}
+  envio-cloud@1.0.0:
+    resolution: {integrity: sha512-6oJ62ZeB2djKUN/2WuMyRZ18HWbp04jXKduMp37+CLycXKxcM1/P1V1wzgaea/UnyswwFc1BuYdO6gkQwU7YXg==}
     hasBin: true
 
   envio-darwin-arm64@3.2.1:
@@ -11280,19 +11280,19 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@envio-dev/envio-cloud-darwin-arm64@0.9.3':
+  '@envio-dev/envio-cloud-darwin-arm64@1.0.0':
     optional: true
 
-  '@envio-dev/envio-cloud-darwin-x64@0.9.3':
+  '@envio-dev/envio-cloud-darwin-x64@1.0.0':
     optional: true
 
-  '@envio-dev/envio-cloud-linux-arm64@0.9.3':
+  '@envio-dev/envio-cloud-linux-arm64@1.0.0':
     optional: true
 
-  '@envio-dev/envio-cloud-linux-x64@0.9.3':
+  '@envio-dev/envio-cloud-linux-x64@1.0.0':
     optional: true
 
-  '@envio-dev/envio-cloud-win32-x64@0.9.3':
+  '@envio-dev/envio-cloud-win32-x64@1.0.0':
     optional: true
 
   '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
@@ -16390,13 +16390,13 @@ snapshots:
     dependencies:
       ajv: 8.18.0
 
-  envio-cloud@0.9.3:
+  envio-cloud@1.0.0:
     optionalDependencies:
-      '@envio-dev/envio-cloud-darwin-arm64': 0.9.3
-      '@envio-dev/envio-cloud-darwin-x64': 0.9.3
-      '@envio-dev/envio-cloud-linux-arm64': 0.9.3
-      '@envio-dev/envio-cloud-linux-x64': 0.9.3
-      '@envio-dev/envio-cloud-win32-x64': 0.9.3
+      '@envio-dev/envio-cloud-darwin-arm64': 1.0.0
+      '@envio-dev/envio-cloud-darwin-x64': 1.0.0
+      '@envio-dev/envio-cloud-linux-arm64': 1.0.0
+      '@envio-dev/envio-cloud-linux-x64': 1.0.0
+      '@envio-dev/envio-cloud-win32-x64': 1.0.0
 
   envio-darwin-arm64@3.2.1:
     optional: true


### PR DESCRIPTION
## The Problem

- The repository pins `envio-cloud` 0.9.3, which calls a retired Envio operator API host and blocks indexer deployment checks.
- The mirrored Envio skill still describes the CLI as pre-1.0.

## The Solution

- Pin `envio-cloud` 1.0.0 and update the lockfile and mirrored guidance together.

## Details

- Update the root dependency and all five optional platform binaries to 1.0.0 with registry SHA-512 integrity pins.
- Keep the existing Git-push deployment, status, verification, promotion, and rollback workflows unchanged.
- Remove the stale pre-1.0 statement from both byte-identical Envio skill mirrors.
- Preserve the current command and JSON contracts used by the deployment wrappers.
- The package contains an opaque native binary. The lockfile fixes the reviewed bytes, but npm does not publish build provenance for this release.
- No Envio deployment or promotion ran as part of this PR.

## Validation

- `CI=true pnpm agent:quality-gate --run --allow-package-script-changes` — all mapped commands passed.
- `pnpm lockfile:lint` — 2,157 registry packages passed supply-chain policy checks.
- Authenticated `envio-cloud` 1.0.0 read-only probe — `indexer get` returned the expected `data.deployments[]` envelope.
- `pnpm deploy:indexer:status b5d14b7 --watch --compact` — current production deployment reported caught up on all chains.
- `pnpm deploy:indexer:info b5d14b7` and `pnpm deploy:indexer:metrics b5d14b7` — passed.
- `pnpm deploy:indexer:verify b5d14b7` — status, metrics, endpoint, GraphQL row probes, and replay integrity passed.
- Focused deployment wrapper tests, skill mirror checks, and `git diff --check` — passed.
- Independent adversarial review — no findings; safe to land.
- Fresh-context sealed review — no findings, confidence 0.97; manifest `f210fd6a6bdc9f8c56547b241a9e86cece670d0c888128df162f4a26c86bfeb3` verified before and after review.
- Claude Security scan: skipped because the plugin is unavailable in Codex; the mapped gate and two source reviews covered the deployment and supply-chain surface.

## Deferrals

- None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major-version bump of an opaque native CLI used for indexer status and deploy checks. Wrappers and command contracts are unchanged, but a 1.0 binary still carries supply-chain and API-compat risk.
> 
> **Overview**
> Pins `envio-cloud` from `0.9.3` to `1.0.0` so hosted indexer tooling talks to the current Envio operator API instead of the retired host.
> 
> Lockfile platform binaries are updated with the new package. Agent skill docs drop the stale “pre-1.0” note; deploy/verify/promote wrappers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7e70052c294599e1bf446265ff022845137387. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI guidance to reference the workspace-pinned version and current help output.
  * Removed outdated pre-1.0 messaging from CLI documentation.

* **Chores**
  * Updated the development CLI tool to version 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->