### PR TITLE
fix(autoreview): recognise escaped shell expansions as references

### DIFF
--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -861,6 +861,18 @@ function placeholderValue(value) {
   const trimmed = value.trim();
   return (
     shellExpansionReference(trimmed) ||
+    // One leading backslash still leaves a reference. Inside a JS template
+    // literal `\${VAR:-}` is a JS escape, so the emitted shell script receives
+    // `${VAR:-}` — a parameter expansion resolved at run time that carries
+    // nothing. Where the backslash instead survives literally, the value is
+    // placeholder text, not credential material. Exactly one backslash is
+    // stripped and the remainder has to be a whole reference on its own; the
+    // narrow form is the point, because normalizing the backslash ahead of the
+    // entire grammar below would also clear escaped GitHub Actions forms
+    // (`\${{ secrets.X }}`) and escaped HCL (`\${var.x}`). Those keep refusing
+    // here: `shellExpansionReference` accepts neither, so only the shell
+    // expansion form is widened.
+    (trimmed.startsWith("\\") && shellExpansionReference(trimmed.slice(1))) ||
     /^(?:\$\{(?:[A-Z_][A-Z0-9_]*|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\]))\}|\$\{\{\s*(?:secrets|vars|github|env|inputs|matrix|needs|steps|job|jobs|runner|strategy)\.[A-Z0-9_.-]+\s*\}\}|\$[A-Z_][A-Z0-9_]*|process\.env(?:\.[A-Z_][A-Z0-9_]*|\[["'][A-Z_][A-Z0-9_]*["']\])|(?:secrets|vars|var|local|module|data)\.[A-Z0-9_.-]+)$/i.test(
       trimmed,
     ) ||

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -863,9 +863,11 @@ function placeholderValue(value) {
     shellExpansionReference(trimmed) ||
     // One leading backslash still leaves a reference. Inside a JS template
     // literal `\${VAR:-}` is a JS escape, so the emitted shell script receives
-    // `${VAR:-}` — a parameter expansion resolved at run time that carries
-    // nothing. Where the backslash instead survives literally, the value is
-    // placeholder text, not credential material. Exactly one backslash is
+    // `${VAR:-}` — a parameter expansion that yields the variable's value when
+    // set and non-null, and the (empty) default otherwise, always at run time.
+    // Either way the committed source carries no literal credential, which is
+    // what this scanner guards. Where the backslash instead survives
+    // literally, the value is placeholder text, not credential material. Exactly one backslash is
     // stripped and the remainder has to be a whole reference on its own; the
     // narrow form is the point, because normalizing the backslash ahead of the
     // entire grammar below would also clear escaped GitHub Actions forms

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -774,6 +774,186 @@ assert.match(
   /literal generic token assignment/,
   "a real literal trailing a github.* expression is still rejected (anchor holds)",
 );
+// Escaped shell expansions. Inside a JS template literal `\${VAR:-}` is a JS
+// escape, so the emitted shell script receives `${VAR:-}` — a parameter
+// expansion resolved at run time that carries nothing. `placeholderValue`
+// strips exactly one leading backslash and requires the remainder to be a
+// whole reference on its own.
+//
+// Every value below uses a long variable name deliberately. A short one such
+// as `\${V}` sits under CREDENTIAL_LITERAL_MIN_LENGTH and clears whether or
+// not the clause exists, which would make the pin vacuous: each assertion here
+// fails against a scanner without the clause.
+const BACKSLASH = "\\";
+const expansionVariable = "SENTRY_TRIAGE_TOKEN";
+const escapedExpansion = (body) => tokenAssignment([BACKSLASH, body].join(""));
+assert.equal(
+  secretLikeReason(escapedExpansion(["${", expansionVariable, "}"].join(""))),
+  null,
+  "an escaped shell expansion is a reference, not a literal token",
+);
+for (const operator of [":-", "-", ":=", "=", ":+", "+", ":?", "?"]) {
+  assert.equal(
+    secretLikeReason(
+      escapedExpansion(["${", expansionVariable, operator, "}"].join("")),
+    ),
+    null,
+    `an escaped ${operator} expansion with an empty word is a reference`,
+  );
+  assert.equal(
+    secretLikeReason(
+      escapedExpansion(
+        ["${", expansionVariable, operator, "$FALLBACK_TOKEN}"].join(""),
+      ),
+    ),
+    null,
+    `an escaped ${operator} expansion with a reference word is a reference`,
+  );
+}
+assert.equal(
+  secretLikeReason(escapedExpansion(nestedShellExpansion(8))),
+  null,
+  "escaped expansions nested to the bound are still references",
+);
+// The motivating line, copied from
+// scripts/sentry/broker/sentry-mcp-broker.test.mjs:1036 (#1970 row 1).
+const brokerShellToken = [
+  "    ",
+  "token",
+  "=",
+  '"',
+  BACKSLASH,
+  "${SENTRY_TRIAGE_TOKEN:-}",
+  '"',
+].join("");
+assert.equal(
+  secretLikeReason(brokerShellToken),
+  null,
+  "the broker suite's escaped shell expansion clears the scanner (#1970 row 1)",
+);
+// Exactly one backslash is stripped, and only the shell-expansion grammar is
+// retried. Material attached to the reference, a second backslash, or another
+// reference dialect all keep refusing.
+assert.match(
+  secretLikeReason(
+    escapedExpansion(
+      ["${", expansionVariable, ":-", genericTokenCredential, "}"].join(""),
+    ),
+  ),
+  /literal generic token assignment/,
+  "a literal default inside an escaped expansion is still rejected",
+);
+assert.match(
+  secretLikeReason(
+    escapedExpansion(
+      ["${", expansionVariable, ":-$FALLBACK_TOKEN}", "suffix"].join(""),
+    ),
+  ),
+  /literal generic token assignment/,
+  "material fused after an escaped expansion fails the ^…$ anchor",
+);
+assert.match(
+  secretLikeReason(
+    tokenAssignment(
+      ["junkjunkjunk", BACKSLASH, "${", expansionVariable, "}"].join(""),
+    ),
+  ),
+  /literal generic token assignment/,
+  "junk before an escaped expansion is rejected: the backslash has to lead",
+);
+assert.match(
+  secretLikeReason(
+    escapedExpansion([BACKSLASH, "${", expansionVariable, "}"].join("")),
+  ),
+  /literal generic token assignment/,
+  "two leading backslashes are rejected: exactly one is stripped",
+);
+assert.match(
+  secretLikeReason(
+    escapedExpansion(["${{ secrets.", expansionVariable, " }}"].join("")),
+  ),
+  /literal generic token assignment/,
+  "escaped GitHub Actions expressions stay refused: the retry is shell-only",
+);
+// An asymmetry worth stating: the unescaped `${var.x}` form clears through
+// placeholderValue's HCL clause, but the escaped form does not, because the
+// new clause retries `shellExpansionReference` alone and that grammar has no
+// HCL clause. Refusing is the fail-closed direction and no fixture needs it.
+assert.match(
+  secretLikeReason(escapedExpansion("${var.sentry_triage_token}")),
+  /literal generic token assignment/,
+  "escaped HCL traversals refuse: the retried grammar is shell-only",
+);
+assert.equal(
+  secretLikeReason(tokenAssignment("${var.sentry_triage_token}")),
+  null,
+  "the unescaped HCL traversal still clears, so the asymmetry is deliberate",
+);
+assert.match(
+  secretLikeReason(escapedExpansion(nestedShellExpansion(9))),
+  /literal generic token assignment/,
+  "escaped expansions nested past the bound are not references",
+);
+// Only the outer backslash is stripped, so the inner `\${…}` is not a valid
+// word and the whole value refuses. Fail-closed, and no real fixture needs it.
+assert.match(
+  secretLikeReason(
+    escapedExpansion(
+      ["${", expansionVariable, ":-", BACKSLASH, "${FALLBACK_TOKEN:-}}"].join(
+        "",
+      ),
+    ),
+  ),
+  /literal generic token assignment/,
+  "a nested escaped inner reference refuses: one backslash is stripped, not each",
+);
+// The other three #1970 rows are a different gap — a `%%` expansion the shell
+// grammar does not accept, and hyphenated-word fixtures — and stay refused.
+const shellOwnerTokenLine = [
+  "const SHELL_OWNER_TOKEN = ",
+  "`",
+  "'",
+  '"',
+  BACKSLASH,
+  "${REPO%%/*}",
+  '"',
+  "'",
+  "`",
+  ";",
+].join("");
+assert.match(
+  secretLikeReason(shellOwnerTokenLine),
+  /literal credential assignment/,
+  "#1970 row 2 still refuses: `%%` is not a shell-expansion operator",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "      ",
+      "AWS_SECRET_ACCESS_KEY",
+      ": ",
+      '"',
+      "aws-secret-value",
+      '",',
+    ].join(""),
+  ),
+  /literal AWS credential assignment/,
+  "#1970 row 3 still refuses: hyphenated-word fixtures are a separate gap",
+);
+assert.match(
+  secretLikeReason(
+    [
+      "      ",
+      "SENTRY_PROJECTION_TOKEN",
+      ": ",
+      '"',
+      "projection-secret-value",
+      '",',
+    ].join(""),
+  ),
+  /literal generic token assignment/,
+  "#1970 row 4 still refuses: hyphenated-word fixtures are a separate gap",
+);
 // Terraform/HCL traversal references (var/local/module/data) name a value
 // resolved at plan/apply time, never an inline secret — the same reference
 // class as the ${{ … }} contexts above. `var.*` was already recognized;

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -776,9 +776,11 @@ assert.match(
 );
 // Escaped shell expansions. Inside a JS template literal `\${VAR:-}` is a JS
 // escape, so the emitted shell script receives `${VAR:-}` — a parameter
-// expansion resolved at run time that carries nothing. `placeholderValue`
-// strips exactly one leading backslash and requires the remainder to be a
-// whole reference on its own.
+// expansion that yields the variable's value when set and non-null, and the
+// (empty) default otherwise, always at run time; the committed source carries
+// no literal credential either way. `placeholderValue` strips exactly one
+// leading backslash and requires the remainder to be a whole reference on its
+// own.
 //
 // Every value below uses a long variable name deliberately. A short one such
 // as `\${V}` sits under CREDENTIAL_LITERAL_MIN_LENGTH and clears whether or


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `agent:autoreview` refuses shell snippets a test writes into a fixture
  script. In `.mjs` source they read `\${VAR:-}`, so the scanner sees a
  backslash instead of `${` and treats a runtime reference as a literal.
- One of the four lines in #1970 is exactly this class:
  `scripts/sentry/broker/sentry-mcp-broker.test.mjs:1036` refuses with
  `literal generic token assignment`, blocking any diff whose context reaches
  it.

## The Solution

- `placeholderValue` accepts one more form: a value that starts with a single
  backslash whose remainder is a complete shell-expansion reference. Nothing
  else in the grammar changes.

## Details

- The whole change is one clause beside the existing
  `shellExpansionReference(trimmed)`:

  ```js
  (trimmed.startsWith("\\") && shellExpansionReference(trimmed.slice(1)))
  ```

- Exactly one backslash is stripped, and the remainder is re-tested against
  `shellExpansionReference` alone — not against the whole placeholder grammar.
  That narrowness is the point: normalizing the backslash ahead of the full
  grammar would also clear escaped GitHub Actions forms
  (`\${{ secrets.X }}`) and escaped HCL (`\${var.x}`). Both keep refusing.
- Inside a JS template literal `\${VAR:-}` is a JS escape, so the emitted shell
  script receives `${VAR:-}` — a parameter expansion resolved at run time that
  carries nothing. Where the backslash instead survives literally, the value is
  placeholder text rather than credential material.
- Deliberate asymmetry: unescaped `${var.x}` clears through the HCL clause,
  while escaped `\${var.x}` refuses, because the retried grammar is shell-only.
  That is the fail-closed direction and no fixture needs it. Pinned in both
  directions.
- Every fixture value in the new battery uses a long variable name on purpose.
  A short one such as `\${V}` sits under `CREDENTIAL_LITERAL_MIN_LENGTH` and
  clears whether or not the clause exists — a vacuous pin. Each of the 20 clear
  assertions fails against a scanner without the clause.
- Credential-shaped adversarial values are composed from fragments at runtime,
  following this file's existing convention, so the PR's own diff stays
  reviewable by the scanner.

## Validation

- Full suite: `node scripts/agent-autoreview-core.test.mjs` →
  `agent-autoreview core tests passed`. No existing expectation changed; the
  diff is additive.
- Pin battery: 31 new assertions — 20 clear, 11 refuse. Clears cover the plain
  escaped reference, all eight operators (`:-` `-` `:=` `=` `:+` `+` `:?` `?`)
  with empty and reference words, nesting at the bound, and the real
  broker:1036 line. Refuses cover a literal default, an attached suffix, a
  leading-junk prefix, two backslashes, escaped GHA, escaped HCL, nesting past
  `MAX_SHELL_EXPANSION_NESTING`, and a nested escaped inner reference.
- #1970 table rows against the live scanner after the change: row 1
  (broker:1036) clears; rows 2–4 still refuse with their original reasons
  (`literal credential assignment`, `literal AWS credential assignment`,
  `literal generic token assignment`). Rows 2–4 are the hyphenated-word and
  `%%`-expansion gap, addressed by the fixture rewrite in PR 1996.
- Mutation proof, both through the generic-token assignment path:
  - Clause deleted → fails at the first new assertion, "an escaped shell
    expansion is a reference, not a literal token", `actual: 'literal generic
    token assignment'`, `expected: null`. All 20 clear pins fail.
  - Condition inverted (`!trimmed.startsWith("\\")`) → fails at the same
    assertion; all 20 clear pins fail and all 11 refusals still hold.
  - Code restored; suite green again.
- Self-scan: all 187 added lines and both full unified diffs scan clean through
  `secretLikeReason` (0 refusals), so `agent:autoreview` does not refuse this
  PR's own diff.

- Local autoreview: the runtime-trust guard correctly refuses to review a
  runtime-changing diff with the changed runtime (`executable autoreview
  runtime differs from its trusted pre-change snapshot`). The review ran via
  the documented trusted-checkout procedure instead: pre-change wrapper and
  helper from a clean detached checkout at `99cc3680` (protected-main state
  this branch is based on) with explicit `AUTOREVIEW_HELPER`; result recorded
  in a PR comment: clean, "patch is correct (0.94)", no actionable findings.
- Local pre-push gate: skipped for this push on explicit operator instruction
  (the machine-wide gate lock was held by another session for 45+ minutes; CI
  is the verifying run). Before the skip, every mapped gate command for this
  diff passed when run directly: `./tools/trunk check` on both files,
  `pnpm lint:scripts`, `pnpm tf:test`, and the full
  `pnpm agent:autoreview:test` suite (514s).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — one acceptance clause inside an
      existing rule, no alternative foreclosed.

References #1970.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens the secret-like scanner’s placeholder grammar, which can hide real literals if the clause is too loose. The change is a one-backslash, shell-only retry with fail-closed tests for fused literals, extra backslashes, and other dialects.
> 
> **Overview**
> Stops `agent:autoreview` from treating JS-escaped shell expansions (`\${VAR:-}`) as literal credentials. In `.mjs` fixtures those backslashes are JS escapes; the emitted script still gets a runtime `${VAR}` expansion that carries no secret.
> 
> `placeholderValue` now accepts a value that starts with **exactly one** backslash whose remainder is a complete `shellExpansionReference`. The retry is shell-only, so escaped GitHub Actions (`\${{ secrets.X }}`) and escaped HCL (`\${var.x}`) still fail closed.
> 
> Pins the broker fixture from #1970 row 1 as allowed. Rows 2–4 (`%%` expansions and hyphenated fixture words) stay refused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7595e6b8bef5a17602f4f79fc0694293c8db8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret scanning to recognize supported escaped shell parameter-expansion references as non-literal values.
  * Continued rejecting malformed, doubly escaped, overly nested, unsupported, or embedded-literal expressions.
  * Preserved validation for HCL expressions and credential patterns, including hyphenated AWS and Sentry token assignments.

* **Tests**
  * Added comprehensive regression coverage for accepted and rejected escaped expressions, fallback references, nesting limits, and credential detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->