### PR TITLE
feat(alerts): warn on incomplete CDP system parameters

### DIFF
--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -11,6 +11,13 @@ templates for Mento monitoring.
 - **Not in this module:** the Aegis dashboard and the Aegis Grafana folder. Those stay in [`aegis/terraform`](../../aegis/terraform); the relocated rule group references the externally owned Aegis folder UID from `main.tf`.
 - **Folder convention:** one folder per `service` label (`FPMMs`, `Oracles`, `Indexer`, `Metrics Bridge`, `Peg Monitoring`, `Oracle Relayers`, `Reserve`, `Trading Modes`, `Trading Limits`, `CDPs`).
 
+The CDP folder includes the `CDP System Parameters Not Loaded` warning. It
+fires when a joined CDP market row reports an incomplete SystemParams snapshot
+for 10 minutes. `liquity.systemParams.deadContract` is one possible exact
+diagnostic cause; inspect the indexer logs for the cause. Metrics Bridge Poll
+Errors owns `cdp_query` and `cdp_update` failures, and the bridge liveness rule
+owns a full bridge outage.
+
 ## State
 
 Separate from `terraform/` (platform) and `aegis/terraform`: `gs://mento-terraform-tfstate-6ed6/alerts-rules`. See [`docs/terraform.md`](../../docs/terraform.md) for the stack registry and completed Aegis-to-alerts state migration record.

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -1,4 +1,4 @@
-<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-07-29 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
+<!-- agent-context: title="Grafana Alert Rules" status=active owner=eng canonical=true last_verified=2026-08-21 doc_type=runbook scope=alerts/rules review_interval_days=90 garden_lane=operator-runbooks -->
 
 # alerts/rules
 

--- a/alerts/rules/README.md
+++ b/alerts/rules/README.md
@@ -13,10 +13,13 @@ templates for Mento monitoring.
 
 The CDP folder includes the `CDP System Parameters Not Loaded` warning. It
 fires when a joined CDP market row reports an incomplete SystemParams snapshot
-for 10 minutes. `liquity.systemParams.deadContract` is one possible exact
-diagnostic cause; inspect the indexer logs for the cause. Metrics Bridge Poll
-Errors owns `cdp_query` and `cdp_update` failures, and the bridge liveness rule
-owns a full bridge outage.
+for 10 minutes and the unlabeled
+`mento_cdp_last_successful_poll` marker proves a successful CDP query and full
+publication within 90 seconds. `liquity.systemParams.deadContract` is one
+possible exact diagnostic cause; inspect the indexer logs for the cause. Query
+and update failures keep the prior CDP bundle while the marker ages. Metrics
+Bridge Poll Errors owns `cdp_query` and `cdp_update` failures, the CDP marker
+owns CDP freshness, and the bridge liveness rule owns a full bridge outage.
 
 ## State
 

--- a/alerts/rules/rules-cdps.tf
+++ b/alerts/rules/rules-cdps.tf
@@ -14,9 +14,9 @@
 # no_data_state / exec_err_state = "OK" on every rule: a missing CDP gauge
 # (deploy-window rollout before the bridge ships, or a stale series after the
 # bridge restarts) must NOT page. The SystemParams rule also requires the
-# unlabeled `mento_cdp_last_successful_poll` marker to be less than 90 seconds
-# old. The marker advances only after a successful CDP query and complete
-# publication; it does not use the FPMM-owned bridge-last-poll gauge or poll
+# unlabeled `mento_cdp_last_successful_poll` marker to have a non-negative age
+# below 90 seconds. The marker advances only after a successful CDP query and
+# complete publication; it does not use the FPMM-owned bridge-last-poll gauge or poll
 # error labels. Bridge liveness and poll errors remain separate owners.
 #
 # NOT covered here (deliberate): TCR / ICR rules. `LiquityInstance.tcrBps`,
@@ -143,7 +143,7 @@ resource "grafana_rule_group" "cdps" {
       model = jsonencode({
         refId   = "metric"
         instant = true
-        expr    = "mento_cdp_system_params_loaded and on() (time() - mento_cdp_last_successful_poll < 90)"
+        expr    = "mento_cdp_system_params_loaded and on() ((time() - mento_cdp_last_successful_poll >= 0) and (time() - mento_cdp_last_successful_poll < 90))"
       })
     }
     data {

--- a/alerts/rules/rules-cdps.tf
+++ b/alerts/rules/rules-cdps.tf
@@ -107,7 +107,85 @@ resource "grafana_rule_group" "cdps" {
     }
   }
 
