### PR TITLE
test(scripts): partition the quality-gate self-test into focusable families

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -1141,14 +1141,20 @@ Rules that keep the focus honest:
   suite has always used. `pnpm agent:quality-gate:test`, the gate's own mapped
   self-test, and CI all run in that mode.
 - **The focus is refused where it could answer for the whole suite.** A set
-  `GATE_TEST_FOCUS` exits 2 when `AGENT_QUALITY_GATE_LOCK_HELD` (any command a
-  real gate run spawns) or `GITHUB_ACTIONS` is set, so an exported focus cannot
-  shrink the gate's self-test or CI's run.
+  `GATE_TEST_FOCUS` exits 2 when `AGENTQG_RUN`, `AGENT_QUALITY_GATE_LOCK_HELD`,
+  or `GITHUB_ACTIONS` is set, so an exported focus cannot shrink the gate's
+  self-test or CI's run. `AGENTQG_RUN` is the load-bearing one: the gate puts it
+  on the argv of every mapped command in every mode, while the lock marker is
+  absent under `--no-lock` and `AGENT_QUALITY_GATE_LOCK=0`, where
+  `acquire_gate_run_lock` returns before exporting it.
 - **The partition is checked, not assumed.** `verify_gate_family_partition`
-  runs before the family definitions. It reds the suite when a test line sits
-  outside every family, when a family is missing from the registry, and when the
-  definitions drift out of registry order. An unassigned test fails there before
-  it can execute — it never silently runs in none of the focused modes.
+  runs before the family definitions, reading the suite file through the path
+  resolved at startup. It reds the suite when a test line sits outside every
+  family, when a family is missing from the registry, when the definitions drift
+  out of registry order, and when the lines after the closing marker are
+  anything but exactly one `dispatch_gate_test_families` call — a second call
+  would run every family twice, and none would run nothing and still exit 0. An
+  unassigned test fails there before it can execute.
 - **A new test goes inside the family that owns its subject.** A new subject
   gets a new family function plus its `gate_test_families` entry, in file order.
 - Selection follows registry order, not the order given, and a repeated family

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -1136,17 +1136,19 @@ GATE_TEST_FOCUS=routing-packaging,routing-docs bash scripts/agent-quality-gate.t
 
 Rules that keep the focus honest:
 
-- **Unset runs everything.** With `GATE_TEST_FOCUS` unset the dispatch runs
-  every family in registry order, which is the file order and the order this
+- **Unset or empty runs everything.** The dispatch tests the value, not its
+  presence, so `GATE_TEST_FOCUS` unset and `GATE_TEST_FOCUS=` behave alike: both
+  run every family in registry order, which is the file order and the order this
   suite has always used. `pnpm agent:quality-gate:test`, the gate's own mapped
   self-test, and CI all run in that mode.
-- **The focus is refused where it could answer for the whole suite.** A set
-  `GATE_TEST_FOCUS` exits 2 when `AGENTQG_RUN`, `AGENT_QUALITY_GATE_LOCK_HELD`,
-  or `GITHUB_ACTIONS` is set, so an exported focus cannot shrink the gate's
-  self-test or CI's run. `AGENTQG_RUN` is the load-bearing one: the gate puts it
-  on the argv of every mapped command in every mode, while the lock marker is
-  absent under `--no-lock` and `AGENT_QUALITY_GATE_LOCK=0`, where
-  `acquire_gate_run_lock` returns before exporting it.
+- **The focus is refused where it could answer for the whole suite.** A
+  non-empty `GATE_TEST_FOCUS` exits 2 when any of `AGENTQG_RUN`,
+  `AGENT_QUALITY_GATE_LOCK_HELD`, or `GITHUB_ACTIONS` holds a non-empty value,
+  so an exported focus cannot shrink the gate's self-test or CI's run.
+  `AGENTQG_RUN` is the load-bearing one: the gate puts it on the argv of every
+  mapped command in every mode, while the lock marker is absent under
+  `--no-lock` and `AGENT_QUALITY_GATE_LOCK=0`, where `acquire_gate_run_lock`
+  returns before exporting it.
 - **The partition is checked, not assumed.** `verify_gate_family_partition`
   runs before the family definitions, reading the suite file through the path
   resolved at startup. It reds the suite when a test line sits outside every

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -1107,6 +1107,53 @@ header prints only when sharing is active. The shared dir is pure cache and
 grows without bound — delete it any time to reclaim disk:
 `rm -rf "$HOME/.cache/turbo-monitoring-monorepo"`. Refs GitHub issue 1411.
 
