### PR TITLE
fix(scripts): close the archive-settlement race in the sentry triage re-queue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -195,7 +195,7 @@ Authority: canonical
 - [`docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md`](adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) — CodeRabbit replaces Cursor BugBot as the third PR review bot
 - [`docs/adr/0067-pool-criticality-is-depletion-risk.md`](adr/0067-pool-criticality-is-depletion-risk.md) — Pool criticality is depletion risk, not deviation magnitude
 - [`docs/adr/0068-sentry-fixture-authoring-policy.md`](adr/0068-sentry-fixture-authoring-policy.md) — Adversarial fixtures are authored to scan clean; no value or line registry
-- [`docs/adr/0069-sentry-requeue-settlement-sentinel.md`](adr/0069-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
+- [`docs/adr/0070-sentry-requeue-settlement-sentinel.md`](adr/0070-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
 
 Authority: non-canonical
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -194,6 +194,7 @@ Authority: canonical
 - [`docs/adr/0065-scripts-file-size-watchlist-scope.md`](adr/0065-scripts-file-size-watchlist-scope.md) — scripts/ is inside the file-size watchlist, with named-mechanism exemptions
 - [`docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md`](adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) — CodeRabbit replaces Cursor BugBot as the third PR review bot
 - [`docs/adr/0067-pool-criticality-is-depletion-risk.md`](adr/0067-pool-criticality-is-depletion-risk.md) — Pool criticality is depletion risk, not deviation magnitude
+- [`docs/adr/0068-sentry-requeue-settlement-sentinel.md`](adr/0068-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
 
 Authority: non-canonical
 

--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -285,6 +285,16 @@ routing, not procedure.
     `documentation-navigation-baseline-fixtures.json` is the frozen contract for
     the committed baseline result and is deliberately left alone; editing it
     would force a rebind of that result's `fixture_digest`.
+11. File-size cap lists in `sentry/triage/sentry-triage-brief.test.mjs` — the
+    1,000-line hard cap for the triage family's shared modules and the 600-line
+    soft cap for the brief leg both enumerate exact repo-relative paths. No
+    ESLint `max-lines` reaches this tree and the watchlist reports rather than
+    blocks (ADR 0065), so these lists are the only thing that reds a file that
+    crosses. A moved path stops matching and the file drops off its cap in
+    silence — the same failure mode as a stale routing arm, with no red run to
+    announce it. Add a module here in the PR that creates it, too: the split
+    that puts a module under the cap is exactly when its entry is easiest to
+    forget.
 
 A shared module under `scripts/lib/` is routed from every arm that reads it,
 not only the arm of the consumer that happens to fail loudest.

--- a/docs/adr/0068-sentry-requeue-settlement-sentinel.md
+++ b/docs/adr/0068-sentry-requeue-settlement-sentinel.md
@@ -1,0 +1,244 @@
+---
+title: A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-21
+scope: ci/process
+date: 2026-08
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0068 — The archive's terminal marker is withheld from the re-queue's shed, and read back as a sentinel
+
+**Status:** Accepted (Aug 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+Two writers can act on one Sentry triage queue stub at the same time, and
+GitHub Actions gives them no lock.
+
+- **The archive leg** (`.github/workflows/sentry-triage-archive.yml`,
+  `scripts/sentry/triage/sentry-triage-archive.mjs`) is human-gated: a writer
+  applies `sentry:approved-archive`, the run archives the underlying Sentry
+  issue as `archived_until_escalating`, then settles the stub — body baseline,
+  close, `sentry:archived` — and verifies that shape with a post-settlement
+  read. Its concurrency group is **per issue**.
+- **The triage compensation** (`scripts/sentry/triage/sentry-triage-workflow-requeue.mjs`)
+  runs from `sentry-triage-agent.yml` whenever a step fails after the stub's
+  `sentry:needs-triage` has been removed. It restores that label, sheds every
+  marker from the previous round (`REOPEN_SHED_LABELS`) and reopens the stub.
+  Its concurrency group is **repo-wide**.
+
+The compensation already revalidated live state immediately before writing and
+declined on a terminal stub (`isTerminalStub`: closed, or carrying
+`sentry:archived`). That read is a snapshot, and its own docstring said so: an
+archive landing after it still raced the writes.
+
+The two runs covered one ordering between them and not the other.
+
+- **Compensation writes land before the archive's verification read.** Caught.
+  That read demands closed + `sentry:archived` + a `sentry:verdict-*` label, and
+  the compensation has reopened the stub and shed the verdict, so
+  `settlementHeld` fails, the archive rolls the queue stub back and the run goes
+  red.
+- **Compensation writes land after it.** Undetected. The archive has already
+  returned success. The compensation then adds `sentry:needs-triage`, sheds
+  `sentry:archived` and reopens — producing a selectable retry stub over an
+  occurrence a human approved archiving, with nothing red anywhere.
+
+A second check on the compensation's side could not see it either, and the
+reason is specific: the shed removed `sentry:archived` with
+`gh issue edit --remove-label`, which succeeds whether or not the label was
+there. After that call no read can testify that the marker ever existed. Both
+terminal signals were erased in the same operation — the reopen took the state,
+the shed took the label — so post-hoc verification had nothing left to observe.
+
+The load-bearing platform facts are narrow:
+
+1. **GitHub's issue API offers exactly one atomic test-and-set:**
+   `DELETE /repos/{repo}/issues/{n}/labels/{name}` returns 404 when the label is
+   already gone. `POST .../labels` is not a lease — adding a label that is
+   already present succeeds. Any serialization here must therefore be expressed
+   as _consuming or observing a token that exists_, never as acquiring one that
+   does not. The archive leg already relies on this for `sentry:approved-archive`
+   (issue #1371).
+2. **A shared Actions `concurrency:` group queues at most one pending run and
+   cancels the one it supersedes.** Two pending runs in a group are not two
+   queued runs.
+
+Filed as finding 3 of issue #1929; the other seven landed in PR #1950, which
+recorded this one as needing a design rather than a fix.
+
+## Decision
+
+**Withhold the settling writer's terminal marker from the re-queue's shed, and
+read it back on the confirming end-state read. Its presence there means the
+settlement landed inside the write window, so the re-queue unwinds instead of
+reporting success.**
+
+The chokepoint (`scripts/sentry/triage/sentry-triage-requeue.mjs`) takes the
+marker as `revalidate.sentinel`. A caller that declares one gets three things:
+
+1. **The marker is excluded from every blind shed** in that call —
+   `buildRequeueShedLabelArgs(..., { except })`, and the post-verification shed
+   retry with it. This is what makes the later read meaningful: a marker the run
+   erases is a marker nothing can testify about.
+2. **Every read taken after the last write is checked for it** — the confirming
+   read from `ensureSelectableForTriage`, and the shed retry's re-read when that
+   path runs. Checking earlier leaves the window between the check and the reopen
+   open; checking only the first read leaves the retry uncovered, and that is not
+   hypothetical — it is precisely a FAILED initial shed that leaves the verdict
+   label standing, which is what lets the archive's own verification hold in the
+   first place.
+3. **On a hit, the re-queue unwinds** through
+   `scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs` and returns
+   `{ requeued: false, reason: "settled-underneath" }`.
+
+The unwind's order is the guarantee, because it can die half-way:
+`sentry:needs-triage` is removed FIRST (selectability is the only property that
+lets another run act on the stub, so every prefix must be unselectable), the
+previous round's markers observed by the revalidating read are restored NEXT,
+and the close goes LAST. Restoring the markers is load-bearing rather than tidy:
+the archive's own post-settlement verification demands a verdict label, so a
+stub left verdict-less would make that run roll a correct archive back.
+`sentry:approved-archive` is never restored (`NEVER_RESTORED_LABELS`) — a spent
+approval is authority, not a record, and re-adding it would both hand a later
+`workflow_dispatch` an approval no human gave and re-fire the archive workflow's
+`issues: labeled` trigger. The unwind's writes are provisional and one confirming
+read decides. That read asks for the SETTLED shape the settling run itself
+demands — closed, the terminal marker, and a `sentry:verdict-*` label — rather
+than for the corrections having been attempted, because the weaker question lets
+the unwind confirm a stub that run then rejects. An unwind that cannot reach that
+shape throws, whether the verdict re-add failed or the premise never carried one:
+the stub is then neither re-queued nor demonstrably settled, which only a human
+can resolve.
+
+**Why every ordering is now DETECTED.** Neither writer can destroy the other's
+evidence any more. The archive's evidence about the compensation is the reopen
+and the shed verdict, which its verification reads. The compensation's evidence
+about the archive is `sentry:archived`, which it no longer erases. So: a marker
+on the stub at any read this run takes after its last write is caught here; a
+marker that lands after the last of them means the archive's own verification
+runs later still, against a stub this run has already reopened and stripped of
+its verdict, which fails it and rolls it back. There is no third ordering.
+
+**What the sentinel proves, exactly.** That an archive run WROTE its terminal
+marker — not that the run accepted its own settlement. Those come apart in one
+sub-ordering: the archive marks and closes, the compensation reopens and sheds,
+the archive's verification reads that broken shape and begins its rollback, and
+the compensation's read still sees the marker and unwinds. Both then converge on
+the archive's own documented post-rollback shape — open, verdicted, unqueued,
+`sentry:archived` removed, Sentry left `archived_until_escalating` (ADR 0036) —
+and the archive run is RED. Serializing that away would need either a marker the
+archive publishes only after its verification, which would be one more racing
+write and not a lock, or a way to stop an in-flight run's writes, which the
+platform does not offer. See Consequences for what it costs.
+
+**Accepted flap.** Between the reopen and the unwind the stub is briefly
+selectable. Nothing can act on it there: the triage workflow holds one repo-wide
+concurrency group and this compensation runs inside its own run, and ingest's
+dedup skips an open stub.
+
+## Alternatives considered
+
+**A shared Actions concurrency group across the archive and triage workflows.**
+The original suggestion on #1929, and rejected on the platform fact above. The
+archive's group is per issue and human-gated; the triage agent's is repo-wide and
+scheduled. Collapsing them means a human-approved archive dispatch and a
+repo-wide triage run contend for one slot, and GitHub keeps a single pending run
+per group: a second approved archive queued behind a triage run is CANCELLED, not
+delayed. Silently dropping an approved archive is worse than the race it closes.
+Keeping the archive per issue and giving the agent a per-issue group is not
+available either — the agent run triages a batch, so it has no single issue to
+key on. The same reasoning already rejected a shared group for the ingest/archive
+pair (issue #1371).
+
+**A per-issue lease or ordering token written into the stub.** The natural shape
+— take a lock label, do the work, release it — is not implementable on this API.
+`POST .../labels` succeeds whether or not the label is present, so two runs both
+"acquire" the lease and both proceed. A lease in the issue body has the same
+problem one level up (`gh issue edit --body` is last-write-wins, with no
+compare-and-swap) and would put a second writer on the surface the archive leg
+deliberately owns alone (#1769). The only atomic primitive is the DELETE, which
+tests a token that already exists — which is what the sentinel uses.
+
+**A re-verify-after-settle loop with bounded retries, on today's shed.**
+Rejected as unimplementable rather than insufficient: after a blind shed there is
+nothing left to re-verify. `sentry:archived` is gone and the state is open,
+because the re-queue removed both. Retrying a read that cannot distinguish "never
+archived" from "archived and shed by us" just costs API calls. Withholding the
+marker is the minimum that makes any post-hoc check possible; once it is
+withheld, one read suffices and a loop buys nothing.
+
+**A second consume gate before the shed, in addition to the read-back.** It
+would decline earlier in the common interleaving and avoid shedding the verdict
+labels the unwind then restores. Rejected as redundant: it closes no ordering the
+read-back does not, and it costs a second decision site for a mechanism whose
+whole value is having one. The unwind restores from the revalidating read's
+observation, so the end state is the same either way.
+
+**Rolling Sentry back when the compensation wins.** Not considered seriously, and
+recorded so it is not proposed later: ADR 0036 caps automation at
+`archived_until_escalating` precisely because it self-heals on escalation, and
+`reconcileToTarget` already documents why reverting it costs a check-then-PUT
+race against Sentry's own transitions.
+
+## Consequences
+
+The compensating re-queue can now end in three ways rather than two:
+re-queued, declined before writing (`revalidated-away`), or unwound after writing
+(`settled-underneath`). Callers that branch on the decline reason must handle the
+third; today only the tests do.
+
+A caller declaring a sentinel MUST use the `verify-end-state` failure policy,
+since that policy is what produces the confirming read. Declared with `abort` the
+chokepoint throws before any I/O rather than degrading into the silence the
+sentinel exists to end.
+
+**The accepted cost, in the sub-ordering where the archive rolls back.** The
+compensation declines, so it does not re-queue a stub that in the end was NOT
+archived. The stub lands in the open-verdicted-unqueued shape, which ingest's
+stranded sweep repairs after a day (#1817) rather than the compensation's usual
+seconds, and both runs are red. That is a latency regression in one narrow
+window, traded for removing the fail-open in the window this ADR exists for —
+where the same code silently produced a selectable retry stub over an archived
+occurrence and reported success. Slow-and-loud beats fast-and-wrong, and the slow
+path is one the pipeline already runs for this exact shape.
+
+The sentinel is opt-in per caller, and must stay that way. Ingest's regression
+reopen and the archive's own live-regression refusal exist precisely TO shed
+`sentry:archived` — a regression must reopen an archived stub — so a chokepoint-
+wide rule would break both. The premise is what selects it: only a re-queue whose
+revalidation declines on a terminal stub can treat that marker's later appearance
+as proof of a race.
+
+Two sibling callers hold the same premise and do NOT yet declare a sentinel:
+`scripts/sentry/autofix/sentry-autofix-hold-revalidate.mjs`, whose revalidation
+is the identical `!isTerminalStub(live)`, and ingest's stranded sweep, whose
+window `docs/notes/sentry-triage-pipeline.md` documents. Both are tracked on
+issue #1994; adopting the sentinel there is a one-option change plus its own
+tests, not a redesign.
+
+`scripts/sentry/triage/sentry-triage-requeue.mjs` reached 1,042 lines with the
+unwind inline, past the 1,000-line hard cap the brief suite enforces for this
+family. The unwind moved to `sentry-triage-requeue-sentinel.mjs` (192 lines) and
+is listed in that cap test, so the split cannot silently rot.
+
+The mechanism generalises only where a settling writer applies a durable terminal
+LABEL before verifying. It says nothing about a settlement whose only trace is
+the issue state: `gh issue close` is idempotent and reports nothing, so a
+close-only settlement is still invisible to a re-queue that reopens.
+
+## Evidence
+
+- The uncovered ordering, reproduced: `scripts/sentry/triage/sentry-triage-requeue.test.mjs` lands the archive's settlement immediately after the compensation restores `sentry:needs-triage` — the point at which the archive's post-settlement verification has already passed. With the sentinel disabled the compensation returns `requeued: true` and leaves the stub open, `sentry:needs-triage` restored and `sentry:archived` shed (`expected false, got true`); with it, the re-queue unwinds and the stub ends closed, archived and unselectable.
+- Withholding the marker is load-bearing, not cosmetic: restoring `except: []` on the shed while keeping the read-back reds four of the five new cases, because the shed erases the marker before anything reads it.
+- Both halves of the completeness argument are pinned in one suite: the sentinel cases, and `settlementHeld` returning false for a stub the compensation has reopened or stripped of its verdict.
+- The three verification gaps review passes found are pinned as their own cases: a settlement first visible to the shed retry's read still unwinds; an unwind whose marker restoration never lands is a hard failure; and an unwind that cannot leave a verdict on the stub fails rather than declining. Removing any one check reds exactly its case.
+- The declaration is validated before any I/O — policy, label and `declineNote` — because a sentinel missing its note would throw at the DETECTION site, after the writes and before any correction, leaving the exact stub this prevents. The unwind's confirming read carries the same bounded retry the revalidating read has, so a transient 5xx does not raise a manual-repair alarm over a settled stub. Both are pinned, and removing either check reds its case.
+- `node scripts/sentry/gate/sentry-suite-gate.mjs` — 14 suites asserted from their own output. No floor moved down; the re-queue suite emitted 41 cases before and 52 now, and its floor rose 40 → 52.
+- Platform facts: `consumeApprovalLabel` in `scripts/sentry/triage/sentry-triage-archive.mjs` documents the DELETE/404 primitive (issue #1371); the single-pending-run behaviour of a shared concurrency group is recorded in `docs/notes/sentry-triage-pipeline.md` and in `sentry-triage-archive.yml`'s own `concurrency:` comment.

--- a/docs/adr/0070-sentry-requeue-settlement-sentinel.md
+++ b/docs/adr/0070-sentry-requeue-settlement-sentinel.md
@@ -11,7 +11,7 @@ review_interval_days: 90
 garden_lane: adrs-architecture
 ---
 
-# ADR 0069 — The archive's terminal marker is withheld from the re-queue's shed, and read back as a sentinel
+# ADR 0070 — The archive's terminal marker is withheld from the re-queue's shed, and read back as a sentinel
 
 **Status:** Accepted (Aug 2026), in force.
 **Scope:** ci/process
@@ -117,6 +117,17 @@ shape throws, whether the verdict re-add failed or the premise never carried one
 the stub is then neither re-queued nor demonstrably settled, which only a human
 can resolve.
 
+On the verdict the read is one notch STRICTER than the settling run: it demands
+exactly one, where `settlementHeld` asks for at least one. The reason is which
+compensation gets here. `verdict-unsettled` fires precisely because more than one
+verdict survived on the stub (#1745), so a multi-verdict premise is the reason
+this path was entered, and the unwind restores every marker the premise carried.
+Accepting the result would undo the repair the re-queue existed to perform and
+report success, leaving a CLOSED archive that `classifyIssue` buckets from
+whichever verdict comes first — a state the settling run would also accept and
+nothing downstream repairs, since the stranded sweep only sees open stubs. So it
+throws with the verdict-less case.
+
 **Why every ordering is now DETECTED.** Neither writer can destroy the other's
 evidence any more. The archive's evidence about the compensation is the reopen
 and the shed verdict, which its verification reads. The compensation's evidence
@@ -132,11 +143,24 @@ sub-ordering: the archive marks and closes, the compensation reopens and sheds,
 the archive's verification reads that broken shape and begins its rollback, and
 the compensation's read still sees the marker and unwinds. Both then converge on
 the archive's own documented post-rollback shape — open, verdicted, unqueued,
-`sentry:archived` removed, Sentry left `archived_until_escalating` (ADR 0036) —
-and the archive run is RED. Serializing that away would need either a marker the
-archive publishes only after its verification, which would be one more racing
-write and not a lock, or a way to stop an in-flight run's writes, which the
-platform does not offer. See Consequences for what it costs.
+`sentry:archived` removed, Sentry left `archived_until_escalating` (ADR 0036).
+Serializing that away would need either a marker the archive publishes only
+after its verification, which would be one more racing write and not a lock, or
+a way to stop an in-flight run's writes, which the platform does not offer. See
+Consequences for what it costs.
+
+**Neither run FAILS on that sub-ordering, and that is a real gap.** The archive
+returns `{ status: "unsettled-reopened" }` from `runArchive` and exits 0 — the
+workflow does not inspect that JSON — and this compensation returns
+`settled-underneath`, also 0. So the only live signal is the `::warning::`
+annotation the detection site emits, and the stub is repaired by ingest's
+stranded sweep a day later rather than in the compensation's usual seconds.
+Making the compensation's `settled-underneath` path nonzero was considered and
+rejected: it would fail every CORRECT unwind — the common case this ADR is
+designed for — to make one sub-ordering visible, and it would still not make the
+end state right. The exit semantics that would close it belong to the archive
+leg, whose rollback path is silent for the plain concurrent-regression case too;
+that is tracked on issue #2004, not decided here.
 
 **Accepted flap.** Between the reopen and the unwind the stub is briefly
 selectable. Nothing can act on it there: the triage workflow holds one repo-wide
@@ -203,8 +227,9 @@ sentinel exists to end.
 compensation declines, so it does not re-queue a stub that in the end was NOT
 archived. The stub lands in the open-verdicted-unqueued shape, which ingest's
 stranded sweep repairs after a day (#1817) rather than the compensation's usual
-seconds, and both runs are red. That is a latency regression in one narrow
-window, traded for removing the fail-open in the window this ADR exists for —
+seconds, and neither run fails — one `::warning::` is the whole live signal
+(issue #2004). That is a latency regression in one narrow window, reported
+quietly, traded for removing the fail-open in the window this ADR exists for —
 where the same code silently produced a selectable retry stub over an archived
 occurrence and reported success. Slow-and-loud beats fast-and-wrong, and the slow
 path is one the pipeline already runs for this exact shape.
@@ -225,8 +250,11 @@ tests, not a redesign.
 
 `scripts/sentry/triage/sentry-triage-requeue.mjs` reached 1,042 lines with the
 unwind inline, past the 1,000-line hard cap the brief suite enforces for this
-family. The unwind moved to `sentry-triage-requeue-sentinel.mjs` (192 lines) and
-is listed in that cap test, so the split cannot silently rot.
+family. The unwind moved to `sentry-triage-requeue-sentinel.mjs` and is listed in
+that cap test, so the split cannot silently rot. That list is a `scripts/` path
+pin and was missing from the move sweep, so ADR 0064's checklist gained it as
+item 11 — `scripts/AGENTS.md` points at that checklist rather than carrying the
+procedure, because its scoped instruction budget has 15 bytes of headroom.
 
 The mechanism generalises only where a settling writer applies a durable terminal
 LABEL before verifying. It says nothing about a settlement whose only trace is
@@ -240,5 +268,7 @@ close-only settlement is still invisible to a re-queue that reopens.
 - Both halves of the completeness argument are pinned in one suite: the sentinel cases, and `settlementHeld` returning false for a stub the compensation has reopened or stripped of its verdict.
 - The three verification gaps review passes found are pinned as their own cases: a settlement first visible to the shed retry's read still unwinds; an unwind whose marker restoration never lands is a hard failure; and an unwind that cannot leave a verdict on the stub fails rather than declining. Removing any one check reds exactly its case.
 - The declaration is validated before any I/O — policy, label and `declineNote` — because a sentinel missing its note would throw at the DETECTION site, after the writes and before any correction, leaving the exact stub this prevents. The unwind's confirming read carries the same bounded retry the revalidating read has, so a transient 5xx does not raise a manual-repair alarm over a settled stub. Both are pinned, and removing either check reds its case.
-- `node scripts/sentry/gate/sentry-suite-gate.mjs` — 14 suites asserted from their own output. No floor moved down; the re-queue suite emitted 41 cases before and 52 now, and its floor rose 40 → 52.
+- The declaration check is a MEMBERSHIP test, not a shape test: a sentinel must name a label this re-queue sheds. A label outside `REOPEN_SHED_LABELS` inverts the mechanism rather than weakening it — `sentry:needs-triage` is never shed and is re-ADDED by this run, so the confirming read would find it every time and unwind a re-queue nothing settled. Widening the permitted set to admit it reds that case.
+- The confirming read demands EXACTLY one verdict. `verdict-unsettled` is the compensation that fires because more than one survived (#1745), so restoring every observed verdict and accepting the result would undo the repair the re-queue exists to perform. Relaxing the count to at-least-one reds the two-verdict case; a one-verdict unwind still passes, pinned as its own case.
+- `node scripts/sentry/gate/sentry-suite-gate.mjs` — 14 suites asserted from their own output. No floor moved down; the re-queue suite emitted 41 cases before and 54 now, and its floor rose 40 → 54.
 - Platform facts: `consumeApprovalLabel` in `scripts/sentry/triage/sentry-triage-archive.mjs` documents the DELETE/404 primitive (issue #1371); the single-pending-run behaviour of a shared concurrency group is recorded in `docs/notes/sentry-triage-pipeline.md` and in `sentry-triage-archive.yml`'s own `concurrency:` comment.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,6 +78,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0064](0064-scripts-module-directories.md)                  | `scripts/` may use module subdirectories; basenames and pinned paths constrain moves |
 | [0065](0065-scripts-file-size-watchlist-scope.md)           | `scripts/` sits inside the file-size watchlist, with named-mechanism exemptions      |
 | [0066](0066-coderabbit-replaces-bugbot-third-reviewer.md)   | CodeRabbit replaces Cursor BugBot as the third advisory PR reviewer                  |
+| [0068](0068-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
 
 ### shared-config
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,7 +79,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0065](0065-scripts-file-size-watchlist-scope.md)           | `scripts/` sits inside the file-size watchlist, with named-mechanism exemptions      |
 | [0066](0066-coderabbit-replaces-bugbot-third-reviewer.md)   | CodeRabbit replaces Cursor BugBot as the third advisory PR reviewer                  |
 | [0068](0068-sentry-fixture-authoring-policy.md)             | Adversarial fixtures are authored to scan clean; no value or line registry           |
-| [0069](0069-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
+| [0070](0070-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
 
 ### shared-config
 

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -305,7 +305,7 @@ An approval landing inside that window is shed, the archive run its label event
 started refuses out loud on its own guard, and the human re-applies the label.
 
 The re-queue CLI's version of that window is CLOSED, by a different mechanism
-(ADR 0069). It declares `sentry:archived` as a settlement SENTINEL: the marker is
+(ADR 0070). It declares `sentry:archived` as a settlement SENTINEL: the marker is
 withheld from its shed, so it survives to be read on the end-state verification,
 and finding it there means the archive settled inside the write window — at which
 point the re-queue unwinds itself rather than leaving a selectable retry stub

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -297,14 +297,20 @@ public repo: a determined commenter can keep a genuine strand below the threshol
 indefinitely. That delays a repair; it can never cause one to happen wrongly, and
 the state it preserves is the one this sweep found.
 
-The window between the sweep's revalidating read and its label shed stays open,
-like the one the re-queue CLI's terminal guard documents, and for the same
-reason: closing it needs a shared concurrency group across ingest and archive,
-which this pipeline rejected on its own terms (GitHub keeps one pending run per
-group and would silently drop a second human-approved archive queued behind an
-ingest run). An approval landing inside that window is shed, the archive run its
-label event started refuses out loud on its own guard, and the human re-applies
-the label.
+The window between the sweep's revalidating read and its label shed stays open.
+A shared concurrency group across ingest and archive is not the close, and this
+pipeline rejected it on its own terms: GitHub keeps one pending run per group and
+would silently drop a second human-approved archive queued behind an ingest run.
+An approval landing inside that window is shed, the archive run its label event
+started refuses out loud on its own guard, and the human re-applies the label.
+
+The re-queue CLI's version of that window is CLOSED, by a different mechanism
+(ADR 0068). It declares `sentry:archived` as a settlement SENTINEL: the marker is
+withheld from its shed, so it survives to be read on the end-state verification,
+and finding it there means the archive settled inside the write window — at which
+point the re-queue unwinds itself rather than leaving a selectable retry stub
+over an archived occurrence. The sweep and the autofix hold-revalidation hold the
+same premise and could adopt the same sentinel; neither does yet.
 
 The sweep re-reads each stub immediately before touching it and acts only if the
 SAME shape still holds — including its idleness, since a comment posted in the

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -122,7 +122,7 @@ breaks silently on the next move.
 
 ## Sweep Checklist for a Move
 
-Work the ten-surface checklist in
+Work the eleven-surface checklist in
 [ADR 0064](../docs/adr/0064-scripts-module-directories.md#sweep-checklist-for-a-move)
 in the PR that moves a file. Every surface there is mandatory.
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4130,12 +4130,17 @@ while IFS= read -r path; do
           add_command "pnpm sentry:broker:test" "Sentry MCP broker or pre-flight probe changed"
           add_command "node scripts/sentry/fixture-scan-canary.test.mjs" "Sentry suite carrying scanned fixtures changed"
           ;;
-        scripts/sentry/triage/sentry-triage-requeue.mjs|scripts/sentry/triage/sentry-triage-requeue.test.mjs|scripts/sentry/triage/sentry-triage-queue-contract.mjs|scripts/sentry/triage/sentry-triage-workflow-requeue.mjs)
-          # The single re-queue chokepoint, the queue contract it reads, and the
-          # workflow CLI that wraps it for every compensating exit in the triage
-          # agent workflow (#1769 round 17, #1782). Every site that re-queues a stub
-          # runs through the chokepoint, so its suite is never the whole story —
-          # run theirs too. The CLI's tests live in the requeue suite.
+        scripts/sentry/triage/sentry-triage-requeue.mjs|scripts/sentry/triage/sentry-triage-requeue.test.mjs|scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs|scripts/sentry/triage/sentry-triage-queue-contract.mjs|scripts/sentry/triage/sentry-triage-workflow-requeue.mjs)
+          # The single re-queue chokepoint, the queue contract it reads, the
+          # settlement-sentinel unwind split out of it for the 1,000-line cap
+          # (#1929, ADR 0070), and the workflow CLI that wraps it for every
+          # compensating exit in the triage agent workflow (#1769 round 17, #1782).
+          # The sentinel module has no suite of its own — its tests live in the
+          # re-queue suite — so an unrouted change to it would ship untested, and
+          # it decides the end state of the archive compensation, which is why the
+          # archive suite is on this arm too. Every site that re-queues a stub runs
+          # through the chokepoint, so its suite is never the whole story — run
+          # theirs too. The CLI's tests live in the requeue suite.
           add_command "pnpm sentry:requeue:test" "Sentry re-queue chokepoint changed"
           add_command "pnpm sentry:ingest:test" "Sentry re-queue chokepoint changed"
           add_command "pnpm sentry:archive:test" "Sentry re-queue chokepoint changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4337,6 +4337,17 @@ run_gate "scripts/sentry/triage/sentry-triage-queue-contract.mjs"
 assert_contains "- pnpm sentry:requeue:test (Sentry re-queue chokepoint changed)"
 assert_contains "- pnpm sentry:project:test (Sentry re-queue chokepoint changed)"
 
+# The settlement-sentinel unwind, split out of the chokepoint for the 1,000-line
+# hard cap (#1929, ADR 0070). It has no suite of its own — its cases live in the
+# re-queue suite — and it decides the end state of the archive compensation, so
+# an unrouted change to it would ship without the archive suite ever running.
+# Pinned one path at a time: a sibling in the same change set would pull the
+# suites in anyway and hide the miss.
+run_gate "scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs"
+assert_contains "- pnpm sentry:requeue:test (Sentry re-queue chokepoint changed)"
+assert_contains "- pnpm sentry:archive:test (Sentry re-queue chokepoint changed)"
+assert_contains "- pnpm sentry:ingest:test (Sentry re-queue chokepoint changed)"
+
 run_gate "scripts/sentry/triage/sentry-triage-project.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 

--- a/scripts/sentry/gate/sentry-suite-manifest.json
+++ b/scripts/sentry/gate/sentry-suite-manifest.json
@@ -74,7 +74,7 @@
     },
     "scripts/sentry/triage/sentry-triage-requeue.test.mjs": {
       "reporter": "count-line",
-      "floor": 52,
+      "floor": 54,
       "readsDirs": ["scripts"]
     }
   }

--- a/scripts/sentry/gate/sentry-suite-manifest.json
+++ b/scripts/sentry/gate/sentry-suite-manifest.json
@@ -74,7 +74,7 @@
     },
     "scripts/sentry/triage/sentry-triage-requeue.test.mjs": {
       "reporter": "count-line",
-      "floor": 40,
+      "floor": 52,
       "readsDirs": ["scripts"]
     }
   }

--- a/scripts/sentry/triage/sentry-triage-brief.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-brief.test.mjs
@@ -2159,6 +2159,7 @@ await test("the pipeline's shared modules stay under the file-size hard cap", ()
     "scripts/sentry/triage/sentry-triage-brief-render.mjs",
     "scripts/sentry/triage/sentry-triage-queue-contract.mjs",
     "scripts/sentry/triage/sentry-triage-requeue.mjs",
+    "scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs",
     "scripts/sentry/triage/sentry-triage-workflow-requeue.mjs",
   ]
     .map((path) => [path, readRepoFile(path).split("\n").length])

--- a/scripts/sentry/triage/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry/triage/sentry-triage-queue-contract.mjs
@@ -285,7 +285,7 @@ export const REOPEN_SHED_LABELS = [
 ];
 
 // Shed markers a re-queue may never put BACK, even when unwinding its own shed
-// against a stub that settled underneath it (ADR 0069). `sentry:approved-archive`
+// against a stub that settled underneath it (ADR 0070). `sentry:approved-archive`
 // is a spent human authority, and re-adding it is doubly wrong: a later
 // workflow_dispatch would read it as still-approved and archive without
 // re-review, and the add itself re-fires `sentry-triage-archive.yml`'s

--- a/scripts/sentry/triage/sentry-triage-queue-contract.mjs
+++ b/scripts/sentry/triage/sentry-triage-queue-contract.mjs
@@ -284,6 +284,15 @@ export const REOPEN_SHED_LABELS = [
   ARCHIVED_LABEL,
 ];
 
+// Shed markers a re-queue may never put BACK, even when unwinding its own shed
+// against a stub that settled underneath it (ADR 0068). `sentry:approved-archive`
+// is a spent human authority, and re-adding it is doubly wrong: a later
+// workflow_dispatch would read it as still-approved and archive without
+// re-review, and the add itself re-fires `sentry-triage-archive.yml`'s
+// `issues: labeled` trigger. Restoring a verdict or a projection/autofix marker
+// only restores a machine record; restoring this one hands out authority.
+export const NEVER_RESTORED_LABELS = [APPROVED_ARCHIVE_LABEL];
+
 // The needs-human brief (issue #1748) is NOT here, and no longer touches this
 // body. It lives as a dedicated, updated-in-place COMMENT on the stub, its
 // marker and lifecycle owned by scripts/sentry/triage/sentry-triage-brief.mjs. Rendering it

--- a/scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs
@@ -1,5 +1,5 @@
 /**
- * THE SETTLEMENT SENTINEL, and the unwind it triggers (issue #1929, ADR 0069).
+ * THE SETTLEMENT SENTINEL, and the unwind it triggers (issue #1929, ADR 0070).
  *
  * The re-queue chokepoint's invariant 7 revalidates a snapshot-derived premise
  * immediately BEFORE mutating. That leaves the write window itself uncovered:
@@ -21,8 +21,12 @@
  * unwind runs. No read can tell the two apart: the archive publishes nothing
  * after its verification, and a marker it published would be one more racing
  * write rather than a lock. Both runs then converge on the archive's own
- * post-rollback shape (open, verdicted, unqueued), both go red, and ingest's
- * stranded sweep repairs it. ADR 0069 records that trade.
+ * post-rollback shape (open, verdicted, unqueued) and ingest's stranded sweep
+ * repairs it a day later (#1817). Neither run FAILS on that path — the archive
+ * returns `unsettled-reopened` and exits 0, and this unwind returns
+ * `settled-underneath` — so the only live signal is the `::warning::` the
+ * detection site emits. ADR 0070 records that trade and issue #2004 tracks the
+ * archive's silent rollback exit.
  *
  * Split out of scripts/sentry/triage/sentry-triage-requeue.mjs to keep that
  * module under the 1,000-line hard cap. It imports the label contract and
@@ -178,13 +182,26 @@ export async function unwindAfterSettlement(
   // the premise never carried one to restore. Both are the same answer here — a
   // verdict-less closed archive is a state only a human can resolve — so both
   // land in the throw below rather than in a quiet decline.
+  //
+  // EXACTLY one, not at least one. `verdict-unsettled` is the compensation that
+  // fires precisely BECAUSE more than one verdict survived on the stub
+  // (`REQUEUE_REASON_VERDICT_UNSETTLED`, #1745), so a multi-verdict premise is
+  // not hypothetical here — it is the reason this code path was entered. The
+  // re-queue was the repair for that ambiguity; restoring every observed verdict
+  // and confirming the result would undo the repair and report success, leaving a
+  // CLOSED archive that `classifyIssue` buckets from whichever verdict comes
+  // first and only the digest's warning ever names. The settling run's own
+  // `settlementHeld` asks the weaker at-least-one question, so it would accept
+  // that stub too; nothing downstream repairs a closed one. So it lands with the
+  // verdict-less case, in the throw below.
   const missing = restorableMarkers({
     sentinelLabel: sentinel.label,
     premise,
   }).filter((name) => !(after?.labels ?? []).includes(name));
-  const verdictHolds = VERDICT_LABELS.some((name) =>
+  const verdicts = VERDICT_LABELS.filter((name) =>
     (after?.labels ?? []).includes(name),
   );
+  const verdictHolds = verdicts.length === 1;
   const held =
     after !== null &&
     String(after.state ?? "").toUpperCase() === "CLOSED" &&
@@ -193,17 +210,22 @@ export async function unwindAfterSettlement(
     missing.length === 0 &&
     verdictHolds;
   if (!held) {
+    const verdictFault = verdictHolds
+      ? ""
+      : verdicts.length === 0
+        ? ", no verdict label"
+        : `, ${verdicts.length} verdict labels (${verdicts.join("|")}) where the queue contract allows exactly one`;
     const seen = after
       ? `state=${after.state}, labels=${(after.labels ?? []).join("|")}${
           missing.length ? `, never restored: ${missing.join("|")}` : ""
-        }${verdictHolds ? "" : ", no verdict label"}`
+        }${verdictFault}`
       : `unreadable (${readError})`;
     process.stderr.write(
       `::error::Queue stub #${issueNumber} settled underneath a re-queue (${sentinel.label} appeared inside the write window), but the re-queue could not be unwound (${seen})${
         provisional.length
           ? `; corrections reported: ${provisional.join("; ")}`
           : ""
-      }. Repair it by hand: close it, remove ${NEEDS_TRIAGE_LABEL}, restore the previous round's markers, and leave ${sentinel.label} in place — the settling run already archived the underlying occurrence.\n`,
+      }. Repair it by hand: close it, remove ${NEEDS_TRIAGE_LABEL}, leave it carrying exactly one sentry:verdict-* label plus the previous round's other markers, and leave ${sentinel.label} in place — the settling run already archived the underlying occurrence.\n`,
     );
     throw new Error(
       `Queue stub #${issueNumber} settled underneath a re-queue and the re-queue could not be unwound (${seen}).`,

--- a/scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue-sentinel.mjs
@@ -1,0 +1,246 @@
+/**
+ * THE SETTLEMENT SENTINEL, and the unwind it triggers (issue #1929, ADR 0068).
+ *
+ * The re-queue chokepoint's invariant 7 revalidates a snapshot-derived premise
+ * immediately BEFORE mutating. That leaves the write window itself uncovered:
+ * `.github/workflows/sentry-triage-archive.yml` holds its own per-issue
+ * concurrency group, so a human-approved archive can settle the stub between the
+ * revalidating read and the writes — and the shed then removed `sentry:archived`
+ * with a `--remove-label` that reports nothing, so no later read could testify
+ * that the marker had ever been there.
+ *
+ * A sentinel is a label that answers exactly that question. The chokepoint
+ * withholds it from the shed, so it survives to be READ on the confirming
+ * end-state read; observing it there means the settlement landed inside this
+ * window, and this module undoes the re-queue rather than letting it report
+ * success over an occurrence a human approved archiving.
+ *
+ * WHAT THE MARKER PROVES is that an archive run WROTE it — not that the run
+ * accepted its own settlement. Those come apart when the archive's verification
+ * rejects the shape this re-queue produced and it starts rolling back while this
+ * unwind runs. No read can tell the two apart: the archive publishes nothing
+ * after its verification, and a marker it published would be one more racing
+ * write rather than a lock. Both runs then converge on the archive's own
+ * post-rollback shape (open, verdicted, unqueued), both go red, and ingest's
+ * stranded sweep repairs it. ADR 0068 records that trade.
+ *
+ * Split out of scripts/sentry/triage/sentry-triage-requeue.mjs to keep that
+ * module under the 1,000-line hard cap. It imports the label contract and
+ * `node:` nothing else, so it stays loadable from a workflow that ran
+ * setup-node without an install, like every module in this family.
+ */
+
+import {
+  NEEDS_TRIAGE_LABEL,
+  NEVER_RESTORED_LABELS,
+  REOPEN_SHED_LABELS,
+  VERDICT_LABELS,
+} from "./sentry-triage-queue-contract.mjs";
+
+/**
+ * The corrections that undo a re-queue, in the order every PREFIX of them is
+ * safe.
+ *
+ * `sentry:needs-triage` goes FIRST because selectability is the only property
+ * that lets another run act on this stub, so an unwind that dies half-way must
+ * already have taken it away. The markers come back next, and they are
+ * load-bearing rather than tidy: the settling run's own post-settlement
+ * verification demands closed + its terminal marker + a verdict label, so a stub
+ * left verdict-less makes THAT run roll a correct archive back. The close goes
+ * last, for the same reason the re-queue puts its state change last — it is the
+ * transition another stage can see.
+ *
+ * `premise` is the revalidating read: an OBSERVATION, the same thing the
+ * archive's `reconcileToTarget` rolls back to. Nothing here replays a log of
+ * what we believe we wrote.
+ *
+ * `NEVER_RESTORED_LABELS` is the one marker that does not come back. A spent
+ * approval is authority, not a record.
+ *
+ * Exported for the test, which asserts the ordering directly rather than
+ * inferring it from a fake's call log.
+ */
+export function restorableMarkers({ sentinelLabel, premise }) {
+  return REOPEN_SHED_LABELS.filter(
+    (name) =>
+      name !== sentinelLabel &&
+      !NEVER_RESTORED_LABELS.includes(name) &&
+      (premise?.labels ?? []).includes(name),
+  );
+}
+
+export function buildUnwindCorrections({
+  repo,
+  issueNumber,
+  sentinelLabel,
+  premise,
+}) {
+  const restore = restorableMarkers({ sentinelLabel, premise });
+  const edit = (flag, value) => [
+    "issue",
+    "edit",
+    String(issueNumber),
+    "-R",
+    repo,
+    flag,
+    value,
+  ];
+  return [
+    {
+      what: "drop-needs-triage",
+      args: edit("--remove-label", NEEDS_TRIAGE_LABEL),
+    },
+    ...(restore.length
+      ? [
+          {
+            what: `restore-${restore.join("+")}`,
+            args: edit("--add-label", restore.join(",")),
+          },
+        ]
+      : []),
+    {
+      what: "close",
+      args: [
+        "issue",
+        "close",
+        String(issueNumber),
+        "-R",
+        repo,
+        "--reason",
+        "completed",
+      ],
+    },
+  ];
+}
+
+/**
+ * Undo this re-queue and leave the settled shape standing.
+ *
+ * A write here can land and lose its response, so the corrections are
+ * PROVISIONAL and one confirming read decides — the same ambiguous-response
+ * discipline the rest of this pipeline uses. An unconfirmed unwind THROWS: the
+ * stub is then neither re-queued nor demonstrably settled, which is exactly the
+ * state that needs a human.
+ *
+ * Returns the chokepoint's own result shape, with `reason: "settled-underneath"`
+ * so a caller can tell this apart from the pre-write `revalidated-away` decline.
+ */
+export async function unwindAfterSettlement(
+  { writeGh, readStub },
+  { repo, issueNumber, sentinel, premise },
+) {
+  const provisional = [];
+  for (const correction of buildUnwindCorrections({
+    repo,
+    issueNumber,
+    sentinelLabel: sentinel.label,
+    premise,
+  })) {
+    try {
+      await writeGh(correction.args);
+    } catch (err) {
+      provisional.push(
+        `${correction.what} reported: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // BOUNDED RETRY on the confirming read, the same allowance the chokepoint
+  // gives its revalidating read. A compensation often runs precisely because a
+  // `gh` read on this stub just failed, so this read is correlated with a
+  // usually-transient failure — and one unretried attempt would turn that blip
+  // into an `::error::` telling a human to repair a stub the three writes above
+  // had already left correctly settled. Bounded, so a real outage still lands in
+  // the throw below.
+  let after = null;
+  let readError = null;
+  for (let round = 1; round <= 2 && after === null; round += 1) {
+    try {
+      // Normalised, so a reader that resolves to nothing is treated as a read
+      // that failed rather than crashing the report below.
+      after = (await readStub(issueNumber)) ?? null;
+      readError = after === null ? "the read returned nothing" : null;
+    } catch (err) {
+      readError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `::notice::Could not read #${issueNumber} to confirm the unwind (${readError}); attempt ${round} of 2.\n`,
+      );
+    }
+  }
+  // The confirmation asks for the SETTLED shape the settling run itself demands
+  // (`settlementHeld` in scripts/sentry/triage/sentry-triage-archive.mjs:
+  // closed, its terminal marker, and a verdict label) — not merely for the three
+  // corrections above having been attempted. Asking the weaker question let the
+  // unwind confirm a stub that run then rejects, which is the outcome the unwind
+  // exists to prevent.
+  //
+  // Two ways the verdict can be absent: the re-add REPORTED a real failure, and
+  // the premise never carried one to restore. Both are the same answer here — a
+  // verdict-less closed archive is a state only a human can resolve — so both
+  // land in the throw below rather than in a quiet decline.
+  const missing = restorableMarkers({
+    sentinelLabel: sentinel.label,
+    premise,
+  }).filter((name) => !(after?.labels ?? []).includes(name));
+  const verdictHolds = VERDICT_LABELS.some((name) =>
+    (after?.labels ?? []).includes(name),
+  );
+  const held =
+    after !== null &&
+    String(after.state ?? "").toUpperCase() === "CLOSED" &&
+    (after.labels ?? []).includes(sentinel.label) &&
+    !(after.labels ?? []).includes(NEEDS_TRIAGE_LABEL) &&
+    missing.length === 0 &&
+    verdictHolds;
+  if (!held) {
+    const seen = after
+      ? `state=${after.state}, labels=${(after.labels ?? []).join("|")}${
+          missing.length ? `, never restored: ${missing.join("|")}` : ""
+        }${verdictHolds ? "" : ", no verdict label"}`
+      : `unreadable (${readError})`;
+    process.stderr.write(
+      `::error::Queue stub #${issueNumber} settled underneath a re-queue (${sentinel.label} appeared inside the write window), but the re-queue could not be unwound (${seen})${
+        provisional.length
+          ? `; corrections reported: ${provisional.join("; ")}`
+          : ""
+      }. Repair it by hand: close it, remove ${NEEDS_TRIAGE_LABEL}, restore the previous round's markers, and leave ${sentinel.label} in place — the settling run already archived the underlying occurrence.\n`,
+    );
+    throw new Error(
+      `Queue stub #${issueNumber} settled underneath a re-queue and the re-queue could not be unwound (${seen}).`,
+    );
+  }
+
+  // Correct the stub's written record LAST, once the state it describes is
+  // confirmed. Advisory, like every other note the chokepoint posts: a failed
+  // post must not undo a converged unwind.
+  if (sentinel.unwindNote) {
+    try {
+      await writeGh([
+        "issue",
+        "comment",
+        String(issueNumber),
+        "-R",
+        repo,
+        "--body",
+        sentinel.unwindNote(after),
+      ]);
+    } catch (err) {
+      process.stderr.write(
+        `::notice::The settled-underneath note on #${issueNumber} could not be posted (${
+          err instanceof Error ? err.message : String(err)
+        }); the stub itself is correctly settled.\n`,
+      );
+    }
+  }
+  if (provisional.length) {
+    process.stderr.write(
+      `::notice::The unwind of #${issueNumber} reported failures the verification read disproves (${provisional.join("; ")}).\n`,
+    );
+  }
+  return {
+    requeued: false,
+    reason: "settled-underneath",
+    verified: after,
+    labelError: null,
+  };
+}

--- a/scripts/sentry/triage/sentry-triage-requeue.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.mjs
@@ -70,6 +70,7 @@ import {
   selectMarkedComment,
   selectVerdictComment,
 } from "./sentry-triage-project-core.mjs";
+import { unwindAfterSettlement } from "./sentry-triage-requeue-sentinel.mjs";
 
 // ---------------------------------------------------------------------------
 // Causes.
@@ -301,7 +302,14 @@ export function buildRequeueAddLabelArgs(issueNumber, repo) {
   ];
 }
 
-export function buildRequeueShedLabelArgs(issueNumber, repo) {
+/**
+ * `except` withholds a marker from the blind shed. Exactly one caller uses it —
+ * a re-queue that declares a settlement SENTINEL (see `requeueQueueStub`) — and
+ * withholding is what makes the sentinel work: a marker this call erases is a
+ * marker no later read can testify about.
+ */
+export function buildRequeueShedLabelArgs(issueNumber, repo, { except } = {}) {
+  const withheld = new Set(except ?? []);
   return [
     "issue",
     "edit",
@@ -309,7 +317,7 @@ export function buildRequeueShedLabelArgs(issueNumber, repo) {
     "-R",
     repo,
     "--remove-label",
-    REOPEN_SHED_LABELS.join(","),
+    REOPEN_SHED_LABELS.filter((name) => !withheld.has(name)).join(","),
   ];
 }
 
@@ -531,9 +539,10 @@ export const REQUEUE_ON_FAILURE_VERIFY_END_STATE = "verify-end-state";
  *                          fence is already on the stub. Sound ONLY where the
  *                          gate that produced this re-queue cannot fire twice for
  *                          one `lastSeen` with a verdict in between; see below.
- *   `revalidate`         — `{ check(live), declineNote(live) }`. When the caller's
- *                          premise is a snapshot, re-read and stop unless it still
- *                          holds. A failed read PROPAGATES.
+ *   `revalidate`         — `{ check(live), declineNote(live), sentinel? }`. When the
+ *                          caller's premise is a snapshot, re-read and stop unless
+ *                          it still holds. A failed read PROPAGATES. `sentinel`
+ *                          extends that premise across the WRITE window; see below.
  *   `onFailure`          — REQUEUE_ON_FAILURE_*.
  *   `fallbackState`      — pre-run state, for the verify-end-state reopen.
  *
@@ -559,6 +568,46 @@ export async function requeueQueueStub(
   const fences = requeueFences(cause);
   const verifyEndState = onFailure === REQUEUE_ON_FAILURE_VERIFY_END_STATE;
 
+  // INVARIANT 7, SECOND HALF — the premise re-checked across the WRITE window
+  // (issue #1929, ADR 0068). `revalidate` alone re-reads and then writes blind:
+  // between those two moments the archive leg — its own per-issue concurrency
+  // group — can settle the stub, and the shed then erases the very marker that
+  // would have said so. The sentinel names that marker. It is withheld from the
+  // shed, so it survives to be READ at the end; observing it on the confirming
+  // read means the settlement landed inside this window, and the re-queue
+  // unwinds instead of reporting success over a settled occurrence.
+  //
+  // Only meaningful with the end-state verification, which is what produces the
+  // confirming read; declared without it, the sentinel would be a promise
+  // nothing checks, so it throws here rather than degrading quietly.
+  // The declaration is validated BEFORE any I/O, shape included. A sentinel
+  // missing its `declineNote` would throw at the detection site instead — after
+  // the add, the shed and the reopen, and before any correction — leaving
+  // exactly the open, queued, still-marked stub this mechanism exists to
+  // prevent. A malformed declaration must cost nothing, so it costs a throw here.
+  const sentinel = revalidate?.sentinel ?? null;
+  if (sentinel && !verifyEndState) {
+    throw new Error(
+      `A re-queue sentinel (${sentinel.label}) needs ${REQUEUE_ON_FAILURE_VERIFY_END_STATE}: without the end-state verification nothing ever reads it back.`,
+    );
+  }
+  if (
+    sentinel &&
+    !(typeof sentinel.label === "string" && sentinel.label.length > 0)
+  ) {
+    throw new Error(
+      "A re-queue sentinel must name the label it watches for as a non-empty string.",
+    );
+  }
+  if (sentinel && typeof sentinel.declineNote !== "function") {
+    throw new Error(
+      `A re-queue sentinel (${sentinel.label}) must supply declineNote(live): the detection site reports before it unwinds, and a missing note would throw there — after the writes and before any correction.`,
+    );
+  }
+  const shedLabels = REOPEN_SHED_LABELS.filter(
+    (name) => name !== sentinel?.label,
+  );
+
   // INVARIANT 4 — the exclusion set records ATTEMPTS, not successes, and the
   // record is written before the first thing that can fail. A Sentry-evidence
   // re-queue that throws half-way must not be inherited by the same run's
@@ -573,8 +622,10 @@ export async function requeueQueueStub(
   // is how a snapshot-driven mutation becomes a snapshot-driven mistake. The read
   // retries within a bound first (see `readForRevalidation`) — a caller reaching
   // here often does so because a read just failed.
+  let premise = null;
   if (revalidate) {
     const live = await readForRevalidation(readStub, issueNumber);
+    premise = live;
     if (!revalidate.check(live)) {
       process.stderr.write(`::notice::${revalidate.declineNote(live)}\n`);
       return {
@@ -677,7 +728,11 @@ export async function requeueQueueStub(
   let labelError = null;
   try {
     await writeGh(buildRequeueAddLabelArgs(issueNumber, repo));
-    await writeGh(buildRequeueShedLabelArgs(issueNumber, repo));
+    await writeGh(
+      buildRequeueShedLabelArgs(issueNumber, repo, {
+        except: sentinel ? [sentinel.label] : [],
+      }),
+    );
   } catch (err) {
     if (!verifyEndState) throw err;
     // Must NOT propagate past the end-state verification below — that is exactly
@@ -737,6 +792,34 @@ export async function requeueQueueStub(
   }
 
   if (verifyEndState) {
+    // THE SENTINEL, read back — after the LAST write, and after EVERY read that
+    // follows one. An earlier-only check leaves the window between it and the
+    // reopen uncovered; a first-read-only check leaves the shed retry below
+    // uncovered, where a second read is taken and a settlement first visible
+    // there would be judged as a successful re-queue. So this runs against
+    // whatever `verified` currently holds, at each point that value can change.
+    //
+    // Both orderings are covered between the two runs: a settlement whose marker
+    // is on the stub at any of these reads is caught here, and one whose marker
+    // lands after the last of them has its own post-settlement verification
+    // looking at a stub this run has already reopened and stripped of its
+    // verdict, which fails it and rolls it back.
+    //
+    // The stub is momentarily selectable, between the reopen above and the
+    // unwind. Nothing can act on it there: the triage workflow holds one
+    // repo-wide concurrency group and this compensation runs inside its run, and
+    // ingest's dedup skips an open stub.
+    const settledUnderneath = () =>
+      sentinel && verified.labels.includes(sentinel.label);
+    const unwind = async () => {
+      process.stderr.write(`::warning::${sentinel.declineNote(verified)}\n`);
+      return unwindAfterSettlement(
+        { writeGh, readStub },
+        { repo, issueNumber, sentinel, premise },
+      );
+    };
+    if (settledUnderneath()) return await unwind();
+
     // RE-ATTEMPT THE SHED against observed state, once, before judging.
     //
     // The add and the shed share one try, so an add that REPORTS failure jumps
@@ -755,7 +838,7 @@ export async function requeueQueueStub(
     // Bounded at one extra attempt, like every other retry here, and the check
     // below still THROWS on anything that survives — the transient case
     // self-heals, the persistent one stays loud.
-    const staleAfterVerify = REOPEN_SHED_LABELS.filter((name) =>
+    const staleAfterVerify = shedLabels.filter((name) =>
       verified.labels.includes(name),
     );
     if (staleAfterVerify.length) {
@@ -763,7 +846,11 @@ export async function requeueQueueStub(
         process.stderr.write(
           `::notice::Stale markers still on #${issueNumber} after selectability was restored (${staleAfterVerify.join(", ")}); re-attempting the shed.\n`,
         );
-        await writeGh(buildRequeueShedLabelArgs(issueNumber, repo));
+        await writeGh(
+          buildRequeueShedLabelArgs(issueNumber, repo, {
+            except: sentinel ? [sentinel.label] : [],
+          }),
+        );
         // Re-read rather than assume: this write can lose its response too. Merge
         // so a reader that serves no comments cannot erase the ones the fence
         // check below judges.
@@ -779,6 +866,12 @@ export async function requeueQueueStub(
           `::notice::Shed retry on #${issueNumber} reported a failure (${retryError}); the end-state verification below still decides.\n`,
         );
       }
+      // The retry's read is a second observation, so it gets the same sentinel
+      // decision as the first. A settlement first visible HERE is the case a
+      // failed initial shed produces: the verdict it left behind is what lets
+      // the archive's verification hold, so the archive really did settle, and
+      // the retry has just removed that verdict.
+      if (settledUnderneath()) return await unwind();
     }
 
     // Judge the fence and the shed from the SAME verification read, for the same
@@ -798,7 +891,7 @@ export async function requeueQueueStub(
         "a previous verdict is still admissible — no regression fence newer than it survives on the stub — so a failing triage round could close that verdict over this live regression; post the fence by hand, or re-run this workflow, before the next triage run",
       );
     }
-    const survivingMarkers = REOPEN_SHED_LABELS.filter((name) =>
+    const survivingMarkers = shedLabels.filter((name) =>
       verified.labels.includes(name),
     );
     if (survivingMarkers.length) {

--- a/scripts/sentry/triage/sentry-triage-requeue.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.mjs
@@ -569,7 +569,7 @@ export async function requeueQueueStub(
   const verifyEndState = onFailure === REQUEUE_ON_FAILURE_VERIFY_END_STATE;
 
   // INVARIANT 7, SECOND HALF — the premise re-checked across the WRITE window
-  // (issue #1929, ADR 0069). `revalidate` alone re-reads and then writes blind:
+  // (issue #1929, ADR 0070). `revalidate` alone re-reads and then writes blind:
   // between those two moments the archive leg — its own per-issue concurrency
   // group — can settle the stub, and the shed then erases the very marker that
   // would have said so. The sentinel names that marker. It is withheld from the
@@ -602,6 +602,20 @@ export async function requeueQueueStub(
   if (sentinel && typeof sentinel.declineNote !== "function") {
     throw new Error(
       `A re-queue sentinel (${sentinel.label}) must supply declineNote(live): the detection site reports before it unwinds, and a missing note would throw there — after the writes and before any correction.`,
+    );
+  }
+  // The sentinel must be a label this call would otherwise SHED. Withholding is
+  // the whole mechanism, and there is nothing to withhold a label from unless the
+  // shed set contains it. A label outside that set inverts the check instead of
+  // weakening it: `sentry:needs-triage` passes every check above, survives the
+  // filter below trivially, and is then re-ADDED by this very re-queue — so the
+  // confirming read finds it every time and unwinds a re-queue nothing settled,
+  // closing a stub that should be selectable. That is worse than the fail-open
+  // this mechanism replaces, so a declaration that could produce it costs a throw
+  // here, before any I/O, like the three above.
+  if (sentinel && !REOPEN_SHED_LABELS.includes(sentinel.label)) {
+    throw new Error(
+      `A re-queue sentinel (${sentinel.label}) must name a label this re-queue sheds (${REOPEN_SHED_LABELS.join(", ")}): the sentinel is a marker withheld from the shed, and a label outside that set is either never removed or re-added by this run, so the confirming read would report a settlement that never happened.`,
     );
   }
   const shedLabels = REOPEN_SHED_LABELS.filter(

--- a/scripts/sentry/triage/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.test.mjs
@@ -18,6 +18,8 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { settlementHeld } from "./sentry-triage-archive.mjs";
+import { buildUnwindCorrections } from "./sentry-triage-requeue-sentinel.mjs";
 import {
   REGRESSION_PREFIX,
   VERDICT_MARKER,
@@ -878,7 +880,15 @@ await test("no re-queue path rewrites the stub body (#1692)", async () => {
 // OPEN-safe, unless the stub went TERMINAL underneath the failing step.
 // ---------------------------------------------------------------------------
 
-function makeClearFailureGh(initial, { failOn = () => null } = {}) {
+/**
+ * `after(args, state)` runs once each call has been applied, which is how the
+ * racing-interleaving tests below land the archive leg's writes at a CHOSEN
+ * point in the compensation's sequence rather than hoping for a timing.
+ */
+function makeClearFailureGh(
+  initial,
+  { failOn = () => null, after = () => {} } = {},
+) {
   const state = {
     state: initial.state ?? "OPEN",
     labels: [...(initial.labels ?? [])],
@@ -917,9 +927,48 @@ function makeClearFailureGh(initial, { failOn = () => null } = {}) {
       state.state = "OPEN";
       return "";
     }
+    if (args[0] === "issue" && args[1] === "close") {
+      state.state = "CLOSED";
+      return "";
+    }
     return "";
   };
-  return { state, calls, runGh };
+  return {
+    state,
+    calls,
+    runGh: async (args) => {
+      const out = await runGh(args);
+      after(args, state);
+      return out;
+    },
+  };
+}
+
+/**
+ * An `after` hook that lands the archive leg's settlement — the stub closes and
+ * gains the terminal marker — at the WORST point for the compensation: right
+ * after it restores `sentry:needs-triage`, so the archive's own post-settlement
+ * verification (closed + terminal marker + a verdict) has already passed and
+ * that run reported success. Everything the compensation does from here is
+ * invisible to it. Landing the settlement any later would let a blind shed
+ * survive the test, which is the mechanism under test.
+ *
+ * ONCE, because the archive settles a given stub once and a hook that re-fired
+ * would quietly repair whatever the unwind got wrong. `settleQueueStub` consumes
+ * the approval before this point, so it goes here too.
+ */
+function settleLikeArchiveOnRequeue() {
+  let settled = false;
+  return (args, state) => {
+    if (settled || args[1] !== "edit" || !args.includes("--add-label")) return;
+    settled = true;
+    state.state = "CLOSED";
+    state.labels = state.labels.filter(
+      (name) => name !== "sentry:approved-archive",
+    );
+    if (!state.labels.includes("sentry:archived"))
+      state.labels.push("sentry:archived");
+  };
 }
 
 await test("runWorkflowRequeue restores needs-triage and sheds the verdict on an OPEN stub (#1769 round 16)", async () => {
@@ -1223,6 +1272,392 @@ await test("the terminal revalidation FAILS CLOSED: an unreadable stub is never 
     2,
     "the revalidating read retries exactly once before failing closed",
   );
+});
+
+// ---------------------------------------------------------------------------
+// The archive-settlement race (#1929, ADR 0068). The revalidating read above is
+// a snapshot, so the archive leg — its own per-issue concurrency group — can
+// settle the stub between it and these writes. The interleaving each test names
+// is the one it drives, by landing the archive's writes at a chosen call.
+// ---------------------------------------------------------------------------
+
+await test("an archive settling INSIDE the write window unwinds the re-queue instead of reporting success (#1929)", async () => {
+  // The undetectable ordering: the archive's post-settlement verification has
+  // already read the stub, so nothing on its side can see this compensation.
+  // Its terminal marker is withheld from the shed, so the confirming read here
+  // still sees it — and the re-queue undoes itself.
+  const gh = makeClearFailureGh(
+    {
+      state: "OPEN",
+      labels: ["sentry-triage", "sentry:verdict-upstream"],
+    },
+    {
+      after: settleLikeArchiveOnRequeue(),
+    },
+  );
+  const result = await runWorkflowRequeue({
+    runGh: gh.runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_BRIEF_CLEAR,
+  });
+  assertEqual(result.requeued, false);
+  assertEqual(result.reason, "settled-underneath");
+  assertEqual(gh.state.state, "CLOSED");
+  assert(
+    gh.state.labels.includes("sentry:archived"),
+    "the archive's terminal marker must survive a re-queue that raced it",
+  );
+  assert(
+    !gh.state.labels.includes(NEEDS_TRIAGE_LABEL),
+    "an archived occurrence must never be left with a selectable retry stub",
+  );
+  assert(
+    gh.state.labels.includes("sentry:verdict-upstream"),
+    "the verdict must come back: the archive's own verification demands one",
+  );
+  assert(
+    gh.state.comments.some((body) =>
+      body.includes("the re-queue was undone rather than completed"),
+    ),
+    "the stub's written record must correct the re-queue note it now contradicts",
+  );
+});
+
+await test("the sentinel marker is never removed blindly, which is what leaves it readable (#1929)", async () => {
+  // A `--remove-label` that carries the marker reports nothing about whether it
+  // was there, so after it no read can testify. Withholding it is the whole
+  // mechanism, and it costs nothing: the revalidation declines outright on a
+  // stub that already carries it, so the only marker this shed ever meets is
+  // one that appeared mid-window.
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    {
+      after: settleLikeArchiveOnRequeue(),
+    },
+  );
+  await runWorkflowRequeue({
+    runGh: gh.runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_VERDICT_UNSETTLED,
+  });
+  for (const args of gh.calls) {
+    const at = args.indexOf("--remove-label");
+    if (at === -1) continue;
+    assert(
+      !args[at + 1].split(",").includes("sentry:archived"),
+      `a re-queue with a sentinel must not shed it: ${args[at + 1]}`,
+    );
+  }
+  // …and everything else the re-queue owes is still shed.
+  const shed = buildRequeueShedLabelArgs(1731, REPO, {
+    except: ["sentry:archived"],
+  });
+  const names = shed[shed.indexOf("--remove-label") + 1].split(",");
+  assert(!names.includes("sentry:archived"), "the sentinel must be withheld");
+  for (const name of [
+    "sentry:verdict-upstream",
+    "sentry:projected",
+    "sentry:approved-archive",
+  ]) {
+    assert(names.includes(name), `${name} must still be shed`);
+  }
+});
+
+await test("the unwind restores the shed markers but NEVER the spent approval (#1929)", async () => {
+  // The archive consumes `sentry:approved-archive` as its compare-and-swap, so
+  // by the time the sentinel fires that approval is spent. Re-adding it would
+  // hand a later workflow_dispatch an approval no human gave — and the add
+  // itself re-fires the archive workflow's `issues: labeled` trigger.
+  const gh = makeClearFailureGh(
+    {
+      state: "OPEN",
+      labels: [
+        "sentry-triage",
+        "sentry:verdict-upstream",
+        "sentry:projected",
+        "sentry:approved-archive",
+      ],
+    },
+    {
+      after: settleLikeArchiveOnRequeue(),
+    },
+  );
+  const result = await runWorkflowRequeue({
+    runGh: gh.runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_CLOSE_FAILURE,
+  });
+  assertEqual(result.reason, "settled-underneath");
+  assert(
+    gh.state.labels.includes("sentry:verdict-upstream") &&
+      gh.state.labels.includes("sentry:projected"),
+    "the previous round's machine records must be restored",
+  );
+  assert(
+    !gh.state.labels.includes("sentry:approved-archive"),
+    "a spent human approval must never be handed back",
+  );
+});
+
+await test("an unwind that cannot be confirmed is a HARD failure, never a quiet decline (#1929)", async () => {
+  // Same discipline as the end-state verification it replaces: the stub is
+  // then neither re-queued nor demonstrably settled, so a human has to look.
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    {
+      failOn: (args) => (args[1] === "close" ? "HTTP 503 unavailable" : null),
+      after: settleLikeArchiveOnRequeue(),
+    },
+  );
+  await assertRejects(
+    runWorkflowRequeue({
+      runGh: gh.runGh,
+      repo: REPO,
+      issueNumber: 1731,
+      reason: REQUEUE_REASON_BRIEF_CLEAR,
+    }),
+    /settled underneath a re-queue and the re-queue could not be unwound/,
+  );
+  assert(
+    !gh.state.labels.includes(NEEDS_TRIAGE_LABEL),
+    "the failed unwind must still have taken selectability away first",
+  );
+});
+
+await test("a settlement first visible to the SHED RETRY's read still unwinds (#1929)", async () => {
+  // The end-state verification can take a second read: when the first shed
+  // failed, the retry sheds again and re-reads. A settlement landing between
+  // those two reads is invisible to the first one — and it is precisely the
+  // failed shed that lets it happen, because the verdict label it left behind is
+  // what makes the archive's own verification hold. The retry then removes that
+  // verdict. Every read that can change `verified` gets the sentinel decision.
+  let views = 0;
+  let sheds = 0;
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    {
+      failOn: (args) => {
+        if (args[1] !== "edit" || !args.includes("--remove-label")) return null;
+        sheds += 1;
+        return sheds === 1 ? "HTTP 503 unavailable" : null;
+      },
+      after: (args, state) => {
+        if (args[1] !== "view") return;
+        views += 1;
+        // View 1 revalidates, view 2 is the end-state confirmation. Settle
+        // immediately after that one, so only the retry's read can see it.
+        if (views !== 2) return;
+        state.state = "CLOSED";
+        if (!state.labels.includes("sentry:archived"))
+          state.labels.push("sentry:archived");
+      },
+    },
+  );
+  const result = await runWorkflowRequeue({
+    runGh: gh.runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_VERDICT_UNSETTLED,
+  });
+  assertEqual(result.reason, "settled-underneath");
+  assertEqual(gh.state.state, "CLOSED");
+  assert(
+    !gh.state.labels.includes(NEEDS_TRIAGE_LABEL),
+    "a stub the archive settled must not keep a re-queue's needs-triage",
+  );
+  assert(
+    gh.state.labels.includes("sentry:verdict-upstream"),
+    "the verdict the retry shed must come back",
+  );
+});
+
+await test("an unwind whose marker restoration never lands is a HARD failure (#1929)", async () => {
+  // Dropping `sentry:needs-triage` and closing while the verdict re-add reported
+  // a real failure leaves a stub the archive's own verification rejects — the
+  // outcome this unwind exists to prevent. Judging only the cheap three would
+  // have called that a success.
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    {
+      failOn: (args) =>
+        args[1] === "edit" &&
+        args.includes("--add-label") &&
+        args[args.indexOf("--add-label") + 1].includes("verdict")
+          ? "HTTP 503 unavailable"
+          : null,
+      after: settleLikeArchiveOnRequeue(),
+    },
+  );
+  await assertRejects(
+    runWorkflowRequeue({
+      runGh: gh.runGh,
+      repo: REPO,
+      issueNumber: 1731,
+      reason: REQUEUE_REASON_BRIEF_CLEAR,
+    }),
+    /could not be unwound/,
+  );
+});
+
+await test("an unwind that cannot leave a VERDICT on the stub fails rather than declining (#1929)", async () => {
+  // The unwind confirms the shape the settling run demands, and that run needs a
+  // `sentry:verdict-*` label. A premise carrying none has nothing to restore, so
+  // the unwind would otherwise confirm a closed, archived, verdict-less stub the
+  // archive's verification rejects. Only a human can resolve that, so it is loud.
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage"] },
+    { after: settleLikeArchiveOnRequeue() },
+  );
+  await assertRejects(
+    runWorkflowRequeue({
+      runGh: gh.runGh,
+      repo: REPO,
+      issueNumber: 1731,
+      reason: REQUEUE_REASON_VERDICT_UNSETTLED,
+    }),
+    /no verdict label/,
+  );
+});
+
+await test("the unwind's write order leaves every PREFIX of it unselectable (#1929)", async () => {
+  // An unwind can die half-way, so its order is a correctness property rather
+  // than a style one: `sentry:needs-triage` goes first because it is the only
+  // thing that lets another run act on the stub, and the close goes last for the
+  // same reason the re-queue puts its state change last. Asserted on the plan,
+  // not inferred from a fake's call log, so a reordering reds here directly.
+  const corrections = buildUnwindCorrections({
+    repo: REPO,
+    issueNumber: 1731,
+    sentinelLabel: "sentry:archived",
+    premise: {
+      state: "OPEN",
+      labels: ["sentry-triage", "sentry:verdict-upstream", "sentry:archived"],
+    },
+  });
+  assertDeepEqual(
+    corrections.map((c) => c.what),
+    ["drop-needs-triage", "restore-sentry:verdict-upstream", "close"],
+  );
+  assertDeepEqual(corrections[0].args.slice(-2), [
+    "--remove-label",
+    NEEDS_TRIAGE_LABEL,
+  ]);
+  assertEqual(corrections.at(-1).args[1], "close");
+  // The sentinel is never re-added: the unwind never removed it.
+  assert(
+    !corrections.some((c) => c.args.join(" ").includes("sentry:archived")),
+    "the sentinel is left in place, so nothing re-adds it",
+  );
+});
+
+await test("the archive's own verification covers the OTHER ordering (#1929)", async () => {
+  // The two runs cover the two orderings between them, and this is the half
+  // that already existed: a compensation whose writes land BEFORE the archive's
+  // post-settlement read is caught there, because that read demands closed +
+  // the terminal marker + a verdict label and the compensation has removed the
+  // verdict and reopened the stub. Pinned here so the claim the sentinel's
+  // scope rests on cannot rot in the other file.
+  const requeued = {
+    state: "OPEN",
+    labels: ["sentry-triage", "sentry:needs-triage", "sentry:archived"],
+    body: "",
+  };
+  assertEqual(settlementHeld(requeued), false);
+  assertEqual(
+    settlementHeld({
+      state: "CLOSED",
+      labels: ["sentry-triage", "sentry:archived"],
+      body: "",
+    }),
+    false,
+  );
+  assertEqual(
+    settlementHeld({
+      state: "CLOSED",
+      labels: ["sentry-triage", "sentry:archived", "sentry:verdict-upstream"],
+      body: "",
+    }),
+    true,
+  );
+});
+
+await test("a malformed sentinel declaration refuses before any I/O (#1929)", async () => {
+  // Two ways to declare one wrongly, both fatal here rather than later. Under
+  // the abort policy the sentinel is a guarantee nothing ever reads back. And a
+  // sentinel with no `declineNote` would throw at the DETECTION site — after the
+  // add, the shed and the reopen, before any correction — leaving the open,
+  // queued, still-marked stub the whole mechanism exists to prevent.
+  const cases = [
+    [
+      { sentinel: { label: "sentry:archived", declineNote: () => "s" } },
+      /needs verify-end-state/,
+      false,
+    ],
+    [
+      { sentinel: { label: "sentry:archived" } },
+      /must supply declineNote/,
+      true,
+    ],
+    [{ sentinel: { declineNote: () => "s" } }, /non-empty string/, true],
+  ];
+  for (const [extra, pattern, verify] of cases) {
+    const writer = makeWriter();
+    await assertRejects(
+      requeueQueueStub(
+        { writeGh: writer.writeGh, readStub: async () => ({}) },
+        {
+          repo: REPO,
+          issueNumber: 1731,
+          cause: REQUEUE_CAUSE_BOOKKEEPING,
+          note: "n",
+          onFailure: verify ? REQUEUE_ON_FAILURE_VERIFY_END_STATE : undefined,
+          revalidate: {
+            check: () => true,
+            declineNote: () => "d",
+            ...extra,
+          },
+        },
+      ),
+      pattern,
+    );
+    assertEqual(writer.calls.length, 0);
+  }
+});
+
+await test("a transient read failure never turns a converged unwind into a manual-repair alarm (#1929)", async () => {
+  // The unwind's confirming read gets the same bounded retry the revalidating
+  // read has, for the same reason: a compensation often runs BECAUSE a `gh` read
+  // just failed, so this read is correlated with a usually-transient failure and
+  // one attempt would raise `repair by hand` over a correctly settled stub.
+  let confirmations = 0;
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    { after: settleLikeArchiveOnRequeue() },
+  );
+  // Fail exactly once, on the first read after the unwind's close — which is
+  // the confirming read and nothing else.
+  let closed = false;
+  const runGh = async (args) => {
+    if (args[1] === "view" && closed && confirmations === 0) {
+      confirmations += 1;
+      throw new Error("HTTP 502 bad gateway");
+    }
+    const out = await gh.runGh(args);
+    if (args[1] === "close") closed = true;
+    return out;
+  };
+  const result = await runWorkflowRequeue({
+    runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_BRIEF_CLEAR,
+  });
+  assertEqual(confirmations, 1);
+  assertEqual(result.reason, "settled-underneath");
+  assertEqual(gh.state.state, "CLOSED");
 });
 
 await test("every note this chokepoint posts reads as intent, never as a completed write", () => {

--- a/scripts/sentry/triage/sentry-triage-requeue.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-requeue.test.mjs
@@ -1275,7 +1275,7 @@ await test("the terminal revalidation FAILS CLOSED: an unreadable stub is never 
 });
 
 // ---------------------------------------------------------------------------
-// The archive-settlement race (#1929, ADR 0069). The revalidating read above is
+// The archive-settlement race (#1929, ADR 0070). The revalidating read above is
 // a snapshot, so the archive leg — its own per-issue concurrency group — can
 // settle the stub between it and these writes. The interleaving each test names
 // is the one it drives, by landing the archive's writes at a chosen call.
@@ -1522,6 +1522,60 @@ await test("an unwind that cannot leave a VERDICT on the stub fails rather than 
   );
 });
 
+await test("an unwind that would leave TWO verdicts on the stub fails rather than declining (#1929)", async () => {
+  // `verdict-unsettled` is the compensation that fires BECAUSE more than one
+  // verdict survived (#1745), so this premise is the one that path was entered
+  // with — not a hypothetical. The unwind restores every marker the premise
+  // carried, so accepting at-least-one would undo the repair the re-queue exists
+  // to perform and report success over a CLOSED archive `classifyIssue` buckets
+  // from whichever verdict comes first. The settling run's own `settlementHeld`
+  // would accept it too, and the stranded sweep only sees OPEN stubs, so nothing
+  // downstream repairs it. It fails here or nowhere.
+  const gh = makeClearFailureGh(
+    {
+      state: "OPEN",
+      labels: [
+        "sentry-triage",
+        "sentry:verdict-upstream",
+        "sentry:verdict-code-fix",
+      ],
+    },
+    { after: settleLikeArchiveOnRequeue() },
+  );
+  await assertRejects(
+    runWorkflowRequeue({
+      runGh: gh.runGh,
+      repo: REPO,
+      issueNumber: 1731,
+      reason: REQUEUE_REASON_VERDICT_UNSETTLED,
+    }),
+    /2 verdict labels .* exactly one/,
+  );
+  // The unwind still ran in the order that leaves every prefix unselectable, so
+  // the stub a human is asked to repair is at least not selectable meanwhile.
+  assert(
+    !gh.state.labels.includes(NEEDS_TRIAGE_LABEL),
+    "the failed unwind must still have taken selectability away first",
+  );
+});
+
+await test("one verdict on the confirming read is still accepted (#1929)", async () => {
+  // The negative control for the case above: the tightening must reject TWO
+  // without rejecting the ordinary one-verdict unwind this mechanism exists for.
+  const gh = makeClearFailureGh(
+    { state: "OPEN", labels: ["sentry-triage", "sentry:verdict-upstream"] },
+    { after: settleLikeArchiveOnRequeue() },
+  );
+  const result = await runWorkflowRequeue({
+    runGh: gh.runGh,
+    repo: REPO,
+    issueNumber: 1731,
+    reason: REQUEUE_REASON_VERDICT_UNSETTLED,
+  });
+  assertEqual(result.reason, "settled-underneath");
+  assertEqual(gh.state.state, "CLOSED");
+});
+
 await test("the unwind's write order leaves every PREFIX of it unselectable (#1929)", async () => {
   // An unwind can die half-way, so its order is a correctness property rather
   // than a style one: `sentry:needs-triage` goes first because it is the only
@@ -1602,6 +1656,25 @@ await test("a malformed sentinel declaration refuses before any I/O (#1929)", as
       true,
     ],
     [{ sentinel: { declineNote: () => "s" } }, /non-empty string/, true],
+    // A sentinel outside REOPEN_SHED_LABELS INVERTS the check rather than
+    // weakening it. `sentry:needs-triage` is the worst case and passes every
+    // other check: nothing sheds it, this re-queue re-ADDS it, so the confirming
+    // read finds it on every run and unwinds a re-queue nothing settled —
+    // closing a stub that is supposed to be selectable. Fatal before any I/O.
+    [
+      {
+        sentinel: { label: NEEDS_TRIAGE_LABEL, declineNote: () => "s" },
+      },
+      /must name a label this re-queue sheds/,
+      true,
+    ],
+    [
+      {
+        sentinel: { label: "sentry-triage", declineNote: () => "s" },
+      },
+      /must name a label this re-queue sheds/,
+      true,
+    ],
   ];
   for (const [extra, pattern, verify] of cases) {
     const writer = makeWriter();

--- a/scripts/sentry/triage/sentry-triage-workflow-requeue.mjs
+++ b/scripts/sentry/triage/sentry-triage-workflow-requeue.mjs
@@ -126,6 +126,31 @@ export function buildRequeueNote(reason) {
   );
 }
 
+/**
+ * THE CORRECTION NOTE, posted only when the sentinel fired: the note above is
+ * already on the stub saying this run was re-queuing it, and the stub ends up
+ * settled instead. Fixed text, like every note this file builds — the reason is
+ * one of a closed set and nothing Sentry-derived reaches here.
+ *
+ * An unknown reason throws for the same cause as `buildRequeueNote`.
+ */
+export function buildSettledUnderneathNote(reason) {
+  if (!REQUEUE_REASON_CAUSES[reason]) {
+    throw new Error(
+      `Unknown re-queue reason ${JSON.stringify(reason)}; a settled-underneath note must name one of ${REQUEUE_REASONS.join(", ")}.`,
+    );
+  }
+  return (
+    "Correction to the note above: the human-approved archive leg settled this " +
+    "queue stub while that re-queue was running, so the re-queue was undone " +
+    "rather than completed. `sentry:needs-triage` is off again, the previous " +
+    "round's markers are back, and the stub is closed and archived. Nothing " +
+    "here can un-archive the Sentry issue, and nothing should: that is the " +
+    "outcome the approver asked for, and an escalation resurfaces it on its " +
+    "own. To triage it again, re-queue the stub by hand."
+  );
+}
+
 function defaultRunGh(args) {
   return new Promise((resolve, reject) => {
     const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] });
@@ -213,10 +238,20 @@ export function isTerminalStub({ state, labels } = {}) {
  * PROPAGATES: the run goes red and the workflow names the manual repair, rather
  * than mutating a stub it could not observe.
  *
- * It narrows the window rather than closing it — an archive that lands after the
- * revalidating read still races the writes below, exactly as it races the brief
- * leg's write-side guard. Serializing the two workflows is the only thing that
- * would close it, and that is a bigger change than this class needs.
+ * THE SENTINEL (#1929, ADR 0068) is what closes the window that guard only
+ * narrowed. The read above is a snapshot too, so an archive settling between it
+ * and the writes below used to complete unseen — the shed erased
+ * `sentry:archived` with a `--remove-label` that reports nothing, so no later
+ * read could testify that it had ever been there. Declaring it as the sentinel
+ * withholds it from the shed and re-reads it after the last write: present on
+ * the confirming read means the archive settled inside this window, and the
+ * chokepoint unwinds this re-queue rather than leaving a selectable retry stub
+ * over an occurrence a human approved archiving.
+ *
+ * The two runs cover the two orderings between them. A marker already on the
+ * stub is caught here; one that lands afterwards is caught by the archive's own
+ * post-settlement verification, which by then reads a stub this run has reopened
+ * and stripped of its verdict, and rolls its settlement back.
  */
 export function runWorkflowRequeue({
   runGh = defaultRunGh,
@@ -239,6 +274,12 @@ export function runWorkflowRequeue({
         check: (live) => !isTerminalStub(live),
         declineNote: (live) =>
           `Queue stub #${issueNumber} went terminal before the ${reason} re-queue could run (state=${live.state}, labels=${live.labels.join(",") || "none"}); leaving it settled rather than reopening it over an archived or already-closed occurrence.`,
+        sentinel: {
+          label: ARCHIVED_LABEL,
+          declineNote: (live) =>
+            `Queue stub #${issueNumber} carried ${ARCHIVED_LABEL} on the ${reason} re-queue's confirming read (state=${live.state}, labels=${live.labels.join(",") || "none"}), so the archive leg settled it inside the write window; unwinding this re-queue and leaving it settled.`,
+          unwindNote: () => buildSettledUnderneathNote(reason),
+        },
       },
       onFailure: REQUEUE_ON_FAILURE_VERIFY_END_STATE,
       fallbackState: "OPEN",

--- a/scripts/sentry/triage/sentry-triage-workflow-requeue.mjs
+++ b/scripts/sentry/triage/sentry-triage-workflow-requeue.mjs
@@ -238,7 +238,7 @@ export function isTerminalStub({ state, labels } = {}) {
  * PROPAGATES: the run goes red and the workflow names the manual repair, rather
  * than mutating a stub it could not observe.
  *
- * THE SENTINEL (#1929, ADR 0069) is what closes the window that guard only
+ * THE SENTINEL (#1929, ADR 0070) is what closes the window that guard only
  * narrowed. The read above is a snapshot too, so an archive settling between it
  * and the writes below used to complete unseen — the shed erased
  * `sentry:archived` with a `--remove-label` that reports nothing, so no later


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The triage compensation's terminal guard read live state and then wrote blind.
  A human-approved archive settling inside that window ended with the stub
  reopened, re-queued and stripped of `sentry:archived` — a selectable retry stub
  over an occurrence a human approved archiving, with nothing red anywhere.
- Neither side could see it. The archive had already taken its post-settlement
  read, and the compensation's shed erased the marker with a `--remove-label`
  that succeeds whether or not the label was there, so no later read could
  testify it had existed.
- The obvious fix makes it worse: a shared Actions concurrency group would put a
  per-issue human-gated archive dispatch and a repo-wide triage run in one group,
  where GitHub cancels the superseded run rather than queueing it.

## The Solution

Stop erasing the evidence, then read it back. `sentry:archived` is withheld from
this compensation's shed, so it survives to be read on the end-state
verification. Finding it there proves the archive settled inside the write
window, and the re-queue undoes itself — drop `sentry:needs-triage`, restore the
previous round's markers, close — instead of reporting success.

The two runs now cover both orderings between them, and ADR 0070 records the
design with the rejected alternatives, including the concurrency group.

## Details

Closes finding 3 of #1929, the last one open; the other seven landed in #1950,
which recorded this one as needing a design rather than a fix.

**The mechanism.** `revalidate.sentinel` on the re-queue chokepoint
(`scripts/sentry/triage/sentry-triage-requeue.mjs`) names a label whose presence
means another writer settled the stub. A caller that declares one gets: the label
withheld from both blind sheds (`buildRequeueShedLabelArgs(..., { except })`,
and the post-verification retry); every read taken after the last write checked
for it; and, on a hit, the unwind in the new
`sentry-triage-requeue-sentinel.mjs`.

**Why it is complete.** Neither writer can destroy the other's evidence any more.
The archive's evidence about the compensation is the reopen and the shed verdict,
which its own verification reads. The compensation's evidence about the archive is
`sentry:archived`, which it no longer erases. A marker on the stub at any read
after the last write is caught here; a marker landing later means the archive's
verification runs later still, against a stub this run has already reopened and
stripped of its verdict, which fails it and rolls it back.

**The unwind's order is the guarantee**, because it can die half-way.
`sentry:needs-triage` goes first (selectability is the only property that lets
another run act on the stub, so every prefix must be unselectable), the markers
observed by the revalidating read come back next — load-bearing, because the
archive's verification demands a verdict label — and the close goes last.
`sentry:approved-archive` never comes back: a spent approval is authority, not a
record, and re-adding it would both hand a later dispatch an approval no human
gave and re-fire the archive workflow's `issues: labeled` trigger. The confirming
read asks for the settled shape the archive itself demands, and on the verdict it
is one notch stricter — exactly one, where `settlementHeld` asks for at least
one, because `verdict-unsettled` is the compensation that fires precisely because
more than one survived (#1745). An unwind that cannot reach that shape throws.

**Opt-in per caller, and it must stay that way.** Ingest's regression reopen and
the archive's own live-regression refusal exist precisely TO shed
`sentry:archived`, so a chokepoint-wide rule would break both. A malformed
declaration — wrong failure policy, no label, no `declineNote`, or a label this
re-queue does not shed — throws before any I/O.

**Scope.** `sentry-triage-requeue.mjs` reached 1,042 lines with the unwind
inline, past the 1,000-line hard cap the brief suite enforces; the unwind moved
to its own module, which is listed in that cap test and routed to the re-queue
arm of `scripts/agent-quality-gate.sh`. That cap list is a `scripts/` path pin
the move sweep did not name, so ADR 0064's checklist gained it as item 11.
`docs/notes/sentry-triage-pipeline.md` claimed this window was open for the
same reason as the ingest sweep's; that half is now corrected. The branch carries
a merge of `main`, which took 0068 for a different decision, and #2002 claims
0069 and merges first — this ADR is 0070.

## Validation

- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`
  — all 15 mapped commands passed, and again at the pre-push form
  (`--parallel 3`) immediately before pushing.
- `node scripts/sentry/gate/sentry-suite-gate.mjs` — 14 suites asserted from
  their own output. No floor moved down; the re-queue suite emitted 41 cases
  before and 54 now, and its floor rose 40 → 54.
- `pnpm agent:context-check` and `pnpm docs:index --check` — both clean.
  `scripts/AGENTS.md` has 15 bytes of headroom under its 9,216-byte scoped cap,
  which is why the new move-sweep surface went to ADR 0064's checklist, the
  place that file points at for procedure.
- Negative controls, per behavioural change. The uncovered interleaving is driven
  by landing the archive's settlement immediately after the compensation restores
  `sentry:needs-triage` — the point at which the archive's own verification has
  already passed:
  - sentinel disabled entirely: five cases red, the main one reporting
    `requeued: true` over a stub left open, queued and un-archived
    (`expected false, got true`);
  - marker shed blindly (`except: []`) with the read-back kept: four cases red,
    because the shed erases the marker before anything reads it;
  - retry-read check removed: the shed-retry interleaving red;
  - restoration and verdict checks removed: their unwind cases red;
  - unwind ordering changed: the write-order case red;
  - declaration validation removed and the confirming read's retry bound cut to
    one: their cases red;
  - the sentinel's membership check widened to admit `sentry:needs-triage` and
    `sentry-triage`: the malformed-declaration case red;
  - the verdict count relaxed from exactly-one to at-least-one: the two-verdict
    case red, with the one-verdict unwind still green as its control.
- `pnpm agent:autoreview -- --engine codex` — clean on the final head, after
  three rounds. It found two verification gaps (a settlement first visible to the
  shed-retry read; an unwind accepting a stub whose marker restoration never
  landed), both fixed with a test each.
- `pnpm agent:autoreview -- --engine claude` — five findings across three passes,
  four fixed with tests (the shed-retry read, the pre-I/O declaration validation,
  the confirming read's bounded retry, plus the verdict requirement). One was a
  defensive-consistency nit on the error-report path (`after.labels.join` beside
  a guarded sibling); guarded, with no test — the production `readStub` always
  yields an array, so there is no reachable behaviour to assert.

### Review round on the open threads

- **Sentinel labels the shed does not remove** (CodeRabbit). Valid, and the
  failure mode inverts the mechanism rather than weakening it: `sentry:archived`
  aside, a label outside `REOPEN_SHED_LABELS` is either never removed or re-added
  by this very run, so `sentry:needs-triage` would make the confirming read fire
  on every re-queue and close a stub that should stay selectable. Membership is
  now checked before any I/O, with two cases.
- **Exactly one verdict before accepting the unwind** (Codex P2). Valid for the
  reason above — `verdict-unsettled` fires because more than one verdict
  survived, so the multi-verdict premise is the one this path is entered with.
  Accepting it would undo the repair the re-queue exists to perform and leave a
  CLOSED archive nothing downstream repairs.
- **The archive can still roll back the sentinel** (Codex P1). The remedy is
  declined; the fact behind it was right and is now recorded correctly. Making
  `settled-underneath` nonzero would fail every CORRECT unwind — the common case
  — to surface one sub-ordering, and would still not make the end state right.
  But the ADR claimed both runs went red on that path and they do not:
  `runArchive` returns `unsettled-reopened` and exits 0, and the workflow does
  not read that JSON. ADR 0070 and the module docstring now state the true end
  state — two green runs, one `::warning::`, and the stranded sweep a day later —
  and the archive leg's silent rollback exit is filed as #2004.
- **Record the new script-path pin** (Codex P1). Valid. It went to ADR 0064's
  sweep checklist as item 11, which is the surface a mover actually works
  through and the place `scripts/AGENTS.md` points at for procedure.
- **Route the sentinel module to its focused suites** (Codex P1). Valid, and
  reproduced first: a dry run with only the sentinel changed mapped Trunk,
  `lint:scripts` and `tf:test` — no Sentry suite at all. The module has no suite
  of its own and decides the end state of the archive compensation, so a
  sentinel-only change could have broken that compensation without running
  `sentry:archive:test`. It joins the re-queue arm, with the route pinned on its
  own path in `agent-quality-gate.test.sh`.

## Deferrals

- Two sibling callers hold the same premise and still carry this window — the autofix hold-revalidation and ingest's stranded sweep — https://github.com/mento-protocol/monitoring-monorepo/issues/1994
- The archive leg's rollback path returns `unsettled-reopened` and exits 0, so a spent approval that did not stick is silent — https://github.com/mento-protocol/monitoring-monorepo/issues/2004

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Yes — `docs/adr/0070-sentry-requeue-settlement-sentinel.md`.

Closes #1929