-  # ── 2. Stability Pool Below Floor (critical) ─────────────────────────────
+  # ── 2. System Parameters Not Loaded (warning) ───────────────────────────
+  # This generic state covers a market whose SystemParams snapshot remains
+  # incomplete. `liquity.systemParams.deadContract` is one possible exact
+  # diagnostic cause; inspect the indexer logs for that and other causes.
+  # Transport failures remain covered by the metrics-bridge poll-error and
+  # liveness rules, not by this CDP state rule.
+  rule {
+    name           = "CDP System Parameters Not Loaded"
+    condition      = "threshold"
+    for            = "10m"
+    no_data_state  = "OK"
+    exec_err_state = "OK"
+
+    annotations = {
+      summary     = "CDP market {{ $labels.symbol }} SystemParams are not loaded."
+      description = "The CDP market's SystemParams snapshot remains incomplete. Check the indexer logs for the exact cause, such as liquity.systemParams.deadContract, and verify the market configuration. Metrics Bridge Poll Errors covers cdp_query/cdp_update transport and update failures; bridge liveness covers a full outage."
+    }
+    labels = {
+      service  = "cdps"
+      severity = "warning"
+    }
+
+    data {
+      ref_id         = "metric"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = local.instant_query_range_seconds
+        to   = 0
+      }
+      model = jsonencode({
+        refId   = "metric"
+        instant = true
+        expr    = "mento_cdp_system_params_loaded"
+      })
+    }
+    data {
+      ref_id         = "reduced"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "reduced"
+        type       = "reduce"
+        reducer    = "last"
+        expression = "metric"
+      })
+    }
+    data {
+      ref_id         = "threshold"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "threshold"
+        type       = "threshold"
+        expression = "reduced"
+        conditions = [{
+          evaluator = { params = [0.5], type = "lt" }
+          operator  = { type = "and" }
+          reducer   = { params = [], type = "last" }
+          type      = "query"
+        }]
+      })
+    }
+
+    notification_settings {
+      contact_point   = local.notify_warning_cdps.contact_point
+      group_by        = local.notify_warning_cdps.group_by
+      group_wait      = local.notify_warning_cdps.group_wait
+      group_interval  = local.notify_warning_cdps.group_interval
+      repeat_interval = local.notify_warning_cdps.repeat_interval
+    }
+  }
+
+  # ── 3. Stability Pool Below Floor (critical) ─────────────────────────────
   # `spHeadroom = spDeposits − MIN_BOLD_IN_SP` went negative: the SP is below
   # the on-chain governance floor, so liquidation-absorption capacity is
   # exhausted. The gauge is withheld until SystemParams is loaded (sentinel
@@ -185,7 +263,7 @@ resource "grafana_rule_group" "cdps" {
     }
   }
 
-  # ── 3. Stability Pool Thin (warning) ─────────────────────────────────────
+  # ── 4. Stability Pool Thin (warning) ─────────────────────────────────────
   # SP deposits below 2% of system debt — early-warning on absorption capacity,
   # well before the floor breach above. Measured against system debt per the
   # issue's chosen basis. 2% sits just under today's lowest market (GBPm 3.0%).
@@ -263,7 +341,7 @@ resource "grafana_rule_group" "cdps" {
     }
   }
 
-  # ── 4. Liquidations Detected (warning) ───────────────────────────────────
+  # ── 5. Liquidations Detected (warning) ───────────────────────────────────
   # Any liquidation in the last hour. CDP markets have had 0 liquidations ever,
   # so even one is worth surfacing. `increase()` over the bridged cumulative
   # counter; a constant counter yields 0 (no false fire). Caveat: an indexer
@@ -341,7 +419,7 @@ resource "grafana_rule_group" "cdps" {
     }
   }
 
-  # ── 5. User Redemptions Detected (warning) ───────────────────────────────
+  # ── 6. User Redemptions Detected (warning) ───────────────────────────────
   # Any USER (non-rebalance) redemption in the last hour. The bridge already
   # subtracts the CDPLiquidityStrategy rebalance subset, so this excludes the
   # ~100%-rebalance-driven redemption noise on production. Same increase()
@@ -417,7 +495,7 @@ resource "grafana_rule_group" "cdps" {
     }
   }
 
-  # ── 6. Redemption Shortfall Subsidized (critical) ────────────────────────
+  # ── 7. Redemption Shortfall Subsidized (critical) ────────────────────────
   # `CDPLiquidityStrategy.RedemptionShortfallSubsidized` fired — the protocol
   # absorbed a redemption shortfall, a direct economic loss. 0 have occurred.
   # 6h window so a subsidy stays visible long enough to action; increase() over

--- a/alerts/rules/rules-cdps.tf
+++ b/alerts/rules/rules-cdps.tf
@@ -13,9 +13,11 @@
 #
 # no_data_state / exec_err_state = "OK" on every rule: a missing CDP gauge
 # (deploy-window rollout before the bridge ships, or a stale series after the
-# bridge restarts) must NOT page. Bridge liveness is owned by the
-# metrics-bridge poll-staleness alert; absence of CDP data is never itself a
-# CDP emergency.
+# bridge restarts) must NOT page. The SystemParams rule also requires the
+# unlabeled `mento_cdp_last_successful_poll` marker to be less than 90 seconds
+# old. The marker advances only after a successful CDP query and complete
+# publication; it does not use the FPMM-owned bridge-last-poll gauge or poll
+# error labels. Bridge liveness and poll errors remain separate owners.
 #
 # NOT covered here (deliberate): TCR / ICR rules. `LiquityInstance.tcrBps`,
 # `icrP1Bps`, and `icrFracBelowMcrBps` are hardcoded −1 sentinels in the