+## Self-test families (`GATE_TEST_FOCUS`)
+
+`scripts/agent-quality-gate.test.sh` is partitioned into families. Every test
+lives inside exactly one `run_<family>_family` function; nothing but blank lines
+and comments sits between those functions. A family is a subject, so a change to
+one part of the gate can be iterated against that subject alone instead of the
+whole ~9-minute suite:
+
+```bash
+GATE_TEST_FOCUS=routing-sources bash scripts/agent-quality-gate.test.sh
+GATE_TEST_FOCUS=routing-packaging,routing-docs bash scripts/agent-quality-gate.test.sh
+```
+
+| Family               | Subject                                                                                                                 | Solo runtime |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `gate-contract`      | Pins on the gate's source text, classifier resolution, Turbo task-graph inputs, agent context check.                    | 2s           |
+| `install-wiring`     | Pre-push hook installation, the install-marker library, the package-script pin validator.                               | 1s           |
+| `routing-packaging`  | Manifests, package-manager config, root package-script and dev-metadata classification, lockfile-importer scoping.      | 52s          |
+| `routing-sources`    | Source-path routing: scoped `vitest related`, indexer codegen order, shared-config blast radius, deploy/terraform arms. | 86s          |
+| `execution-phases`   | Phase order, fail-fast prerequisites, the parallel quality pool, quality-setup, dashboard serialization.                | 41s          |
+| `stamps-freshness`   | The fresh-run stamp: what busts it and what may reuse it.                                                               | 15s          |
+| `failure-output`     | Quiet failure output, stack traces, React Doctor, renames, the manifest-change refusal.                                 | 10s          |
+| `routing-docs`       | Documentation, agent context, code-health, Sentry and PR-tooling routing, including the `scripts/` symlink reach.       | 92s          |
+| `stamps-commands`    | Per-command stamps, always-rerun exemptions, command timeouts and interrupts.                                           | 27s          |
+| `execution-parallel` | Parallel teardown process groups, the production identity contract, prerequisite reuse.                                 | 51s          |
+| `lock-drain`         | Cross-run mutual exclusion: acquisition, stale-holder reclaim, drain obligations, crash-point recovery.                 | 319s         |
+
+Rules that keep the focus honest:
+
+- **Unset runs everything.** With `GATE_TEST_FOCUS` unset the dispatch runs
+  every family in registry order, which is the file order and the order this
+  suite has always used. `pnpm agent:quality-gate:test`, the gate's own mapped
+  self-test, and CI all run in that mode.
+- **The focus is refused where it could answer for the whole suite.** A set
+  `GATE_TEST_FOCUS` exits 2 when `AGENT_QUALITY_GATE_LOCK_HELD` (any command a
+  real gate run spawns) or `GITHUB_ACTIONS` is set, so an exported focus cannot
+  shrink the gate's self-test or CI's run.
+- **The partition is checked, not assumed.** `verify_gate_family_partition`
+  runs before the family definitions. It reds the suite when a test line sits
+  outside every family, when a family is missing from the registry, and when the
+  definitions drift out of registry order. An unassigned test fails there before
+  it can execute — it never silently runs in none of the focused modes.
+- **A new test goes inside the family that owns its subject.** A new subject
+  gets a new family function plus its `gate_test_families` entry, in file order.
+- Selection follows registry order, not the order given, and a repeated family
+  runs once. Unknown family names exit 2 and print the known set.
+
 ## Common local-gate traps
 
 - `codespell` flags short variable names that match common abbreviations (e.g. a two-letter loop var that looks like a misspelling). Use descriptive names like `netData` to avoid this.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -12,7 +12,16 @@ set -euo pipefail
 # which is exactly how a CI-only failure stays undiagnosable. Name the dying
 # command on stdout (some CI captures drop stderr) and dump the in-flight
 # gate output, which usually holds the actual error.
-trap 'echo "agent-quality-gate test suite aborted: line $LINENO: $BASH_COMMAND (exit $?)"; echo "Last gate output (tail):"; tail -40 "$output_file" 2>/dev/null | sed "s/^/  /"' ERR
+#
+# Bash resets the ERR trap on entry to a shell function and every test lives in
+# one, so arming is a helper that each family calls on entry as well. `set -E`
+# would arm it globally, but it also fires inside the fixture subshells and
+# command substitutions that run failing commands on purpose — output this
+# suite never had, and which a capture would swallow.
+arm_suite_abort_trap() {
+  trap 'echo "agent-quality-gate test suite aborted: line $LINENO: $BASH_COMMAND (exit $?)"; echo "Last gate output (tail):"; tail -40 "$output_file" 2>/dev/null | sed "s/^/  /"' ERR
+}
+arm_suite_abort_trap
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -414,6 +423,244 @@ assert_script_occurrences() {
     fail "expected $expected_count occurrence(s) of '$expected' in scripts/agent-quality-gate.sh, found $actual_count"
 }
 
