### PR TITLE
fix(scripts): thread the message argument through the remaining assertEqual helpers

### DIFF
--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -60,10 +60,14 @@ function test(name, fn) {
   }
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -109,6 +113,21 @@ async function assertRejects(fn, pattern) {
   }
   throw new Error("expected function to reject");
 }
+
+test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 test("parses repeated, comma-separated, and URL issue references", () => {
   assertDeepEqual(

--- a/scripts/pr/pr-feedback-state.test.mjs
+++ b/scripts/pr/pr-feedback-state.test.mjs
@@ -33,10 +33,14 @@ function assert(condition, msg) {
   if (!condition) throw new Error(msg);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -529,6 +533,21 @@ const readyState = {
   unrepliedRootReviewComments: [{ id: 123 }],
   topLevelBotComments: [{ id: 456 }],
 };
+
+test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 test("summarizes only feedback blockers and counts", () => {
   const summary = summarizeFeedbackState(readyState);

--- a/scripts/pr/pr-ready-state.test.mjs
+++ b/scripts/pr/pr-ready-state.test.mjs
@@ -54,10 +54,14 @@ function assert(condition, msg) {
   if (!condition) throw new Error(msg);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -109,6 +113,21 @@ const basePr = {
     { name: "optional", conclusion: "SKIPPED", status: "COMPLETED" },
   ],
 };
+
+test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 test("classifies checks by GitHub status and conclusion", () => {
   assertEqual(classifyCheck({ conclusion: "SUCCESS" }), "pass");

--- a/scripts/pr/review-materiality.test.mjs
+++ b/scripts/pr/review-materiality.test.mjs
@@ -39,10 +39,14 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -108,6 +112,21 @@ function runMaterialityCli(cwd, pathsFile, json = false) {
 }
 
 console.log("\nreview-materiality.mjs tests\n");
+
+test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 test("context helper separates base authority from valid head presence", () => {
   const note = "docs/notes/runbook.md";

--- a/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
@@ -87,10 +87,14 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -108,6 +112,21 @@ function captureCli(argv) {
 }
 
 const SHORT_ID = "APP-MENTO-ORG-2S";
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // --- diff guard --------------------------------------------------------------
 

--- a/scripts/sentry/triage/sentry-triage-archive.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-archive.test.mjs
@@ -64,10 +64,14 @@ async function test(name, fn) {
   }
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -461,6 +465,21 @@ function baseOptions(overrides = {}) {
 }
 
 const FIXED_NOW = () => new Date("2026-07-19T12:00:00.000Z");
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // Pure helpers.

--- a/scripts/sentry/triage/sentry-triage-brief.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-brief.test.mjs
@@ -90,10 +90,14 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -307,6 +311,21 @@ const patched = (gh) =>
   gh.calls.filter((c) => c.args[0] === "api" && c.args.includes("PATCH"));
 const deleted = (gh) =>
   gh.calls.filter((c) => c.args[0] === "api" && c.args.includes("DELETE"));
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // Contract: the two new verdict fields.

--- a/scripts/sentry/triage/sentry-triage-digest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.test.mjs
@@ -47,10 +47,14 @@ async function test(name, fn) {
   }
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -141,6 +145,21 @@ function queueBody(permalink = SENTRY_PERMALINK) {
     `[View in Sentry](${permalink})`,
   ].join("\n");
 }
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // Slack escaping (reused notifier pattern)

--- a/scripts/sentry/triage/sentry-triage-ingest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-ingest.test.mjs
@@ -89,10 +89,14 @@ async function test(name, fn) {
   }
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -132,6 +136,21 @@ function assertThrows(fn, pattern) {
   }
   throw new Error("expected function to throw");
 }
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // Title truncation

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -63,10 +63,14 @@ async function test(name, fn) {
   }
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -296,6 +300,21 @@ function makeRunGh({
 const PAT = "ghp_projection_token";
 const CREATED_URL =
   "https://github.com/mento-protocol/frontend-monorepo/issues/999";
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // Neutralization

--- a/scripts/sentry/triage/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.test.mjs
@@ -70,10 +70,14 @@ function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function assertEqual(actual, expected) {
+function assertEqual(actual, expected, message) {
   if (actual !== expected) {
+    // The message is what says WHICH property was being asserted; call sites
+    // already pass one, and dropping it left a bare value mismatch to read.
     throw new Error(
-      `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      `${message ? `${message}: ` : ""}expected ${JSON.stringify(
+        expected,
+      )}, got ${JSON.stringify(actual)}`,
     );
   }
 }
@@ -116,6 +120,21 @@ function makeWriter({ failOn = () => null } = {}) {
     verbs: () => calls.map((args) => args[1]),
   };
 }
+
+await test("assertEqual reports the message its call site passed", () => {
+  let thrown = null;
+  try {
+    assertEqual(3, 10, "the count is the signal; the list is an affordance");
+  } catch (err) {
+    thrown = err instanceof Error ? err.message : String(err);
+  }
+  assert(thrown !== null, "a mismatch must throw");
+  assert(
+    thrown.includes("the count is the signal; the list is an affordance"),
+    `the failure output must name what was asserted; got: ${thrown}`,
+  );
+  assert(thrown.includes("expected 10, got 3"), `values kept: ${thrown}`);
+});
 
 // ---------------------------------------------------------------------------
 // The rule itself.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Ten more homegrown `assertEqual(actual, expected)` test helpers, copied
  across the sentry, PR-state, and issue-board harnesses, silently drop the
  third message argument their call sites already pass.
- A failed assertion renders as a bare value mismatch — nothing says which
  property was being asserted.
- Issue #1929 fixed one file (`sentry-autofix-run-record.test.mjs`, PR #1950);
  the sibling copies stayed lossy.

## The Solution

- Give each `assertEqual` helper the same optional `message` parameter as the
  reference fix, and prefix it to the thrown text when present.
- Add the same one self-test per file that PR #1950 added: assert the message
  survives into the failure output.

## Details

- The issue's own count was a bot sample ("bots sample, they do not
  enumerate"), so I re-enumerated with `grep -rn "function assertEqual"
  scripts/` instead of trusting the issue's table. That turned up 11 files
  carrying the two-parameter helper, not the ten named in the title: the
  issue's table lists 8 files with current 3-arg call sites, plus separately
  names 3 more (`pr-ready-state.test.mjs`, `review-materiality.test.mjs`,
  `agent-issue-board.test.mjs`) as carrying the same helper with no 3-arg call
  site "today" — i.e. latent, not currently lossy. All 11 are fixed here so
  the fix is uniform and the latent ones don't need a second PR the next time
  a call site adds a message.
- `sentry-autofix-select.test.mjs`, `sentry-autofix-run-record.test.mjs`, and
  the fixture `sentry-suite-gate-fixtures.mjs` already carried the 3-parameter
  signature and needed no change.
- No call sites changed — they already pass a message where one exists.
- Each file's self-test is placed as the first test call, matching each
  file's own sync/`await` harness convention (PR #1950's file uses `await
  test`; several of the fixed files use synchronous `test`).
- `scripts/pr/agent-issue-board.test.mjs` picked up an unrelated upstream
  `assertRejects` helper while this PR was in flight (PR #1982, backfill
  claim fields); rebased cleanly, kept both additions.

## Validation

- `node <file>` for each of the 11 touched suites: all pass (591 individual
  assertions across the 11 files' own totals).
- Negative control: reverted the fix in `pr-feedback-state.test.mjs`, reran —
  the new self-test failed with `expected 10, got 3` and no message prefix;
  restored the fix, reran — green again.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base
  origin/main` — all 18 mapped commands passed, including `pnpm tf:test` and
  every `sentry:*:test` / `pr:*:test` command mapped to the changed files.
- `pnpm agent:autoreview -- --engine codex` — clean, no actionable findings.
- `pnpm agent:autoreview -- --engine claude` — clean, no actionable findings
  (two non-blocking nits noted: the helper/self-test pair is duplicated
  verbatim 11 times, which is the existing per-file harness pattern this
  issue explicitly scoped to match rather than consolidate).
- Pre-push gate (`scripts/agent-quality-gate.sh --run --parallel 3
  --skip-if-fresh --base origin/main`) ran the same 18 mapped commands green
  as part of the push.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — mechanical test-helper fix, no
      architecture change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change: assertion error text and a self-test per file. No production, auth, or data-path code.
> 
> **Overview**
> Homegrown `assertEqual` helpers in 11 PR/Sentry test files now keep the optional third `message` argument and prefix it onto mismatch errors, so failures name the property being asserted instead of only showing expected vs actual.
> 
> Each file also gets a small self-test that a dropped message would fail. Call sites are unchanged; this matches the earlier one-file fix and covers both currently lossy helpers and latent copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55333bd6d52ee01ae76c35598980f79b8122245a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure messages with optional context, making assertion mismatches easier to identify.
  * Error output now includes the relevant context alongside expected and actual values.
  * Added regression coverage across pull request and workflow validation scenarios to ensure diagnostic details remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->