### PR TITLE
fix(scripts): accept redaction diffs in the autoreview secret scanner

### DIFF
--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -1765,10 +1765,13 @@ function placeholderRedactionOf(removed, spans, added) {
 // line with that token replaced by placeholder vocabulary — a redaction, not an
 // exfiltration. A removal with no replacement, a removal replaced by a different
 // credential-shaped literal, a replacement in another hunk, and every addition
-// or context line stay refused.
+// or context line stay refused. Each added line redacts at most one removal, so
+// a single placeholder cannot cover a second credential-bearing removal that is
+// really an unreplaced deletion.
 function strongCredentialTokenReason(text) {
   const lines = text.split("\n");
   const { hunkOfLine, hunks } = splitDiffHunks(lines);
+  const claimed = hunks.map(() => new Set());
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
     const hunk = hunkOfLine[index];
@@ -1777,10 +1780,17 @@ function strongCredentialTokenReason(text) {
     const spans = strongCredentialSpans(scanned);
     if (spans.length === 0) continue;
     if (!isRemoval) return "credential-like token";
-    const redacted = hunks[hunk].some((added) =>
-      placeholderRedactionOf(scanned, spans, added),
-    );
-    if (!redacted) return "credential-like token";
+    const additions = hunks[hunk];
+    let redaction = -1;
+    for (let candidate = 0; candidate < additions.length; candidate += 1) {
+      if (claimed[hunk].has(candidate)) continue;
+      if (placeholderRedactionOf(scanned, spans, additions[candidate])) {
+        redaction = candidate;
+        break;
+      }
+    }
+    if (redaction === -1) return "credential-like token";
+    claimed[hunk].add(redaction);
   }
   return null;
 }

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -1768,9 +1768,19 @@ function placeholderRedactionOf(removed, spans, added) {
 // or context line stay refused. Each added line redacts at most one removal, so
 // a single placeholder cannot cover a second credential-bearing removal that is
 // really an unreplaced deletion.
-function strongCredentialTokenReason(text) {
+//
+// The exception applies only when `gitDiff` is set, which one call site does for
+// the git-generated review bundle. Supplemental input — `--prompt`, prompt
+// files, datasets, branch names, refs — is arbitrary text that an author can
+// shape at will, so no line there belongs to a hunk and every credential-shaped
+// token is refused exactly as it was before the exception existed. Requiring a
+// `diff --git` header instead would not close this: an author who can write
+// `@@ -1 +1 @@` into a prompt can write that header too.
+function strongCredentialTokenReason(text, gitDiff) {
   const lines = text.split("\n");
-  const { hunkOfLine, hunks } = splitDiffHunks(lines);
+  const { hunkOfLine, hunks } = gitDiff
+    ? splitDiffHunks(lines)
+    : { hunkOfLine: new Array(lines.length).fill(-1), hunks: [] };
   const claimed = hunks.map(() => new Set());
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
@@ -1795,7 +1805,10 @@ function strongCredentialTokenReason(text) {
   return null;
 }
 
-export function secretLikeReason(text) {
+// `gitDiff` marks text the caller knows is a git-generated patch. It is the only
+// input for which the redaction accept-shape applies; it defaults to closed so a
+// new call site cannot acquire the exception by omission.
+export function secretLikeReason(text, { gitDiff = false } = {}) {
   const privateKeyHeader =
     /-----BEGIN (?:(?:[A-Z0-9][A-Z0-9 -]* )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----/g;
   for (const match of text.matchAll(privateKeyHeader)) {
@@ -1811,7 +1824,7 @@ export function secretLikeReason(text) {
   ) {
     return "Bearer JWT";
   }
-  const strongCredential = strongCredentialTokenReason(text);
+  const strongCredential = strongCredentialTokenReason(text, gitDiff);
   if (strongCredential) return strongCredential;
   const secretUrlPatterns = [
     /https:\/\/hooks\.slack\.com\/services\/[A-Z0-9]{8,}\/[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/i,
@@ -2131,8 +2144,8 @@ export function secretLikeReason(text) {
   return null;
 }
 
-export function assertNoSecretLikeContent(label, text) {
-  const reason = secretLikeReason(text);
+export function assertNoSecretLikeContent(label, text, options) {
+  const reason = secretLikeReason(text, options);
   if (reason) {
     throw new Error(
       `refusing to include secret-like content in review bundle (${reason}); clean or redact ${label} before running autoreview`,

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -1660,6 +1660,131 @@ function literalAuthorizationCredential(value) {
   );
 }
 
+const STRONG_CREDENTIAL_PATTERNS = [
+  /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{30,}\b/g,
+  /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{30,}\b/g,
+  /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{24,}\b/g,
+  /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/g,
+  /\bnpm_[A-Za-z0-9]{30,}\b/g,
+];
+
+const DIFF_HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/;
+
+// Merged, ordered spans of every strong-pattern match on one line. Overlapping
+// matches collapse so a span never splits a single credential-shaped run.
+function strongCredentialSpans(line) {
+  const spans = [];
+  for (const pattern of STRONG_CREDENTIAL_PATTERNS) {
+    for (const match of line.matchAll(pattern)) {
+      spans.push([match.index, match.index + match[0].length]);
+    }
+  }
+  if (spans.length < 2) return spans;
+  spans.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const merged = [spans[0]];
+  for (const span of spans.slice(1)) {
+    const last = merged.at(-1);
+    if (span[0] <= last[1]) last[1] = Math.max(last[1], span[1]);
+    else merged.push(span);
+  }
+  return merged;
+}
+
+// Maps each diff line to the hunk it belongs to and collects that hunk's added
+// content. Only `+`/`-` lines between a hunk header and the first line that is
+// neither diff content nor context belong to a hunk, so file headers such as
+// `--- a/x` and `+++ b/x` are never mistaken for hunk lines.
+function splitDiffHunks(lines) {
+  const hunkOfLine = new Array(lines.length).fill(-1);
+  const hunks = [];
+  let current = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (DIFF_HUNK_HEADER.test(line)) {
+      hunks.push([]);
+      current = hunks.length - 1;
+      continue;
+    }
+    if (current === -1) continue;
+    const marker = line.charAt(0);
+    if (line === "" || marker === " " || marker === "\\") continue;
+    if (marker === "+") {
+      hunks[current].push(line.slice(1));
+      hunkOfLine[index] = current;
+      continue;
+    }
+    if (marker === "-") {
+      hunkOfLine[index] = current;
+      continue;
+    }
+    current = -1;
+  }
+  return { hunkOfLine, hunks };
+}
+
+// True when `added` is `removed` with every credential-shaped span replaced by
+// placeholder vocabulary and nothing else changed. Every literal segment around
+// the spans must match exactly, so a rewritten line, a line that merely happens
+// to mention a placeholder, or a swap to a different opaque literal all fail.
+// The leftmost search for each following segment is deterministic; when it does
+// not reconstruct `removed` exactly the answer is false, which refuses.
+function placeholderRedactionOf(removed, spans, added) {
+  let removedIndex = 0;
+  let addedIndex = 0;
+  for (let index = 0; index < spans.length; index += 1) {
+    const [start, end] = spans[index];
+    const prefix = removed.slice(removedIndex, start);
+    if (!added.startsWith(prefix, addedIndex)) return false;
+    addedIndex += prefix.length;
+    removedIndex = end;
+    const nextStart =
+      index + 1 < spans.length ? spans[index + 1][0] : removed.length;
+    const following = removed.slice(removedIndex, nextStart);
+    let replacementEnd;
+    if (following === "") {
+      if (index + 1 < spans.length) return false;
+      replacementEnd = added.length;
+    } else {
+      const found = added.indexOf(following, addedIndex + 1);
+      if (found === -1) return false;
+      replacementEnd = found;
+    }
+    const replacement = added.slice(addedIndex, replacementEnd);
+    if (replacement.length === 0 || !placeholderValue(replacement))
+      return false;
+    addedIndex = replacementEnd;
+  }
+  return added.slice(addedIndex) === removed.slice(removedIndex);
+}
+
+// A credential-shaped token is refused wherever it appears, with one narrow
+// exception: on the REMOVED side of a hunk whose added side carries the same
+// line with that token replaced by placeholder vocabulary — a redaction, not an
+// exfiltration. A removal with no replacement, a removal replaced by a different
+// credential-shaped literal, a replacement in another hunk, and every addition
+// or context line stay refused.
+function strongCredentialTokenReason(text) {
+  const lines = text.split("\n");
+  const { hunkOfLine, hunks } = splitDiffHunks(lines);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const hunk = hunkOfLine[index];
+    const isRemoval = hunk !== -1 && line.startsWith("-");
+    const scanned = isRemoval ? line.slice(1) : line;
+    const spans = strongCredentialSpans(scanned);
+    if (spans.length === 0) continue;
+    if (!isRemoval) return "credential-like token";
+    const redacted = hunks[hunk].some((added) =>
+      placeholderRedactionOf(scanned, spans, added),
+    );
+    if (!redacted) return "credential-like token";
+  }
+  return null;
+}
+
 export function secretLikeReason(text) {
   const privateKeyHeader =
     /-----BEGIN (?:(?:[A-Z0-9][A-Z0-9 -]* )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----/g;
@@ -1676,19 +1801,8 @@ export function secretLikeReason(text) {
   ) {
     return "Bearer JWT";
   }
-  const strongPatterns = [
-    /\bgh[pousr]_[A-Za-z0-9]{30,}\b/,
-    /\bgithub_pat_[A-Za-z0-9_]{30,}\b/,
-    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/,
-    /\bAIza[0-9A-Za-z_-]{30,}\b/,
-    /\bxox[baprs]-[0-9A-Za-z-]{20,}\b/,
-    /\bsk-[A-Za-z0-9_-]{24,}\b/,
-    /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/,
-    /\bnpm_[A-Za-z0-9]{30,}\b/,
-  ];
-  if (strongPatterns.some((pattern) => pattern.test(text))) {
-    return "credential-like token";
-  }
+  const strongCredential = strongCredentialTokenReason(text);
+  if (strongCredential) return strongCredential;
   const secretUrlPatterns = [
     /https:\/\/hooks\.slack\.com\/services\/[A-Z0-9]{8,}\/[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/i,
     /https:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com\/api\/webhooks\/[0-9]{15,20}\/[A-Za-z0-9._-]{20,}/i,

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -165,6 +165,176 @@ assert.throws(
   () => assertNoSecretLikeContent("fixture", `token=${secret}`),
   /refusing to include secret-like content/,
 );
+
+// Redaction accept-shape: a credential-shaped token on a hunk's REMOVED side is
+// acceptable only when the same hunk's added side carries the same line with
+// that token replaced by placeholder vocabulary. Every fixture below builds its
+// credential-shaped literal by joining fragments so this corpus itself never
+// carries a bundle-refusable literal.
+const otherSecret = ["gh", "s_", "B".repeat(36)].join("");
+const redactionHunk = (removedLines, addedLines) =>
+  [
+    "diff --git a/scripts/fixture.test.mjs b/scripts/fixture.test.mjs",
+    "--- a/scripts/fixture.test.mjs",
+    "+++ b/scripts/fixture.test.mjs",
+    "@@ -1,3 +1,3 @@",
+    " const before = 1;",
+    ...removedLines.map((line) => `-${line}`),
+    ...addedLines.map((line) => `+${line}`),
+    " const after = 2;",
+  ].join("\n");
+
+const wordPlaceholderRedaction = redactionHunk(
+  [`const sample = "${secret}";`],
+  ['const sample = "redacted-fixture-token";'],
+);
+assert.equal(
+  secretLikeReason(wordPlaceholderRedaction),
+  null,
+  "a removal replaced in-place by placeholder vocabulary is a redaction, not an exfiltration",
+);
+assert.doesNotThrow(() =>
+  assertNoSecretLikeContent("redaction", wordPlaceholderRedaction),
+);
+assert.equal(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`],
+      ['const sample = "<redacted>";'],
+    ),
+  ),
+  null,
+  "angle-bracket placeholders are recognized replacement vocabulary",
+);
+assert.equal(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`],
+      ['const sample = "${SAMPLE_TOKEN}";'],
+    ),
+  ),
+  null,
+  "an env-reference placeholder is recognized replacement vocabulary",
+);
+assert.equal(
+  secretLikeReason(
+    redactionHunk(
+      [`const pair = ["${secret}", "${otherSecret}"];`],
+      ['const pair = ["<redacted>", "<redacted>"];'],
+    ),
+  ),
+  null,
+  "every credential-shaped span on the removed line must be replaced, and all of them may be",
+);
+
+const unreplacedRemoval = redactionHunk([`const sample = "${secret}";`], []);
+assert.match(
+  secretLikeReason(unreplacedRemoval),
+  /credential-like token/,
+  "a removal with no replacement stays refused",
+);
+assert.throws(
+  () => assertNoSecretLikeContent("unreplaced removal", unreplacedRemoval),
+  /refusing to include secret-like content/,
+);
+const swappedLiteral = redactionHunk(
+  [`const sample = "${secret}";`],
+  [`const sample = "${otherSecret}";`],
+);
+assert.match(
+  secretLikeReason(swappedLiteral),
+  /credential-like token/,
+  "a removal replaced by a different credential-shaped literal stays refused",
+);
+assert.throws(
+  () => assertNoSecretLikeContent("swapped literal", swappedLiteral),
+  /refusing to include secret-like content/,
+);
+assert.match(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`],
+      ['const sample = "9f3c1a2b4d5e6f708192a3b4";'],
+    ),
+  ),
+  /credential-like token/,
+  "an opaque replacement that is not placeholder vocabulary stays refused",
+);
+assert.match(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`],
+      ['const renamed = "redacted-fixture-token";'],
+    ),
+  ),
+  /credential-like token/,
+  "the line outside the credential span must match exactly, so a rewritten line stays refused",
+);
+assert.match(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`],
+      ['const sample = "redacted" + resolveSuffix();'],
+    ),
+  ),
+  /credential-like token/,
+  "a replacement expression that merely starts with placeholder vocabulary stays refused",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "@@ -1,2 +1,2 @@",
+      `-const sample = "${secret}";`,
+      " const tail = 1;",
+      "@@ -20,2 +20,2 @@",
+      '-const sample = "old-value-placeholder";',
+      '+const sample = "redacted-fixture-token";',
+    ].join("\n"),
+  ),
+  /credential-like token/,
+  "a placeholder replacement in a different hunk does not redact this removal",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "@@ -1,3 +1,3 @@",
+      ` const sample = "${secret}";`,
+      "-const other = 1;",
+      '+const other = "redacted-token";',
+    ].join("\n"),
+  ),
+  /credential-like token/,
+  "a context line carrying the literal is not a removal and stays refused",
+);
+assert.match(
+  secretLikeReason(
+    redactionHunk(
+      ['const sample = "redacted-fixture-token";'],
+      [`const sample = "${secret}";`],
+    ),
+  ),
+  /credential-like token/,
+  "add-side detection is untouched: replacing a placeholder with a literal stays refused",
+);
+assert.match(
+  secretLikeReason(`-const sample = "${secret}";`),
+  /credential-like token/,
+  "a removal-shaped line outside any hunk stays refused",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "@@ -1,2 +1,2 @@",
+      " const before = 1;",
+      "diff --git a/scripts/other.mjs b/scripts/other.mjs",
+      `-const sample = "${secret}";`,
+      '+const sample = "redacted-fixture-token";',
+    ].join("\n"),
+  ),
+  /credential-like token/,
+  "a new file header closes the hunk, so the lines after it are not hunk removals",
+);
+
 for (const label of [
   "PRIVATE KEY",
   "RSA PRIVATE KEY",

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -227,6 +227,34 @@ assert.equal(
   "every credential-shaped span on the removed line must be replaced, and all of them may be",
 );
 
+const sharedPlaceholderRemovals = redactionHunk(
+  [`const sample = "${secret}";`, `const sample = "${otherSecret}";`],
+  ['const sample = "redacted-fixture-token";'],
+);
+assert.match(
+  secretLikeReason(sharedPlaceholderRemovals),
+  /credential-like token/,
+  "one placeholder redacts one removal, so a second credential-bearing removal is an unreplaced deletion",
+);
+assert.throws(
+  () =>
+    assertNoSecretLikeContent("shared placeholder", sharedPlaceholderRemovals),
+  /refusing to include secret-like content/,
+);
+assert.equal(
+  secretLikeReason(
+    redactionHunk(
+      [`const sample = "${secret}";`, `const sample = "${otherSecret}";`],
+      [
+        'const sample = "redacted-fixture-token";',
+        'const sample = "redacted-fixture-token";',
+      ],
+    ),
+  ),
+  null,
+  "two removals redacted by two placeholder lines are both replacements",
+);
+
 const unreplacedRemoval = redactionHunk([`const sample = "${secret}";`], []);
 assert.match(
   secretLikeReason(unreplacedRemoval),

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -184,20 +184,27 @@ const redactionHunk = (removedLines, addedLines) =>
     " const after = 2;",
   ].join("\n");
 
+// The accept-shape applies only to text a caller vouches is a git-generated
+// patch, so every assertion in this block scans in that mode explicitly. The
+// supplemental-input controls at the end of the block cover the closed default.
+const diffScan = (text) => secretLikeReason(text, { gitDiff: true });
+
 const wordPlaceholderRedaction = redactionHunk(
   [`const sample = "${secret}";`],
   ['const sample = "redacted-fixture-token";'],
 );
 assert.equal(
-  secretLikeReason(wordPlaceholderRedaction),
+  diffScan(wordPlaceholderRedaction),
   null,
   "a removal replaced in-place by placeholder vocabulary is a redaction, not an exfiltration",
 );
 assert.doesNotThrow(() =>
-  assertNoSecretLikeContent("redaction", wordPlaceholderRedaction),
+  assertNoSecretLikeContent("redaction", wordPlaceholderRedaction, {
+    gitDiff: true,
+  }),
 );
 assert.equal(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`],
       ['const sample = "<redacted>";'],
@@ -207,7 +214,7 @@ assert.equal(
   "angle-bracket placeholders are recognized replacement vocabulary",
 );
 assert.equal(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`],
       ['const sample = "${SAMPLE_TOKEN}";'],
@@ -217,7 +224,7 @@ assert.equal(
   "an env-reference placeholder is recognized replacement vocabulary",
 );
 assert.equal(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const pair = ["${secret}", "${otherSecret}"];`],
       ['const pair = ["<redacted>", "<redacted>"];'],
@@ -232,17 +239,19 @@ const sharedPlaceholderRemovals = redactionHunk(
   ['const sample = "redacted-fixture-token";'],
 );
 assert.match(
-  secretLikeReason(sharedPlaceholderRemovals),
+  diffScan(sharedPlaceholderRemovals),
   /credential-like token/,
   "one placeholder redacts one removal, so a second credential-bearing removal is an unreplaced deletion",
 );
 assert.throws(
   () =>
-    assertNoSecretLikeContent("shared placeholder", sharedPlaceholderRemovals),
+    assertNoSecretLikeContent("shared placeholder", sharedPlaceholderRemovals, {
+      gitDiff: true,
+    }),
   /refusing to include secret-like content/,
 );
 assert.equal(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`, `const sample = "${otherSecret}";`],
       [
@@ -257,12 +266,15 @@ assert.equal(
 
 const unreplacedRemoval = redactionHunk([`const sample = "${secret}";`], []);
 assert.match(
-  secretLikeReason(unreplacedRemoval),
+  diffScan(unreplacedRemoval),
   /credential-like token/,
   "a removal with no replacement stays refused",
 );
 assert.throws(
-  () => assertNoSecretLikeContent("unreplaced removal", unreplacedRemoval),
+  () =>
+    assertNoSecretLikeContent("unreplaced removal", unreplacedRemoval, {
+      gitDiff: true,
+    }),
   /refusing to include secret-like content/,
 );
 const swappedLiteral = redactionHunk(
@@ -270,16 +282,19 @@ const swappedLiteral = redactionHunk(
   [`const sample = "${otherSecret}";`],
 );
 assert.match(
-  secretLikeReason(swappedLiteral),
+  diffScan(swappedLiteral),
   /credential-like token/,
   "a removal replaced by a different credential-shaped literal stays refused",
 );
 assert.throws(
-  () => assertNoSecretLikeContent("swapped literal", swappedLiteral),
+  () =>
+    assertNoSecretLikeContent("swapped literal", swappedLiteral, {
+      gitDiff: true,
+    }),
   /refusing to include secret-like content/,
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`],
       ['const sample = "9f3c1a2b4d5e6f708192a3b4";'],
@@ -289,7 +304,7 @@ assert.match(
   "an opaque replacement that is not placeholder vocabulary stays refused",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`],
       ['const renamed = "redacted-fixture-token";'],
@@ -299,7 +314,7 @@ assert.match(
   "the line outside the credential span must match exactly, so a rewritten line stays refused",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       [`const sample = "${secret}";`],
       ['const sample = "redacted" + resolveSuffix();'],
@@ -309,7 +324,7 @@ assert.match(
   "a replacement expression that merely starts with placeholder vocabulary stays refused",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     [
       "@@ -1,2 +1,2 @@",
       `-const sample = "${secret}";`,
@@ -323,7 +338,7 @@ assert.match(
   "a placeholder replacement in a different hunk does not redact this removal",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     [
       "@@ -1,3 +1,3 @@",
       ` const sample = "${secret}";`,
@@ -335,7 +350,7 @@ assert.match(
   "a context line carrying the literal is not a removal and stays refused",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     redactionHunk(
       ['const sample = "redacted-fixture-token";'],
       [`const sample = "${secret}";`],
@@ -345,12 +360,12 @@ assert.match(
   "add-side detection is untouched: replacing a placeholder with a literal stays refused",
 );
 assert.match(
-  secretLikeReason(`-const sample = "${secret}";`),
+  diffScan(`-const sample = "${secret}";`),
   /credential-like token/,
   "a removal-shaped line outside any hunk stays refused",
 );
 assert.match(
-  secretLikeReason(
+  diffScan(
     [
       "@@ -1,2 +1,2 @@",
       " const before = 1;",
@@ -361,6 +376,59 @@ assert.match(
   ),
   /credential-like token/,
   "a new file header closes the hunk, so the lines after it are not hunk removals",
+);
+
+// Supplemental input — `--prompt`, prompt files, datasets, branch names, refs —
+// is arbitrary text the author controls, so it never earns the accept-shape. A
+// diff-shaped prompt carrying a real credential is refused on the closed
+// default, which is what `secretLikeReason` and `assertNoSecretLikeContent` do
+// when no caller vouches for the text.
+const promptShapedAsRedaction = [
+  "@@ -1 +1 @@",
+  `-sample ${secret}`,
+  "+sample <redacted>",
+].join("\n");
+assert.equal(
+  diffScan(promptShapedAsRedaction),
+  null,
+  "negative control: this fixture is accepted when it is scanned as a git diff",
+);
+assert.match(
+  secretLikeReason(promptShapedAsRedaction),
+  /credential-like token/,
+  "a diff-shaped supplemental prompt is not a git diff, so the redaction exception does not apply",
+);
+assert.throws(
+  () => assertNoSecretLikeContent("--prompt", promptShapedAsRedaction),
+  /refusing to include secret-like content/,
+  "assertNoSecretLikeContent defaults to the closed scan, so no call site gets the exception by omission",
+);
+const promptWithFabricatedFileHeader = [
+  "diff --git a/sample.txt b/sample.txt",
+  "--- a/sample.txt",
+  "+++ b/sample.txt",
+  promptShapedAsRedaction,
+].join("\n");
+assert.match(
+  secretLikeReason(promptWithFabricatedFileHeader),
+  /credential-like token/,
+  "an author who can write a hunk header into a prompt can write a file header too, so neither earns the exception",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "Please review the following change.",
+      promptShapedAsRedaction,
+      "Focus on the error handling.",
+    ].join("\n"),
+  ),
+  /credential-like token/,
+  "prose wrapped around a redaction-shaped fragment stays refused",
+);
+assert.match(
+  secretLikeReason(wordPlaceholderRedaction),
+  /credential-like token/,
+  "even a genuine bundle redaction is refused when it arrives as supplemental input",
 );
 
 for (const label of [

--- a/scripts/agent-autoreview.mjs
+++ b/scripts/agent-autoreview.mjs
@@ -4469,7 +4469,10 @@ function assertReviewableBundle(paths, bundle) {
       "refusing gitlink/submodule changes because dependency contents are absent from the review bundle",
     );
   }
-  assertNoSecretLikeContent("selected change", bundle);
+  // The bundle is the only scanned text git itself produced, so it is the only
+  // one whose hunk structure can be trusted and therefore the only one allowed
+  // the redaction accept-shape. Supplemental input stays on the closed default.
+  assertNoSecretLikeContent("selected change", bundle, { gitDiff: true });
 }
 
 function hashHeadIdentity(hash, state) {


### PR DESCRIPTION
## The Problem

- The autoreview bundle scanner refuses a credential-shaped literal on both diff
  sides, so redacting a look-alike literal already on `main` is refused exactly
  like adding a new one.
- That is a trap: the two fixture literals in
  `scripts/sentry/triage/sentry-triage-agent-comment.test.mjs` can never be
  cleaned up through the normal reviewed path, and any edit near those lines
  hits the same refusal. It blocked PR 1930's final round on both engines.

## The Solution

- Teach the strong-pattern check one accept-shape: a credential-shaped token on
  a hunk's REMOVED side is acceptable only when the same hunk's ADDED side
  carries the identical line with that token replaced by placeholder vocabulary
  — the diff is a redaction, not an exfiltration.
- Confine that accept-shape to text the caller knows git produced. The review
  bundle opts in; supplemental review input — `--prompt`, prompt files,
  datasets, branch names, refs — stays on the closed default, so a diff-shaped
  prompt is still just a prompt.
- Everything else stays refused, including the case that looks closest to the
  accepted one: a removal with no replacement, a removal swapped for a different
  credential-shaped literal, a replacement that lives in another hunk, and every
  addition or context line.

## Details

- The check was a whole-text `some(pattern.test(text))`. It is now line-aware:
  `splitDiffHunks` maps each line to its hunk and collects that hunk's added
  content, and only `+`/`-` lines between a hunk header and the first
  non-content line belong to a hunk, so `--- a/x` and `+++ b/x` file headers are
  never read as hunk lines.
- `placeholderRedactionOf` accepts an added line only when every literal segment
  around the credential spans matches the removed line exactly and each span's
  replacement satisfies the existing `placeholderValue` vocabulary. A rewritten
  line, an opaque replacement, and a replacement expression that merely starts
  with placeholder text all fail. Every ambiguity — the leftmost segment search,
  greedy claiming — resolves toward refusal.
- Each added line redacts at most one removal in its hunk. Without that, a hunk
  removing two different credential-shaped literals with matching surrounding
  text passed on a single placeholder addition and the second removal rode
  through as an unreplaced deletion. That gap was found by the local review and
  is fixed in the second commit with its own test.
- `secretLikeReason` and `assertNoSecretLikeContent` take a `gitDiff` option that
  defaults to closed, and `assertReviewableBundle` is the only caller that sets
  it. Without it `splitDiffHunks` is never consulted, so no line belongs to a
  hunk and the accept-shape cannot fire. That closes the review finding on the
  first two commits: a three-line `@@ -1 +1 @@` payload in `--prompt` carried an
  arbitrary credential past a boundary that had refused it. Requiring a real
  `diff --git` section instead would not close it — an author who can write a
  hunk header into a prompt can write a file header too, and that variant was
  accepted as well. Defaulting closed also stops a future call site acquiring
  the exception by omission.
- Detection on the added side, on context lines, and outside any diff is
  byte-for-byte what it was: the same eight patterns, applied to the same text.
- Scope: this changes the strong-pattern block only. The credential-assignment
  rules still refuse the removal side of the same redaction — see Deferrals.

## Validation

- `node scripts/agent-autoreview-core.test.mjs` — the full existing corpus, 13
  redaction assertions, and 6 supplemental-input controls. Every redaction
  assertion scans with `{ gitDiff: true }` explicitly, so the refusal controls
  stay meaningful on the closed default rather than passing vacuously.
- Negative control on the fix: restoring the old whole-text `some()` makes the
  accept-shape assertion fail (`credential-like token` where `null` is
  expected); restoring the fix makes it pass.
- Mutation controls proving the accept-shape is narrower than "removal is fine":
  forcing `placeholderRedactionOf` to `true` fails the opaque-replacement
  control; widening the search to `hunks.flat()` fails the cross-hunk control;
  dropping the claimed-addition check fails the shared-placeholder control.
  Hardcoding `gitDiff` to `true` fails the supplemental-input control, and to
  `false` fails the accept-shape assertion. Each reverts clean.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`
  — all mapped commands passed, including the full `pnpm agent:autoreview:test`
  adversarial suite (engine-isolation, target-selection, runtime-trust,
  bundle-integrity, adapter all ok).
- Local autoreview from a separate trusted checkout at `origin/main`
  (`99cc3680`) with an explicit `AUTOREVIEW_HELPER`, because the diff changes
  the autoreview runtime itself. On the first two commits, `--engine codex`:
  clean, "patch is correct (0.91)"; `--engine claude`: "patch is correct (0.72)"
  with one P2 follow-up recorded under Deferrals. On the third commit,
  `--engine codex`: clean, "patch is correct (0.93)". The `claude` engine binary
  was not on PATH for that re-run, so only `codex` covers the third commit.
- The scanner did not refuse this PR's own bundle: the new fixtures build their
  credential-shaped literals by joining fragments, matching the corpus idiom.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/1941 — the
  proving redaction of `main`'s two literals is a follow-up PR, because local
  autoreview runs the `origin/main` scanner and cannot see this change until it
  merges. Measured while building this: after the accept-shape those two lines
  are still refused, now with `literal credential assignment` from the
  credential-assignment `keyPattern` scan, so 1941 needs the same accept-shape
  extended to those rules before the redaction can land. Detail is in the issue
  comment.
- https://github.com/mento-protocol/monitoring-monorepo/issues/1997 — an
  accepted redaction still transmits the removed literal verbatim to the review
  engine. Masking the span in the bundle, or warning the author, touches bundle
  construction and manifest hashing and is out of scope here. The `gitDiff`
  scoping narrows that exposure to the git-generated bundle; it does not remove
  it.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this narrows one existing check
      inside the established scanner design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fail-closed secret scanning that gates review bundles. A too-broad accept-shape could ship credential-like tokens to review engines; the exception is intentionally narrow but still security-critical.
> 
> **Overview**
> The strong-pattern check in `secretLikeReason` no longer treats every credential-shaped token as a refusal. A token on a hunk’s **removed** side is allowed only when the **same hunk** adds the identical line with that span replaced by existing placeholder vocabulary (word placeholders, `<…>`, env refs).
> 
> Everything else still fails: unreplaced deletions, swaps to another credential-shaped or opaque literal, rewritten lines, context/add lines, cross-hunk replacements, and one placeholder covering two removals. File headers are not treated as hunk content.
> 
> Assignment-key rules are unchanged, so some real redactions can still be refused until that accept-shape is extended. Tests cover the accept path and the nearby refusal cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcaa15be469974517ff6e7fd53056d150a5f22b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential detection in code changes to distinguish intentional redactions from exposed secrets.
  * Redacted credentials are accepted only in explicitly identified Git-generated diffs.
  * Supplemental text and other non-diff inputs continue to reject credential-like content by default.
  * Added safeguards for fabricated diff markers, prose-wrapped redactions, mismatched values, and multiple redactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
