### PR TITLE
test(sentry): redact the triage fixture credentials to placeholder vocabulary

### DIFF
--- a/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
@@ -25,7 +25,8 @@ import {
 const RUNNER_TEMP_FOR_TESTS = "/runner/_temp";
 // Placeholder vocabulary, per ADR 0068. `assertBodyPostable` and
 // `buildChildEnv` match these values verbatim against the environment, so no
-// provider prefix or length is load-bearing — only that the three differ.
+// provider prefix is required; each value must remain distinct and meet
+// `MIN_SECRET_LENGTH`.
 const SENTRY_CRED = "example-service-credential-value";
 const GH_CRED = "example-access-token-value";
 const OAUTH_CRED = "example-auth-credential-value";

--- a/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-agent-comment.test.mjs
@@ -23,9 +23,12 @@ import {
 } from "./sentry-triage-agent-comment.mjs";
 
 const RUNNER_TEMP_FOR_TESTS = "/runner/_temp";
-const SENTRY_CRED = "sntrys_deadbeefdeadbeefdeadbeef";
-const GH_CRED = "ghs" + "_0123456789abcdefghijklmnopqrstuvwxyz";
-const OAUTH_CRED = "sk" + "-ant-oat01-abcdefghijklmnopqrstuvwxyz";
+// Placeholder vocabulary, per ADR 0068. `assertBodyPostable` and
+// `buildChildEnv` match these values verbatim against the environment, so no
+// provider prefix or length is load-bearing — only that the three differ.
+const SENTRY_CRED = "example-service-credential-value";
+const GH_CRED = "example-access-token-value";
+const OAUTH_CRED = "example-auth-credential-value";
 
 const VERDICT_BODY = [
   VERDICT_MARKER,


### PR DESCRIPTION
## The Problem

- The Sentry triage agent-comment suite still held three look-alike provider
  credentials: a Sentry auth token, a GitHub app token and a Claude OAuth token.
- Issue #1941 asked for the scanner accept-shape (landed as #1998) and then the
  redaction itself as the proving change. The redaction was never landed.

## The Solution

- Replace all three fixture values with placeholder vocabulary
  (`example-service-credential-value`, `example-access-token-value`,
  `example-auth-credential-value`) and drop the string-concatenation workaround
  that carried the provider prefixes past the bundle scanner.

## Details

- No provider prefix or length is load-bearing here. `assertBodyPostable` and
  `buildChildEnv` compare each value verbatim against the environment, so the
  suite only needs three distinct strings at or above `MIN_SECRET_LENGTH` (8).
  A comment on the block records that, so the next reader does not restore a
  realistic shape on the assumption it was doing work.
- ADR 0068 names placeholder vocabulary as the first-choice authoring style for
  these fixtures and calls composition a narrow escape, not a general one. This
  moves the file to the preferred style.
- **The accept-shape gets no live exercise from this diff, and the reason
  matters.** #1998 accepts a strong-pattern match on a removed line when the
  hunk's added side replaces it with placeholder vocabulary. This diff's removed
  lines carry `"ghs" + "_0123…"`, not `ghs_0123…`: PR #1996 had already split
  every contiguous literal with concatenation, so no removed line matches a
  strong pattern and no exception is consulted. Scanning all 2231 readable
  tracked files on `origin/main` with the eight `STRONG_CREDENTIAL_PATTERNS`
  returns zero hits, so no redaction anywhere in the tree can exercise the
  accept-shape today.
- Measured directly against `secretLikeReason` with the literals as they stood
  before #1996, the accept-shape does clear the redaction, and its negative
  controls hold:

  | Case | Result |
  | ---- | ------ |
  | Both literals removed, placeholder added in the same hunk | accepted |
  | Removal with no replacement | `credential-like token` |
  | Removal swapped for a different credential-shaped literal | `credential-like token` |
  | Plain addition | `credential-like token` |
  | Same text with `gitDiff` unset | `credential-like token` |

- One residual trap, filed as #2010: run that same measurement with the
  credential-named bindings the file used before #1996 (`GH_TOKEN`,
  `OAUTH_TOKEN`) and the redaction is still refused, now with
  `literal credential assignment`. #1998 fixed the strong-pattern leg only; the
  credential-assignment rules have no redaction accept-shape. #1996's rename to
  `GH_CRED`/`OAUTH_CRED` is what makes this file redactable, not the scanner
  change alone.

## Validation

- `node --test scripts/sentry/triage/sentry-triage-agent-comment.test.mjs` — 40
  passed, 0 failed.
- `node --test scripts/sentry/fixture-scan-canary.test.mjs` — the four
  adversarial suites still scan clean behind the negative control.
- `node --test 'scripts/sentry/triage/*.test.mjs' scripts/agent-autoreview-core.test.mjs`
  — 48 passed, 0 failed.
- `pnpm agent:autoreview -- --engine codex` at `5223bea` — bundle built (1270
  bytes), `autoreview clean: no accepted/actionable findings reported`, overall
  `patch is correct (0.99)`.
- `pnpm agent:autoreview -- --engine claude` at `5223bea` — bundle built (1270
  bytes), `autoreview clean: no accepted/actionable findings reported`, overall
  `patch is correct (0.8)`.
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main`
  — all 8 mapped commands passed (trunk check, `pnpm lint:scripts`, the triage
  suite, the fixture-scan canary, the Sentry CI-wiring check, the Sentry suite
  gate and its test, `pnpm tf:test`). Two earlier attempts exited 2 without
  running anything, having waited out the 1800s shared run-lock behind sibling
  worktrees; the third acquired the lock and ran clean.
- An earlier claude-engine pass raised one P2 (0.35) asking whether the provider
  shape was load-bearing and noting that `SENTRY_CRED` kept its `sntrys_`
  prefix. Answered by reading `assertBodyPostable` (verbatim match) and closed by
  redacting the Sentry fixture too, so all three are now consistent.

## Deferrals

- #2010 — the credential-assignment rules still refuse a removal-side literal,
  so a redaction under a credential-named binding remains untestable through the
  normal path.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this applies ADR 0068, it does not
      change it.

Closes #1941

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture string changes; production logic is untouched.
> 
> **Overview**
> Replaces the three look-alike provider tokens in `sentry-triage-agent-comment.test.mjs` with ADR 0068 placeholder vocabulary (`example-service-credential-value`, `example-access-token-value`, `example-auth-credential-value`) and drops the concatenation workaround that hid prefixes from the scanner.
> 
> The suite still only needs three distinct strings for verbatim env matching in `assertBodyPostable` / `buildChildEnv`; a comment records that prefix and length are not load-bearing so realistic shapes are not restored later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5223beaec94d44799e13d937447f69d1d67fc375. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test credential placeholders to use provider-neutral example values.
  * Clarified that placeholder values must remain distinct and meet the minimum required secret length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->