### PR TITLE
fix(sentry): rewrite credential-shaped fixtures so the suites scan clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,6 +1148,17 @@ jobs:
         # shared module, so they belong in a required job rather than only in
         # the advisory supply-chain workflow.
         run: node --test scripts/lib/pnpm-override-selector.test.mjs
+      - name: Sentry fixture scan canary
+        # Issues #1943/#1970, ADR 0068. Proves the four Sentry suites that carry
+        # credential-shaped fixtures still scan clean as whole text under
+        # scripts/agent-autoreview-core.mjs, and that none of the four paths has
+        # vanished. It is NOT a `sentry-*.test.mjs`, so the `sentry-suites` gate
+        # neither enumerates nor runs it; this step and the local quality gate
+        # are its two routes. The `rootScripts` filter is `scripts/**`, so the
+        # scanner, the four suites and the canary itself all admit this job —
+        # the same recursive entry every other scripts/ suite here relies on,
+        # rather than a new enumerated list to keep in sync.
+        run: node scripts/sentry/fixture-scan-canary.test.mjs
       # The Sentry suites used to run here, one step each (issue #1721). They
       # now run in the unconditional `sentry-suites` job, which also proves from
       # their own output that each one asserted (issue #1779, ADR 0062) — a

--- a/docs/README.md
+++ b/docs/README.md
@@ -194,6 +194,7 @@ Authority: canonical
 - [`docs/adr/0065-scripts-file-size-watchlist-scope.md`](adr/0065-scripts-file-size-watchlist-scope.md) — scripts/ is inside the file-size watchlist, with named-mechanism exemptions
 - [`docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md`](adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) — CodeRabbit replaces Cursor BugBot as the third PR review bot
 - [`docs/adr/0067-pool-criticality-is-depletion-risk.md`](adr/0067-pool-criticality-is-depletion-risk.md) — Pool criticality is depletion risk, not deviation magnitude
+- [`docs/adr/0068-sentry-fixture-authoring-policy.md`](adr/0068-sentry-fixture-authoring-policy.md) — Adversarial fixtures are authored to scan clean; no value or line registry
 
 Authority: non-canonical
 

--- a/docs/adr/0068-sentry-fixture-authoring-policy.md
+++ b/docs/adr/0068-sentry-fixture-authoring-policy.md
@@ -1,0 +1,197 @@
+---
+title: Adversarial fixtures are authored to scan clean; no value or line registry
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-21
+scope: ci/process
+date: 2026-08
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0068 — Adversarial fixtures are authored to scan clean; no value or line registry
+
+**Status:** Accepted (Aug 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+`pnpm agent:autoreview` builds a review bundle and refuses to send it when
+`secretLikeReason` in `scripts/agent-autoreview-core.mjs` recognizes anything
+credential-shaped in it. The scanner is fail-closed by design: it refuses on
+recognition, it never asks where the text came from, and five rounds of
+red-teaming have gone into keeping it that way.
+
+Four Sentry suites carry adversarial fixtures — credential-shaped values whose
+whole point is to prove the pipeline refuses to leak them:
+
+- `scripts/sentry/autofix/sentry-autofix-finalize.test.mjs`
+- `scripts/sentry/broker/sentry-mcp-broker.test.mjs`
+- `scripts/sentry/triage/sentry-triage-agent-comment.test.mjs`
+- `scripts/sentry/triage/sentry-triage-archive.test.mjs`
+
+Written the wrong way, those fixtures make the suite file itself trip the
+scanner. Every autoreview run whose bundle contains such a file then refuses
+before a model sees the diff. That is issue #1943. Issue #1970 is the same
+failure reached through a different door: git copies a fixture line into the
+`@@` hunk-header funcname, so the trap text arrives in the bundle even when the
+edit is nowhere near it.
+
+The trap shape is narrow and was measured, not guessed: a **credential-named
+identifier or key holding a realistic-shaped literal value**. The identifier is
+usually the trigger, not the value. `SHELL_OWNER_TOKEN` held a shell parameter
+expansion — no credential at all — and tripped the scanner purely because
+`credentialAssignmentKey` recognizes `TOKEN` as a credential key. PR #1974 read
+that as "shell-code fixtures cannot be renamed" and went looking for an
+exemption mechanism instead; that was a misdiagnosis.
+
+Measured surface, 60 days on `origin/main`, bound to an immutable tip:
+
+| Measurement                                              | Value            |
+| -------------------------------------------------------- | ---------------- |
+| Tracked files that trip `secretLikeReason` as whole text | 73 of 2228       |
+| Squash commits producing a refusing bundle               | 37 of 497 (7.4%) |
+| Of those 37, attributable solely to the four suites      | 5                |
+| Commits a correct provenance oracle would have cleared   | 9 of 37 (24%)    |
+| Oracle yield against all commits                         | ≈1.8%            |
+
+The file-count harness silently skipped unreadable files. Re-run fail-closed in
+an independent environment it read 72 of 2228, not 73, against the same
+denominator. Both figures are recorded; the harness fix (fail on an unreadable
+file) is a precondition for the re-measurement below.
+
+## Decision
+
+**1. Fixtures are authored to scan clean.** New or edited adversarial fixtures
+use placeholder vocabulary for the value (`example-…`, `placeholder-…`), or a
+non-credential-named identifier for the binding, or both. A credential-named key
+holding a realistic-shaped literal is the shape to avoid. Composition
+(`"pre" + "fix"`) is not a general escape: `staticConcatenation` folds
+concatenated literals back together before the credential-key rules run, so
+composition only helps for **provider-prefix** patterns (`ghs_…`, `sk-ant-…`)
+on keys the scanner does not read as credential names.
+
+**2. No value registry and no line registry.** An allowlist of known-safe
+credential-shaped values, or of file/line coordinates, was rejected. Both make
+the scanner's answer depend on a list a PR can edit, in the one function with a
+five-round bypass record, and both go stale the moment a fixture moves. #1974 is
+the evidence: it pursued that class of fix, and the underlying problem turned
+out to be a fixture-authoring problem an eight-identifier rename solved outright.
+
+**3. The provenance oracle is the recorded design of record, deferred.** The
+principled fix — clear a finding only when every byte of evidence supporting it
+is already published on `origin/main` — survived adversarial review as a
+principle. It is not being built now: its measured yield is ≈1.8% of commits,
+and it would add a large exemption mechanism to the fail-closed scanner. Its
+corrected invariants are recorded below so it can be built safely later.
+
+**4. A drift canary keeps the rewrite from rotting.**
+`scripts/sentry/fixture-scan-canary.test.mjs` asserts, for each of the four
+paths, that the file exists and that its whole text scans clean, behind a
+negative control that proves the scanner still refuses the trap shape. Its
+basename deliberately does not start with `sentry-`: `findSentrySuites()`
+reconciles that glob against `scripts/sentry/gate/sentry-suite-manifest.json`
+by exact set equality, so a `sentry-*.test.mjs` here would have to become a
+manifest-owned suite. It is routed by `scripts/agent-quality-gate.sh` and by the
+`scripts` job in `.github/workflows/ci.yml` instead, and it runs when the scanner
+changes as well as when any of the four suites change.
+
+## Alternatives considered
+
+- **Build the provenance oracle now.** Rejected on measurement: it clears 9 of
+  the 37 refusing commits and 65 of 65 synthetic steady-state cases, but only
+  ≈1.8% of all commits, against ~300 lines and ~40 new pinned invariants inside
+  the scanner's most bypass-prone function.
+- **A value or line allowlist.** Rejected — see decision 2.
+- **Widen the scanner instead of the fixtures.** A separate proposal to clear
+  `0x` + 40 hex under any credential-named key was dropped in review: 40 hex
+  digits prove a 160-bit value, not a public address, so a random bearer secret
+  written that way would newly clear. The narrow `key === "token"` rule stands.
+- **Accept the refusals.** Autoreview is a package script, not a pre-push hook,
+  so a refusal costs the local pre-model review and not the push — but it costs
+  it on 7.4% of commits, silently, and #1970 makes it reachable from edits that
+  never touch the fixture.
+
+## Consequences
+
+- **A coupling to keep in view.** The renames rely on `cred` and `splice`
+  staying outside `credentialAssignmentKey`'s vocabulary. Widening that
+  vocabulary re-traps the fixtures. The gate routes the canary on any change to
+  `scripts/agent-autoreview-core.mjs` for exactly this reason; a widening PR
+  must re-run it and rewrite whatever it reds on.
+- **A new path pin.** The canary hardcodes the four suite paths and the manifest
+  path. A renamed or moved suite must be updated there in the same PR, and
+  `scripts/AGENTS.md` records the pin.
+- **One-time bootstrap cost.** The PR performing the rewrite cannot pass local
+  autoreview: its own `-` lines carry the old fixture values. That refusal was
+  waived once, pinned to a single head SHA, with cloud review (Codex,
+  CodeRabbit), trunk trufflehog, and GitHub secret scanning still covering the
+  push. The waiver is not reusable.
+- **Residual.** Roughly 60 tracked files outside the Sentry suites still trip the
+  scanner as whole text. This ADR does not clear them; it removes the four the
+  Sentry pipeline owns and records the policy that stops new ones appearing.
+
+## Deferred design of record — provenance oracle v2
+
+Build only if the re-measurement justifies it. Trigger: re-run the 60-day trap
+measurement about **2026-10-20** with `repowide-yield.mjs`, and build only if the
+residual trap rate stays above ~3% of commits **and** the residual is dominated
+by the steady-state class the oracle actually clears. `repowide-yield.mjs` is a
+proxy, not an oracle replay — it matches identical lines instead of mapping
+positions — so the denominator, the immutable tip, the unreadable-file behavior,
+and the numeric meaning of "dominated" must be fixed in writing before that
+measurement can authorize implementation.
+
+Corrected invariants, merged from both review rounds (the v1 span rule was
+broken; "span = the regex match" is narrower than the evidence the rule read for
+at least 8 of 22 return sites):
+
+- **Findings API.** `secretLikeFindings(text, oracle?)` returning
+  `{reason, span, exemptible}`; `secretLikeReason` stays as a first-result
+  wrapper. Every existing assertion runs on the legacy path, the oracle-threaded
+  path with a null oracle, and with a nothing-published oracle — byte-identical.
+- **Support envelope.** A conservative half-open enclosing interval covering
+  every byte between the first evidence byte and the furthest byte consumed, not
+  a union — a discontiguous union recreates the composition bypass through an
+  unpublished gap. The whole interval must map to one contiguous old-side
+  pre-image range in one file. Rules with no derivable span are never exemptible.
+- **Eligibility.** git-generated context and `-` lines only, mapped positionally
+  against the pre-image blob; `+` lines never exempt; unstaged-vs-index sections
+  never exempt; merges and grafts fail closed.
+- **Hunk headers.** Funcname bytes are exempt only when the entire finding sits
+  inside the funcname payload; a published funcname fragment may never be
+  combined with context from another collector part.
+- **Boundaries.** Separators and collector boundaries are unpublished; any
+  finding crossing a part or diff section refuses. Provenance is attached by the
+  emitter per part, never by re-parsing the joined bundle.
+- **Arming.** Canonical slug check, same-run fetch, public-visibility check, and
+  `merge-base --is-ancestor` against the freshly fetched immutable OID. Snapshot
+  worktree, index, and OIDs and recheck immediately before egress; the
+  fetch-to-egress remote race is stated, not hidden. Any failure means today's
+  behaviour exactly.
+- **Diff grammar.** `--no-ext-diff`, `--no-textconv`, pinned prefixes and output
+  indicators, bytes-only comparison, rename a-side attribution. Binary,
+  submodule, malformed, and combined diffs fail closed.
+- **Honest residual.** The gate would guarantee that no recognized finding
+  supported by unpublished lines clears. It would not guarantee a secret-free
+  bundle: a published fixture would no longer accidentally block an unrecognized
+  secret sharing the bundle.
+- **Mutation coverage.** Removing or inverting any exempt guard must fail at
+  least one test, at all 22 return sites.
+
+## Evidence
+
+- Issues #1943 (fixtures trip the scanner) and #1970 (hunk-header funcname
+  reaches the bundle), both closed by the rewrite PR.
+- PR #1974 — the closed attempt whose misdiagnosis is decision 2's evidence.
+- `scripts/sentry/fixture-scan-canary.test.mjs` — the canary that enforces
+  decision 4, with its negative control and existence checks.
+- `scripts/agent-quality-gate.sh` and `.github/workflows/ci.yml` — the two
+  routes that run it.
+- `scripts/agent-autoreview-core.mjs` — `secretLikeReason`,
+  `credentialAssignmentKey`, and `staticConcatenation`, the functions the policy
+  is written against.
+- [ADR 0062](0062-sentry-suites-self-run-gate.md) — the manifest and
+  `findSentrySuites()` set-equality rule the canary's name is chosen around.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,6 +78,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0064](0064-scripts-module-directories.md)                  | `scripts/` may use module subdirectories; basenames and pinned paths constrain moves |
 | [0065](0065-scripts-file-size-watchlist-scope.md)           | `scripts/` sits inside the file-size watchlist, with named-mechanism exemptions      |
 | [0066](0066-coderabbit-replaces-bugbot-third-reviewer.md)   | CodeRabbit replaces Cursor BugBot as the third advisory PR reviewer                  |
