### PR TITLE
fix: align Peg alert history with Slack notifications

### DIFF
--- a/alerts/rules/peg-message-templates.tf
+++ b/alerts/rules/peg-message-templates.tf
@@ -1,7 +1,9 @@
 # Peg alerts carry a bounded decision package in annotations. Dedicated named
 # templates keep peg-only fields out of the protocol-wide dispatchers. Template
 # names are globally unique inside Grafana; contact points depend on these
-# resources explicitly because their template calls are plain strings.
+# resources explicitly because their template calls are plain strings. Grafana
+# hardcodes the Slack attachment title_link to its alert detail page. Keep that
+# title to one status icon. Render the linked human title in the message body.
 
 resource "grafana_message_template" "peg_slack_title" {
   for_each = local.peg_alert_instances
@@ -9,11 +11,7 @@ resource "grafana_message_template" "peg_slack_title" {
   name     = "Peg - Slack Title"
   template = <<-EOT
 {{ define "peg.slack.title" -}}
-{{ if (len .Alerts.Firing) -}}
-{{ if eq .CommonLabels.severity "critical" }}🚨{{ else }}🟡{{ end }} {{ range $i, $alert := .Alerts.Firing }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.summary }}{{ . }}{{ else }}Peg monitoring needs attention{{ end }}{{ end }}
-{{- else -}}
-✅ {{ range $i, $alert := .Alerts.Resolved }}{{ if $i }}, {{ end }}{{ with $alert.Annotations.resolved_summary }}{{ . }}{{ else }}Peg monitoring recovered{{ end }}{{ end }}
-{{- end }}
+{{ if (len .Alerts.Firing) }}{{ if eq .CommonLabels.severity "critical" }}🚨{{ else }}🟡{{ end }}{{ else }}✅{{ end }}
 {{- end }}
 EOT
 }
@@ -28,7 +26,7 @@ resource "grafana_message_template" "peg_slack_message" {
 <!subteam^${var.oncall_support_usergroup_id}> Please investigate.
 {{ end -}}
 {{ range .Alerts.Firing -}}
-{{ with .Annotations.summary }}*{{ . }}*{{ else }}*Peg monitoring needs attention*{{ end }}
+{{ with .Annotations.summary }}*<https://monitoring.mento.org/peg-monitoring|{{ . }}>*{{ else }}*<https://monitoring.mento.org/peg-monitoring|Peg monitoring needs attention>*{{ end }}
 {{ with .Annotations.asset_name }}*Asset:* {{ . }}{{ end }}
 {{ with .Annotations.source_name }}*Source:* {{ . }}{{ end }}
 {{ with .Annotations.executable_price }}*Executable price:* {{ . }}{{ end }}
@@ -45,7 +43,7 @@ resource "grafana_message_template" "peg_slack_message" {
 *Alert ID:* `{{ .Fingerprint }}`
 {{ end -}}
 {{ range .Alerts.Resolved -}}
-{{ with .Annotations.resolved_summary }}*{{ . }}*{{ else }}*Peg monitoring recovered*{{ end }}
+{{ with .Annotations.resolved_summary }}*<https://monitoring.mento.org/peg-monitoring|{{ . }}>*{{ else }}*<https://monitoring.mento.org/peg-monitoring|Peg monitoring recovered>*{{ end }}
 {{ with .Annotations.asset_name }}*Asset:* {{ . }}{{ end }}
 {{ with .Annotations.source_name }}*Source:* {{ . }}{{ end }}
 *Ended:* {{ .EndsAt.Format "Mon Jan 02 15:04 UTC" }}

--- a/alerts/rules/peg-rule-definitions.tftest.hcl
+++ b/alerts/rules/peg-rule-definitions.tftest.hcl
@@ -65,13 +65,19 @@ run "peg_rule_definitions_preserve_consumer_guard_invariant" {
 
   assert {
     condition = (
-      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "$alert.Annotations.summary") &&
-      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "$alert.Annotations.resolved_summary") &&
+      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "🚨") &&
+      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "🟡") &&
+      strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "✅") &&
+      !strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "Annotations.summary") &&
+      !strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, "Annotations.resolved_summary") &&
       !strcontains(grafana_message_template.peg_slack_title["peg-monitoring"].template, ".CommonLabels.alertname") &&
+      strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "<https://monitoring.mento.org/peg-monitoring|{{ . }}>") &&
+      strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "Peg monitoring needs attention") &&
+      strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "Peg monitoring recovered") &&
       !strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "FIRING:") &&
       !strcontains(grafana_message_template.peg_slack_message["peg-monitoring"].template, "*Policy:*")
     )
