### PR TITLE
fix(dashboard): ignore zero-exposure stETH history rows

### DIFF
--- a/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
@@ -84,6 +84,7 @@ function stethReserveSnapshot(
   wallet: string,
   dailyEarnedYieldAmount: number,
   totalEarnedYieldAmount = dailyEarnedYieldAmount,
+  overrides: Partial<StethYieldDailySnapshotRow> = {},
 ): StethYieldDailySnapshotRow {
   return {
     id: `1-steth-${wallet}-${timestamp}`,
@@ -102,6 +103,7 @@ function stethReserveSnapshot(
     dailyUnrealizedYieldAmount: usdWei(dailyEarnedYieldAmount),
     sampledAtBlock: "1",
     sampledAtTimestamp: String(timestamp),
+    ...overrides,
   };
 }
 
@@ -310,6 +312,101 @@ describe("buildCanonicalRevenue", () => {
       "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
     );
   });
+
+  it("keeps mixed active and zero-exposure stETH wallet history complete", () => {
+    const activeWallet = "0xd0697f70e79476195b742d5afab14be50f98cc1e";
+    const dormantWallet = "0xd3d2e5c5af667da817b2d752d86c8f40c22137e1";
+    const result = buildCanonicalRevenue({
+      networkData: [],
+      cdpDailySeries: [],
+      cdpMarkets: [],
+      reserveYield: reserveYield({
+        holdings: [
+          stethHolding({
+            identifier: activeWallet,
+            principalUsd: 4_000,
+            balance: 2,
+          }),
+        ],
+      }),
+      reserveDailySnapshots: [
+        stethReserveSnapshot(ts("2026-06-11"), activeWallet, 1, 1, {
+          balanceAmount: usdWei(2),
+          principalAmount: usdWei(1),
+        }),
+        stethReserveSnapshot(ts("2026-06-11"), dormantWallet, 0),
+        stethReserveSnapshot(ts("2026-06-12"), activeWallet, 1, 2, {
+          balanceAmount: usdWei(2),
+          principalAmount: usdWei(1),
+        }),
+        stethReserveSnapshot(ts("2026-06-12"), dormantWallet, 0),
+      ],
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBe(4_000);
+    expect(result.periods.allTimeSinceV3.totalUsd).toBe(4_000);
+    expect(result.partialReasons).not.toContain(
+      "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+    );
+  });
+
+  it.each([
+    ["balance", { balanceAmount: "1" }],
+    ["principal", { principalAmount: "1" }],
+    ["cumulative yield dust", { totalEarnedYieldAmount: "1" }],
+    ["daily yield dust", { dailyEarnedYieldAmount: "1" }],
+  ])(
+    "keeps an unpriced stETH row partial when its %s is nonzero",
+    (_label, overrides) => {
+      const wallet = "0xd3d2e5c5af667da817b2d752d86c8f40c22137e1";
+      const result = buildCanonicalRevenue({
+        networkData: [],
+        cdpDailySeries: [],
+        cdpMarkets: [],
+        reserveYield: reserveYield(),
+        reserveDailySnapshots: [
+          stethReserveSnapshot(ts("2026-06-12"), wallet, 0, 0, overrides),
+        ],
+        nowSeconds: NOW_SECONDS,
+      });
+
+      expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBeNull();
+      expect(result.partialReasons).toContain(
+        "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+      );
+    },
+  );
+
+  it.each([
+    ["balance", { balanceAmount: "not-wei" }],
+    ["principal", { principalAmount: "not-wei" }],
+    ["cumulative yield", { totalEarnedYieldAmount: "not-wei" }],
+    ["daily yield", { dailyEarnedYieldAmount: "not-wei" }],
+    ["blank balance", { balanceAmount: "" }],
+    ["whitespace-only balance", { balanceAmount: "  " }],
+    ["non-decimal balance", { balanceAmount: "0x0" }],
+  ])(
+    "keeps an unpriced stETH row partial when its %s is malformed",
+    (_label, overrides) => {
+      const wallet = "0xd3d2e5c5af667da817b2d752d86c8f40c22137e1";
+      const result = buildCanonicalRevenue({
+        networkData: [],
+        cdpDailySeries: [],
+        cdpMarkets: [],
+        reserveYield: reserveYield(),
+        reserveDailySnapshots: [
+          stethReserveSnapshot(ts("2026-06-12"), wallet, 0, 0, overrides),
+        ],
+        nowSeconds: NOW_SECONDS,
+      });
+
+      expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBeNull();
+      expect(result.partialReasons).toContain(
+        "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+      );
+    },
+  );
 
   it("marks stETH reserve history partial when current wallet pricing is missing", () => {
     const wallet = "0xd0697f70e79476195b742d5afab14be50f98cc1e";

--- a/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
@@ -351,7 +351,7 @@ describe("buildCanonicalRevenue", () => {
     );
   });
 
-  it("records zero revenue and resets the baseline when stETH exposure reaches zero", () => {
+  it("subtracts prior stETH yield and resets the baseline at zero exposure", () => {
     const wallet = "0xd0697f70e79476195b742d5afab14be50f98cc1e";
     const activeExposure = {
       balanceAmount: usdWei(2),
@@ -377,9 +377,83 @@ describe("buildCanonicalRevenue", () => {
     expect(
       result.dailySeries.find((point) => point.timestamp === ts("2026-06-11"))
         ?.reserveYieldUsd,
-    ).toBe(0);
-    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBe(4_000);
+    ).toBe(-2_000);
+    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBe(2_000);
     expect(result.partialReasons).not.toContain(
+      "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+    );
+  });
+
+  it("nets an internal tracked-wallet stETH transfer without partial pricing", () => {
+    const sender = "0xd0697f70e79476195b742d5afab14be50f98cc1e";
+    const receiver = "0xd3d2e5c5af667da817b2d752d86c8f40c22137e1";
+    const yieldExposure = {
+      balanceAmount: usdWei(2),
+      principalAmount: usdWei(1),
+    };
+    const principalOnlyExposure = {
+      balanceAmount: usdWei(1),
+      principalAmount: usdWei(1),
+    };
+    const result = buildCanonicalRevenue({
+      networkData: [],
+      cdpDailySeries: [],
+      cdpMarkets: [],
+      reserveYield: reserveYield({
+        holdings: [
+          stethHolding({ identifier: sender, principalUsd: 2_000, balance: 1 }),
+          stethHolding({
+            identifier: receiver,
+            principalUsd: 2_000,
+            balance: 1,
+          }),
+        ],
+      }),
+      reserveDailySnapshots: [
+        stethReserveSnapshot(ts("2026-06-10"), sender, 1, 1, yieldExposure),
+        stethReserveSnapshot(ts("2026-06-11"), sender, 0),
+        stethReserveSnapshot(ts("2026-06-11"), receiver, 1, 1, yieldExposure),
+        stethReserveSnapshot(
+          ts("2026-06-12"),
+          sender,
+          0,
+          0,
+          principalOnlyExposure,
+        ),
+        stethReserveSnapshot(ts("2026-06-12"), receiver, 0, 1, yieldExposure),
+      ],
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(
+      result.dailySeries.find((point) => point.timestamp === ts("2026-06-11"))
+        ?.reserveYieldUsd,
+    ).toBe(0);
+    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBe(2_000);
+    expect(result.partialReasons).not.toContain(
+      "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+    );
+  });
+
+  it("keeps earlier unpriced stETH history partial after a zero-exposure row", () => {
+    const wallet = "0xd0697f70e79476195b742d5afab14be50f98cc1e";
+    const result = buildCanonicalRevenue({
+      networkData: [],
+      cdpDailySeries: [],
+      cdpMarkets: [],
+      reserveYield: reserveYield(),
+      reserveDailySnapshots: [
+        stethReserveSnapshot(ts("2026-06-11"), wallet, 0, 1, {
+          balanceAmount: usdWei(1),
+          principalAmount: usdWei(1),
+        }),
+        stethReserveSnapshot(ts("2026-06-12"), wallet, 0),
+      ],
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBeNull();
+    expect(result.partialReasons).toContain(
       "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
     );
   });

--- a/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
+++ b/ui-dashboard/src/lib/__tests__/canonical-revenue.test.ts
@@ -351,6 +351,39 @@ describe("buildCanonicalRevenue", () => {
     );
   });
 
+  it("records zero revenue and resets the baseline when stETH exposure reaches zero", () => {
+    const wallet = "0xd0697f70e79476195b742d5afab14be50f98cc1e";
+    const activeExposure = {
+      balanceAmount: usdWei(2),
+      principalAmount: usdWei(1),
+    };
+    const result = buildCanonicalRevenue({
+      networkData: [],
+      cdpDailySeries: [],
+      cdpMarkets: [],
+      reserveYield: reserveYield({
+        holdings: [
+          stethHolding({ identifier: wallet, principalUsd: 4_000, balance: 2 }),
+        ],
+      }),
+      reserveDailySnapshots: [
+        stethReserveSnapshot(ts("2026-06-10"), wallet, 1, 1, activeExposure),
+        stethReserveSnapshot(ts("2026-06-11"), wallet, 0),
+        stethReserveSnapshot(ts("2026-06-12"), wallet, 1, 1, activeExposure),
+      ],
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(
+      result.dailySeries.find((point) => point.timestamp === ts("2026-06-11"))
+        ?.reserveYieldUsd,
+    ).toBe(0);
+    expect(result.periods.allTimeSinceV3.reserveYieldUsd).toBe(4_000);
+    expect(result.partialReasons).not.toContain(
+      "Reserve stETH earned-yield history is unavailable: current stETH USD/token pricing is missing.",
+    );
+  });
+
   it.each([
     ["balance", { balanceAmount: "1" }],
     ["principal", { principalAmount: "1" }],

--- a/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
+++ b/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
@@ -116,7 +116,6 @@ function reserveSnapshotTotalUsd(
   stethRates: ReadonlyMap<string, number>,
 ): number | null {
   if (!isStethSnapshot(row)) return numericUsdWei(row.totalEarnedYieldUsdWei);
-  if (isZeroExposureStethSnapshot(row)) return 0;
   const usdPerToken = stethRates.get(row.wallet.toLowerCase());
   return stethAmountUsd(row.totalEarnedYieldAmount, usdPerToken);
 }
@@ -148,7 +147,6 @@ function reserveSnapshotBaseline(
   if (!isStethSnapshot(row)) {
     return reserveSnapshotBaselineUsd(row, totalYieldUsd);
   }
-  if (isZeroExposureStethSnapshot(row)) return 0;
   const usdPerToken = stethRates.get(row.wallet.toLowerCase());
   const dailyYieldUsd = stethAmountUsd(row.dailyEarnedYieldAmount, usdPerToken);
   return dailyYieldUsd === null ? null : totalYieldUsd - dailyYieldUsd;
@@ -186,12 +184,17 @@ export function buildRevenueBuckets(args: {
   for (const row of reserveRows) {
     const timestamp = Number(row.timestamp);
     if (!Number.isFinite(timestamp)) continue;
+    const sourceKey = reserveSnapshotSourceKey(row);
+    if (isStethSnapshot(row) && isZeroExposureStethSnapshot(row)) {
+      previousReserveTotalsBySource.set(sourceKey, 0);
+      addBucketValue(buckets, timestamp, { reserveYieldUsd: 0 });
+      continue;
+    }
     const totalYieldUsd = reserveSnapshotTotalUsd(row, stethRates);
     if (totalYieldUsd === null) {
       if (isStethSnapshot(row)) reserveHistoryUnpriced = true;
       continue;
     }
-    const sourceKey = reserveSnapshotSourceKey(row);
     const previousTotalUsd = previousReserveTotalsBySource.get(sourceKey);
     const baselineUsd =
       previousTotalUsd ??

--- a/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
+++ b/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
@@ -63,6 +63,25 @@ function isStethSnapshot(
   return "wallet" in row;
 }
 
+function isZeroWei(value: string): boolean {
+  const trimmed = value.trim();
+  if (!/^-?\d+$/.test(trimmed)) return false;
+  try {
+    return BigInt(trimmed) === BigInt(0);
+  } catch {
+    return false;
+  }
+}
+
+function isZeroExposureStethSnapshot(row: StethYieldDailySnapshotRow): boolean {
+  return [
+    row.balanceAmount,
+    row.principalAmount,
+    row.totalEarnedYieldAmount,
+    row.dailyEarnedYieldAmount,
+  ].every(isZeroWei);
+}
+
 function stethUsdPerTokenByWallet(
   reserveYield: ReserveYieldResponse | null,
 ): Map<string, number> {
@@ -97,11 +116,9 @@ function reserveSnapshotTotalUsd(
   stethRates: ReadonlyMap<string, number>,
 ): number | null {
   if (!isStethSnapshot(row)) return numericUsdWei(row.totalEarnedYieldUsdWei);
+  if (isZeroExposureStethSnapshot(row)) return 0;
   const usdPerToken = stethRates.get(row.wallet.toLowerCase());
-  const earnedAmount = numericTokenWei(row.totalEarnedYieldAmount);
-  return usdPerToken === undefined || earnedAmount === null
-    ? null
-    : earnedAmount * usdPerToken;
+  return stethAmountUsd(row.totalEarnedYieldAmount, usdPerToken);
 }
 
 function reserveSnapshotBaselineUsd(
@@ -112,15 +129,15 @@ function reserveSnapshotBaselineUsd(
   return dailyYieldUsd === null ? null : totalYieldUsd - dailyYieldUsd;
 }
 
-function stethSnapshotBaselineUsd(
-  row: StethYieldDailySnapshotRow,
-  totalYieldUsd: number,
-  usdPerToken: number,
+function stethAmountUsd(
+  value: string,
+  usdPerToken: number | undefined,
 ): number | null {
-  const dailyYieldAmount = numericTokenWei(row.dailyEarnedYieldAmount);
-  return dailyYieldAmount === null
-    ? null
-    : totalYieldUsd - dailyYieldAmount * usdPerToken;
+  if (usdPerToken === undefined) return null;
+  const amount = numericTokenWei(value);
+  if (amount === null) return null;
+  const usd = amount * usdPerToken;
+  return Number.isFinite(usd) ? usd : null;
 }
 
 function reserveSnapshotBaseline(
@@ -131,10 +148,10 @@ function reserveSnapshotBaseline(
   if (!isStethSnapshot(row)) {
     return reserveSnapshotBaselineUsd(row, totalYieldUsd);
   }
+  if (isZeroExposureStethSnapshot(row)) return 0;
   const usdPerToken = stethRates.get(row.wallet.toLowerCase());
-  return usdPerToken === undefined
-    ? null
-    : stethSnapshotBaselineUsd(row, totalYieldUsd, usdPerToken);
+  const dailyYieldUsd = stethAmountUsd(row.dailyEarnedYieldAmount, usdPerToken);
+  return dailyYieldUsd === null ? null : totalYieldUsd - dailyYieldUsd;
 }
 
 export function buildRevenueBuckets(args: {

--- a/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
+++ b/ui-dashboard/src/lib/canonical-revenue/daily-series.ts
@@ -152,6 +152,35 @@ function reserveSnapshotBaseline(
   return dailyYieldUsd === null ? null : totalYieldUsd - dailyYieldUsd;
 }
 
+function addReserveSnapshotRow(
+  row: ReserveYieldDailySnapshotRow,
+  stethRates: ReadonlyMap<string, number>,
+  previousTotalsBySource: Map<string, number>,
+  buckets: Map<number, RevenueBucket>,
+): boolean {
+  const timestamp = Number(row.timestamp);
+  if (!Number.isFinite(timestamp)) return false;
+  const sourceKey = reserveSnapshotSourceKey(row);
+  if (isStethSnapshot(row) && isZeroExposureStethSnapshot(row)) {
+    const previousTotalUsd = previousTotalsBySource.get(sourceKey);
+    addBucketValue(buckets, timestamp, {
+      reserveYieldUsd: previousTotalUsd === undefined ? 0 : -previousTotalUsd,
+    });
+    previousTotalsBySource.set(sourceKey, 0);
+    return false;
+  }
+  const totalYieldUsd = reserveSnapshotTotalUsd(row, stethRates);
+  if (totalYieldUsd === null) return isStethSnapshot(row);
+  const previousTotalUsd = previousTotalsBySource.get(sourceKey);
+  const baselineUsd =
+    previousTotalUsd ?? reserveSnapshotBaseline(row, totalYieldUsd, stethRates);
+  if (baselineUsd === null) return isStethSnapshot(row);
+  const dailyYieldUsd = totalYieldUsd - baselineUsd;
+  previousTotalsBySource.set(sourceKey, totalYieldUsd);
+  addBucketValue(buckets, timestamp, { reserveYieldUsd: dailyYieldUsd });
+  return false;
+}
+
 export function buildRevenueBuckets(args: {
   swapSeries: ReadonlyArray<SwapDailyFeePoint>;
   cdpDailySeries: ReadonlyArray<CdpBorrowingFeeSeriesPoint>;
@@ -182,30 +211,13 @@ export function buildRevenueBuckets(args: {
     (a, b) => Number(a.timestamp) - Number(b.timestamp),
   );
   for (const row of reserveRows) {
-    const timestamp = Number(row.timestamp);
-    if (!Number.isFinite(timestamp)) continue;
-    const sourceKey = reserveSnapshotSourceKey(row);
-    if (isStethSnapshot(row) && isZeroExposureStethSnapshot(row)) {
-      previousReserveTotalsBySource.set(sourceKey, 0);
-      addBucketValue(buckets, timestamp, { reserveYieldUsd: 0 });
-      continue;
-    }
-    const totalYieldUsd = reserveSnapshotTotalUsd(row, stethRates);
-    if (totalYieldUsd === null) {
-      if (isStethSnapshot(row)) reserveHistoryUnpriced = true;
-      continue;
-    }
-    const previousTotalUsd = previousReserveTotalsBySource.get(sourceKey);
-    const baselineUsd =
-      previousTotalUsd ??
-      reserveSnapshotBaseline(row, totalYieldUsd, stethRates);
-    if (baselineUsd === null) {
-      if (isStethSnapshot(row)) reserveHistoryUnpriced = true;
-      continue;
-    }
-    const dailyYieldUsd = totalYieldUsd - baselineUsd;
-    previousReserveTotalsBySource.set(sourceKey, totalYieldUsd);
-    addBucketValue(buckets, timestamp, { reserveYieldUsd: dailyYieldUsd });
+    const rowUnpriced = addReserveSnapshotRow(
+      row,
+      stethRates,
+      previousReserveTotalsBySource,
+      buckets,
+    );
+    reserveHistoryUnpriced = rowUnpriced || reserveHistoryUnpriced;
   }
 
   return { buckets, reserveHistoryUnpriced };


### PR DESCRIPTION
## The Problem

- A dormant tracked stETH wallet has exact zero exposure but no current USD/token rate.
- The revenue dashboard treated that zero-value history row as unpriced.
- One harmless row therefore hid all reserve actuals and showed a false partial-data warning.

## The Solution

- Accept a missing stETH price only when balance, principal, cumulative yield, and daily yield are all valid decimal zero values.
- Record a first exact-zero row as $0 and reset that wallet's cumulative baseline before later snapshots.
- When an established wallet reaches zero, subtract its prior cumulative total so an internal tracked-wallet transfer does not duplicate yield on the recipient.
- Keep every malformed or nonzero row fail-closed so active exposure still requires a valid price.

## Details

- Handle exact-zero stETH rows in the daily-series reducer before price lookup.
- Reset each source baseline at zero exposure. Internal sender and recipient deltas then cancel, and later independent accrual starts from zero.
- Preserve zero rows in wallet chronology and staleness checks.
- Reject non-decimal zero spellings and one-wei dust.
- Keep schema, GraphQL, indexer, reserve API, and rendering contracts unchanged.

Refs #1993

## Validation

- `CI=true pnpm --filter @mento-protocol/ui-dashboard exec vitest run src/lib/__tests__/canonical-revenue.test.ts` — 36 tests passed.
- Dashboard typecheck and lint passed.
- Targeted Trunk checks and `git diff --check` passed.
- The initial patch and both review repairs passed fresh sealed source reviews with no findings. The final repair retained manifest `51ff870cbcc9affecf85e245dd12e17e39d95372b26237902d15ec319c76fdf3` before and after review.
- Local `/revenue` verification used production Envio data at base `d23602614e19904cdc6a6ce880dd89989c748661` and final head `6d2648dbe319920ebf991181826acb40dc456030` with a 1440 x 1050 viewport. The base showed reserve `N/A` and the false stETH pricing warning. The final head showed reserve actuals, including `$6.7K` all-time, `$1.3K` for 30 days, and `$254.50` for 7 days; the false warning was absent.
- The 1W, 1M, and All chart controls updated their pressed state, chart range, and totals without a revenue-path console error.
- `/api/reserve-yield` returned 200 with `earnedYieldError: null`; relevant GraphQL requests returned 200 without top-level errors.
- Lighthouse snapshot: Accessibility 94, Best Practices 100, SEO 100, Agentic Browsing 100.
- The full mapped local gate was skipped once at the user's explicit direction after it spent 13 minutes queued on the shared lock. Hosted CI is the full-matrix verification for this PR.
- Local address-label requests returned 500 because the isolated server had no Upstash credentials. This unrelated route used its documented last-good-data state; reserve API and GraphQL requests remained healthy.