+| [0068](0068-sentry-fixture-authoring-policy.md)             | Adversarial fixtures are authored to scan clean; no value or line registry           |
 
 ### shared-config
 

--- a/docs/notes/autoreview-runtime-trust.md
+++ b/docs/notes/autoreview-runtime-trust.md
@@ -3,7 +3,7 @@ title: Autoreview Runtime Trust Model
 status: active
 owner: eng
 canonical: false
-last_verified: 2026-07-29
+last_verified: 2026-08-21
 doc_type: reference
 scope: repo-wide
 review_interval_days: 180
@@ -343,9 +343,19 @@ call expression rather than a substitution, and an argument over that length,
 such as a deep path. Both refuse today too, so nothing regresses; they are the
 price of a rule that proves inertness from syntax alone.
 A literal in value position stays refused whatever names it: a fixture
-string is a quoted literal, and no syntax separates one from a weak credential,
-so fixtures compose the value from parts or use a documented placeholder marker
-(`fixture-token`, `example-secret`).
+string is a quoted literal, and no syntax separates one from a weak credential.
+Composing the value from parts is not a general escape. `staticConcatenation`
+folds adjacent literals back together before the credential-key rules run, so a
+credential-named key holding two concatenated halves refuses exactly as the
+fused literal does (measured — an example written out here re-trapped this very
+file). Composition clears only provider-prefix patterns — `ghs_…`,
+`sk-ant-…` — bound to an identifier the scanner does not read as a credential
+name; the same prefix written whole still refuses. Author fixtures with a
+documented placeholder marker (`fixture-token`, `example-secret`,
+`example-secret-value`), or with a non-credential-named identifier, and reach
+for composition only for a provider prefix that has to stay recognizable.
+`docs/adr/0068-sentry-fixture-authoring-policy.md` is the policy and the
+`scripts/sentry/fixture-scan-canary.test.mjs` canary that enforces it.
 Evidence reads reject symlinks and verify that the opened descriptor still
 identifies the file that was inspected, closing path-swap races.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -22,7 +22,7 @@ repo maintenance utilities.
 ## Layout
 
 [ADR 0064](../docs/adr/0064-scripts-module-directories.md) governs these
-subdirectories; reorganization phases P1–P15 are complete.
+subdirectories.
 
 | Directory       | Holds                                  |
 | --------------- | -------------------------------------- |
@@ -40,8 +40,7 @@ subdirectories; reorganization phases P1–P15 are complete.
 | `gate/`         | quality-gate satellites                |
 | `sentry/`       | triage/autofix/gate/broker/ci-wiring   |
 
-`lib/` (the shared tier) and
-`production-infra-identity-contract/` predate the reorganization. `setup.sh`
+`lib/` and `production-infra-identity-contract/` predate the reorganization. `setup.sh`
 stays flat: `.config/wt.toml` runs that exact path as the Worktrunk pre-start
 hook, and eight docs name it. `redrive-onchain-deadletter.{mjs,test.mjs}` stays
 flat although `alerts/infra/` owns it; ADR 0064 has the lint reason.