-    error_message = "Peg Slack copy must lead with the cause and leave state to the title icon."
+    error_message = "Peg Slack titles must contain only status icons, and message bodies must link the human title to Peg Monitoring."
   }
 
   assert {

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -132,8 +132,9 @@ the decision package only when the event and package use the same policy
 version. Older events without cause telemetry say that the exact cause was not
 recorded. The history backend reads fired, resolved, evaluation-failure, and
 evaluation-recovery transitions from the displayed seven days. It does not read
-Pending or canceled transitions. Evaluation failures use distinct monitoring
-copy and never become confirmed peg breaches. When a matching fired transition
+general Pending or canceled history. The bounded evaluation-recovery query can
+accept an `Error` to `Pending` transition. Evaluation failures use distinct
+monitoring copy and never become confirmed peg breaches. When a matching fired transition
 is available, a resolved row keeps its cause and shows how long the alert stayed
 active. A resolution remains visible without that active time when the alert
 fired before the displayed window. Its details can still show the configured

--- a/docs/notes/peg-monitoring.md
+++ b/docs/notes/peg-monitoring.md
@@ -3,7 +3,7 @@ title: Peg monitoring alert source validation and activation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-15
+last_verified: 2026-08-21
 doc_type: runbook
 scope: alerts/peg-monitoring
 review_interval_days: 90
@@ -115,13 +115,14 @@ terms, and internal rule names. For example, a downside transition reads
 
 Grafana rule summaries and Peg notification templates use the same copy
 contract. Grafana keeps the internal rule name stable for alert identity, but
-the user-facing summary leads with the measured cause. Slack titles use the
-severity icon plus that summary. Slack bodies do not repeat `FIRING`,
-`RESOLVED`, the policy slot, or the internal rule name. Resolved notifications
-usually use the matching past-tense summary. Stale-data and unavailable-price
-recoveries state that the data or price is available again. Splunk On-Call uses
-the same summaries and keeps its required `P1` or `RESOLVED` state text because
-it has no color icon.
+the user-facing summary leads with the measured cause. Slack attachment titles
+use only the severity icon because Grafana fixes their link to its alert page.
+The Slack body links the human summary to Peg Monitoring. Slack bodies do not
+repeat `FIRING`, `RESOLVED`, the policy slot, or the internal rule name.
+Resolved notifications usually use the matching past-tense summary. Stale-data
+and unavailable-price recoveries state that the data or price is available
+again. Splunk On-Call uses the same summaries and keeps its required `P1` or
+`RESOLVED` state text because it has no color icon.
 Canonical display-name maps preserve asset and provider casing such as `KESm`
 and `VALR` across the dashboard, Grafana, and notifications.
 
@@ -129,13 +130,14 @@ Each dashboard alert row has a collapsed `Details` disclosure. The disclosure
 explains the fixed condition and its configured wait. It reads thresholds from
 the decision package only when the event and package use the same policy
 version. Older events without cause telemetry say that the exact cause was not
-recorded. The history backend reads only fired and resolved transitions from
-the displayed seven days. It does not read Pending or canceled transitions.
-When a matching fired transition is available, a resolved row keeps its cause
-and shows how long the alert stayed active. A resolution remains visible
-without that active time when the alert fired before the displayed window. Its
-details can still show the configured wait when the event and current policy
-versions match.
+recorded. The history backend reads fired, resolved, evaluation-failure, and
+evaluation-recovery transitions from the displayed seven days. It does not read
+Pending or canceled transitions. Evaluation failures use distinct monitoring
+copy and never become confirmed peg breaches. When a matching fired transition
+is available, a resolved row keeps its cause and shows how long the alert stayed
+active. A resolution remains visible without that active time when the alert
+fired before the displayed window. Its details can still show the configured
+wait when the event and current policy versions match.
 
 Grafana state history stores the evaluated query values for each transition.
 Every Peg rule therefore includes two helper queries, `Reason` and

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1212,11 +1212,28 @@ test("Peg Grafana and Slack copy leads with the concrete cause", () => {
     path.join(rulesDir, "peg-message-templates.tf"),
     "utf8",
   );
+  const slackTitleStart = templates.indexOf(
+    'resource "grafana_message_template" "peg_slack_title"',
+  );
+  const slackMessageStart = templates.indexOf(
+    'resource "grafana_message_template" "peg_slack_message"',
+  );
+  const victorOpsTitleStart = templates.indexOf(
+    'resource "grafana_message_template" "peg_victorops_title"',
+  );
+  assert(
+    slackTitleStart >= 0 &&
+      slackMessageStart > slackTitleStart &&
+      victorOpsTitleStart > slackMessageStart,
+    "Peg notification template resources must exist in the expected order",
+  );
   const slackTitleTemplate = templates.slice(
-    templates.indexOf('resource "grafana_message_template" "peg_slack_title"'),
-    templates.indexOf(
-      'resource "grafana_message_template" "peg_slack_message"',
-    ),
+    slackTitleStart,
+    slackMessageStart,
+  );
+  const slackMessageTemplate = templates.slice(
+    slackMessageStart,
+    victorOpsTitleStart,
   );
 
   assert(
@@ -1257,13 +1274,16 @@ test("Peg Grafana and Slack copy leads with the concrete cause", () => {
   assert(
     !slackTitleTemplate.includes("Annotations.summary") &&
       !slackTitleTemplate.includes("Annotations.resolved_summary") &&
-      templates.includes(
+      slackTitleTemplate.includes("🚨") &&
+      slackTitleTemplate.includes("🟡") &&
+      slackTitleTemplate.includes("✅") &&
+      slackMessageTemplate.includes(
         "*<https://monitoring.mento.org/peg-monitoring|{{ . }}>*",
       ) &&
-      templates.includes(
+      slackMessageTemplate.includes(
         "*<https://monitoring.mento.org/peg-monitoring|Peg monitoring needs attention>*",
       ) &&
-      templates.includes(
+      slackMessageTemplate.includes(
         "*<https://monitoring.mento.org/peg-monitoring|Peg monitoring recovered>*",
       ),
     "Peg Slack must keep Grafana's fixed title link on a status icon and link each human title to Peg Monitoring",

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1212,6 +1212,12 @@ test("Peg Grafana and Slack copy leads with the concrete cause", () => {
     path.join(rulesDir, "peg-message-templates.tf"),
     "utf8",
   );
+  const slackTitleTemplate = templates.slice(
+    templates.indexOf('resource "grafana_message_template" "peg_slack_title"'),
+    templates.indexOf(
+      'resource "grafana_message_template" "peg_slack_message"',
+    ),
+  );
 
   assert(
     definitions.includes("sell price is") &&
@@ -1246,7 +1252,21 @@ test("Peg Grafana and Slack copy leads with the concrete cause", () => {
       !templates.includes(".CommonLabels.alertname") &&
       !templates.includes("*FIRING:") &&
       !templates.includes("*RESOLVED:"),
-    "Peg Slack titles and bodies must use the cause instead of internal alert state or rule names",
+    "Peg notification bodies and pager titles must use the cause instead of internal alert state or rule names",
+  );
+  assert(
+    !slackTitleTemplate.includes("Annotations.summary") &&
+      !slackTitleTemplate.includes("Annotations.resolved_summary") &&
+      templates.includes(
+        "*<https://monitoring.mento.org/peg-monitoring|{{ . }}>*",
+      ) &&
+      templates.includes(
+        "*<https://monitoring.mento.org/peg-monitoring|Peg monitoring needs attention>*",
+      ) &&
+      templates.includes(
+        "*<https://monitoring.mento.org/peg-monitoring|Peg monitoring recovered>*",
+      ),
+    "Peg Slack must keep Grafana's fixed title link on a status icon and link each human title to Peg Monitoring",
   );
 });
 

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -395,6 +395,78 @@ describe("GET /api/peg-monitoring/alerts", () => {
     ]);
   });
 
+  it.each([
+    {
+      title: "Peg Structural Saturation Warning [europ-schuman · active]",
+      asset: "europ-schuman",
+      policyVersion: "europ-v1",
+      subject: "EUROP Structural Saturation Warning rule",
+    },
+    {
+      title: "Peg Indexed Pool Unreachable [europ-schuman · active]",
+      asset: "europ-schuman",
+      policyVersion: "europ-v1",
+      subject: "EUROP Indexed Pool Unreachable rule",
+    },
+    {
+      title: "Peg Heartbeat Missing [europ-schuman · active]",
+      asset: "europ-schuman",
+      policyVersion: "europ-v1",
+      subject: "EUROP Heartbeat Missing rule",
+    },
+    {
+      title: "Peg Policy Rollover Stuck",
+      asset: "policy",
+      policyVersion: "europ-v1",
+      subject: "Policy Rollover Stuck rule for policy europ-v1",
+    },
+  ])(
+    "labels source-less evaluation failures by rule for $title",
+    ({ title, asset, policyVersion, subject }) => {
+      const labels = {
+        alertname: title,
+        asset,
+        policy_version: policyVersion,
+        source: "",
+      };
+      const failed = stateLine({
+        previous: "Normal",
+        current: "Error",
+        fingerprint: `source-less-${asset}`,
+        ruleTitle: title,
+        values: {},
+        labels,
+      });
+      const recovered = stateLine({
+        previous: "Error",
+        current: "Normal",
+        fingerprint: `source-less-${asset}`,
+        ruleTitle: title,
+        values: {},
+        labels,
+      });
+      const events = combinePegAlertEvents(
+        parseStateTransitions(
+          stateFrame([
+            { at: NOW_SECONDS - 120, line: failed },
+            { at: NOW_SECONDS - 60, line: recovered },
+          ]),
+          FROM_SECONDS,
+          NOW_SECONDS,
+        ),
+        4,
+      );
+
+      expect(events.map(({ lead }) => lead)).toEqual([
+        `Grafana can evaluate the ${subject} again`,
+        `Grafana could not evaluate the ${subject}`,
+      ]);
+      expect(events.map(({ lead }) => lead).join(" ")).not.toContain(
+        "Price source",
+      );
+    },
+  );
+
   it("keeps Alerting to Error to Alerting separate from breach copy", () => {
     const title = "Peg Deep-Venue Downside Critical [europ-schuman · active]";
     const failed = stateLine({

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -266,7 +266,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("current"),
       ),
-    ).toEqual(["Alerting", "Error", "Normal", "Normal"]);
+    ).toEqual(["Alerting", "Error", "Normal", null]);
     expect(
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("previous"),
@@ -445,6 +445,131 @@ describe("GET /api/peg-monitoring/alerts", () => {
         severity: "page",
         lead: "Grafana could not evaluate the Bitvavo Peg rule",
         evidence: expect.objectContaining({ evaluationState: "failed" }),
+      }),
+    ]);
+  });
+
+  it("shows monitoring recovery when Grafana resumes in Pending", () => {
+    const title = "Peg Deep-Venue Downside Critical [europ-schuman · active]";
+    const failed = stateLine({
+      previous: "Normal",
+      current: "Error",
+      fingerprint: "pending-recovery",
+      ruleTitle: title,
+      values: {},
+      labels: { alertname: title, route: "page", severity: "critical" },
+    });
+    const recoveredPending = stateLine({
+      previous: "Error",
+      current: "Pending",
+      fingerprint: "pending-recovery",
+      ruleTitle: title,
+      values: { A: 51 },
+      labels: { alertname: title, route: "page", severity: "critical" },
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 120, line: failed },
+        { at: NOW_SECONDS - 60, line: recoveredPending },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:pending-recovery:error-recovered-pending:${NOW_SECONDS - 60}`,
+        severity: "warning",
+        lead: "Grafana can evaluate the Bitvavo Peg rule again; its alert condition is pending",
+        detail: "EUROP · lasted 1 min.",
+        evidence: expect.objectContaining({
+          evaluationState: "recovered-pending",
+        }),
+      }),
+      expect.objectContaining({
+        id: `state:pending-recovery:error:${NOW_SECONDS - 120}`,
+        evidence: expect.objectContaining({ evaluationState: "failed" }),
+      }),
+    ]);
+  });
+
+  it("closes an active alert when evaluation recovers to Normal", () => {
+    const fingerprint = "alert-error-normal";
+    const raised = stateLine({ fingerprint, values: { A: 51 } });
+    const failed = stateLine({
+      previous: "Alerting",
+      current: "Error",
+      fingerprint,
+      values: {},
+    });
+    const recovered = stateLine({
+      previous: "Error",
+      current: "Normal",
+      fingerprint,
+      values: {},
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 180, line: raised },
+        { at: NOW_SECONDS - 120, line: failed },
+        { at: NOW_SECONDS - 60, line: recovered },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 6)).toEqual([
+      expect.objectContaining({
+        id: `state:${fingerprint}:cleared:${NOW_SECONDS - 60}`,
+        severity: "cleared",
+        detail: "EUROP · lasted 2 min.",
+      }),
+      expect.objectContaining({
+        id: `state:${fingerprint}:error-recovered:${NOW_SECONDS - 60}`,
+        severity: "cleared",
+      }),
+      expect.objectContaining({
+        id: `state:${fingerprint}:error:${NOW_SECONDS - 120}`,
+      }),
+      expect.objectContaining({
+        id: `state:${fingerprint}:raised:${NOW_SECONDS - 180}`,
+      }),
+    ]);
+  });
+
+  it("pairs a boundary Error to Alerting recovery with its later clear", () => {
+    const fingerprint = "boundary-error-alerting";
+    const recoveredAlerting = stateLine({
+      previous: "Error",
+      current: "Alerting",
+      fingerprint,
+      values: { A: 51 },
+    });
+    const cleared = stateLine({
+      previous: "Alerting",
+      current: "Normal",
+      fingerprint,
+      values: {},
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 120, line: recoveredAlerting },
+        { at: NOW_SECONDS - 60, line: cleared },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:${fingerprint}:cleared:${NOW_SECONDS - 60}`,
+        detail: "EUROP · lasted 1 min.",
+      }),
+      expect.objectContaining({
+        id: `state:${fingerprint}:error-recovered-alerting:${NOW_SECONDS - 120}`,
+        evidence: expect.objectContaining({
+          evaluationState: "recovered-alerting",
+        }),
       }),
     ]);
   });
@@ -816,7 +941,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
   it("fails closed for malformed frames and oversized bodies", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json({ schema: {}, data: {} }))
-      .mockResolvedValue(json(stateFrame([])));
+      .mockImplementation(async () => json(stateFrame([])));
     expect((await GET()).status).toBe(502);
 
     vi.restoreAllMocks();
@@ -829,7 +954,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
           },
         }),
       )