@@ -109,8 +111,10 @@ resource "grafana_rule_group" "cdps" {
 
   # ── 2. System Parameters Not Loaded (warning) ───────────────────────────
   # This generic state covers a market whose SystemParams snapshot remains
-  # incomplete. `liquity.systemParams.deadContract` is one possible exact
-  # diagnostic cause; inspect the indexer logs for that and other causes.
+  # incomplete after a fresh successful CDP query and publication.
+  # `liquity.systemParams.deadContract` is one possible exact diagnostic
+  # cause; inspect the indexer logs for that and other causes. Query and update
+  # failures retain the last good CDP bundle while its success marker ages.
   # Transport failures remain covered by the metrics-bridge poll-error and
   # liveness rules, not by this CDP state rule.
   rule {
@@ -139,7 +143,7 @@ resource "grafana_rule_group" "cdps" {
       model = jsonencode({
         refId   = "metric"
         instant = true
-        expr    = "mento_cdp_system_params_loaded"
+        expr    = "mento_cdp_system_params_loaded and on() (time() - mento_cdp_last_successful_poll < 90)"
       })
     }
     data {

--- a/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
+++ b/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
@@ -44,6 +44,13 @@ transport.
   alerting plane. An event that requires warning or paging must expose an
   owned metric and have a Grafana rule with severity and routing. A
   `context.log.error` event alone creates no alert.
+- CDP SystemParams readiness requires both the per-market
+  `mento_cdp_system_params_loaded` state and a fresh unlabeled
+  `mento_cdp_last_successful_poll` marker. The marker advances only after the
+  metrics bridge completes a successful CDP query and publishes the full CDP
+  bundle. Query failures and malformed updates retain the last bundle while
+  the marker ages. The CDP marker owns CDP freshness; the FPMM
+  `mento_pool_bridge_last_poll` gauge and bounded poll-error labels do not.
 - Handlers continue to use structured `<area>.<event>` names. Do not add Sentry
   to the hosted indexer.
 - Current structured error families are diagnostic-only:
@@ -72,8 +79,9 @@ transport.
 
 - The four structured families remain diagnostic surfaces. Issue [#1624](https://github.com/mento-protocol/monitoring-monorepo/issues/1624)
   adds generic warning coverage for persistent incomplete CDP SystemParams
-  state. It does not turn `deadContract` or `diagnosticFailed` into alert
-  labels, and the generic state does not identify one exact cause.
+  state, gated by a fresh successful query and publication marker. It does not
+  turn `deadContract` or `diagnosticFailed` into alert labels, and the generic
+  state does not identify one exact cause.
 - Existing operators use status and metrics to assess deployment health, then
   inspect the exact deployment's bounded error logs. A deployment is not
   healthy merely because a log query returns data or no error records.

--- a/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
+++ b/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
@@ -3,7 +3,7 @@ title: Envio logs diagnose; Prometheus and Grafana alert
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-26
+last_verified: 2026-08-21
 scope: indexer-envio / alerts
 date: 2026-07
 doc_type: adr

--- a/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
+++ b/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
@@ -4,7 +4,7 @@ status: active
 owner: eng
 canonical: true
 last_verified: 2026-08-21
-scope: indexer-envio / alerts
+scope: indexer-envio / metrics-bridge / alerts
 date: 2026-07
 doc_type: adr
 review_interval_days: 90
@@ -16,7 +16,7 @@ supersedes: ADR-0018
 
 **Status:** Accepted (Jul 2026), in force. Supersedes
 [ADR 0018](0018-indexer-observability-loki.md).
-**Scope:** indexer-envio / alerts
+**Scope:** indexer-envio / metrics-bridge / alerts
 
 ## Context
 

--- a/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
+++ b/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
@@ -48,12 +48,12 @@ transport.
   to the hosted indexer.
 - Current structured error families are diagnostic-only:
 
-  | Family                                       | Source                             | Classification                                                                                                  |
-  | -------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-  | `sortedOracles.oracleExpiryStateUnavailable` | `handlers/oracleExpiryState.ts`    | Diagnostic-only; no metric/rule tracks bootstrap failure.                                                       |
-  | `sortedOracles.oracleFeedStateUnavailable`   | `handlers/oracleFeedState.ts`      | Diagnostic-only; existing oracle-freshness rules detect resulting stale pool state, not this bootstrap failure. |
-  | `liquity.systemParams.deadContract`          | `handlers/liquity/systemParams.ts` | Diagnostic-only; CDP gauges are withheld until parameters load and no rule detects this configuration failure.  |
-  | `liquity.systemParams.diagnosticFailed`      | `handlers/liquity/systemParams.ts` | Diagnostic-only; no metric/rule tracks diagnostic-RPC failure.                                                  |
+  | Family                                       | Source                             | Classification                                                                                                                          |
+  | -------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+  | `sortedOracles.oracleExpiryStateUnavailable` | `handlers/oracleExpiryState.ts`    | Diagnostic-only; no metric/rule tracks bootstrap failure.                                                                               |
+  | `sortedOracles.oracleFeedStateUnavailable`   | `handlers/oracleFeedState.ts`      | Diagnostic-only; existing oracle-freshness rules detect resulting stale pool state, not this bootstrap failure.                         |
+  | `liquity.systemParams.deadContract`          | `handlers/liquity/systemParams.ts` | Diagnostic-only; one possible exact cause of the generic `mento_cdp_system_params_loaded` incomplete state, which has warning coverage. |
+  | `liquity.systemParams.diagnosticFailed`      | `handlers/liquity/systemParams.ts` | Diagnostic-only; no metric/rule tracks diagnostic-RPC failure.                                                                          |
 
   `envio_effect_cache_invalidations_count` is separately represented by the
   Prometheus-backed `Envio Effect Cache Invalidations` Grafana rule; it is not
@@ -70,9 +70,10 @@ transport.
 
 ## Consequences
 
-- The four diagnostic-only families need a separate owned-metric/rule decision
-  before they can notify operators. [Issue #1624](https://github.com/mento-protocol/monitoring-monorepo/issues/1624)
-  owns that work; this ADR does not claim alert coverage for them.
+- The four structured families remain diagnostic surfaces. Issue [#1624](https://github.com/mento-protocol/monitoring-monorepo/issues/1624)
+  adds generic warning coverage for persistent incomplete CDP SystemParams
+  state. It does not turn `deadContract` or `diagnosticFailed` into alert
+  labels, and the generic state does not identify one exact cause.
 - Existing operators use status and metrics to assess deployment health, then
   inspect the exact deployment's bounded error logs. A deployment is not
   healthy merely because a log query returns data or no error records.

--- a/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
+++ b/docs/adr/0052-envio-logs-prometheus-grafana-alerting.md
@@ -55,12 +55,12 @@ transport.
   to the hosted indexer.
 - Current structured error families are diagnostic-only:
 
-  | Family                                       | Source                             | Classification                                                                                                                          |
-  | -------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-  | `sortedOracles.oracleExpiryStateUnavailable` | `handlers/oracleExpiryState.ts`    | Diagnostic-only; no metric/rule tracks bootstrap failure.                                                                               |
-  | `sortedOracles.oracleFeedStateUnavailable`   | `handlers/oracleFeedState.ts`      | Diagnostic-only; existing oracle-freshness rules detect resulting stale pool state, not this bootstrap failure.                         |
-  | `liquity.systemParams.deadContract`          | `handlers/liquity/systemParams.ts` | Diagnostic-only; one possible exact cause of the generic `mento_cdp_system_params_loaded` incomplete state, which has warning coverage. |
-  | `liquity.systemParams.diagnosticFailed`      | `handlers/liquity/systemParams.ts` | Diagnostic-only; no metric/rule tracks diagnostic-RPC failure.                                                                          |
+  | Family                                       | Source                             | Classification                                                                                                                                                                                |
+  | -------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `sortedOracles.oracleExpiryStateUnavailable` | `handlers/oracleExpiryState.ts`    | Diagnostic-only; the handler throws, so a state entity written in the failing transaction would roll back. Existing oracle-down and freshness rules own sustained operator impact.            |
+  | `sortedOracles.oracleFeedStateUnavailable`   | `handlers/oracleFeedState.ts`      | Diagnostic-only; the handler throws, so a state entity written in the failing transaction would roll back. Existing oracle-down and freshness rules own sustained operator impact.            |
+  | `liquity.systemParams.deadContract`          | `handlers/liquity/systemParams.ts` | Diagnostic-only; one possible exact cause of the generic `mento_cdp_system_params_loaded` incomplete state, which has warning coverage.                                                       |
+  | `liquity.systemParams.diagnosticFailed`      | `handlers/liquity/systemParams.ts` | Diagnostic-only; this secondary `getCode` diagnostic runs after primary parameter reads fail. Persistent primary failure leaves `systemParamsLoaded=false`, which the generic warning covers. |
 
   `envio_effect_cache_invalidations_count` is separately represented by the
   Prometheus-backed `Envio Effect Cache Invalidations` Grafana rule; it is not
@@ -107,5 +107,17 @@ Invalidations` rule with `service=indexer` and `severity=warning`.
 - `alerts/rules/rules-indexer.tf` defines the Prometheus-backed effect-cache
   invalidation rule. Oracle freshness rules consume `mento_pool_oracle_*`
   metrics in `alerts/rules/rules-fpmms.tf` and `rules-vp-oracles.tf`.
+- `indexer-envio/src/handlers/oracleExpiryState.ts` and
+  `indexer-envio/src/handlers/oracleFeedState.ts` log their named bootstrap
+  failures and then throw. `indexer-envio/src/handlers/liquity/systemParams.ts`
+  retains `systemParamsLoaded=false` when primary parameter reads fail and
+  emits `diagnosticFailed` only if the secondary `getCode` diagnostic also
+  fails.
+- `metrics-bridge/src/cdp-metrics.ts` publishes the bounded readiness and
+  freshness gauges. `metrics-bridge/test/cdp-metrics.test.ts` and
+  `metrics-bridge/test/poller.test.ts` pin their publication, recovery, and
+  failure semantics. `alerts/rules/rules-cdps.tf` defines the warning, and
+  `scripts/alerts/alert-rules-lint.test.mjs` pins its evaluation and routing
+  contract.
 - [Issue #1561](https://github.com/mento-protocol/monitoring-monorepo/issues/1561)
   is the task record for this supersession.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -138,6 +138,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0045](0045-peg-paging-semantics.md)                          | Peg paging measures executable sell price; the deep venue pages alone         |
 | [0048](0048-private-gcs-peg-policy-artifact.md)               | Archived: private GCS artifact with superseded dedicated-project hosting      |
 | [0049](0049-peg-decision-package-read-model.md)               | Peg decisions use a bounded Metrics Bridge read model                         |
+| [0052](0052-envio-logs-prometheus-grafana-alerting.md)        | Envio logs diagnose; Prometheus metrics and Grafana rules alert               |
 | [0054](0054-same-project-peg-policy-artifact.md)              | Peg policy stays private and generation-pinned in the monitoring project      |
 | [0055](0055-peg-policy-bucket-controller-recovery.md)         | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery   |
 | [0057](0057-peg-observation-advancement.md)                   | Repeated provider observations retain bounded health, never sample authority  |

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -26,6 +26,15 @@ const cdpLabels = [
 type CdpLabelValues = Record<(typeof cdpLabels)[number], string>;
 
 export const cdpGauges = {
+  // This scalar is the CDP freshness boundary. It advances only after a
+  // successful Hasura CDP query has been fully prepared and published. It is
+  // deliberately separate from `mento_pool_bridge_last_poll`: that gauge is
+  // owned by the FPMM poll leg and cannot prove that CDP data is fresh.
+  lastSuccessfulPoll: new Gauge({
+    name: "mento_cdp_last_successful_poll",
+    help: "Unix timestamp of the last successful CDP query and complete metric publication. 0 before the first successful CDP poll.",
+    registers: [register],
+  }),
   shutdown: new Gauge({
     name: "mento_cdp_shutdown",
     help: "1 when a CDP market has triggered Liquity ShutDown (system below SCR; borrowing disabled), 0 otherwise.",
@@ -162,15 +171,22 @@ function prepareCdpSeries({
 //
 // All conversions happen up front (prepareCdpSeries): a malformed value throws
 // BEFORE any gauge is reset, so the poll loop's cdp_update handler keeps the
-// last good series instead of leaving a half-cleared registry — which
-// `no_data_state=OK` would otherwise read as a silent all-clear. The reset +
-// publish loop below is pure `.set()` and cannot throw, so the registry only
-// ever transitions between two consistent states. The reset still evicts the
-// series of any market that dropped out of the indexer response.
-export function updateCdpMetrics(cdps: CdpInstance[]): void {
+// last good series and freshness timestamp instead of leaving a half-cleared
+// registry — which `no_data_state=OK` would otherwise read as a silent
+// all-clear. The reset + publish loop below is pure `.set()` and cannot throw,
+// so the registry only ever transitions between two consistent states. The
+// reset still evicts the series of any market that dropped out of the indexer
+// response. An empty response is a successful query and publication, so it
+// advances the timestamp after evicting the prior market series.
+export function updateCdpMetrics(
+  cdps: CdpInstance[],
+  nowSeconds = Math.floor(Date.now() / 1000),
+): void {
   const prepared = cdps.map(prepareCdpSeries);
 
-  for (const g of Object.values(cdpGauges)) g.reset();
+  for (const [name, g] of Object.entries(cdpGauges)) {
+    if (name !== "lastSuccessfulPoll") g.reset();
+  }
 
   for (const row of prepared) {
     cdpGauges.shutdown.set(row.labels, row.shutdown);
@@ -184,4 +200,9 @@ export function updateCdpMetrics(cdps: CdpInstance[]): void {
       cdpGauges.spHeadroom.set(row.labels, row.spHeadroom);
     }
   }
+
+  // Publish this marker only after every CDP series has been prepared and
+  // published. Query failures never call this updater; preparation failures
+  // return before reset; both paths therefore retain the prior timestamp.
+  cdpGauges.lastSuccessfulPoll.set(nowSeconds);
 }

--- a/metrics-bridge/src/cdp-metrics.ts
+++ b/metrics-bridge/src/cdp-metrics.ts
@@ -32,6 +32,12 @@ export const cdpGauges = {
     labelNames: cdpLabels,
     registers: [register],
   }),
+  systemParamsLoaded: new Gauge({
+    name: "mento_cdp_system_params_loaded",
+    help: "1 when the CDP market's SystemParams snapshot loaded successfully, 0 while it remains incomplete.",
+    labelNames: cdpLabels,
+    registers: [register],
+  }),
   spHeadroom: new Gauge({
     name: "mento_cdp_sp_headroom",
     help: "Stability Pool headroom in debt-token units (spDeposits − MIN_BOLD_IN_SP). ≤ 0 means the SP is at/below the on-chain minimum buffer. Absent until SystemParams is loaded.",
@@ -87,6 +93,7 @@ function cdpDisplayLabels({
 interface PreparedCdpSeries {
   labels: CdpLabelValues;
   shutdown: number;
+  systemParamsLoaded: number;
   spDeposits: number;
   systemDebt: number;
   liquidationTotal: number;
@@ -134,6 +141,7 @@ function prepareCdpSeries({
   return {
     labels: cdpDisplayLabels({ instance, collateral }),
     shutdown: instance.isShutDown ? 1 : 0,
+    systemParamsLoaded: collateral.systemParamsLoaded ? 1 : 0,
     spDeposits: toHumanUnits(BigInt(instance.spDeposits), DEBT_TOKEN_DECIMALS),
     systemDebt: toHumanUnits(BigInt(instance.systemDebt), DEBT_TOKEN_DECIMALS),
     liquidationTotal: instance.liqCountCum,
@@ -166,6 +174,7 @@ export function updateCdpMetrics(cdps: CdpInstance[]): void {
 
   for (const row of prepared) {
     cdpGauges.shutdown.set(row.labels, row.shutdown);
+    cdpGauges.systemParamsLoaded.set(row.labels, row.systemParamsLoaded);
     cdpGauges.spDeposits.set(row.labels, row.spDeposits);
     cdpGauges.systemDebt.set(row.labels, row.systemDebt);
     cdpGauges.liquidationTotal.set(row.labels, row.liquidationTotal);

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -58,6 +58,33 @@ describe("updateCdpMetrics", () => {
     expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(1);
   });
 
+  it("publishes SystemParams readiness as a binary gauge", async () => {
+    updateCdpMetrics([makeCdp()]);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(1);
+
+    updateCdpMetrics([makeCdp({ collateral: { systemParamsLoaded: false } })]);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(0);
+  });
+
+  it("keeps SystemParams labels bounded to the existing CDP label set", async () => {
+    updateCdpMetrics([makeCdp()]);
+    const [series] = await getMetricValues(
+      register,
+      "mento_cdp_system_params_loaded",
+    );
+    expect(Object.keys(series.labels).sort()).toEqual([
+      "block_explorer_url",
+      "chain_id",
+      "chain_name",
+      "collateral_id",
+      "symbol",
+    ]);
+  });
+
   it("converts token-denominated columns to human units", async () => {
     updateCdpMetrics([makeCdp()]);
     expect(
@@ -153,6 +180,9 @@ describe("updateCdpMetrics", () => {
     ).toBeUndefined();
     // Other gauges still publish.
     expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(0);
   });
 
   it("evicts series for markets that drop out of the response", async () => {
@@ -182,6 +212,9 @@ describe("updateCdpMetrics", () => {
     expect(
       await getGaugeValue(register, "mento_cdp_system_debt", labels),
     ).toBeCloseTo(305501.17, 1);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(1);
   });
 
   it("carries a TroveManager block-explorer deep link", async () => {

--- a/metrics-bridge/test/cdp-metrics.test.ts
+++ b/metrics-bridge/test/cdp-metrics.test.ts
@@ -50,6 +50,45 @@ describe("updateCdpMetrics", () => {
     register.resetMetrics();
   });
 
+  it("starts with no successful CDP poll", async () => {
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(0);
+  });
+
+  it("marks both loaded and incomplete rows fresh when publication succeeds", async () => {
+    updateCdpMetrics(
+      [
+        makeCdp(),
+        makeCdp({
+          instance: {
+            id: "42220-0x2222222222222222222222222222222222222222",
+            collateralId: "42220-0x2222222222222222222222222222222222222222",
+          },
+          collateral: {
+            id: "42220-0x2222222222222222222222222222222222222222",
+            symbol: "CHFm",
+            troveManager: "0x2222222222222222222222222222222222222222",
+            systemParamsLoaded: false,
+          },
+        }),
+      ],
+      100,
+    );
+
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(100);
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(1);
+    expect(
+      (await getMetricValues(register, "mento_cdp_system_params_loaded")).find(
+        (series) => series.labels.symbol === "CHFm",
+      )?.value,
+    ).toBe(0);
+  });
+
   it("sets shutdown 0 when not shut down, 1 when shut down", async () => {
     updateCdpMetrics([makeCdp()]);
     expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
@@ -186,19 +225,22 @@ describe("updateCdpMetrics", () => {
   });
 
   it("evicts series for markets that drop out of the response", async () => {
-    updateCdpMetrics([makeCdp()]);
+    updateCdpMetrics([makeCdp()], 100);
     expect((await getMetricValues(register, "mento_cdp_shutdown")).length).toBe(
       1,
     );
-    updateCdpMetrics([]);
+    updateCdpMetrics([], 130);
     expect((await getMetricValues(register, "mento_cdp_shutdown")).length).toBe(
       0,
     );
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(130);
   });
 
   it("throws on a malformed row BEFORE clearing the registry (no silent all-clear)", async () => {
     // Seed a known-good poll.
-    updateCdpMetrics([makeCdp()]);
+    updateCdpMetrics([makeCdp()], 100);
     expect(await getGaugeValue(register, "mento_cdp_shutdown", labels)).toBe(0);
 
     // A row with an unparsable BigInt must throw during preparation, leaving
@@ -215,6 +257,56 @@ describe("updateCdpMetrics", () => {
     expect(
       await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
     ).toBe(1);
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(100);
+  });
+
+  it("keeps the restart timestamp at zero when the first update is malformed", async () => {
+    expect(() =>
+      updateCdpMetrics(
+        [makeCdp({ instance: { systemDebt: "not-a-number" } })],
+        100,
+      ),
+    ).toThrow();
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(0);
+  });
+
+  it("retains the last successful publication while a malformed update ages", async () => {
+    updateCdpMetrics(
+      [makeCdp({ collateral: { systemParamsLoaded: false } })],
+      100,
+    );
+    expect(() =>
+      updateCdpMetrics(
+        [makeCdp({ instance: { systemDebt: "not-a-number" } })],
+        130,
+      ),
+    ).toThrow();
+
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(0);
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(100);
+  });
+
+  it("updates freshness across incomplete-to-loaded recovery", async () => {
+    updateCdpMetrics(
+      [makeCdp({ collateral: { systemParamsLoaded: false } })],
+      100,
+    );
+    updateCdpMetrics([makeCdp()], 160);
+
+    expect(
+      await getGaugeValue(register, "mento_cdp_system_params_loaded", labels),
+    ).toBe(1);
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(160);
   });
 
   it("carries a TroveManager block-explorer deep link", async () => {

--- a/metrics-bridge/test/poller.test.ts
+++ b/metrics-bridge/test/poller.test.ts
@@ -21,9 +21,15 @@ vi.mock("../src/cdp-graphql.js", () => ({
   fetchCdps: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../src/cdp-metrics.js", () => ({
-  updateCdpMetrics: vi.fn(),
-}));
+vi.mock("../src/cdp-metrics.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/cdp-metrics.js")>();
+  return {
+    ...actual,
+    // Keep the real publication semantics so poller tests can prove that a
+    // query failure or shared 429 leaves the CDP freshness marker unchanged.
+    updateCdpMetrics: vi.fn(actual.updateCdpMetrics),
+  };
+});
 
 vi.mock("../src/server.js", () => ({
   markHealthy: vi.fn(),
@@ -194,6 +200,36 @@ describe("poll", () => {
     // A CDP query failure must not flip the FPMM bridge unhealthy.
     expect(mockUpdateCdpMetrics).not.toHaveBeenCalled();
     expect(mockMarkHealthy).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the CDP freshness marker at restart zero across query and shared-429 failures", async () => {
+    mockFetchPools.mockResolvedValue(makePoolResponse());
+    mockFetchCdps.mockRejectedValueOnce(new Error("cdp hasura down"));
+
+    await poll();
+
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(0);
+
+    mockFetchPools.mockResolvedValueOnce(makePoolResponse());
+    mockFetchCdps.mockRejectedValueOnce(
+      new ClientError(
+        {
+          data: undefined,
+          errors: undefined,
+          status: 429,
+          headers: new Headers(),
+        },
+        { query: "..." },
+      ),
+    );
+
+    await poll();
+
+    expect(
+      await getGaugeValue(register, "mento_cdp_last_successful_poll"),
+    ).toBe(0);
   });
 
   it("increments pollErrors with cdp_update kind when the CDP metric update throws", async () => {

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1850,6 +1850,42 @@ function ruleBlockNamed(source, namePattern) {
   return blocks[0];
 }
 
+test("CDP System Parameters Not Loaded keeps the approved warning contract", () => {
+  const source = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-cdps.tf"),
+    "utf8",
+  );
+  const rule = ruleBlockNamed(
+    source,
+    /\bname\s*=\s*"CDP System Parameters Not Loaded"/,
+  );
+  assert(
+    rule.includes('expr    = "mento_cdp_system_params_loaded"'),
+    "the CDP readiness rule must read the system_params_loaded gauge",
+  );
+  assert(
+    /\bfor\s*=\s*"10m"/.test(rule),
+    "the CDP readiness warning must require 10 minutes",
+  );
+  assert(
+    /\bno_data_state\s*=\s*"OK"/.test(rule) &&
+      /\bexec_err_state\s*=\s*"OK"/.test(rule),
+    "the CDP readiness warning must treat missing data and evaluation errors as OK",
+  );
+  assert(
+    /evaluator\s*=\s*\{\s*params\s*=\s*\[0\.5\]\s*,\s*type\s*=\s*"lt"/.test(
+      rule,
+    ),
+    "the CDP readiness warning must fire below 0.5",
+  );
+  assert(
+    /\bservice\s*=\s*"cdps"/.test(rule) &&
+      /\bseverity\s*=\s*"warning"/.test(rule) &&
+      /\blocal\.notify_warning_cdps\.contact_point/.test(rule),
+    "the CDP readiness warning must use service=cdps, warning severity, and notify_warning_cdps",
+  );
+});
+
 test("flap-prone criticals keep incidents open across short recoveries", () => {
   const fpmmRules = readFileSync(
     path.resolve(repoRoot, "alerts/rules/rules-fpmms.tf"),

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1860,8 +1860,15 @@ test("CDP System Parameters Not Loaded keeps the approved warning contract", () 
     /\bname\s*=\s*"CDP System Parameters Not Loaded"/,
   );
   assert(
-    rule.includes('expr    = "mento_cdp_system_params_loaded"'),
-    "the CDP readiness rule must read the system_params_loaded gauge",
+    rule.includes(
+      'expr    = "mento_cdp_system_params_loaded and on() (time() - mento_cdp_last_successful_poll < 90)"',
+    ),
+    "the CDP readiness rule must require fresh CDP publication and read the system_params_loaded gauge",
+  );
+  assert(
+    /mento_cdp_system_params_loaded/.test(rule) &&
+      /mento_cdp_last_successful_poll/.test(rule),
+    "the CDP readiness rule must pin both CDP metric names",
   );
   assert(
     /\bfor\s*=\s*"10m"/.test(rule),

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1861,7 +1861,7 @@ test("CDP System Parameters Not Loaded keeps the approved warning contract", () 
   );
   assert(
     rule.includes(
-      'expr    = "mento_cdp_system_params_loaded and on() (time() - mento_cdp_last_successful_poll < 90)"',
+      'expr    = "mento_cdp_system_params_loaded and on() ((time() - mento_cdp_last_successful_poll >= 0) and (time() - mento_cdp_last_successful_poll < 90))"',
     ),
     "the CDP readiness rule must require fresh CDP publication and read the system_params_loaded gauge",
   );


### PR DESCRIPTION
## The Problem

- Four indexer bootstrap error families exist only in commit-scoped Envio logs.
- Persistent incomplete CDP `SystemParams` state has no owned warning metric or Grafana rule.

## The Solution

- Export bounded CDP readiness and freshness metrics, then warn when a fresh CDP row remains incomplete for 10 minutes.

## Details

- `mento_cdp_system_params_loaded` reuses the existing five bounded CDP labels and publishes `1` or `0` for each joined market.
- `mento_cdp_last_successful_poll` advances only after a successful CDP query and complete metric publication. Query and update failures retain the last bundle while this marker ages.
- `CDP System Parameters Not Loaded` uses `severity=warning`, `service=cdps`, `notify_warning_cdps`, and `no_data_state=OK` / `exec_err_state=OK`.
- The alert requires a non-negative publication age below 90 seconds. Existing poll-error and bridge-liveness rules retain transport and outage ownership.
- The ADR records why both oracle bootstrap families and `liquity.systemParams.diagnosticFailed` remain diagnostic-only. `liquity.systemParams.deadContract` remains an exact diagnostic cause of the generic incomplete state.
- Production closeout requires the exact merged Metrics Bridge deployment, three live readiness series at `1`, and an approved Alerts Rules Terraform apply. The apply requires separate human approval.

Refs #1624.

## Validation

- `pnpm agent:quality-gate --run` — all mapped commands passed.
- Metrics Bridge lint, typecheck, build, knip, dependency checks, and 618 tests passed.
- Metrics Bridge coverage passed.
- Alert lint validated 173 PromQL expressions, 57 referenced metrics, and 72 gauges.
- Alert rule tests passed: 51 tests.
- The clock-skew regression and an independent follow-up review passed on `42ffa6f1`.
- Terraform format, initialization, validation, and repository Terraform tests passed.
- Docs index, context checks, navigation fixtures, ADR check, script lint, and targeted Trunk passed.
- Independent semantic review passed after the ADR evidence correction.
- `pnpm agent:autoreview` found no deterministic findings.
- Claude Security scan: skipped because the Claude-only plugin is unavailable in Codex.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0052 records the metric, alert, and diagnostic-only decisions.