+# ── Family partition (GATE_TEST_FOCUS) ───────────────────────────────────────
+# Every test below lives inside exactly one `run_<family>_family` function, and
+# nothing but blank lines and comments may sit between those functions. Set
+# GATE_TEST_FOCUS to a comma-separated list of family names to run just those
+# subjects while iterating; with the variable unset the dispatch at the bottom
+# of this file runs every family in file order, which is exactly the sequence
+# this suite ran before the partition existed. Adding a test means adding it
+# inside the family that owns its subject — see the families' documented
+# subjects and docs/notes/agent-quality-gate-mechanics.md.
+#
+# verify_gate_family_partition reds the suite when a test lands outside a
+# family, when a family is missing from the registry, or when the definitions
+# drift out of registry order — so a test added without a family cannot
+# silently run in none of the focused modes. It runs before the definitions, so
+# an unassigned test is caught before it executes, and it covers the file from
+# the marker below to the end: past the closing marker only the one dispatch
+# call may run.
+#
+# The bodies are deliberately NOT re-indented. They carry heredoc fixtures whose
+# bytes are asserted, so a mechanical re-indent would rewrite fixture content;
+# leaving the columns alone also keeps this partition's diff to its wrapper
+# lines, where a reviewer can see that no test moved. The one line added inside
+# each family is the `arm_suite_abort_trap` call on its first line, which bash
+# requires: it resets the ERR trap on entry to a function.
+
+# ── Family registry ──────────────────────────────────────────────────────────
+# The single source of truth for both the dispatch and the structural check
+# below: registry order is the file order of the definitions that follow, so an
+# unfocused run executes the families in the order this suite has always used.
+# Both properties are enforced by verify_gate_family_partition, not assumed.
+gate_test_families=(
+  gate-contract
+  install-wiring
+  routing-packaging
+  routing-sources
+  execution-phases
+  stamps-freshness
+  failure-output
+  routing-docs
+  stamps-commands
+  execution-parallel
+  lock-drain
+)
+
+fail_partition() {
+  # Same both-streams reporting as fail(), without the gate-output dump: a
+  # partition failure is about this file's structure, not about a gate run.
+  {
+    echo "agent-quality-gate family partition failed: $*"
+  } | tee /dev/stderr
+  exit 1
+}
+
+# Structural completeness. The families' union must be the whole suite body: a
+# test line between the body markers that sits outside every family function is
+# a test no focused mode would run, and it reds the suite here instead of
+# passing quietly. Also pins the definition set and its order against the
+# registry. It reads this file rather than the shell's state, so it runs BEFORE
+# the family definitions below — an unassigned test never gets to execute.
+verify_gate_family_partition() {
+  local source_file="${BASH_SOURCE[0]}"
+  local expected
+  local observed
+  # The suite cd's to the repo root at startup, so a path relative to the
+  # caller's directory may no longer resolve; the canonical location does.
+  [[ -f "$source_file" ]] ||
+    source_file="$repo_root/scripts/agent-quality-gate.test.sh"
+  [[ -f "$source_file" ]] ||
+    fail_partition "cannot read this suite's own source at $source_file"
+  expected="$(printf '%s\n' "${gate_test_families[@]}")"
+  if ! observed="$(
+    awk '
+      $0 == "# >>> gate family body start" {
+        if (previous != "verify_gate_family_partition") {
+          printf "line %d must be the verify_gate_family_partition call, not: %s\n", \
+            NR - 1, previous > "/dev/stderr"
+          failed = 1
+          exit 1
+        }
+        body = 1
+        next
+      }
+      $0 == "# <<< gate family body end" { body = 2; seen_end = 1; next }
+      body == 0 { previous = $0; next }
+      body == 2 {
+        # Past the partition, the suite may only make its one dispatch call.
+        # Everything else here would run in every focused mode and, at the
+        # bottom of the file, after the success line has been printed.
+        if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) { next }
+        if ($0 == "dispatch_gate_test_families") { next }
+        printf "line %d runs outside the family partition: %s\n", NR, $0 > "/dev/stderr"
+        failed = 1
+        exit 1
+      }
+      /^run_[a-z0-9_]+_family\(\) \{$/ {
+        if (open != "") {
+          printf "family %s is still open at line %d\n", open, NR > "/dev/stderr"
+          failed = 1
+          exit 1
+        }
+        open = substr($0, 5, length($0) - 15)
+        gsub(/_/, "-", open)
+        print open
+        next
+      }
+      /^\} # end family: / {
+        closing = substr($0, 17)
+        if (open == "") {
+          printf "family end without a start at line %d\n", NR > "/dev/stderr"
+          failed = 1
+          exit 1
+        }
+        if (closing != open) {
+          printf "family %s closed as %s at line %d\n", open, closing, NR > "/dev/stderr"
+          failed = 1
+          exit 1
+        }
+        open = ""
+        next
+      }
+      open != "" { next }
+      /^[[:space:]]*$/ { next }
+      /^[[:space:]]*#/ { next }
+      {
+        printf "line %d belongs to no family: %s\n", NR, $0 > "/dev/stderr"
+        failed = 1
+        exit 1
+      }
+      END {
+        if (failed == 1) { exit 1 }
+        if (open != "") {
+          printf "family %s is never closed\n", open > "/dev/stderr"
+          exit 1
+        }
+        if (seen_end != 1) {
+          print "the gate family body end marker is missing" > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$source_file"
+  )"; then
+    fail_partition "the suite body is not fully covered by the family functions"
+  fi
+  if [[ "$observed" != "$expected" ]]; then
+    printf 'registry (expected) vs definitions (observed):\n' >&2
+    diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$observed") >&2 || true
+    fail_partition "the family definitions do not match gate_test_families in order and membership"
+  fi
+}
+
+# ── Focus dispatch ───────────────────────────────────────────────────────────
+# The dispatch is a function, defined here rather than run at the bottom of the
+# file, so that the only line after the partition's end marker is a single call
+# to it. Appending a test to the bottom of this file — the habit this suite grew
+# up with — would otherwise run it in every focused mode, and after the success
+# line had already been printed. verify_gate_family_partition enforces that.
+dispatch_gate_test_families() {
+  local gate_test_focus="${GATE_TEST_FOCUS:-}"
+  local gate_test_family
+  local gate_test_request
+  local gate_test_known
+  local -a gate_test_requested=()
+  local -a gate_test_selected=()
+
+  # GATE_TEST_FOCUS is a developer convenience for iterating on one subject, and
+  # it must never be able to answer for the whole suite. The gate schedules this
+  # file as a mapped command, so a focus exported in a developer's shell would
+  # otherwise be inherited and silently shrink the gate's own self-test; the same
+  # goes for CI's `pnpm agent:quality-gate:test`. Refuse loudly under either.
+  # AGENT_QUALITY_GATE_LOCK_HELD is exported by a `--run` that holds (or
+  # inherited from one that holds) the machine-wide lock, so every command a real
+  # gate run spawns carries it. GITHUB_ACTIONS marks CI itself — CI="${CI:-true}"
+  # is not usable here because the gate exports that to mapped commands AND agent
+  # shells set it, which would refuse the focus on the very machines it is for.
+  if [[ -n "$gate_test_focus" ]]; then
+    if [[ -n "${AGENT_QUALITY_GATE_LOCK_HELD:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
+      printf 'GATE_TEST_FOCUS is not honored inside a gate run or in CI: unset it to run the full suite\n' >&2
+      exit 2
+    fi
+  fi
+
+  if [[ -z "$gate_test_focus" ]]; then
+    gate_test_selected=("${gate_test_families[@]}")
+  else
+    IFS=',' read -r -a gate_test_requested <<< "$gate_test_focus"
+    for gate_test_request in "${gate_test_requested[@]}"; do
+      gate_test_request="${gate_test_request// /}"
+      [[ -n "$gate_test_request" ]] || continue
+      gate_test_known=false
+      for gate_test_family in "${gate_test_families[@]}"; do
+        if [[ "$gate_test_family" == "$gate_test_request" ]]; then
+          gate_test_known=true
+          break
+        fi
+      done
+      if [[ "$gate_test_known" != true ]]; then
+        printf 'unknown GATE_TEST_FOCUS family: %s\n' "$gate_test_request" >&2
+        printf 'known families: %s\n' "${gate_test_families[*]}" >&2
+        exit 2
+      fi
+    done
+    # Selection follows registry order, not the order the caller listed, so a
+    # focused run can never claim an ordering the full run does not have. It also
+    # collapses a repeated family to one run.
+    for gate_test_family in "${gate_test_families[@]}"; do
+      for gate_test_request in "${gate_test_requested[@]}"; do
+        if [[ "${gate_test_request// /}" == "$gate_test_family" ]]; then
+          gate_test_selected+=("$gate_test_family")
+          break
+        fi
+      done
+    done
+    if [[ "${#gate_test_selected[@]}" -eq 0 ]]; then
+      printf 'GATE_TEST_FOCUS selected no families: %s\n' "$gate_test_focus" >&2
+      exit 2
+    fi
+  fi
+
+  for gate_test_family in "${gate_test_selected[@]}"; do
+    "run_${gate_test_family//-/_}_family"
+  done
+
+  if [[ -z "$gate_test_focus" ]]; then
+    echo "agent quality gate tests passed"
+  else
+    echo "agent quality gate focused tests passed: ${gate_test_selected[*]}"
+  fi
+}
+
+verify_gate_family_partition
+# >>> gate family body start
+
+# family: gate-contract
+# Pins on the gate's own source text, the routing and lockfile-scope
+# classifier resolution contracts, the Turbo task-graph inputs, and the
+# agent context check.
+run_gate_contract_family() {
+arm_suite_abort_trap
 assert_script_occurrences 1 "trap cleanup_tmpfiles EXIT"
 assert_script_occurrences 1 'changed_paths_file="$(make_tmpfile)"'
 assert_script_occurrences 0 "trap 'rm -f \"\$changed_paths_file\"' EXIT"
@@ -699,7 +946,13 @@ printf 'scratch\n' > "$untracked_skill_artifact"
 node scripts/context/check-agent-context.mjs > "$output_file"
 assert_contains "Agent context check passed"
 rm -f "$untracked_skill_artifact"
+} # end family: gate-contract
 
+# family: install-wiring
+# Pre-push hook installation, the shared install-marker library, and the
+# package-script pin validator.
+run_install_wiring_family() {
+arm_suite_abort_trap
 hook_repo="$(mktemp -d)"
 (
   cd "$hook_repo"
@@ -887,7 +1140,14 @@ JSON
 )
 rm -rf "$validator_repo"
 assert_contains 'package.json scripts.agent:quality-gate must be "./scripts/agent-quality-gate.sh"'
+} # end family: install-wiring
 
+# family: routing-packaging
+# Routing for packaging inputs: workspace manifests, package-manager
+# config, root package-script and dev-metadata classification, the Turbo
+# shared-cache export, and lockfile-importer scoping.
+run_routing_packaging_family() {
+arm_suite_abort_trap
 run_gate "ui-dashboard/package.json"
 assert_contains "- ./tools/trunk check --all (changed paths require full-repo Trunk checks)"
 assert_contains "- pnpm install --frozen-lockfile (workspace package manifest changed)"
@@ -1803,7 +2063,14 @@ assert_order \
 assert_order \
   "- pnpm install --frozen-lockfile (link generated package after indexer codegen)" \
   "- pnpm --filter @mento-protocol/indexer-envio lint (indexer-envio changed)"
+} # end family: routing-packaging
 
+# family: routing-sources
+# Routing for source paths: scoped `vitest related` selection, indexer
+# codegen order, shared-config blast radius, the deploy/status/terraform
+# arms, and the hermetic setup routes.
+run_routing_sources_family() {
+arm_suite_abort_trap
 run_gate "indexer-envio/src/bridge.ts"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 # Single production-source edit → scoped `vitest related` (issue #1413); the
@@ -2811,7 +3078,13 @@ terraform_fmt_mapped_command="$(
 if [[ "${terraform_fmt_mapped_command/scripts\/terraform\//scripts/}" == $terraform_fmt_setup_pattern ]]; then
   fail "is_quality_setup_command still matches the pre-move flat terraform-fmt-check path"
 fi
+} # end family: routing-sources
 
+# family: execution-phases
+# Real fixture runs: phase order, fail-fast prerequisites, the parallel
+# quality pool, quality-setup commands, and dashboard serialization.
+run_execution_phases_family() {
+arm_suite_abort_trap
 fail_fast_repo="$(mktemp -d)"
 (
   cd "$fail_fast_repo"
@@ -3417,7 +3690,13 @@ STUB
 rm -rf "$dashboard_setup_failure_repo"
 assert_contains "chromium install unavailable"
 assert_contains "Running quality commands with parallelism 8."
+} # end family: execution-phases
 
+# family: stamps-freshness
+# The fresh-run stamp: what busts it (content, file mode, index state,
+# command plan, base OID, gate implementation) and what may reuse it.
+run_stamps_freshness_family() {
+arm_suite_abort_trap
 fresh_stamp_repo="$(mktemp -d)"
 (
   cd "$fresh_stamp_repo"
@@ -3946,7 +4225,13 @@ STUB
 )
 rm -rf "$sha256sum_repo"
 assert_contains "+ ./tools/trunk check fixture.txt"
+} # end family: stamps-freshness
 
+# family: failure-output
+# How a run reports trouble: quiet failure output, stack traces, the React
+# Doctor wrapper, renames, and the manifest-change refusal.
+run_failure_output_family() {
+arm_suite_abort_trap
 quiet_failure_repo="$(mktemp -d)"
 (
   cd "$quiet_failure_repo"
@@ -4096,7 +4381,13 @@ rename_repo="$(mktemp -d)"
 rm -rf "$rename_repo"
 assert_contains "Refusing to run because package manifests, patches, or lockfile changed."
 assert_contains "dependency install scripts"
+} # end family: failure-output
 
+# family: routing-docs
+# Routing for documentation, agent context, code-health, Sentry and PR
+# tooling paths, including the scripts/ symlink reach cases.
+run_routing_docs_family() {
+arm_suite_abort_trap
 scripts/agent-quality-gate.sh \
   --changed-paths-file <(printf '%s\n' "docs/deployment.md") \
   --base origin/test \
@@ -4971,7 +5262,13 @@ assert_not_contains "(ESLint baseline wrapper changed)"
 # Root ESLint config changes trigger scripts lint.
 run_gate "eslint.config.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
+} # end family: routing-docs
 
+# family: stamps-commands
+# Per-command stamps: resume after a flaky failure, invalidation on any
+# content change, always-rerun exemptions, command timeouts and interrupts.
+run_stamps_commands_family() {
+arm_suite_abort_trap
 # GitHub issue #1410: a run that fails on one flaky command must, on rerun,
 # reuse the commands that already passed against unchanged content instead of
 # re-executing them. `pnpm lint:scripts` appends a side-effect line every time
@@ -5321,7 +5618,13 @@ STUB
   fi
 )
 rm -rf "$command_interrupt_repo"
+} # end family: stamps-commands
 
+# family: execution-parallel
+# Parallel teardown process groups, the production identity contract, and
+# prerequisite commands that are never stamped or reused.
+run_execution_parallel_family() {
+arm_suite_abort_trap
 # GitHub issue #1522: every parallel mapped command must be registered as a
 # dedicated process group before INT/TERM teardown can run. Cover both sides of
 # the original race:
@@ -5622,7 +5925,13 @@ STUB
     fail "expected the quality command to be reused on the second run"
 )
 rm -rf "$prereq_reuse_repo"
+} # end family: execution-parallel
 
+# family: lock-drain
+# Cross-run mutual exclusion: lock acquisition, stale-holder reclaim, drain
+# obligations, and crash-point recovery.
+run_lock_drain_family() {
+arm_suite_abort_trap
 # --- Cross-run mutual exclusion (GitHub issue #1802) -------------------------
 # Two gate runs on one machine starve each other, and the pre-push hook starts
 # one of its own while a manual run is still going, so `--run` takes a
@@ -7160,5 +7469,8 @@ $(sed 's/^/      /' "$gate_race_out/$race_tag.out")"
   done
 )
 rm -rf "$gate_race_repo" "$gate_race_root" "$gate_race_out"
+} # end family: lock-drain
 
-echo "agent quality gate tests passed"
+# <<< gate family body end
+
+dispatch_gate_test_families

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -18,10 +18,19 @@ set -euo pipefail
 # would arm it globally, but it also fires inside the fixture subshells and
 # command substitutions that run failing commands on purpose — output this
 # suite never had, and which a capture would swallow.
+#
+# The trap is armed before the scratch files exist, so it must survive a failure
+# in between: under `set -u` a bare $output_file there kills the handler with an
+# unbound-variable error instead of printing what died.
 arm_suite_abort_trap() {
-  trap 'echo "agent-quality-gate test suite aborted: line $LINENO: $BASH_COMMAND (exit $?)"; echo "Last gate output (tail):"; tail -40 "$output_file" 2>/dev/null | sed "s/^/  /"' ERR
+  trap 'echo "agent-quality-gate test suite aborted: line $LINENO: $BASH_COMMAND (exit $?)"; echo "Last gate output (tail):"; tail -40 "${output_file:-/dev/null}" 2>/dev/null | sed "s/^/  /"' ERR
 }
 arm_suite_abort_trap
+
+# This suite's own path, resolved before the cd below moves the ground under a
+# relative BASH_SOURCE. verify_gate_family_partition reads the file itself, so
+# it needs a path that survives the move and names no location of its own.
+gate_test_suite_source="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -438,8 +447,8 @@ assert_script_occurrences() {
 # drift out of registry order — so a test added without a family cannot
 # silently run in none of the focused modes. It runs before the definitions, so
 # an unassigned test is caught before it executes, and it covers the file from
-# the marker below to the end: past the closing marker only the one dispatch
-# call may run.
+# the marker below to the end: past the closing marker exactly one dispatch call
+# may run, and nothing else.
 #
 # The bodies are deliberately NOT re-indented. They carry heredoc fixtures whose
 # bytes are asserted, so a mechanical re-indent would rewrite fixture content;
@@ -483,13 +492,11 @@ fail_partition() {
 # registry. It reads this file rather than the shell's state, so it runs BEFORE
 # the family definitions below — an unassigned test never gets to execute.
 verify_gate_family_partition() {
-  local source_file="${BASH_SOURCE[0]}"
+  local source_file="$gate_test_suite_source"
   local expected
   local observed
-  # The suite cd's to the repo root at startup, so a path relative to the
-  # caller's directory may no longer resolve; the canonical location does.
-  [[ -f "$source_file" ]] ||
-    source_file="$repo_root/scripts/agent-quality-gate.test.sh"
+  # Fail closed: a suite that cannot read itself cannot vouch for its partition,
+  # and skipping the check is exactly the silence it exists to prevent.
   [[ -f "$source_file" ]] ||
     fail_partition "cannot read this suite's own source at $source_file"
   expected="$(printf '%s\n' "${gate_test_families[@]}")"
@@ -508,11 +515,13 @@ verify_gate_family_partition() {
       $0 == "# <<< gate family body end" { body = 2; seen_end = 1; next }
       body == 0 { previous = $0; next }
       body == 2 {
-        # Past the partition, the suite may only make its one dispatch call.
-        # Everything else here would run in every focused mode and, at the
-        # bottom of the file, after the success line has been printed.
+        # Past the partition, the suite may only make its one dispatch call —
+        # counted, because a second one would run every family twice and a
+        # missing one would exit 0 having run nothing. Everything else here
+        # would run in every focused mode and, at the bottom of the file, after
+        # the success line has been printed.
         if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) { next }
-        if ($0 == "dispatch_gate_test_families") { next }
+        if ($0 == "dispatch_gate_test_families") { dispatch_calls++; next }
         printf "line %d runs outside the family partition: %s\n", NR, $0 > "/dev/stderr"
         failed = 1
         exit 1
@@ -561,6 +570,11 @@ verify_gate_family_partition() {
           print "the gate family body end marker is missing" > "/dev/stderr"
           exit 1
         }
+        if (dispatch_calls != 1) {
+          printf "expected exactly one dispatch_gate_test_families call after the body, found %d\n", \
+            dispatch_calls > "/dev/stderr"
+          exit 1
+        }
       }
     ' "$source_file"
   )"; then
@@ -591,14 +605,23 @@ dispatch_gate_test_families() {
   # it must never be able to answer for the whole suite. The gate schedules this
   # file as a mapped command, so a focus exported in a developer's shell would
   # otherwise be inherited and silently shrink the gate's own self-test; the same
-  # goes for CI's `pnpm agent:quality-gate:test`. Refuse loudly under either.
-  # AGENT_QUALITY_GATE_LOCK_HELD is exported by a `--run` that holds (or
-  # inherited from one that holds) the machine-wide lock, so every command a real
-  # gate run spawns carries it. GITHUB_ACTIONS marks CI itself — CI="${CI:-true}"
-  # is not usable here because the gate exports that to mapped commands AND agent
-  # shells set it, which would refuse the focus on the very machines it is for.
+  # goes for CI's `pnpm agent:quality-gate:test`. Refuse loudly under any of:
+  #
+  # - AGENTQG_RUN, which the gate puts on the argv of every mapped command it
+  #   runs, in every mode. This is the one that has to be here: the lock marker
+  #   below is absent under `--no-lock` and AGENT_QUALITY_GATE_LOCK=0, because
+  #   acquire_gate_run_lock returns before exporting it, so a focus would have
+  #   survived into the self-test of exactly the runs that skip the lock.
+  # - AGENT_QUALITY_GATE_LOCK_HELD, exported by a `--run` holding the
+  #   machine-wide lock and inherited by nested runs. Kept as a second key on the
+  #   same door.
+  # - GITHUB_ACTIONS, which marks CI itself. CI="${CI:-true}" is not usable
+  #   here: the gate exports that to mapped commands AND agent shells set it,
+  #   which would refuse the focus on the very machines it is for.
   if [[ -n "$gate_test_focus" ]]; then
-    if [[ -n "${AGENT_QUALITY_GATE_LOCK_HELD:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
+    if [[ -n "${AGENTQG_RUN:-}" ||
+      -n "${AGENT_QUALITY_GATE_LOCK_HELD:-}" ||
+      -n "${GITHUB_ACTIONS:-}" ]]; then
       printf 'GATE_TEST_FOCUS is not honored inside a gate run or in CI: unset it to run the full suite\n' >&2
       exit 2
     fi

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -436,8 +436,8 @@ assert_script_occurrences() {
 # Every test below lives inside exactly one `run_<family>_family` function, and
 # nothing but blank lines and comments may sit between those functions. Set
 # GATE_TEST_FOCUS to a comma-separated list of family names to run just those
-# subjects while iterating; with the variable unset the dispatch at the bottom
-# of this file runs every family in file order, which is exactly the sequence
+# subjects while iterating; with the variable unset or empty the dispatch at the
+# bottom of this file runs every family in file order, which is the sequence
 # this suite ran before the partition existed. Adding a test means adding it
 # inside the family that owns its subject — see the families' documented
 # subjects and docs/notes/agent-quality-gate-mechanics.md.
@@ -605,7 +605,9 @@ dispatch_gate_test_families() {
   # it must never be able to answer for the whole suite. The gate schedules this
   # file as a mapped command, so a focus exported in a developer's shell would
   # otherwise be inherited and silently shrink the gate's own self-test; the same
-  # goes for CI's `pnpm agent:quality-gate:test`. Refuse loudly under any of:
+  # goes for CI's `pnpm agent:quality-gate:test`. Refuse loudly when any of these
+  # holds a non-empty value — the test below reads the value, not the presence,
+  # so a marker exported empty reads the same as one that was never exported:
   #
   # - AGENTQG_RUN, which the gate puts on the argv of every mapped command it
   #   runs, in every mode. This is the one that has to be here: the lock marker


### PR DESCRIPTION
## The Problem

- `scripts/agent-quality-gate.test.sh` was one flat 7,164-line script with no partition, so any change to the gate paid the whole ~13-minute suite on every iteration.
- That cost lands on every future gate change, starting with the D5 routing-table rewrite, where the loop is almost entirely routing.

## The Solution

- Wrap the suite body in eleven subject families and dispatch through `GATE_TEST_FOCUS`, so a developer can run one subject: `GATE_TEST_FOCUS=routing-sources bash scripts/agent-quality-gate.test.sh` is 86s, `stamps-freshness` 15s, `gate-contract` 2s. Unset runs everything, exactly as before.
- Nothing moved and no test changed. The family bodies are the original lines in the original order, verbatim and unindented, so the diff is the wrapper lines only.
- A structural check reds the suite if any test escapes the partition, so the shortcut cannot quietly become a hole.

## Details

**Families** (file order = registry order = run order):

| Family | Subject | Solo runtime |
| --- | --- | --- |
| `gate-contract` | Gate source-text pins, classifier resolution, Turbo task-graph inputs, agent context check | 2s |
| `install-wiring` | Pre-push hook install, install-marker library, package-script pin validator | 1s |
| `routing-packaging` | Manifests, package-manager config, root package-script and dev-metadata classification, lockfile-importer scoping | 52s |
| `routing-sources` | Scoped `vitest related`, indexer codegen order, shared-config blast radius, deploy/terraform arms | 86s |
| `execution-phases` | Phase order, fail-fast prerequisites, parallel quality pool, dashboard serialization | 41s |
| `stamps-freshness` | The fresh-run stamp: what busts it, what may reuse it | 15s |
| `failure-output` | Quiet failure output, stack traces, React Doctor, renames, manifest refusal | 10s |
| `routing-docs` | Docs, agent context, code-health, Sentry and PR-tooling routing, `scripts/` symlink reach | 92s |
| `stamps-commands` | Per-command stamps, always-rerun exemptions, timeouts, interrupts | 27s |
| `execution-parallel` | Parallel teardown process groups, production identity contract, prerequisite reuse | 51s |
| `lock-drain` | Cross-run mutual exclusion: acquisition, stale-holder reclaim, drain obligations, crash-point recovery | 319s |

**Nothing was weakened.**

- Default behaviour is unchanged: with `GATE_TEST_FOCUS` unset the dispatch runs every family in file order — the sequence the suite has always used — and prints the same `agent quality gate tests passed` line with the same exit codes. `pnpm agent:quality-gate:test` (pinned by `scripts/check-agent-quality-gate-package-scripts.mjs`), the gate's own mapped self-test, and CI are untouched and stay full-suite.
- A focus is refused outright, exit 2, when `AGENTQG_RUN`, `AGENT_QUALITY_GATE_LOCK_HELD`, or `GITHUB_ACTIONS` is set. An exported `GATE_TEST_FOCUS` therefore cannot shrink the gate's self-test or CI's run. `AGENTQG_RUN` is the load-bearing one — the gate puts it on the argv of every mapped command in every mode — because the lock marker is absent under `--no-lock` and `AGENT_QUALITY_GATE_LOCK=0`. `CI` is deliberately not used: the gate exports `CI="${CI:-true}"` to mapped commands and agent shells set it too, so it would refuse the focus on the machines the focus is for.
- `verify_gate_family_partition` runs **before** the family definitions, reading this file (through its own absolute path, resolved at startup) rather than shell state. It reds the suite when a test line sits outside every family, when the definition set or order drifts from `gate_test_families`, when a family is unclosed or mis-closed, and when the lines after the closing marker are anything but exactly one `dispatch_gate_test_families` call. An unassigned test never executes.
- Bodies are deliberately not re-indented: they carry heredoc fixtures whose bytes are asserted, and leaving the columns alone keeps the diff to wrapper lines where a reviewer can see that no test moved.

**The one line added inside each family is `arm_suite_abort_trap`.** Bash resets the ERR trap on entry to a shell function, so moving the tests into functions would have silenced the suite's abort diagnostic — the one the file's own header calls "exactly how a CI-only failure stays undiagnosable". It is not hypothetical: the first gate run on this branch failed inside `lock-drain` and printed nothing at all. Each family now re-arms the trap on entry, through a helper that holds the single copy of the trap body. `set -E` was rejected: it arms the trap globally, but also fires it inside the fixture subshells and command substitutions that run failing commands on purpose — a full run under `-E` printed spurious aborts and broke on captured output.

**Scope**: the test suite and its runbook. `scripts/agent-quality-gate.sh` is untouched. A pointer was drafted for `scripts/AGENTS.md` and dropped again: that file sits 28 bytes under the scoped agent-context cap, and `pnpm agent:context-budget --strict` reds on any addition. The runbook stays the canonical home, and the suite's own header names it.

## Validation

- **Full suite, default mode**: `bash scripts/agent-quality-gate.test.sh` → `agent quality gate tests passed`, exit 0 (590s on the final commit; 813s on an earlier one). No trap output in either.
- **Every family individually green**: `gate-contract` 2s, `install-wiring` 1s, `routing-packaging` 52s, `routing-sources` 86s, `execution-phases` 41s, `stamps-freshness` 15s, `failure-output` 10s, `routing-docs` 92s, `stamps-commands` 27s, `execution-parallel` 51s, `lock-drain` 319s — all exit 0.
- **Sum of families = whole suite**: enforced in code by `verify_gate_family_partition`, and proven mechanically for this diff — extracting the family bodies from the new file, minus each family's `arm_suite_abort_trap` first line, yields the 6,200 non-blank body lines of the pre-change file, identical and in the same order.
- **Negative controls** (each mutation applied, suite run, mutation reverted):
  - unassigned test between two families → `line 940 belongs to no family: run_unassigned_probe_test() {`, exit 1;
  - passing test appended after the dispatch call, the historical habit of this file → `line 7456 runs outside the family partition: ...`, exit 1;
  - test inserted between the check call and the body marker → `line 646 must be the verify_gate_family_partition call, not: ...`, exit 1;
  - one family dropped from the registry → registry-vs-definitions diff, exit 1;
  - the dispatch call duplicated → `expected exactly one dispatch_gate_test_families call after the body, found 2`, exit 1;
  - the dispatch call deleted → same check, `found 0`, exit 1 (without it the suite would define every family, run none, and exit 0).
  - Every control used an assertion that passes if executed, so the red comes from the guard, not from the probe. Controls removed afterwards; the suite is green again.
- **Focus guards, both ways**: `GATE_TEST_FOCUS=gate-contract` runs (exit 0); with `AGENT_QUALITY_GATE_LOCK_HELD=tok` or `GITHUB_ACTIONS=true` it exits 2 without running; an unknown name exits 2 and prints the known set; `"failure-output, gate-contract,failure-output"` runs `gate-contract failure-output` — registry order, deduplicated.
- `./tools/trunk check` (shellcheck, prettier, markdownlint) clean on all three changed files.
- **Abort diagnostic, both ways**: with a bare failing command planted inside a family, the suite prints `agent-quality-gate test suite aborted: line 664: grep -q never-in-this-file … (exit 1)` and exits 1; with the `arm_suite_abort_trap` call removed, the same failure exits 1 silently.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main` — all mapped commands passed, including `pnpm agent:quality-gate:test` at 9m18s (the full suite, run as a mapped command with the gate lock held).
- `git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main` — re-run at the hook's exact form on the final commit: all mapped commands passed, self-test 9m47s.
- `pnpm agent:autoreview -- --engine codex` — clean, `patch is correct (0.9)`.
- `pnpm agent:autoreview -- --engine claude` — clean, `patch is correct (0.8)`. An earlier round raised one P3: the guard did not cover code appended after the dispatch. Fixed by moving the dispatch into a function above the markers and extending the check past the closing marker; that gap is now the second negative control above.

### Review round (commit `59e6225b`)

Four findings, each verified before it was fixed, each closed with a measurement:

- **The refusal missed the runs that skip the lock.** `acquire_gate_run_lock` returns before exporting `AGENT_QUALITY_GATE_LOCK_HELD` when locking is off, so a `--no-lock` gate run's mapped self-test with `GATE_TEST_FOCUS` exported ran one family and reported success (`suite exit=0 … focused tests passed: gate-contract`). Probed with a fixture repo whose stub dumps its environment: locked → `AGENTQG_RUN=agentqg:Mac-…` + lock marker; `--no-lock` → `AGENTQG_RUN=agentqg:nolock-…`, marker unset. Refusing on `AGENTQG_RUN` closes it end to end: the same `--no-lock` run now gives `suite exit=2`.
- **The validator accepted any number of dispatch calls.** Two would run every family twice; zero would exit 0 having run nothing. Now counted, exactly one, with both cases as negative controls.
- **The abort trap could die before it spoke.** Armed above the `mktemp` calls, it expanded an unset `output_file` under `set -u`: measured from outside a checkout, the handler printed two lines then died with `output_file: unbound variable` and replaced git's exit 128 with 1. Defaulted to `/dev/null`; the real status now survives.
- **The source-file fallback hard-coded the suite's path.** Removed, not registered: the file resolves its own absolute path once at startup before any `cd`, and the checker reads that with no fallback and fails closed. Verified from five invocation shapes.

Refs #1877 (pre-work for D5, the gate routing-table rewrite).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this partitions an existing suite; it makes no decision that constrains future work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focused test execution by selecting one or more test families.
  * Added safeguards preventing focused runs during CI or nested quality-gate executions.
  * Improved protection for focused runs when quality-gate locking is disabled.

* **Bug Fixes**
  * Strengthened validation to detect missing, duplicate, or incorrectly positioned test dispatches.
  * Improved handling of test-suite paths and early execution failures.

* **Documentation**
  * Documented test-family organization, execution commands, runtimes, ordering, duplicate handling, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->