-      .mockResolvedValue(json(stateFrame([])));
+      .mockImplementation(async () => json(stateFrame([])));
     expect((await GET()).status).toBe(502);
   });
 
@@ -843,7 +968,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
     );
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json(stateFrame(sentinelRows)))
-      .mockResolvedValue(json(stateFrame([])));
+      .mockImplementation(async () => json(stateFrame([])));
 
     expect((await GET()).status).toBe(502);
   });

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/__tests__/route.test.ts
@@ -261,17 +261,17 @@ describe("GET /api/peg-monitoring/alerts", () => {
       ],
     });
     expect(PEG_ALERTS_MAX_EVENTS).toBe(4);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("current"),
       ),
-    ).toEqual(["Alerting", "Normal"]);
+    ).toEqual(["Alerting", "Error", "Normal", "Normal"]);
     expect(
       fetchMock.mock.calls.map(([input]) =>
         new URL(String(input)).searchParams.get("previous"),
       ),
-    ).toEqual([null, "Alerting"]);
+    ).toEqual([null, null, "Alerting", "Error"]);
     for (const [input, init] of fetchMock.mock.calls) {
       const query = new URL(String(input)).searchParams;
       expect(query.get("from")).toBe(String(FROM_SECONDS));
@@ -301,7 +301,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
     const response = await GET();
 
     expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(await response.json()).toEqual({
       from: FROM_SECONDS,
       to: NOW_SECONDS,
@@ -338,6 +338,113 @@ describe("GET /api/peg-monitoring/alerts", () => {
       expect.objectContaining({
         id: `state:active:raised:${NOW_SECONDS - 1}`,
         lead: "Bitvavo buy and sell prices are 31 bps apart",
+      }),
+    ]);
+  });
+
+  it("renders Grafana Error notifications as monitoring failures", () => {
+    const title = "Peg Deep-Venue Downside Critical [europ-schuman · active]";
+    const failed = stateLine({
+      previous: "Normal",
+      current: "Error",
+      fingerprint: "query-error-page",
+      ruleTitle: title,
+      values: {},
+      labels: {
+        alertname: title,
+        route: "page",
+        severity: "critical",
+      },
+    });
+    const recovered = stateLine({
+      previous: "Error",
+      current: "Normal (NoData)",
+      fingerprint: "query-error-page",
+      ruleTitle: title,
+      values: {},
+      labels: {
+        alertname: title,
+        route: "page",
+        severity: "critical",
+      },
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 120, line: failed },
+        { at: NOW_SECONDS - 60, line: recovered },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:query-error-page:error-recovered:${NOW_SECONDS - 60}`,
+        severity: "cleared",
+        lead: "Grafana can evaluate the Bitvavo Peg rule again",
+        detail: "EUROP · lasted 1 min.",
+        evidence: expect.objectContaining({ evaluationState: "recovered" }),
+      }),
+      expect.objectContaining({
+        id: `state:query-error-page:error:${NOW_SECONDS - 120}`,
+        severity: "page",
+        lead: "Grafana could not evaluate the Bitvavo Peg rule",
+        detail: "EUROP.",
+        evidence: expect.objectContaining({ evaluationState: "failed" }),
+      }),
+    ]);
+  });
+
+  it("keeps Alerting to Error to Alerting separate from breach copy", () => {
+    const title = "Peg Deep-Venue Downside Critical [europ-schuman · active]";
+    const failed = stateLine({
+      previous: "Alerting",
+      current: "Error",
+      fingerprint: "interrupted-page",
+      ruleTitle: title,
+      values: {},
+      labels: {
+        alertname: title,
+        route: "page",
+        severity: "critical",
+      },
+    });
+    const recoveredAlerting = stateLine({
+      previous: "Error",
+      current: "Alerting",
+      fingerprint: "interrupted-page",
+      ruleTitle: title,
+      values: { A: 51 },
+      labels: {
+        alertname: title,
+        route: "page",
+        severity: "critical",
+      },
+    });
+    const transitions = parseStateTransitions(
+      stateFrame([
+        { at: NOW_SECONDS - 120, line: failed },
+        { at: NOW_SECONDS - 60, line: recoveredAlerting },
+      ]),
+      FROM_SECONDS,
+      NOW_SECONDS,
+    );
+
+    expect(combinePegAlertEvents(transitions, 4)).toEqual([
+      expect.objectContaining({
+        id: `state:interrupted-page:error-recovered-alerting:${NOW_SECONDS - 60}`,
+        severity: "page",
+        lead: "Grafana can evaluate the Bitvavo Peg rule again; its alert condition is active",
+        detail: "EUROP · lasted 1 min.",
+        evidence: expect.objectContaining({
+          evaluationState: "recovered-alerting",
+        }),
+      }),
+      expect.objectContaining({
+        id: `state:interrupted-page:error:${NOW_SECONDS - 120}`,
+        severity: "page",
+        lead: "Grafana could not evaluate the Bitvavo Peg rule",
+        evidence: expect.objectContaining({ evaluationState: "failed" }),
       }),
     ]);
   });
@@ -709,7 +816,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
   it("fails closed for malformed frames and oversized bodies", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json({ schema: {}, data: {} }))
-      .mockResolvedValueOnce(json(stateFrame([])));
+      .mockResolvedValue(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
 
     vi.restoreAllMocks();
@@ -722,7 +829,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
           },
         }),
       )
-      .mockResolvedValueOnce(json(stateFrame([])));
+      .mockResolvedValue(json(stateFrame([])));
     expect((await GET()).status).toBe(502);
   });
 
@@ -736,7 +843,7 @@ describe("GET /api/peg-monitoring/alerts", () => {
     );
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(json(stateFrame(sentinelRows)))
-      .mockResolvedValueOnce(json(stateFrame([])));
+      .mockResolvedValue(json(stateFrame([])));
 
     expect((await GET()).status).toBe(502);
   });

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -81,7 +81,8 @@ type PegStateTransition = {
     | "cleared"
     | "error"
     | "error-recovered"
-    | "error-recovered-alerting";
+    | "error-recovered-alerting"
+    | "error-recovered-pending";
   identity: string;
   line: StateLine;
 };
@@ -108,6 +109,8 @@ function transitionKind(line: StateLine): PegStateTransition["kind"] | null {
   if (current === "Error") return "error";
   if (previous === "Error" && current === "Alerting")
     return "error-recovered-alerting";
+  if (previous === "Error" && current === "Pending")
+    return "error-recovered-pending";
   if (previous === "Error" && current === "Normal") return "error-recovered";
   if (current === "Alerting") return "raised";
   if (previous === "Alerting" && current === "Normal") return "cleared";
@@ -207,6 +210,13 @@ type PhrasedEvent = PegAlertEvent & {
   policySlot: ReturnType<typeof policySlot>;
 };
 
+type TransitionCycleState = {
+  open: Map<string, PegStateTransition>;
+  observedRaised: Set<string>;
+  unpairedCleared: Map<string, PegStateTransition>;
+  events: PhrasedEvent[];
+};
+
 type EvaluationState = NonNullable<
   PegAlertEvent["evidence"]["evaluationState"]
 >;
@@ -217,6 +227,7 @@ function evaluationStateFor(
   if (kind === "error") return "failed";
   if (kind === "error-recovered") return "recovered";
   if (kind === "error-recovered-alerting") return "recovered-alerting";
+  if (kind === "error-recovered-pending") return "recovered-pending";
   return undefined;
 }
 
@@ -239,7 +250,9 @@ function evaluationCause(
     lead:
       evaluationState === "recovered"
         ? `Grafana can evaluate the ${sourceName} Peg rule again`
-        : `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is active`,
+        : evaluationState === "recovered-alerting"
+          ? `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is active`
+          : `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is pending`,
   };
 }
 
@@ -249,6 +262,7 @@ function transitionSeverity(
   evaluationState: EvaluationState | undefined,
 ): PegAlertEvent["severity"] {
   if (cleared || evaluationState === "recovered") return "cleared";
+  if (evaluationState === "recovered-pending") return "warning";
   return evidence.labels.route === "page" ||
     evidence.labels.severity === "critical"
     ? "page"
@@ -264,7 +278,9 @@ function phraseTransition(
   const evaluationState = evaluationStateFor(transition.kind);
   const cause = evaluationCause(evidence, evaluationState, cleared);
   const recovered =
-    evaluationState === "recovered" || evaluationState === "recovered-alerting";
+    evaluationState === "recovered" ||
+    evaluationState === "recovered-alerting" ||
+    evaluationState === "recovered-pending";
   const detail = [
     cause.includesAsset ? null : pegAlertAssetName(evidence.labels.asset),
     (cleared || recovered) && raised !== undefined
@@ -312,6 +328,56 @@ function normalizedFailureReason(reason: number | undefined): number | null {
     : null;
 }
 
+function closeAlertCycle(
+  recovery: PegStateTransition,
+  state: TransitionCycleState,
+): void {
+  const alertKey = `${recovery.identity}:alert`;
+  const alertRaised = state.open.get(alertKey);
+  if (alertRaised === undefined) return;
+  if (alertRaised.kind !== "error-recovered-alerting")
+    state.events.push(phraseTransition(alertRaised, alertRaised));
+  state.events.push(
+    phraseTransition({ ...recovery, kind: "cleared" }, alertRaised),
+  );
+  state.open.delete(alertKey);
+}
+
+function applyRecoveryToAlertCycle(
+  transition: PegStateTransition,
+  state: TransitionCycleState,
+): void {
+  if (
+    transition.kind === "error-recovered" ||
+    transition.kind === "error-recovered-pending"
+  ) {
+    closeAlertCycle(transition, state);
+    return;
+  }
+  if (transition.kind !== "error-recovered-alerting") return;
+  const alertKey = `${transition.identity}:alert`;
+  state.observedRaised.add(alertKey);
+  if (!state.open.has(alertKey)) state.open.set(alertKey, transition);
+}
+
+function closeStateCycle(
+  transition: PegStateTransition,
+  key: string,
+  state: TransitionCycleState,
+): void {
+  const raised = state.open.get(key);
+  if (raised === undefined) {
+    if (!state.observedRaised.has(key))
+      state.unpairedCleared.set(key, transition);
+    return;
+  }
+  if (transition.at < raised.at) return;
+  if (raised.kind !== "error-recovered-alerting")
+    state.events.push(phraseTransition(raised, raised));
+  state.events.push(phraseTransition(transition, raised));
+  state.open.delete(key);
+}
+
 function pairStateTransitions(
   transitions: readonly PegStateTransition[],
 ): PhrasedEvent[] {
@@ -329,6 +395,7 @@ function pairStateTransitions(
   const observedRaised = new Set<string>();
   const unpairedCleared = new Map<string, PegStateTransition>();
   const events: PhrasedEvent[] = [];
+  const state = { events, observedRaised, open, unpairedCleared };
   for (const transition of ordered) {
     const key = cycleKey(transition);
     if (isOpening(transition)) {
@@ -341,19 +408,14 @@ function pairStateTransitions(
       if (!open.has(key)) open.set(key, transition);
       continue;
     }
-    const raised = open.get(key);
-    if (raised === undefined) {
-      if (!observedRaised.has(key)) unpairedCleared.set(key, transition);
-      continue;
-    }
-    if (transition.at < raised.at) continue;
-    events.push(phraseTransition(raised, raised));
-    events.push(phraseTransition(transition, raised));
-    open.delete(key);
+    closeStateCycle(transition, key, state);
+    applyRecoveryToAlertCycle(transition, state);
   }
   for (const cleared of unpairedCleared.values())
     events.push(phraseTransition(cleared));
-  for (const raised of open.values()) events.push(phraseTransition(raised));
+  for (const raised of open.values())
+    if (raised.kind !== "error-recovered-alerting")
+      events.push(phraseTransition(raised));
   return events;
 }
 

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -231,6 +231,15 @@ function evaluationStateFor(
   return undefined;
 }
 
+function evaluationRuleSubject(evidence: StateLine): string {
+  if (evidence.labels.source !== "")
+    return `${pegAlertSourceName(evidence.labels.source)} Peg rule`;
+  const rule = pegAlertRuleKind(evidence);
+  return evidence.labels.asset === "policy"
+    ? `${rule} rule for policy ${evidence.labels.policy_version}`
+    : `${pegAlertAssetName(evidence.labels.asset)} ${rule} rule`;
+}
+
 function evaluationCause(
   evidence: StateLine,
   evaluationState: EvaluationState | undefined,
@@ -238,21 +247,21 @@ function evaluationCause(
 ): { includesAsset: boolean; lead: string } {
   if (evaluationState === undefined)
     return pegAlertCauseCopy(evidence, cleared);
-  const sourceName = pegAlertSourceName(evidence.labels.source);
+  const subject = evaluationRuleSubject(evidence);
   if (evaluationState === "failed") {
     return {
       includesAsset: false,
-      lead: `Grafana could not evaluate the ${sourceName} Peg rule`,
+      lead: `Grafana could not evaluate the ${subject}`,
     };
   }
   return {
     includesAsset: false,
     lead:
       evaluationState === "recovered"
-        ? `Grafana can evaluate the ${sourceName} Peg rule again`
+        ? `Grafana can evaluate the ${subject} again`
         : evaluationState === "recovered-alerting"
-          ? `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is active`
-          : `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is pending`,
+          ? `Grafana can evaluate the ${subject} again; its alert condition is active`
+          : `Grafana can evaluate the ${subject} again; its alert condition is pending`,
   };
 }
 

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/peg-alert-events.ts
@@ -76,7 +76,12 @@ class InvalidPegAlertsUpstreamError extends Error {}
 
 type PegStateTransition = {
   at: number;
-  kind: "raised" | "cleared";
+  kind:
+    | "raised"
+    | "cleared"
+    | "error"
+    | "error-recovered"
+    | "error-recovered-alerting";
   identity: string;
   line: StateLine;
 };
@@ -98,16 +103,29 @@ function baseState(value: string): string {
 }
 
 function transitionKind(line: StateLine): PegStateTransition["kind"] | null {
-  if (baseState(line.current) === "Alerting") return "raised";
-  if (
-    baseState(line.previous) === "Alerting" &&
-    baseState(line.current) === "Normal"
-  )
-    return "cleared";
+  const current = baseState(line.current);
+  const previous = baseState(line.previous);
+  if (current === "Error") return "error";
+  if (previous === "Error" && current === "Alerting")
+    return "error-recovered-alerting";
+  if (previous === "Error" && current === "Normal") return "error-recovered";
+  if (current === "Alerting") return "raised";
+  if (previous === "Alerting" && current === "Normal") return "cleared";
   return null;
 }
 
 export function parseStateTransitions(
+  raw: unknown,
+  fromSeconds: number,
+  toSeconds: number,
+): PegStateTransition[] {
+  const frames = Array.isArray(raw) ? raw : [raw];
+  return frames.flatMap((frame) =>
+    parseStateFrameTransitions(frame, fromSeconds, toSeconds),
+  );
+}
+
+function parseStateFrameTransitions(
   raw: unknown,
   fromSeconds: number,
   toSeconds: number,
@@ -189,16 +207,67 @@ type PhrasedEvent = PegAlertEvent & {
   policySlot: ReturnType<typeof policySlot>;
 };
 
+type EvaluationState = NonNullable<
+  PegAlertEvent["evidence"]["evaluationState"]
+>;
+
+function evaluationStateFor(
+  kind: PegStateTransition["kind"],
+): EvaluationState | undefined {
+  if (kind === "error") return "failed";
+  if (kind === "error-recovered") return "recovered";
+  if (kind === "error-recovered-alerting") return "recovered-alerting";
+  return undefined;
+}
+
+function evaluationCause(
+  evidence: StateLine,
+  evaluationState: EvaluationState | undefined,
+  cleared: boolean,
+): { includesAsset: boolean; lead: string } {
+  if (evaluationState === undefined)
+    return pegAlertCauseCopy(evidence, cleared);
+  const sourceName = pegAlertSourceName(evidence.labels.source);
+  if (evaluationState === "failed") {
+    return {
+      includesAsset: false,
+      lead: `Grafana could not evaluate the ${sourceName} Peg rule`,
+    };
+  }
+  return {
+    includesAsset: false,
+    lead:
+      evaluationState === "recovered"
+        ? `Grafana can evaluate the ${sourceName} Peg rule again`
+        : `Grafana can evaluate the ${sourceName} Peg rule again; its alert condition is active`,
+  };
+}
+
+function transitionSeverity(
+  evidence: StateLine,
+  cleared: boolean,
+  evaluationState: EvaluationState | undefined,
+): PegAlertEvent["severity"] {
+  if (cleared || evaluationState === "recovered") return "cleared";
+  return evidence.labels.route === "page" ||
+    evidence.labels.severity === "critical"
+    ? "page"
+    : "warning";
+}
+
 function phraseTransition(
   transition: PegStateTransition,
   raised?: PegStateTransition,
 ): PhrasedEvent {
   const evidence = raised?.line ?? transition.line;
   const cleared = transition.kind === "cleared";
-  const cause = pegAlertCauseCopy(evidence, cleared);
+  const evaluationState = evaluationStateFor(transition.kind);
+  const cause = evaluationCause(evidence, evaluationState, cleared);
+  const recovered =
+    evaluationState === "recovered" || evaluationState === "recovered-alerting";
   const detail = [
     cause.includesAsset ? null : pegAlertAssetName(evidence.labels.asset),
-    cleared && raised !== undefined
+    (cleared || recovered) && raised !== undefined
       ? `lasted ${durationLabel(Math.max(0, transition.at - raised.at))}`
       : null,
   ]
@@ -207,12 +276,7 @@ function phraseTransition(
   return {
     id: `state:${transition.identity}:${transition.kind}:${transition.at}`,
     at: transition.at,
-    severity: cleared
-      ? "cleared"
-      : evidence.labels.route === "page" ||
-          evidence.labels.severity === "critical"
-        ? "page"
-        : "warning",
+    severity: transitionSeverity(evidence, cleared, evaluationState),
     lead: cause.lead,
     detail: detail === "" ? "" : `${detail}.`,
     evidence: {
@@ -223,7 +287,11 @@ function phraseTransition(
       sourceName: pegAlertSourceName(evidence.labels.source),
       quoteCurrency: pegAlertSourceCurrency(evidence.labels.source),
       policyVersion: evidence.labels.policy_version,
-      failureReason: normalizedFailureReason(evidence.values.Reason),
+      failureReason:
+        evaluationState === undefined
+          ? normalizedFailureReason(evidence.values.Reason)
+          : null,
+      ...(evaluationState === undefined ? {} : { evaluationState }),
     },
     duplicateKey: [
       pegAlertRuleKind(evidence),
@@ -247,10 +315,14 @@ function normalizedFailureReason(reason: number | undefined): number | null {
 function pairStateTransitions(
   transitions: readonly PegStateTransition[],
 ): PhrasedEvent[] {
+  const isOpening = (transition: PegStateTransition): boolean =>
+    transition.kind === "raised" || transition.kind === "error";
+  const cycleKey = (transition: PegStateTransition): string =>
+    `${transition.identity}:${transition.kind.startsWith("error") ? "error" : "alert"}`;
   const ordered = [...transitions].sort(
     (left, right) =>
       left.at - right.at ||
-      (left.kind === right.kind ? 0 : left.kind === "raised" ? -1 : 1) ||
+      (isOpening(left) === isOpening(right) ? 0 : isOpening(left) ? -1 : 1) ||
       left.identity.localeCompare(right.identity),
   );
   const open = new Map<string, PegStateTransition>();
@@ -258,27 +330,26 @@ function pairStateTransitions(
   const unpairedCleared = new Map<string, PegStateTransition>();
   const events: PhrasedEvent[] = [];
   for (const transition of ordered) {
-    if (transition.kind === "raised") {
-      const boundaryResolution = unpairedCleared.get(transition.identity);
+    const key = cycleKey(transition);
+    if (isOpening(transition)) {
+      const boundaryResolution = unpairedCleared.get(key);
       if (boundaryResolution !== undefined) {
         events.push(phraseTransition(boundaryResolution));
-        unpairedCleared.delete(transition.identity);
+        unpairedCleared.delete(key);
       }
-      observedRaised.add(transition.identity);
-      if (!open.has(transition.identity))
-        open.set(transition.identity, transition);
+      observedRaised.add(key);
+      if (!open.has(key)) open.set(key, transition);
       continue;
     }
-    const raised = open.get(transition.identity);
+    const raised = open.get(key);
     if (raised === undefined) {
-      if (!observedRaised.has(transition.identity))
-        unpairedCleared.set(transition.identity, transition);
+      if (!observedRaised.has(key)) unpairedCleared.set(key, transition);
       continue;
     }
     if (transition.at < raised.at) continue;
     events.push(phraseTransition(raised, raised));
     events.push(phraseTransition(transition, raised));
-    open.delete(transition.identity);
+    open.delete(key);
   }
   for (const cleared of unpairedCleared.values())
     events.push(phraseTransition(cleared));

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -40,26 +40,47 @@ function stateHistoryUrl(
   return url;
 }
 
+function errorStateHistoryUrl(url: URL): URL | null {
+  const current = url.searchParams.get("current");
+  const previous = url.searchParams.get("previous");
+  const errorUrl = new URL(url);
+  if (current === "Alerting" && previous === null) {
+    errorUrl.searchParams.set("current", "Error");
+    return errorUrl;
+  }
+  if (current === "Normal" && previous === "Alerting") {
+    errorUrl.searchParams.set("previous", "Error");
+    return errorUrl;
+  }
+  return null;
+}
+
 async function fetchJson(
   url: URL,
   token: string,
   maximumBytes: number,
 ): Promise<unknown> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    cache: "no-store",
-    redirect: "error",
-    signal: AbortSignal.timeout(PEG_ALERTS_UPSTREAM_TIMEOUT_MS),
-  });
-  if (!response.ok) throw new Error("Grafana unavailable");
-  if (!response.headers.get("content-type")?.includes("application/json"))
-    throw new Error("Grafana returned non-JSON");
-  return JSON.parse(
-    await readBoundedGrafanaResponse(response, maximumBytes),
-  ) as unknown;
+  const errorUrl = errorStateHistoryUrl(url);
+  const urls = errorUrl === null ? [url] : [url, errorUrl];
+  return Promise.all(
+    urls.map(async (requestUrl) => {
+      const response = await fetch(requestUrl, {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        cache: "no-store",
+        redirect: "error",
+        signal: AbortSignal.timeout(PEG_ALERTS_UPSTREAM_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error("Grafana unavailable");
+      if (!response.headers.get("content-type")?.includes("application/json"))
+        throw new Error("Grafana returned non-JSON");
+      return JSON.parse(
+        await readBoundedGrafanaResponse(response, maximumBytes),
+      ) as unknown;
+    }),
+  );
 }
 
 export async function GET(): Promise<NextResponse> {

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -49,6 +49,7 @@ function errorStateHistoryUrl(url: URL): URL | null {
     return errorUrl;
   }
   if (current === "Normal" && previous === "Alerting") {
+    errorUrl.searchParams.delete("current");
     errorUrl.searchParams.set("previous", "Error");
     return errorUrl;
   }

--- a/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
+++ b/ui-dashboard/src/app/api/peg-monitoring/alerts/route.ts
@@ -59,7 +59,7 @@ async function fetchJson(
   url: URL,
   token: string,
   maximumBytes: number,
-): Promise<unknown> {
+): Promise<unknown[]> {
   const errorUrl = errorStateHistoryUrl(url);
   const urls = errorUrl === null ? [url] : [url, errorUrl];
   return Promise.all(

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -190,7 +190,42 @@ describe("RecentAlerts", () => {
     expect(row.textContent).toContain(
       "This entry records a monitoring failure and does not confirm a peg breach.",
     );
-    expect(row.textContent).not.toContain("sell price is below peg");
+    expect(row.textContent).not.toContain(
+      "The monitor uses the average price available when selling the monitored amount",
+    );
+  });
+
+  it("labels and explains monitoring recovery into Pending", () => {
+    const recovery: PegAlertEvent = {
+      ...events[0]!,
+      id: "grafana-evaluation-recovered-pending",
+      severity: "warning",
+      lead: "Grafana can evaluate the Bitvavo Peg rule again; its alert condition is pending",
+      detail: "EUROP · lasted 1 min.",
+      evidence: {
+        ...events[0]!.evidence,
+        evaluationState: "recovered-pending",
+      },
+    };
+    act(() =>
+      root.render(
+        <RecentAlerts
+          nowMs={NOW_MS}
+          events={[recovery]}
+          monitoring={monitoring}
+          state="ready"
+        />,
+      ),
+    );
+
+    const row = container.querySelector("li")!;
+    expect(row.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "Monitoring recovered; alert pending",
+    );
+    act(() => row.querySelector("summary")!.click());
+    expect(row.textContent).toContain(
+      "Grafana resumed evaluating this Peg rule, and the rule entered Pending.",
+    );
   });
 
   it("omits the separator when the cause needs no detail", () => {

--- a/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/__tests__/recent-alerts.test.tsx
@@ -157,6 +157,42 @@ describe("RecentAlerts", () => {
     );
   });
 
+  it("labels and explains Grafana evaluation failures without breach copy", () => {
+    const failure: PegAlertEvent = {
+      ...events[0]!,
+      id: "grafana-evaluation-failed",
+      severity: "page",
+      lead: "Grafana could not evaluate the Bitvavo Peg rule",
+      detail: "EUROP.",
+      evidence: {
+        ...events[1]!.evidence,
+        rule: "Deep-Venue Downside Critical",
+        failureReason: null,
+        evaluationState: "failed",
+      },
+    };
+    act(() =>
+      root.render(
+        <RecentAlerts
+          nowMs={NOW_MS}
+          events={[failure]}
+          monitoring={monitoring}
+          state="ready"
+        />,
+      ),
+    );
+
+    const row = container.querySelector("li")!;
+    expect(row.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "Monitoring failed",
+    );
+    act(() => row.querySelector("summary")!.click());
+    expect(row.textContent).toContain(
+      "This entry records a monitoring failure and does not confirm a peg breach.",
+    );
+    expect(row.textContent).not.toContain("sell price is below peg");
+  });
+
   it("omits the separator when the cause needs no detail", () => {
     act(() =>
       root.render(

--- a/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
@@ -25,6 +25,8 @@ function eventStatusLabel(event: PegAlertEvent): string {
     return "Monitoring recovered";
   if (event.evidence.evaluationState === "recovered-alerting")
     return "Monitoring recovered; alert active";
+  if (event.evidence.evaluationState === "recovered-pending")
+    return "Monitoring recovered; alert pending";
   return SEVERITY_LABEL[event.severity];
 }
 

--- a/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
+++ b/ui-dashboard/src/app/peg-monitoring/_components/recent-alerts.tsx
@@ -19,6 +19,15 @@ const SEVERITY_LABEL: Record<PegAlertSeverity, string> = {
   page: "Urgent alert active",
 };
 
+function eventStatusLabel(event: PegAlertEvent): string {
+  if (event.evidence.evaluationState === "failed") return "Monitoring failed";
+  if (event.evidence.evaluationState === "recovered")
+    return "Monitoring recovered";
+  if (event.evidence.evaluationState === "recovered-alerting")
+    return "Monitoring recovered; alert active";
+  return SEVERITY_LABEL[event.severity];
+}
+
 const clock = new Intl.DateTimeFormat("en-US", {
   hour: "2-digit",
   minute: "2-digit",
@@ -59,7 +68,7 @@ function AlertEntry({
           <span
             className="pt-[5px]"
             role="img"
-            aria-label={SEVERITY_LABEL[event.severity]}
+            aria-label={eventStatusLabel(event)}
           >
             <SeverityDot size={8} color={SEVERITY_COLOR[event.severity]} />
           </span>

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
@@ -300,6 +300,9 @@ export function pegAlertExplanation(
   if (event.evidence.evaluationState === "recovered-alerting") {
     return "Grafana resumed evaluating this Peg rule, and the rule entered Alerting. The upstream error text is not shown.";
   }
+  if (event.evidence.evaluationState === "recovered-pending") {
+    return "Grafana resumed evaluating this Peg rule, and the rule entered Pending. The upstream error text is not shown.";
+  }
   const policy = exactPolicyContext(event, monitoring);
   return RULE_EXPLANATIONS[event.evidence.rule](event, policy, monitoring);
 }

--- a/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
+++ b/ui-dashboard/src/app/peg-monitoring/_lib/peg-alert-explanation.ts
@@ -291,6 +291,15 @@ export function pegAlertExplanation(
   event: PegAlertEvent,
   monitoring: PegMonitoringResponse,
 ): string {
+  if (event.evidence.evaluationState === "failed") {
+    return "Grafana could not evaluate this Peg rule. This entry records a monitoring failure and does not confirm a peg breach. The upstream error text is not shown.";
+  }
+  if (event.evidence.evaluationState === "recovered") {
+    return "Grafana resumed evaluating this Peg rule. This entry records monitoring recovery and does not confirm that the rule's market condition occurred.";
+  }
+  if (event.evidence.evaluationState === "recovered-alerting") {
+    return "Grafana resumed evaluating this Peg rule, and the rule entered Alerting. The upstream error text is not shown.";
+  }
   const policy = exactPolicyContext(event, monitoring);
   return RULE_EXPLANATIONS[event.evidence.rule](event, policy, monitoring);
 }

--- a/ui-dashboard/src/lib/peg-alerts.ts
+++ b/ui-dashboard/src/lib/peg-alerts.ts
@@ -33,6 +33,7 @@ type PegAlertEvidence = {
   quoteCurrency: string | null;
   policyVersion: string;
   failureReason: number | null;
+  evaluationState?: "failed" | "recovered" | "recovered-alerting";
 };
 
 export type PegAlertEvent = {

--- a/ui-dashboard/src/lib/peg-alerts.ts
+++ b/ui-dashboard/src/lib/peg-alerts.ts
@@ -33,7 +33,11 @@ type PegAlertEvidence = {
   quoteCurrency: string | null;
   policyVersion: string;
   failureReason: number | null;
-  evaluationState?: "failed" | "recovered" | "recovered-alerting";
+  evaluationState?:
+    | "failed"
+    | "recovered"
+    | "recovered-alerting"
+    | "recovered-pending";
 };
 
 export type PegAlertEvent = {


### PR DESCRIPTION
## The Problem

- Grafana notified Slack when Peg rules entered `Error`, but Recent alerts queried only `Alerting` transitions and omitted the monitoring incident.
- Grafana fixes each Slack attachment title link to its alert detail page, so the visible Peg alert title could not open Peg Monitoring.

## The Solution

- Show Grafana evaluation failures and recoveries as distinct Recent alerts, and put the human Slack title in a body link to Peg Monitoring.

## Visual comparison

| Before (`d2360261`) | After (`f2b0b9dd`; unchanged at `e2a5eab2`) |
| --- | --- |
| ![Before: Recent alerts omits Grafana evaluation failures](https://github.com/user-attachments/assets/0e2935df-2450-4761-9701-035152c902ac) | ![After: Recent alerts shows Grafana evaluation failure and recovery](https://github.com/user-attachments/assets/cf04088d-baa8-4353-89f8-ae12eb16df11) |

Both images use a 1440 x 1000 viewport, one fixed Metrics Bridge payload, and one fixed Grafana state-history fixture.

## Details

- The API makes four bounded Grafana state-history reads: alert start, alert recovery, evaluation failure, and evaluation recovery.
- Alert cycles and evaluation-error cycles use separate pairing keys.
- Source-less evaluation errors identify the asset-wide rule, or the policy rollover rule and policy version.
- An `Error` state never becomes a confirmed peg breach. The UI uses generic failure and recovery copy and does not expose Grafana upstream error text.
- A malformed, oversized, or timed-out companion response fails the endpoint closed. Grafana full history remains the operator escape hatch.
- The Slack attachment title contains only status. The human firing and resolved titles link to `https://monitoring.mento.org/peg-monitoring` in the message body.
- This PR does not change Metrics Bridge runtime behavior, alert rule conditions, notification routing, or applied Terraform state.

Closes #1986

## Validation

- Exact-source agent quality gate: passed all mapped dashboard, browser, coverage, Terraform, alert-rule, script, Trunk, React Doctor, dependency, and size checks before an upstream-only rebase.
- Final rebased local gate: skipped by user because the shared non-FIFO gate mutex starved the push; GitHub CI is the authoritative final-head verification for this PR.
- Focused current-head route Vitest run: 50 tests passed.
- Dashboard lint and typecheck passed.
- Fresh-context semantic review passed with no findings after the evaluation-error semantics fix.
- Published browser comparison used the exact base `d23602614e19904cdc6a6ce880dd89989c748661` and head `f2b0b9dd0979c4f11d2032887d1a547f6b8216ed` at 1440 x 1000 with one fixed Metrics Bridge payload and one fixed Grafana state-history fixture. The current-head follow-up changes only source-less evaluation copy, which this fixture does not render.
- Current-head browser checks at `e2a5eab203d8baacc4d101d1f69f60f92671c9a9` confirmed the failure and recovery rows, the monitoring-failure detail text, hidden upstream error text, and the absence of false sell-price breach copy. The current-head screenshot upload failed in the connected browser, so the table retains the equivalent published `f2b0b9dd` image.
- Chrome DevTools MCP was unavailable. Verification used the connected Chrome browser through the browser control plugin and DevTools protocol.
- Claude Security scan: skipped (network-facing dashboard API and alert Terraform surface).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This change extends the existing bounded Grafana state-history adapter and alert-message pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grafana state-history querying (four bounded reads) and how operator-facing Peg incidents are classified, so a pairing or copy bug could hide or mislabel monitoring failures versus market breaches.
>
> **Overview**
> Peg Recent alerts now show Grafana **evaluation failures and recoveries** as their own incidents, instead of only `Alerting`/`Normal` transitions. Slack titles shrink to a status icon so Grafana’s hardcoded title link stays on the alert page; the human title is a body link to Peg Monitoring.
>
> The alerts API fetches companion `Error` state-history pages alongside raise/clear, pairs error cycles separately from breach cycles, and never treats `Error` as a peg breach. UI copy, a11y labels, and explanations stay generic and omit upstream error text. A bad companion Grafana response still fails the endpoint closed.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9845490149e2ff1f3f20c0d0b6d24cd5877bdc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Peg Monitoring now identifies monitoring evaluation failures, recoveries, and recovered-but-still-alerting states.
  - Alert details explain when monitoring failed without implying a confirmed peg breach.
  - Recent alerts display status labels based on the monitoring state for improved accessibility and clarity.
  - Slack alert summaries link directly to Peg Monitoring while retaining readable status-specific messages.

- **Bug Fixes**
  - Improved handling of evaluation errors and recovery transitions in alert history and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
