### PR TITLE
test(scripts): pin that the autoreview capture budget charges Git spawn time only

### DIFF
--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -7015,12 +7015,15 @@ run_capture_deadline_engine_time_arm() {
   local json_output="$state_dir/report.json"
   local human_output="$state_dir/report.txt"
   # Sized the way the accumulation arm sizes its stalls, in the other
-  # direction. The engine gap has to dominate the budget so the refusal a wall-
-  # clock charge produces is not a near thing, and the budget has to stay far
-  # above what the captures themselves cost -- a two-file repository spends
-  # well under a second across every Git spawn a run makes, even loaded.
+  # direction, and the budget is the half that cannot shrink: it also carries
+  # every quick Git spawn the run makes, and those get slower on a loaded
+  # machine. Ten seconds against the well under a second a two-file repository
+  # spends across all of them is the same reserve that arm leaves above its own
+  # stalls. The engine gap only has to clear that budget by enough that the
+  # refusal a wall-clock charge produces is not a near thing, so it is the half
+  # kept small -- five seconds of margin, and the whole arm costs fifteen.
   local deadline_seconds=10
-  local engine_seconds=20
+  local engine_seconds=15
   local engine_started
   local engine_finished
   local engine_elapsed

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6707,6 +6707,7 @@ run_capture_deadline_regressions() {
   run_capture_deadline_byte_refusal_arm
   run_capture_deadline_helper_accumulation_arm
   run_capture_deadline_wrapper_accumulation_arm
+  run_capture_deadline_engine_time_arm
   run_capture_deadline_interrupt_arm
 }
 
@@ -6991,6 +6992,125 @@ run_capture_deadline_helper_accumulation_arm() {
       "$bundle_output" >&2
     exit 1
   fi
+}
+
+# What the helper charges its budget, and what it must never charge. The
+# accumulation arm above proves Git spawns add up; this one proves the wall
+# clock between them does not. The helper's spawns bracket a semantic review
+# that legitimately runs for half an hour, so the budget is the time those
+# spawns take -- unlike the wrapper's stage clock, which is absolute because its
+# captures are one contiguous stage with no engine inside them. Giving the
+# helper that absolute clock is the natural refactor for a reader who notices
+# the difference, and it would make every real review longer than the budget
+# refuse at the post-review source fingerprint.
+#
+# So: a fake engine that burns more than the whole budget between the
+# pre-review captures and that fingerprint. Per-spawn charging leaves the
+# fingerprint the budget it needs and the run publishes; a clock charging
+# elapsed time between spawns has nothing left and refuses.
+run_capture_deadline_engine_time_arm() {
+  local review_repo="$tmp_dir/capture-deadline-engine-time"
+  local engine_bin="$tmp_dir/capture-deadline-engine-time-bin"
+  local state_dir="$tmp_dir/capture-deadline-engine-time-state"
+  local json_output="$state_dir/report.json"
+  local human_output="$state_dir/report.txt"
+  # Sized the way the accumulation arm sizes its stalls, in the other
+  # direction. The engine gap has to dominate the budget so the refusal a wall-
+  # clock charge produces is not a near thing, and the budget has to stay far
+  # above what the captures themselves cost -- a two-file repository spends
+  # well under a second across every Git spawn a run makes, even loaded.
+  local deadline_seconds=10
+  local engine_seconds=20
+  local engine_started
+  local engine_finished
+  local engine_elapsed
+  local status=0
+
+  init_review_repo "$review_repo"
+  printf 'base\n' >"$review_repo/README.md"
+  commit_review_repo "$review_repo" init
+  printf 'change\n' >>"$review_repo/README.md"
+
+  mkdir "$engine_bin" "$state_dir"
+  # The reviewer forwards `AUTOREVIEW_FAKE_*` into the engine's sanitized
+  # environment, which is how the sleep and the state directory reach a script
+  # the helper spawns with nothing else of the caller's environment.
+  cat >"$engine_bin/codex" <<'CODEX'
+#!/bin/bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'codex-cli 9.9.9\n'
+  exit 0
+fi
+output=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >/dev/null
+date +%s >"$AUTOREVIEW_FAKE_ENGINE_STATE_DIR/engine-started"
+sleep "$AUTOREVIEW_FAKE_ENGINE_SECONDS"
+date +%s >"$AUTOREVIEW_FAKE_ENGINE_STATE_DIR/engine-finished"
+printf '%s\n' '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"clean","overall_confidence":0.9}' >"$output"
+CODEX
+  chmod +x "$engine_bin/codex"
+
+  : >"$stdout"
+  : >"$stderr"
+  (
+    cd "$review_repo"
+    env -i \
+      "PATH=$engine_bin:$hermetic_git_bin" \
+      "HOME=$HOME" \
+      "TMPDIR=${TMPDIR:-/tmp}" \
+      "GIT_CONFIG_GLOBAL=/dev/null" \
+      "AUTOREVIEW_EXTRA_BIN_DIRS=" \
+      "AGENT_AUTOREVIEW_CAPTURE_DEADLINE_SECONDS=$deadline_seconds" \
+      "AUTOREVIEW_FAKE_ENGINE_STATE_DIR=$state_dir" \
+      "AUTOREVIEW_FAKE_ENGINE_SECONDS=$engine_seconds" \
+      "$node_bin" "$repo_root/scripts/agent-autoreview.mjs" \
+      --mode local \
+      --engine codex \
+      --json-output "$json_output" \
+      --output "$human_output" >"$stdout" 2>"$stderr"
+  ) || status=$?
+  cleanup_retained_test_command_runtimes
+
+  # Negative control on the fixture. The arm proves nothing unless the engine
+  # really did consume more than the whole budget between the captures around
+  # it, so read the span the engine itself recorded rather than trusting the
+  # sleep to have happened.
+  if [[ ! -s "$state_dir/engine-started" || ! -s "$state_dir/engine-finished" ]]; then
+    printf 'the capture-budget engine fixture never completed a review\nstdout:\n%s\nstderr:\n%s\n' \
+      "$(cat "$stdout")" "$(cat "$stderr")" >&2
+    exit 1
+  fi
+  engine_started="$(cat "$state_dir/engine-started")"
+  engine_finished="$(cat "$state_dir/engine-finished")"
+  engine_elapsed=$((engine_finished - engine_started))
+  if ((engine_elapsed <= deadline_seconds)); then
+    printf 'the capture-budget engine fixture burned %ss, inside the %ss budget; the arm would pass vacuously\n' \
+      "$engine_elapsed" "$deadline_seconds" >&2
+    exit 1
+  fi
+
+  if [[ "$status" -ne 0 ]]; then
+    printf 'a review whose engine outlasted the capture budget refused to publish\nstdout:\n%s\nstderr:\n%s\n' \
+      "$(cat "$stdout")" "$(cat "$stderr")" >&2
+    exit 1
+  fi
+  expect_stdout_contains "autoreview clean"
+  # The refusal a wall-clock charge produces names the deadline; an empty stderr
+  # rules out a run that published while warning about one.
+  expect_empty_stderr
+  expect_file_contains "$human_output" "autoreview clean"
+  expect_file_contains "$json_output" "patch is correct"
 }
 
 # The deadline kills a capture with SIGKILL, and spawnSync reports an exhausted


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The autoreview helper charges its capture budget per Git spawn, not by the clock, so a semantic review that legitimately runs for half an hour does not eat the budget the post-review source fingerprint still needs. No test pinned that scope.
- Giving the helper the wrapper's absolute stage clock is the natural refactor for a reader who notices the difference, and it would make every real review longer than the budget start refusing at that fingerprint — with the suite still green.

## The Solution

- Add one arm to the capture-deadline family that runs a deliberately slow engine under a small budget and requires the run to publish anyway.

## Details

- `run_capture_deadline_engine_time_arm` in `scripts/agent-autoreview.test.sh` runs the helper with `--engine codex` against a fake `codex` on `PATH`. The fake answers `--version`, records the span it burns, sleeps 15 seconds, then writes a clean report. The budget is 10 seconds. The run must publish its JSON report, its human output file, and an empty stderr.
- The existing arms in the family cover the opposite direction: `run_capture_deadline_helper_accumulation_arm` proves spawns accumulate against one budget, and `run_capture_deadline_headroom_arm` runs a fast `--engine local` review. Neither puts substantial non-Git time between the pre-review captures and the fingerprint.
- The reviewer forwards `AUTOREVIEW_FAKE_*` into the engine's sanitized environment; that is how the sleep length and the state directory reach a script spawned with nothing else of the caller's environment. The fixture reuses the `--version` / `-o` contract and the `env -i` invocation the codex resolution arms established.
- The arm carries its own negative control. It reads the start and finish timestamps the fake engine recorded and fails if the engine did not outlast the whole budget, so a sleep that stopped happening cannot make it pass vacuously.
- Constant sizing follows the family idiom. The budget also carries every quick Git spawn a run makes, and those get slower on a loaded machine, so 10 seconds against the well under a second a two-file repository spends on them matches the reserve the accumulation arm leaves above its own stalls. The engine gap only has to clear that budget outright, so it is the half kept small: 5 seconds of margin, and the arm costs 15 seconds.
- Test-only change. `scripts/agent-autoreview.mjs` is untouched, and the invariant is already documented in `docs/notes/autoreview-runtime-trust.md`.

Closes #1973

## Validation

- Negative control, both directions, at the shipped constants. Mutated `spawnGitWithinCaptureDeadline` to charge elapsed wall clock since process start instead of per-spawn time: the new arm fails with `review capture exceeded the 10-second capture deadline while capturing git status (16s spent capturing)`, and no earlier arm in the family fails. Restored the helper and the family passes.
- `AUTOREVIEW_TEST_FOCUS=capture-deadline bash scripts/agent-autoreview.test.sh` — passed.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main` — all mapped commands passed, including the full `pnpm agent:autoreview:test` suite.
- `git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main` — all mapped commands passed.
- `pnpm agent:autoreview -- --engine codex` — clean, `patch is correct (0.94)`.
- `pnpm agent:autoreview -- --engine claude` — clean, `patch is correct (0.8)`. An earlier round raised one P3 about the arm's fixed wall-time cost; the engine gap dropped from 20 to 15 seconds and both directions were re-proved.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this adds a test arm to an existing family.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the capture-deadline family; production helper logic is untouched.
> 
> **Overview**
> Adds a capture-deadline test arm so a long engine run cannot eat the helper’s Git capture budget.
> 
> `run_capture_deadline_engine_time_arm` runs `--engine codex` against a fake `codex` that sleeps 15s under a 10s capture deadline. The review must still publish a clean report with empty stderr. A negative control fails the arm if the engine did not actually outlast the budget, so a wall-clock charge of elapsed time between Git spawns would refuse at the post-review fingerprint while this arm stays green only for per-spawn charging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58ffe04b2a1a35a46cddbe8bdb60cfcc52cd234. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify capture-deadline accounting excludes time spent in semantic engine reviews.
  * Confirmed delayed reviews can complete successfully and produce valid human-readable and JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->