@@ -80,6 +79,8 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
 - **Sentry suite manifest.** `scripts/sentry/gate/sentry-suite-manifest.json`
   keys are exact repo-relative paths, reconciled against `findSentrySuites()`
   by set equality both ways. A moved or renamed suite fails the gate closed.
+  `sentry/fixture-scan-canary.test.mjs` re-pins four of them; ADR 0068 is the
+  fixture-authoring policy.
 - **Enumerated workflow paths-filters.** 22 of 32 files in
   `.github/workflows/` pin a `scripts/` path. `ci.yml` (`autoreviewSuite`,
   `autoreviewRootRuntime`, `versionSkew`; `rootScripts` is the recursive

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -81,8 +81,7 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
 - **Sentry suite manifest.** `scripts/sentry/gate/sentry-suite-manifest.json`
   keys are exact repo-relative paths, reconciled against `findSentrySuites()`
   by set equality both ways. A moved or renamed suite fails the gate closed.
-  `sentry/fixture-scan-canary.test.mjs` re-pins four of them; ADR 0068 is the
-  fixture-authoring policy.
+  `sentry/fixture-scan-canary.test.mjs` re-pins four; ADR 0068 has the policy.
 - **Enumerated workflow paths-filters.** 22 of 32 files in
   `.github/workflows/` pin a `scripts/` path. `ci.yml` (`autoreviewSuite`,
   `autoreviewRootRuntime`, `versionSkew`; `rootScripts` is the recursive

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3907,6 +3907,11 @@ while IFS= read -r path; do
           ;;
         scripts/agent-autoreview.mjs|scripts/agent-autoreview-core.mjs|scripts/agent-autoreview-core.test.mjs|scripts/agent-autoreview-target-guard.test.mjs)
           add_command "pnpm agent:autoreview:test" "agent autoreview helper changed"
+          # The scanner half of the #1943/#1970 canary (ADR 0068). Widening
+          # `credentialAssignmentKey`'s vocabulary re-traps the renamed Sentry
+          # fixtures, and nothing else would say so until the next autoreview
+          # run refused.
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "autoreview secret scanner changed"
           ;;
         scripts/context/check-agent-context.mjs|scripts/context/check-agent-context-helpers.mjs|scripts/context/check-agent-context.test.mjs)
           add_command "pnpm agent:context-check" "agent context checker changed"
@@ -3986,6 +3991,14 @@ while IFS= read -r path; do
           # routes to it.
           add_command "pnpm issue:board:test" "agent issue board helper changed"
           ;;
+        scripts/sentry/fixture-scan-canary.test.mjs)
+          # The #1943/#1970 drift canary (ADR 0068). Its own arm, ABOVE the
+          # per-suite arms below, because those arms name exact paths and a
+          # combined pattern here would shadow them — the routing bug #1974
+          # shipped. The canary's watch list is a path pin: a renamed suite has
+          # to move here too, and this route is what makes that loud.
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry fixture drift canary changed"
+          ;;
         scripts/sentry/triage/sentry-triage-ingest.mjs|scripts/sentry/triage/sentry-triage-ingest.test.mjs)
           add_command "pnpm sentry:ingest:test" "Sentry triage ingest helper changed"
           ;;
@@ -4036,6 +4049,7 @@ while IFS= read -r path; do
           ;;
         scripts/sentry/triage/sentry-triage-agent-comment.mjs|scripts/sentry/triage/sentry-triage-agent-comment.test.mjs)
           add_command "node scripts/sentry/triage/sentry-triage-agent-comment.test.mjs" "Sentry triage agent comment wrapper changed"
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry suite carrying scanned fixtures changed"
           ;;
         scripts/sentry/autofix/sentry-autofix-select.mjs|scripts/sentry/autofix/sentry-autofix-select.test.mjs)
           add_command "pnpm sentry:autofix:select:test" "Sentry autofix select helper changed"
@@ -4087,6 +4101,7 @@ while IFS= read -r path; do
           ;;
         scripts/sentry/autofix/sentry-autofix-finalize.mjs|scripts/sentry/autofix/sentry-autofix-finalize.test.mjs)
           add_command "pnpm sentry:autofix:finalize:test" "Sentry autofix finalize helper changed"
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry suite carrying scanned fixtures changed"
           ;;
         scripts/sentry/autofix/sentry-autofix-run-record.mjs|scripts/sentry/autofix/sentry-autofix-run-record.test.mjs)
           # The tracker run-record body builder, extracted from finalize.mjs.
@@ -4105,12 +4120,14 @@ while IFS= read -r path; do
           ;;
         scripts/sentry/triage/sentry-triage-archive.mjs|scripts/sentry/triage/sentry-triage-archive.test.mjs)
           add_command "pnpm sentry:archive:test" "Sentry triage archive helper changed"
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry suite carrying scanned fixtures changed"
           ;;
         scripts/sentry/broker/sentry-mcp-broker.mjs|scripts/sentry/broker/sentry-mcp-broker.test.mjs|scripts/sentry/broker/sentry-mcp-probe.mjs)
           # The broker and the MCP pre-flight probe (#1938) share one suite:
           # sentry-mcp-broker.test.mjs holds both, so the probe must route here
           # too or a change touching only the probe runs none of its own tests.
           add_command "pnpm sentry:broker:test" "Sentry MCP broker or pre-flight probe changed"
+          add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry suite carrying scanned fixtures changed"
           ;;
         scripts/sentry/triage/sentry-triage-requeue.mjs|scripts/sentry/triage/sentry-triage-requeue.test.mjs|scripts/sentry/triage/sentry-triage-queue-contract.mjs|scripts/sentry/triage/sentry-triage-workflow-requeue.mjs)
           # The single re-queue chokepoint, the queue contract it reads, and the

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4402,6 +4402,39 @@ assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper change
 run_gate "scripts/sentry/triage/sentry-triage-archive.test.mjs"
 assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper changed)"
 
+# The #1943/#1970 fixture drift canary (ADR 0068). Three routes, all pinned:
+# its own file, the scanner whose credential-key vocabulary decides whether the
+# renamed fixtures still scan clean, and each of the four suites that carry
+# those fixtures. The canary's own arm sits ABOVE the per-suite arms in the
+# gate: a single combined pattern there would match those four paths first and
+# silently drop each suite's focused test, which is the routing bug #1974
+# shipped. The per-suite assertions below are what would red if someone
+# collapsed these arms that way.
+fixture_canary="- node scripts/sentry/fixture-scan-canary.test.mjs"
+
+run_gate "scripts/sentry/fixture-scan-canary.test.mjs"
+assert_contains "$fixture_canary (Sentry fixture drift canary changed)"
+
+run_gate "scripts/agent-autoreview-core.mjs"
+assert_contains "- pnpm agent:autoreview:test (agent autoreview helper changed)"
+assert_contains "$fixture_canary (autoreview secret scanner changed)"
+
+run_gate "scripts/sentry/autofix/sentry-autofix-finalize.test.mjs"
+assert_contains "- pnpm sentry:autofix:finalize:test (Sentry autofix finalize helper changed)"
+assert_contains "$fixture_canary (Sentry suite carrying scanned fixtures changed)"
+
+run_gate "scripts/sentry/broker/sentry-mcp-broker.test.mjs"
+assert_contains "- pnpm sentry:broker:test (Sentry MCP broker or pre-flight probe changed)"
+assert_contains "$fixture_canary (Sentry suite carrying scanned fixtures changed)"
+
+run_gate "scripts/sentry/triage/sentry-triage-agent-comment.test.mjs"
+assert_contains "- node scripts/sentry/triage/sentry-triage-agent-comment.test.mjs (Sentry triage agent comment wrapper changed)"
+assert_contains "$fixture_canary (Sentry suite carrying scanned fixtures changed)"
+
+run_gate "scripts/sentry/triage/sentry-triage-archive.test.mjs"
+assert_contains "- pnpm sentry:archive:test (Sentry triage archive helper changed)"
+assert_contains "$fixture_canary (Sentry suite carrying scanned fixtures changed)"
+
 # The handled-family lookup, split out of sentry-autofix-queue-io.mjs for the
 # 600-line soft cap. Pinned ALONE — a module added to this leg without a routing
 # case matches nothing and its edits run zero tests, and a pin that lists several

