### PR TITLE
docs(review): record public marker trust checks

### DIFF
--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -131,12 +131,13 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 - If a setup/cache script uses marker files or input hashes to skip work, the skip condition MUST verify the actual output that downstream commands need, not just the marker. Examples: dependency skips should verify a representative package resolves, Playwright skips should verify the browser executable exists, and codegen skips should verify the generated facade file exists.
 - Write marker files only after every validation step represented by that marker has passed. A failed post-install validation must not leave a fresh marker that makes the next run skip the install or rebuild path.
 
-### Public PR comment markers
+### Public PR request and completion markers
 
-- Treat a marker in a public PR comment as untrusted input. Accept it only from
-  an allowed author association or a known agent identity.
-- Require the command and its completion marker in the same comment. Bind the
-  marker to the exact PR head SHA.
+- Treat a public PR comment marker as untrusted input when a workflow consumes
+  it as request or completion evidence. Accept it only from an allowed author
+  association or a known agent identity.
+- Require the relevant command and its evidence marker in the same comment.
+  Bind the marker to the exact PR head SHA.
 - When the API supplies comment and head-update timestamps, require the marker
   to be at or after the head update. Do not infer recency from list order.
 - Apply the same identity, command, marker, SHA, and recency checks to REST and

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -3,7 +3,7 @@ title: Recurring PR Review Patterns
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-20
+last_verified: 2026-08-21
 doc_type: checklist
 scope: repo-wide
 review_interval_days: 90
@@ -130,6 +130,18 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 
 - If a setup/cache script uses marker files or input hashes to skip work, the skip condition MUST verify the actual output that downstream commands need, not just the marker. Examples: dependency skips should verify a representative package resolves, Playwright skips should verify the browser executable exists, and codegen skips should verify the generated facade file exists.
 - Write marker files only after every validation step represented by that marker has passed. A failed post-install validation must not leave a fresh marker that makes the next run skip the install or rebuild path.
+
+### Public PR comment markers
+
+- Treat a marker in a public PR comment as untrusted input. Accept it only from
+  an allowed author association or a known agent identity.
+- Require the command and its completion marker in the same comment. Bind the
+  marker to the exact PR head SHA.
+- When the API supplies comment and head-update timestamps, require the marker
+  to be newer than the head update. Do not infer recency from list order.
+- Apply the same identity, command, marker, SHA, and recency checks to REST and
+  GraphQL data. Test the local CLI and MCP fallback paths against the same
+  fixtures so one path cannot accept evidence that another rejects.
 
 ### Shell failure propagation and fixture environments
 

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -138,7 +138,7 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, the Vercel checks) M
 - Require the command and its completion marker in the same comment. Bind the
   marker to the exact PR head SHA.
 - When the API supplies comment and head-update timestamps, require the marker
-  to be newer than the head update. Do not infer recency from list order.
+  to be at or after the head update. Do not infer recency from list order.
 - Apply the same identity, command, marker, SHA, and recency checks to REST and
   GraphQL data. Test the local CLI and MCP fallback paths against the same
   fixtures so one path cannot accept evidence that another rejects.


### PR DESCRIPTION
## The Problem

- Public PR comments can contain forged request or completion evidence.
- Review guidance did not state the complete trust checks for comment-based evidence.

## The Solution

- Add one recurring-review checklist section for trusted public PR request and completion markers.

## Details

- Require an allowed author association or known agent identity.
- Require the relevant command and evidence marker in the same comment.
- Bind evidence to the exact head SHA and verify inclusive recency when timestamps exist.
- Apply the same rules to REST, GraphQL, local CLI, and MCP paths.
- Exclude sticky-comment locator keys that workflows do not consume as request or completion evidence.

## Validation

- `./tools/trunk fmt docs/pr-checklists/recurring-review-patterns.md` — passed.
- `git diff --check` — passed.
- Full mapped local gate skipped by explicit request after it queued behind the machine-wide lock for more than eight minutes. Required CI is the full validation gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the recurring review patterns checklist with the latest verification date.
  * Clarified guidance for pull request request and completion markers.
  * Specified that validation applies when workflows use markers as evidence.
  * Generalized the same-comment requirement to the relevant command and evidence marker.
  * Clarified that markers created at the same time as a head update satisfy timestamp validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->