--- a/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
+++ b/scripts/sentry/autofix/sentry-autofix-finalize.test.mjs
@@ -68,6 +68,8 @@ import {
   skipReportFromIssueList,
 } from "./sentry-autofix-record-labels.mjs";
 
+const GHS_LEAK = "ghs" + "_AbCdEfGhIjKlMnOpQrStUvWxYz012345";
+
 let passed = 0;
 let failed = 0;
 
@@ -203,7 +205,7 @@ await test("guard refuses a diff whose file content is credential-shaped", () =>
   mkdirSync(join(dir, "ui-dashboard"), { recursive: true });
   writeFileSync(
     join(dir, "ui-dashboard", "leak.ts"),
-    'const t = "ghs_AbCdEfGhIjKlMnOpQrStUvWxYz012345";\n',
+    `const t = "${GHS_LEAK}";\n`,
   );
   writeFileSync(
     join(dir, "ui-dashboard", "clean.ts"),
@@ -259,7 +261,7 @@ await test("guard refuses a credential file whose path has a trailing space (#15
   mkdirSync(join(dir, "ui-dashboard"), { recursive: true });
   writeFileSync(
     join(dir, "ui-dashboard", "leak.ts "),
-    'const t = "ghs_AbCdEfGhIjKlMnOpQrStUvWxYz012345";\n',
+    `const t = "${GHS_LEAK}";\n`,
   );
   const r = evaluateDiffGuard(["ui-dashboard/leak.ts "], { workRoot: dir });
   assert(
@@ -431,10 +433,7 @@ await test("analysis comment is deterministic — no summary channel to smuggle 
   // buildAnalysisComment takes ONLY the machine-generated guard reason. Even if
   // a caller tried to pass extra args, the signature ignores them.
   const reason = "The autofix diff touches 25 files (limit 20).";
-  const c = buildAnalysisComment(
-    reason,
-    "ghs_AbCdEfGhIjKlMnOpQrStUvWxYz012345 leak attempt",
-  );
+  const c = buildAnalysisComment(reason, `${GHS_LEAK} leak attempt`);
   assert(c.includes(reason), "deterministic reason rendered");
   assert(
     !c.includes("ghs_AbCd"),
@@ -850,14 +849,14 @@ await test("guard resists filename-credential obfuscation and avoids false posit
   // Filenames are agent-controlled: padding before the prefix, or splitting the
   // body/prefix with a separator, must not hide a recoverable token. Fixtures are
   // concatenated so no contiguous credential literal sits in this source.
-  const TOKEN = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"; // 36 alnum
+  const T36 = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8"; // 36 alnum
   const G = "ghs" + "_";
   const attacks = [
-    `ui-dashboard/lib/x${G}${TOKEN}.ts`, // padded before the prefix (kills \b)
+    `ui-dashboard/lib/x${G}${T36}.ts`, // padded before the prefix (kills \b)
     `${G}a1b2/c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8.ts`, // body split by /
     `${G}a1b2-c3d4-e5f6-g7h8-i9j0-k1l2-m3n4-o5p6.ts`, // body split by -
-    `g/hs_${TOKEN}.ts`, // prefix split by /
-    `x${"github" + "_pat_"}${TOKEN}.ts`, // padded github_pat
+    `g/hs_${T36}.ts`, // prefix split by /
+    `x${"github" + "_pat_"}${T36}.ts`, // padded github_pat
   ];
   for (const p of attacks) {
     assert(
@@ -879,7 +878,7 @@ await test("guard resists filename-credential obfuscation and avoids false posit
     );
   }
   // A padded token that reaches a path-echoing reason is masked by redaction.
-  const red = redactCredentialShaped(`forbidden: scripts/x${G}${TOKEN}.ts`);
+  const red = redactCredentialShaped(`forbidden: scripts/x${G}${T36}.ts`);
   assert(!red.includes(`${G}a1b2`), "padded token masked in a redacted reason");
 });
 
@@ -1694,10 +1693,10 @@ function workflowCode() {
 // The org owner is spliced into the fence jq via a shell breakout
 // (`("` + `'"${REPO%%/*}"'` + `"` -> `("mento-protocol"`), so a real jq receives
 // it as a string literal. Reconstruct that EFFECTIVE program for the test.
-const SHELL_OWNER_TOKEN = `'"\${REPO%%/*}"'`;
+const SHELL_OWNER_SPLICE = `'"\${REPO%%/*}"'`;
 
 function effectiveProgram(raw, owner = "mento-protocol") {
-  return raw.split(SHELL_OWNER_TOKEN).join(owner);
+  return raw.split(SHELL_OWNER_SPLICE).join(owner);
 }
 
 /** Every jq ownership-fence program the workflow feeds an owner-qualified

--- a/scripts/sentry/broker/sentry-mcp-broker.test.mjs
+++ b/scripts/sentry/broker/sentry-mcp-broker.test.mjs
@@ -55,7 +55,7 @@ import {
 } from "./sentry-mcp-probe.mjs";
 
 const HANDLE = "h".repeat(64);
-const REAL_TOKEN = "sntrys_the_real_read_only_token_value";
+const REAL_CRED = "sntrys_the_real_read_only_token_value";
 
 /** A stub Sentry that records what it was asked and with which credential. */
 async function startUpstream(respond) {
@@ -90,7 +90,7 @@ async function withBroker(respond, run, overrides = {}) {
   const upstream = await startUpstream(respond);
   const logs = [];
   const broker = await startBroker({
-    token: REAL_TOKEN,
+    token: REAL_CRED,
     handle: HANDLE,
     upstream: upstream.origin,
     port: 0,
@@ -158,7 +158,7 @@ test("an allowed GET reaches Sentry with the REAL token, never the handle", asyn
         upstream.seen[0].pathname,
         "/api/0/organizations/mento-org/issues/MONITORING-1/",
       );
-      assert.equal(upstream.seen[0].authorization, `Bearer ${REAL_TOKEN}`);
+      assert.equal(upstream.seen[0].authorization, `Bearer ${REAL_CRED}`);
       assert.ok(
         !upstream.seen[0].authorization.includes(HANDLE),
         "the run handle must never reach Sentry",
@@ -573,7 +573,7 @@ test("both broker diagnostics survive a caller that supplies no log sink", async
   const upstream = await startUpstream(jsonUpstream([]));
   const exits = [];
   const broker = await startBroker({
-    token: REAL_TOKEN,
+    token: REAL_CRED,
     handle: HANDLE,
     upstream: upstream.origin,
     port: 0,
@@ -582,7 +582,7 @@ test("both broker diagnostics survive a caller that supplies no log sink", async
   // An unparsable upstream makes the handler throw INSIDE the request path,
   // which is the only way to reach HANDLER-ERROR.
   const broken = await startBroker({
-    token: REAL_TOKEN,
+    token: REAL_CRED,
     handle: HANDLE,
     upstream: "not-a-url",
     port: 0,
@@ -718,7 +718,7 @@ test("an unreachable upstream fails closed with 502", async () => {
   const dead = upstream.origin;
   await new Promise((resolve) => upstream.server.close(resolve));
   const broker = await startBroker({
-    token: REAL_TOKEN,
+    token: REAL_CRED,
     handle: HANDLE,
     upstream: dead,
     port: 0,
@@ -806,14 +806,14 @@ test("resolveConfig fails loudly on a weak wiring, and takes NO token", () => {
 test("readTokenFromStdin reassembles a chunked pipe and trims the writer's newline", async () => {
   const { Readable } = await import("node:stream");
   assert.equal(
-    await readTokenFromStdin(Readable.from([`${REAL_TOKEN}\n`])),
-    REAL_TOKEN,
+    await readTokenFromStdin(Readable.from([`${REAL_CRED}\n`])),
+    REAL_CRED,
   );
   assert.equal(
     await readTokenFromStdin(
-      Readable.from([REAL_TOKEN.slice(0, 5), REAL_TOKEN.slice(5)]),
+      Readable.from([REAL_CRED.slice(0, 5), REAL_CRED.slice(5)]),
     ),
-    REAL_TOKEN,
+    REAL_CRED,
   );
 });
 
@@ -832,23 +832,23 @@ test("readTokenFromStdin fails closed on a TTY and on silence", async () => {
 
 test("assertTokenAbsentFromExecEnv names the leaking variable, never the value", () => {
   assert.equal(
-    assertTokenAbsentFromExecEnv(REAL_TOKEN, { PATH: "/usr/bin", CI: "true" }),
+    assertTokenAbsentFromExecEnv(REAL_CRED, { PATH: "/usr/bin", CI: "true" }),
     undefined,
   );
   for (const leaking of [
-    { SENTRY_TRIAGE_TOKEN: REAL_TOKEN },
-    { SENTRY_MCP_BROKER_TOKEN: REAL_TOKEN },
-    { SOME_URL: `https://x/?t=${REAL_TOKEN}&y=1` }, // embedded counts too
+    { SENTRY_TRIAGE_TOKEN: REAL_CRED },
+    { SENTRY_MCP_BROKER_TOKEN: REAL_CRED },
+    { SOME_URL: `https://x/?t=${REAL_CRED}&y=1` }, // embedded counts too
   ]) {
     const name = Object.keys(leaking)[0];
     assert.throws(
-      () => assertTokenAbsentFromExecEnv(REAL_TOKEN, leaking),
+      () => assertTokenAbsentFromExecEnv(REAL_CRED, leaking),
       (error) => {
         assert.match(error.message, new RegExp(`as ${name};`));
         assert.match(error.message, /\/proc\/<pid>\/environ/);
         assert.match(error.message, /Do not scrub it at runtime/);
         assert.ok(
-          !error.message.includes(REAL_TOKEN),
+          !error.message.includes(REAL_CRED),
           "the refusal must name the variable, never the value",
         );
         return true;
@@ -959,14 +959,14 @@ test("a RUNTIME scrub does not satisfy the guard — only an exec-time absence d
   // The tempting wrong fix: the variable is gone from live process.env, but the
   // exec-time block — what /proc/<pid>/environ serves — still has it.
   const liveEnvHadItDeleted = { ...base };
-  const execTimeEnv = { ...base, SENTRY_TRIAGE_TOKEN: REAL_TOKEN };
+  const execTimeEnv = { ...base, SENTRY_TRIAGE_TOKEN: REAL_CRED };
   assert.ok(!("SENTRY_TRIAGE_TOKEN" in liveEnvHadItDeleted));
 
   await assert.rejects(
     () =>
       resolveRuntime({
         envAtExec: execTimeEnv,
-        stdin: Readable.from([REAL_TOKEN]),
+        stdin: Readable.from([REAL_CRED]),
       }),
     /exec-time environment as SENTRY_TRIAGE_TOKEN/,
     "scrubbing at runtime must not make the guard pass — /proc keeps the exec-time block",
@@ -975,9 +975,9 @@ test("a RUNTIME scrub does not satisfy the guard — only an exec-time absence d
   // And the clean wiring resolves.
   const config = await resolveRuntime({
     envAtExec: base,
-    stdin: Readable.from([`${REAL_TOKEN}\n`]),
+    stdin: Readable.from([`${REAL_CRED}\n`]),
   });
-  assert.equal(config.token, REAL_TOKEN);
+  assert.equal(config.token, REAL_CRED);
   assert.equal(config.port, 9401);
 });
 
@@ -985,11 +985,11 @@ test("the Linux reader decodes a real /proc/<pid>/environ block", () => {
   // Runs on every platform: the decoding half of the Linux branch, which the
   // macOS host cannot exercise through an actual file read.
   const block = Buffer.from(
-    `PATH=/usr/bin\0SENTRY_MCP_BROKER_HANDLE=${HANDLE}\0SENTRY_TRIAGE_TOKEN=${REAL_TOKEN}\0`,
+    `PATH=/usr/bin\0SENTRY_MCP_BROKER_HANDLE=${HANDLE}\0SENTRY_TRIAGE_TOKEN=${REAL_CRED}\0`,
     "utf8",
   );
   const decoded = decodeProcBlock(block);
-  assert.ok(decoded.includes(`SENTRY_TRIAGE_TOKEN=${REAL_TOKEN}`));
+  assert.ok(decoded.includes(`SENTRY_TRIAGE_TOKEN=${REAL_CRED}`));
   assert.ok(decoded.includes("SENTRY_MCP_BROKER_HANDLE"));
   // Entries must not run together, or a leak could hide across a boundary.
   assert.deepEqual(decoded.split("\n").slice(0, 2), [
@@ -1005,7 +1005,7 @@ test("POSITIVE CONTROL: an outsider reads a child's exec-time env, and a runtime
   const child = spawn(
     process.execPath,
     ["-e", "delete process.env.PROBE_TOKEN; setTimeout(() => {}, 4000);"],
-    { env: { ...process.env, PROBE_TOKEN: REAL_TOKEN }, stdio: "ignore" },
+    { env: { ...process.env, PROBE_TOKEN: REAL_CRED }, stdio: "ignore" },
   );
   try {
     await settle(500);
@@ -1013,7 +1013,7 @@ test("POSITIVE CONTROL: an outsider reads a child's exec-time env, and a runtime
     // negative result below is only worth what this positive result is worth.
     const seen = execEnvironOf(child.pid);
     assert.ok(
-      seen.includes(REAL_TOKEN),
+      seen.includes(REAL_CRED),
       `${READER} did not detect a token in a child's exec-time env; every assertion below is vacuous until it does`,
     );
     // Belt: prove the reader returns a populated block, not a lucky substring.
@@ -1033,9 +1033,9 @@ test("the broker, spawned the way the workflow spawns it, has NO token in its ex
   const port = await freePort();
   const script = `
     set -euo pipefail
-    token="\${SENTRY_TRIAGE_TOKEN:-}"
+    tok="\${SENTRY_TRIAGE_TOKEN:-}"
     unset SENTRY_TRIAGE_TOKEN
-    printf '%s' "\${token}" | \
+    printf '%s' "\${tok}" | \
       SENTRY_MCP_BROKER_HANDLE="${HANDLE}" \
       SENTRY_MCP_BROKER_PORT=${port} \
       SENTRY_MCP_BROKER_TTL_SECONDS=30 \
@@ -1044,14 +1044,14 @@ test("the broker, spawned the way the workflow spawns it, has NO token in its ex
   `;
   const pid = execFileSync("bash", ["-c", script], {
     encoding: "utf8",
-    env: { ...process.env, SENTRY_TRIAGE_TOKEN: REAL_TOKEN },
+    env: { ...process.env, SENTRY_TRIAGE_TOKEN: REAL_CRED },
   }).trim();
   try {
     await settle(700);
     // Throws if the broker died or the read failed — never a soft null.
     const environ = execEnvironOf(pid);
     assert.ok(
-      !environ.includes(REAL_TOKEN),
+      !environ.includes(REAL_CRED),
       `the token is in the broker's exec-time environment (read via ${READER}) — the agent could take it straight out of /proc`,
     );
     // The load-bearing sanity check on BOTH reader paths: without it, a reader
@@ -1062,7 +1062,7 @@ test("the broker, spawned the way the workflow spawns it, has NO token in its ex
     );
     // /proc/<pid>/cmdline is readable the same way; the token is never an argv.
     assert.ok(
-      !commandLineOf(pid).includes(REAL_TOKEN),
+      !commandLineOf(pid).includes(REAL_CRED),
       "the token must never appear on the broker's command line",
     );
   } finally {
@@ -1080,14 +1080,14 @@ test("the broker REFUSES to start when the token is in its exec-time env", async
   const child = spawn(process.execPath, [BROKER_PATH], {
     env: {
       ...process.env,
-      SENTRY_TRIAGE_TOKEN: REAL_TOKEN, // the leak
+      SENTRY_TRIAGE_TOKEN: REAL_CRED, // the leak
       SENTRY_MCP_BROKER_HANDLE: HANDLE,
       SENTRY_MCP_BROKER_PORT: String(await freePort()),
       SENTRY_MCP_BROKER_TTL_SECONDS: "30",
     },
     stdio: ["pipe", "pipe", "pipe"],
   });
-  child.stdin.end(REAL_TOKEN);
+  child.stdin.end(REAL_CRED);
   let stderr = "";
   child.stderr.on("data", (chunk) => (stderr += chunk));
   const code = await new Promise((resolve) => child.on("exit", resolve));
@@ -1096,7 +1096,7 @@ test("the broker REFUSES to start when the token is in its exec-time env", async
   assert.match(stderr, /exec-time environment as SENTRY_TRIAGE_TOKEN/);
   assert.match(stderr, /Do not scrub it at runtime/);
   assert.ok(
-    !stderr.includes(REAL_TOKEN),
+    !stderr.includes(REAL_CRED),
     "the refusal must not print the credential it is complaining about",
   );
 });

--- a/scripts/sentry/fixture-scan-canary.test.mjs
+++ b/scripts/sentry/fixture-scan-canary.test.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Drift canary for the credential-shaped fixtures in the Sentry suites
+ * (issues #1943 and #1970, ADR 0068).
+ *
+ * The four suites below carry adversarial fixtures — credential-shaped values
+ * that prove the pipeline refuses to leak them. Written the wrong way, those
+ * fixtures make the suite file itself trip `secretLikeReason`, and every
+ * `pnpm agent:autoreview` run that puts the file in its bundle refuses before
+ * a model ever sees the diff. The fixtures were rewritten to scan clean; this
+ * canary keeps them that way.
+ *
+ * Two failure modes, both covered:
+ *   - a fixture regresses to the trap shape (credential-named key + a
+ *     realistic-shaped literal), so the whole-file scan stops being null;
+ *   - a suite is renamed or deleted and the canary silently watches nothing.
+ *
+ * The name deliberately does NOT start with `sentry-`: `findSentrySuites()` in
+ * scripts/sentry/gate/sentry-suite-gate.mjs keys on that basename prefix and
+ * reconciles what it finds against sentry-suite-manifest.json by exact set
+ * equality, so a `sentry-*.test.mjs` here would have to be a manifest-owned
+ * suite. This file is routed by scripts/agent-quality-gate.sh and by the
+ * `scripts` job in .github/workflows/ci.yml instead.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { secretLikeReason } from "../agent-autoreview-core.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MANIFEST = join(
+  ROOT,
+  "scripts",
+  "sentry",
+  "gate",
+  "sentry-suite-manifest.json",
+);
+
+/**
+ * The four suites the #1943/#1970 rewrite touched. Every one of them holds
+ * credential-shaped fixtures; each must scan clean as whole text.
+ */
+const SCANNED_SUITES = [
+  "scripts/sentry/autofix/sentry-autofix-finalize.test.mjs",
+  "scripts/sentry/broker/sentry-mcp-broker.test.mjs",
+  "scripts/sentry/triage/sentry-triage-agent-comment.test.mjs",
+  "scripts/sentry/triage/sentry-triage-archive.test.mjs",
+];
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`ok ${name}\n`);
+    passed += 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`not ok ${name}\n  ${message}\n`);
+    failed += 1;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// The load-bearing sanity check: every assertion below is a claim that
+// `secretLikeReason` returned null, which a broken import or a gutted scanner
+// satisfies for free. Prove first that this scanner still refuses the exact
+// trap shape the rewrite moved the fixtures off — a credential-named key with a
+// realistic-shaped literal value. Composed from fragments at runtime so this
+// file's own source stays scannable (the convention in
+// scripts/agent-autoreview-core.test.mjs).
+test("negative control: the scanner still refuses a credential-named literal", () => {
+  const trapShape = [
+    ["api", "Key", ": "].join(""),
+    '"',
+    ["prod-", "secret-", "1234567890"].join(""),
+    '"',
+  ].join("");
+  const reason = secretLikeReason(trapShape);
+  assert(
+    reason !== null,
+    "secretLikeReason cleared a credential-named literal — the canary below is vacuous until it refuses again",
+  );
+});
+
+test("the canary watches every suite the rewrite touched", () => {
+  assert(
+    SCANNED_SUITES.length === 4,
+    `expected the four rewritten suites, got ${SCANNED_SUITES.length}`,
+  );
+  const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+  for (const suite of SCANNED_SUITES) {
+    assert(
+      Object.prototype.hasOwnProperty.call(manifest.suites, suite),
+      `${suite} is not in sentry-suite-manifest.json — one of the two lists moved without the other`,
+    );
+  }
+});
+
+for (const suite of SCANNED_SUITES) {
+  test(`${suite} exists`, () => {
+    assert(
+      existsSync(join(ROOT, suite)),
+      `${suite} is gone — a rename or deletion must update SCANNED_SUITES here, or this canary watches nothing`,
+    );
+  });
+
+  test(`${suite} scans clean as whole text`, () => {
+    const reason = secretLikeReason(readFileSync(join(ROOT, suite), "utf8"));
+    assert(
+      reason === null,
+      `${suite} trips the autoreview scanner (${reason}). A fixture regressed to the trap shape: a credential-named identifier or key holding a realistic-shaped literal. Use placeholder vocabulary, or a non-credential-named identifier — see docs/adr/0068-sentry-fixture-authoring-policy.md.`,
+    );
+  });
+}
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exitCode = 1;

--- a/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
@@ -23,9 +23,9 @@ import {
 } from "./sentry-triage-agent-comment.mjs";
 
 const RUNNER_TEMP_FOR_TESTS = "/runner/_temp";
-const SENTRY_TOKEN = "sntrys_deadbeefdeadbeefdeadbeef";
-const GH_TOKEN = "ghs_0123456789abcdefghijklmnopqrstuvwxyz";
-const OAUTH_TOKEN = "sk-ant-oat01-abcdefghijklmnopqrstuvwxyz";
+const SENTRY_CRED = "sntrys_deadbeefdeadbeefdeadbeef";
+const GH_CRED = "ghs" + "_0123456789abcdefghijklmnopqrstuvwxyz";
+const OAUTH_CRED = "sk" + "-ant-oat01-abcdefghijklmnopqrstuvwxyz";
 
 const VERDICT_BODY = [
   VERDICT_MARKER,
@@ -45,9 +45,9 @@ function baseEnv(overrides = {}) {
     RUNNER_TEMP: RUNNER_TEMP_FOR_TESTS,
     GITHUB_REPOSITORY: "mento-protocol/monitoring-monorepo",
     [ISSUE_ENV_VAR]: "123",
-    GH_TOKEN,
-    SENTRY_TRIAGE_TOKEN: SENTRY_TOKEN,
-    CLAUDE_CODE_OAUTH_TOKEN: OAUTH_TOKEN,
+    GH_TOKEN: GH_CRED,
+    SENTRY_TRIAGE_TOKEN: SENTRY_CRED,
+    CLAUDE_CODE_OAUTH_TOKEN: OAUTH_CRED,
     ...overrides,
   };
 }
@@ -269,26 +269,26 @@ test("--body is required, non-empty, and single", () => {
 
 test("a body that accidentally reproduces the Sentry token is refused", async () => {
   const err = await refusal({
-    argv: ["--body", `${VERDICT_BODY}\n\nnote: ${SENTRY_TOKEN}`],
+    argv: ["--body", `${VERDICT_BODY}\n\nnote: ${SENTRY_CRED}`],
   });
   assert.match(err.message, /SENTRY_TRIAGE_TOKEN/);
   assert.ok(
-    !err.message.includes(SENTRY_TOKEN),
+    !err.message.includes(SENTRY_CRED),
     "the refusal must name the variable, never echo the value",
   );
 });
 
 test("a body that accidentally reproduces GH_TOKEN is refused", async () => {
   const err = await refusal({
-    argv: ["--body", `${VERDICT_BODY}\n\n${GH_TOKEN}`],
+    argv: ["--body", `${VERDICT_BODY}\n\n${GH_CRED}`],
   });
   assert.match(err.message, /GH_TOKEN/);
-  assert.ok(!err.message.includes(GH_TOKEN));
+  assert.ok(!err.message.includes(GH_CRED));
 });
 
 test("a body that accidentally reproduces the Claude OAuth token is refused", async () => {
   const err = await refusal({
-    argv: ["--body", `${VERDICT_BODY}\n\n${OAUTH_TOKEN}`],
+    argv: ["--body", `${VERDICT_BODY}\n\n${OAUTH_CRED}`],
   });
   assert.match(err.message, /CLAUDE_CODE_OAUTH_TOKEN/);
 });
@@ -296,7 +296,7 @@ test("a body that accidentally reproduces the Claude OAuth token is refused", as
 test("the verbatim value only has to appear somewhere in the body", () => {
   const secrets = collectSecretValues(baseEnv());
   assert.throws(
-    () => assertBodyPostable(`${VERDICT_MARKER} ${SENTRY_TOKEN} tail`, secrets),
+    () => assertBodyPostable(`${VERDICT_MARKER} ${SENTRY_CRED} tail`, secrets),
     /SENTRY_TRIAGE_TOKEN/,
   );
 });
@@ -308,8 +308,8 @@ test("DOCUMENTED LIMIT: the guard is not containment — a shell-transformed tok
   // did that expansion; argv is all we ever see. Splitting the value across two
   // lines defeats the scan just as easily. Asserted, not fixed — exact-value
   // scanning is the wrong layer when the adversary controls the shell.
-  const spliced = `${SENTRY_TOKEN.slice(0, 4)}x${SENTRY_TOKEN.slice(4)}`;
-  const split = `${SENTRY_TOKEN.slice(0, 10)}\n${SENTRY_TOKEN.slice(10)}`;
+  const spliced = `${SENTRY_CRED.slice(0, 4)}x${SENTRY_CRED.slice(4)}`;
+  const split = `${SENTRY_CRED.slice(0, 10)}\n${SENTRY_CRED.slice(10)}`;
   for (const evaded of [spliced, split]) {
     assert.doesNotThrow(
       () => assertBodyPostable(`${VERDICT_MARKER}\n\n${evaded}`, secrets),
@@ -378,17 +378,17 @@ test("the gh child env drops every secret except gh's own credential", async () 
   const { calls } = await post();
   const childEnv = calls[0].childEnv;
   assert.deepEqual(Object.keys(childEnv).sort(), ["GH_TOKEN", "HOME", "PATH"]);
-  assert.equal(childEnv.GH_TOKEN, GH_TOKEN);
+  assert.equal(childEnv.GH_TOKEN, GH_CRED);
   const values = Object.values(childEnv);
-  assert.ok(!values.includes(SENTRY_TOKEN), "Sentry token must not reach gh");
-  assert.ok(!values.includes(OAUTH_TOKEN), "OAuth token must not reach gh");
+  assert.ok(!values.includes(SENTRY_CRED), "Sentry token must not reach gh");
+  assert.ok(!values.includes(OAUTH_CRED), "OAuth token must not reach gh");
 });
 
 test("nothing outside the allowlist is inherited", () => {
   const childEnv = buildChildEnv(
     baseEnv({
-      AWS_SECRET_ACCESS_KEY: "aws-secret-value",
-      SENTRY_PROJECTION_TOKEN: "projection-secret-value",
+      AWS_SECRET_ACCESS_KEY: "example-secret-value",
+      SENTRY_PROJECTION_TOKEN: "example-token-value",
       GH_HOST: "evil.example.com",
     }),
   );

--- a/scripts/sentry/triage/sentry-triage-archive.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-archive.test.mjs
@@ -116,7 +116,7 @@ async function assertRejects(promise, pattern) {
 // Fixtures + mocks.
 // ---------------------------------------------------------------------------
 
-const TOKEN = "sntrys_archive_token";
+const SENTRY_CRED = "sntrys_archive_token";
 const APPROVER = "octomaintainer";
 const QUEUE_URL =
   "https://github.com/mento-protocol/monitoring-monorepo/issues/42";
@@ -455,7 +455,7 @@ function baseOptions(overrides = {}) {
     sentryBaseUrl: "https://us.sentry.io",
     queueIssue: 42,
     approver: APPROVER,
-    sentryToken: TOKEN,
+    sentryToken: SENTRY_CRED,
     ...overrides,
   };
 }
@@ -647,7 +647,7 @@ await test("resolveIssueIdFromShortId returns the numeric groupId", async () => 
   const id = await resolveIssueIdFromShortId(fetchImpl, {
     baseUrl: "https://us.sentry.io",
     org: "mento-labs",
-    token: TOKEN,
+    token: SENTRY_CRED,
     shortId: "GOVERNANCE-MENTO-ORG-51",
   });
   assertEqual(id, "99");
@@ -665,7 +665,7 @@ await test("resolveIssueIdFromShortId throws on a non-numeric resolution", async
     resolveIssueIdFromShortId(fetchImpl, {
       baseUrl: "https://us.sentry.io",
       org: "mento-labs",
-      token: TOKEN,
+      token: SENTRY_CRED,
       shortId: "GOV-1",
     }),
     /did not resolve to a numeric issue id/,
@@ -677,7 +677,7 @@ await test("archiveIssue PUTs the archive payload with a bearer token", async ()
   await archiveIssue(fetchImpl, {
     baseUrl: "https://us.sentry.io",
     org: "mento-labs",
-    token: TOKEN,
+    token: SENTRY_CRED,
     issueId: "6197137101",
   });
   const put = calls.find((c) => c.method === "PUT");
@@ -687,7 +687,7 @@ await test("archiveIssue PUTs the archive payload with a bearer token", async ()
     "must hit the update-an-issue endpoint",
   );
   assertDeepEqual(put.body, ARCHIVE_PAYLOAD);
-  assertEqual(put.headers.Authorization, `Bearer ${TOKEN}`);
+  assertEqual(put.headers.Authorization, `Bearer ${SENTRY_CRED}`);
 });
 
 await test("archiveIssue throws on a non-ok response", async () => {
@@ -696,7 +696,7 @@ await test("archiveIssue throws on a non-ok response", async () => {
     archiveIssue(fetchImpl, {
       baseUrl: "https://us.sentry.io",
       org: "mento-labs",
-      token: TOKEN,
+      token: SENTRY_CRED,
       issueId: "1",
     }),
     /Sentry archive request failed: 403/,
@@ -723,7 +723,7 @@ await test("restoreArchivedIssue restores only when the issue is still ours", as
   const out = await restoreArchivedIssue(stillOurs.fetchImpl, {
     baseUrl: "https://us.sentry.io",
     org: "mento-labs",
-    token: TOKEN,
+    token: SENTRY_CRED,
     issueId: "9",
     preArchive: { status: "unresolved" },
   });
@@ -737,7 +737,7 @@ await test("restoreArchivedIssue restores only when the issue is still ours", as
   const skip = await restoreArchivedIssue(moved.fetchImpl, {
     baseUrl: "https://us.sentry.io",
     org: "mento-labs",
-    token: TOKEN,
+    token: SENTRY_CRED,
     issueId: "9",
     preArchive: { status: "unresolved" },
   });
@@ -852,7 +852,7 @@ await test("runArchive happy path archives and settles the queue stub", async ()
 
   // The Sentry token must never appear in a gh argument.
   assert(
-    !ghCalls.some((args) => args.some((a) => String(a).includes(TOKEN))),
+    !ghCalls.some((args) => args.some((a) => String(a).includes(SENTRY_CRED))),
     "the Sentry token must never reach a gh call",
   );
 });
@@ -3276,7 +3276,7 @@ await test("reconciliation is idempotent — a second pass changes nothing", asy
       sentry: {
         baseUrl: "https://us.sentry.io",
         org: "mento-labs",
-        token: TOKEN,
+        token: SENTRY_CRED,
       },
       issueId: "6197137101",
       preArchive: { status: "unresolved", lastSeen: BASELINE_LAST_SEEN },


### PR DESCRIPTION
## The Problem

- Four Sentry suites carry adversarial fixtures that make the suite FILE trip
  the autoreview secret scanner, so `pnpm agent:autoreview` refuses any bundle
  containing one before a model ever sees the diff (#1943).
- The same refusal reaches edits nowhere near a fixture: git copies fixture text
  into the `@@` hunk-header funcname, which lands in the bundle (#1970).
- Measured cost: 37 of 497 squash commits over 60 days produced a refusing
  bundle; 5 of those were attributable solely to these four suites.

## The Solution

- Rewrite the fixtures so the four files scan clean. The trigger is the
  credential-named IDENTIFIER, not the value — `SHELL_OWNER_TOKEN` held a shell
  parameter expansion and tripped purely because `credentialAssignmentKey`
  reads `TOKEN` as a credential key. Renaming off that vocabulary, plus two
  placeholder values, clears all four with zero test-expectation changes.
- Add a drift canary that fails if any of the four files disappears or stops
  scanning clean, routed to run when the scanner OR any of the four suites
  change.
- Record the policy as ADR 0068 and correct the one place the repo told authors
  the wrong thing about composing fixture values from parts.

Closes #1943
Closes #1970

## Details

**The rewrite (13 trigger sites; 74 added / 75 deleted, because callers move
with the identifiers).** `REAL_TOKEN` → `REAL_CRED`, `SHELL_OWNER_TOKEN` →
`SHELL_OWNER_SPLICE`, `TOKEN` → `SENTRY_CRED` / `T36`, plus placeholder
vocabulary where the value itself was the trigger. Composition is used only
where a provider prefix has to stay recognizable under a neutral identifier;
it is not a general escape (see below). No test expectation changed.

**The canary — `scripts/sentry/fixture-scan-canary.test.mjs`.** For each of the
four paths it asserts the file EXISTS and that `secretLikeReason` returns null
for its whole text. A negative control runs first and composes the trap shape
from fragments at runtime, so a broken import or a gutted scanner reds the
canary instead of making it vacuously green.

The basename deliberately does not start with `sentry-`: `findSentrySuites()`
keys on that prefix and reconciles what it finds against
`sentry-suite-manifest.json` by exact set equality, so a `sentry-*.test.mjs`
here would have to become a manifest-owned suite. Verified: the suite gate still
enumerates 14 suites, unchanged.

**Routing, both surfaces.**

- `scripts/agent-quality-gate.sh`: the canary gets its own `case` arm placed
  ABOVE the per-suite arms, and the canary command is added to the
  autoreview-core arm and to all four suite arms. A single combined arm would
  have shadowed the per-suite arms — the routing bug #1974 shipped. Probed: with
  the arms collapsed that way, a change to `sentry-mcp-broker.test.mjs` stops
  routing `pnpm sentry:broker:test` entirely. `agent-quality-gate.test.sh` pins
  all six routes, so that collapse now reds.
- `.github/workflows/ci.yml`: one step in the path-gated `scripts` job. Its
  `rootScripts` filter is the recursive `scripts/**`, which already admits the
  scanner, the four suites and the canary itself — so this adds no new
  enumerated filter list to keep in sync and no new 300-file paths-filter cap
  surface. The `sentry-suites` job was deliberately left alone: its step list is
  closed-world and order-load-bearing.

**ADR 0068** records the authoring policy, the rejection of value/line
registries (evidence: closed PR #1974), the provenance oracle as the deferred
design of record with its corrected invariants and a fail-closed re-measurement
trigger, the measured numbers, and the coupling that `cred`/`splice` must stay
outside `credentialAssignmentKey`'s vocabulary — which is why the gate routes
the canary on any `scripts/agent-autoreview-core.mjs` change.

**Corrected guidance.** `docs/notes/autoreview-runtime-trust.md` told authors to
"compose the value from parts". Measured: `staticConcatenation` folds the halves
back together before the credential-key rules run, so composition under a
credential-named key still refuses; it clears only provider-prefix patterns
under an identifier the scanner does not read as a credential name. Writing a
worked example of the wrong advice into that note re-trapped the note itself,
which is why the corrected text describes the shape instead of printing it.

**scripts/AGENTS.md** gains the canary's path pin (the file's own rule: every
`scripts/` path pin is listed there). The file sits within a few bytes of its
9 KiB scoped cap, so the rider is one line and two stale fragments elsewhere in
the file were compressed to pay for it — no cap was raised.

## Validation

- Whole-file `secretLikeReason` (imported from `scripts/agent-autoreview-core.mjs`):
  `null` for all four suites, and for every file this PR adds or changes.
- Suites, after merging `origin/main`: finalize 65/65, broker 68/68,
  agent-comment 40/40, archive 119 asserts. (Before the merge: finalize 64 —
  #1984 added one.)
- Old identifiers repo-wide: zero remaining references to `REAL_TOKEN`,
  `SHELL_OWNER_TOKEN`, `SENTRY_TOKEN`, `OAUTH_TOKEN`, the bare `TOKEN` consts,
  and the two replaced values. Surviving `GH_TOKEN` hits are the real
  environment-variable name and must stay.
- Canary mutation probe, against a staged copy so nothing tracked was touched:
  a fixture regressed to the trap shape, a deleted suite, and a
  `secretLikeReason` stubbed to always return null each red it (exit 1);
  unmutated, 10 passed.
- Routing probe: collapsing the canary arm to also match the four suite paths
  drops `pnpm sentry:broker:test` from the plan for a broker-suite change;
  restored, it comes back.
- `sentry-suite-gate.mjs`: 14 suites ran and were asserted, 1 exempt by route —
  the canary is correctly not enumerated.
- `pnpm agent:context-budget --strict`: passes.
- `pnpm docs:index --check`: clean after regenerating `docs/README.md`.
- `pnpm agent:context-check`: passed (150 managed files).
- Pre-push gate: `scripts/agent-quality-gate.sh --run --parallel 4
  --skip-if-fresh` — **all 43 mapped commands passed**, exit 0. That includes
  `pnpm agent:quality-gate:test` (the routing pins above), the four suites, the
  canary, `sentry-suite-gate.mjs`, `check-sentry-suites-in-ci.test.mjs`,
  `pnpm agent:context-budget --strict`, and `pnpm docs:index --check`. An
  earlier attempt exited 2 without running anything after waiting out the
  machine-wide gate run lock (other worktrees held it); re-run with a longer
  `--lock-wait`.

## Local autoreview waiver

`pnpm agent:autoreview --mode branch --base origin/main` refuses on this PR:

```
autoreview failed: refusing to include secret-like content in review bundle (credential-like token); clean or redact selected change before running autoreview
```

This is expected and is the one-time bootstrap cost the design records: the
rewrite's own `-` lines carry the OLD fixture values, so the diff contains
exactly the credential-shaped text the scanner exists to refuse. Quoting the
decision: "One-time recorded no-local-autoreview for this PR (its own '-' lines
carry the old values — measured; cloud review covers it). This is the bootstrap
cost paid once, in the PR whose whole diff is fixture renames."

The waiver covers ONLY head `cfe19458fa4cc909fcce2945560de976920b040d`. It is
not a reusable bypass:
any later push to this PR must re-run local autoreview, which will refuse again
only if the old values still appear in that push's diff — and if it does, that
push repeats this waiver with its own SHA. Cloud review (Codex, CodeRabbit),
trunk trufflehog, and GitHub secret scanning cover this push unchanged.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Yes — `docs/adr/0068-sentry-fixture-authoring-policy.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential-scanner coupling and CI quality-gate routing, but does not change scanner logic or production secret handling—only test identifiers, placeholders, and enforcement of scan-clean fixtures.
> 
> **Overview**
> Stops four Sentry suites from poisoning `pnpm agent:autoreview` (#1943/#1970). The trap is a **credential-named identifier** holding a realistic literal; identifiers like `REAL_TOKEN` / `SHELL_OWNER_TOKEN` are renamed (`CRED`, `SPLICE`) and a few values become placeholders or split provider prefixes. Test expectations are unchanged.
> 
> Adds `scripts/sentry/fixture-scan-canary.test.mjs`: each of the four files must exist and `secretLikeReason` must return null, behind a negative control that the scanner still refuses the trap shape. Routed from the local quality gate (own arm above per-suite arms, plus scanner and the four suites) and as a `scripts` CI step—not the `sentry-suites` job, because the basename is not `sentry-*`.
> 
> **ADR 0068** records the authoring policy (no value/line registry; provenance oracle deferred). Autoreview docs now say composition is not a general escape because `staticConcatenation` folds literals before credential-key rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe19458fa4cc909fcce2945560de976920b040d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated checks to detect credential-shaped fixtures and verify required Sentry test coverage.
  - CI now runs these checks when related scanner, fixture, or test files change.
  - Updated test fixtures to avoid embedding contiguous credential-like values while preserving security coverage.

- **Documentation**
  - Added and indexed a new policy covering secure Sentry fixture authoring.
  - Clarified guidance for composing placeholder values and maintaining fixture coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->