### PR TITLE
feat(scripts): gate mapping engine, proven at parity with the bash arms (D5b part 1)

### DIFF
--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4008,11 +4008,18 @@ while IFS= read -r path; do
           # the engine's own checks rather than the gate self-test.
           #
           # The quoting test alone would leave routing, facts, verbs, ordering,
-          # compaction and scoped-test selection unchecked, so the two CHEAP
+          # compaction and scoped-test selection unchecked, so the three CHEAP
           # parity corpora run too: `fixture` (2s) covers the branch that skips
-          # repository-specific groups, and `multi` (57s) is where the four
-          # whole-set post-passes are actually exercised. The tracked, synthetic
-          # and base corpora are a 35-minute run and stay a per-PR step.
+          # repository-specific groups, `symlink` (6s) covers the dynamic
+          # pattern source no committed path can reach, and `multi` (57s) is
+          # where the four whole-set post-passes are actually exercised. The
+          # tracked, synthetic and base corpora are a 35-minute run and stay a
+          # per-PR step.
+          #
+          # `symlink` creates a directory symlink under scripts/ and removes it
+          # again, the way the gate self-test does, so it must not run
+          # concurrently with another gate in this same worktree — the run lock
+          # already guarantees that.
           #
           # These nested gate runs are dry-run and set AGENT_QUALITY_GATE_LOCK=0
           # themselves, so they do not queue behind the outer run's lock. When
@@ -4021,6 +4028,7 @@ while IFS= read -r path; do
           # arm already has it.
           add_command "node --test scripts/gate/mapping/shell-quote.test.mjs" "gate mapping engine changed"
           add_command "node scripts/gate/routing-parity.mjs --corpus fixture" "gate mapping engine changed (parity against the live arms, fixture repository)"
+          add_command "node scripts/gate/routing-parity.mjs --corpus symlink" "gate mapping engine changed (parity against the live arms, scripts/ symlink source)"
           add_command "node scripts/gate/routing-parity.mjs --corpus multi" "gate mapping engine changed (parity against the live arms, whole-set post-passes)"
           ;;
         scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs)

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4001,6 +4001,15 @@ while IFS= read -r path; do
           add_command "pnpm gate:routing-table:test" "gate routing table changed"
           add_command "pnpm agent:quality-gate:test" "gate routing table is an implementation-signature input"
           ;;
+        scripts/gate/mapping.mjs|scripts/gate/mapping/*.mjs|scripts/gate/routing-parity.mjs)
+          # The Node mapping engine (ADR 0069, D5b) and the parity harness that
+          # proves it against these arms. Nothing consults the engine yet — the
+          # `case` arms below are still the routing that runs — so this routes
+          # the engine's own checks rather than the gate self-test. When the
+          # gate is flipped to read the engine's plan, this arm gains the
+          # self-test the way the routing-table arm already has it.
+          add_command "node --test scripts/gate/mapping/shell-quote.test.mjs" "gate mapping engine changed"
+          ;;
         scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs)
           # The bash-from-Node machinery. Its own suite already runs, because
           # check-sentry-suites-in-ci.test.mjs imports it and the coverage arm

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4005,10 +4005,23 @@ while IFS= read -r path; do
           # The Node mapping engine (ADR 0069, D5b) and the parity harness that
           # proves it against these arms. Nothing consults the engine yet — the
           # `case` arms below are still the routing that runs — so this routes
-          # the engine's own checks rather than the gate self-test. When the
-          # gate is flipped to read the engine's plan, this arm gains the
-          # self-test the way the routing-table arm already has it.
+          # the engine's own checks rather than the gate self-test.
+          #
+          # The quoting test alone would leave routing, facts, verbs, ordering,
+          # compaction and scoped-test selection unchecked, so the two CHEAP
+          # parity corpora run too: `fixture` (2s) covers the branch that skips
+          # repository-specific groups, and `multi` (57s) is where the four
+          # whole-set post-passes are actually exercised. The tracked, synthetic
+          # and base corpora are a 35-minute run and stay a per-PR step.
+          #
+          # These nested gate runs are dry-run and set AGENT_QUALITY_GATE_LOCK=0
+          # themselves, so they do not queue behind the outer run's lock. When
+          # the gate is flipped to read the engine's plan the harness is
+          # deleted, and this arm gains the self-test the way the routing-table
+          # arm already has it.
           add_command "node --test scripts/gate/mapping/shell-quote.test.mjs" "gate mapping engine changed"
+          add_command "node scripts/gate/routing-parity.mjs --corpus fixture" "gate mapping engine changed (parity against the live arms, fixture repository)"
+          add_command "node scripts/gate/routing-parity.mjs --corpus multi" "gate mapping engine changed (parity against the live arms, whole-set post-passes)"
           ;;
         scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs)
           # The bash-from-Node machinery. Its own suite already runs, because

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * The gate's mapping layer: changed paths + repo facts in, command plan out.
+ *
+ * One Node process per gate run. It walks `ROUTING_GROUPS`, applies the four
+ * whole-set post-passes, and writes the plan in the exact TSV shape
+ * `write_command_plan` already emits, plus two further sections for the
+ * surfaces and checklists the gate prints.
+ *
+ * NOT YET WIRED INTO THE GATE. D5b lands this inert and proves it against the
+ * live bash routing with the parity harness first; the gate is flipped to read
+ * from it only once that parity is zero with a proven mutation control. Until
+ * then the bash `case` arms are still the routing that runs, and this module
+ * changes nothing about a gate run.
+ *
+ * FAIL CLOSED. Any unknown verb, guard, dispatch subject or dynamic source
+ * throws, and this exits non-zero with the reason. The one outcome that must
+ * never happen is a smaller plan produced quietly — a gate that runs fewer
+ * checks and still prints "All mapped commands passed."
+ *
+ * Output format, one record per line:
+ *
+ *   surface\t<name>
+ *   checklist\t<path>\t<reason>
+ *   <bucket>\t<command>\t<reason>
+ *
+ * with buckets in preflight → codegen → post-codegen → quality order.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { ROUTING_PLAN } from "./routing-table/index.mjs";
+import { Plan, BUCKETS } from "./mapping/plan.mjs";
+import { routeChangedPaths } from "./mapping/route.mjs";
+import {
+  addTrunkCheckCommand,
+  applyScopedTestCommands,
+  compactTurboQualityCommands,
+  sortCodegenCommands,
+} from "./mapping/post-passes.mjs";
+import * as verbs from "./mapping/verbs.mjs";
+
+/** Importer directory → the bundle a scoped lockfile change routes. */
+const LOCKFILE_IMPORTER_BUNDLES = {
+  aegis: (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/aegis");
+    verbs.addAegisQualityCommands(plan, reason);
+  },
+  "ui-dashboard": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/ui-dashboard");
+    verbs.addDashboardQualityCommands(plan, reason);
+    // Dependency resolution can regress bundle size, and the workspace route
+    // ran size-limit for lockfile edits, so the scoped route must too.
+    verbs.addUiSizeLimit(plan, reason);
+  },
+  "indexer-envio": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/indexer-envio");
+    // A changed Envio resolution can break testnet/bridge codegen even when
+    // mainnet passes; keep the workspace route's coverage.
+    verbs.addAllIndexerCodegen(plan, reason);
+    verbs.addPackageQualityCommands(
+      plan,
+      "@mento-protocol/indexer-envio",
+      reason,
+    );
+  },
+  "metrics-bridge": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/metrics-bridge");
+    verbs.addPackageQualityCommands(
+      plan,
+      "@mento-protocol/metrics-bridge",
+      reason,
+    );
+  },
+  "integration-probes": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/integration-probes");
+    verbs.addPackageQualityCommands(
+      plan,
+      "@mento-protocol/integration-probes",
+      reason,
+    );
+  },
+  "shared-config": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/config");
+    verbs.addPackageQualityCommands(plan, "@mento-protocol/config", reason);
+  },
+  "governance-watchdog": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/governance-watchdog");
+    verbs.addPackageQualityCommands(
+      plan,
+      "@mento-protocol/governance-watchdog",
+      reason,
+    );
+  },
+  "alerts/infra/onchain-event-handler": (plan, reason) => {
+    plan.markLockfileScopedPackage(
+      "@mento-protocol/alerts-onchain-event-handler",
+    );
+    verbs.addPackageQualityCommands(
+      plan,
+      "@mento-protocol/alerts-onchain-event-handler",
+      reason,
+    );
+  },
+  "alerts/infra/oncall-announcer": (plan, reason) => {
+    plan.markLockfileScopedPackage("@mento-protocol/alerts-oncall-announcer");
+    verbs.addAlertsOncallQualityCommands(plan, reason);
+  },
+};
+
+/** Workspace-manifest-class paths whose presence disqualifies lockfile scoping. */
+const MANIFEST_CLASS = [
+  /^package\.json$/,
+  /\/package\.json$/,
+  /^pnpm-workspace\.yaml$/,
+  /^patches\//,
+  /^\.npmrc$/,
+  /\/\.npmrc$/,
+  /^pnpmfile\.cjs$/,
+  /^\.pnpmfile\.cjs$/,
+  /^\.node-version$/,
+];
+
+/**
+ * Route a `pnpm-lock.yaml` change: scoped when the lockfile is the only
+ * manifest-class change AND every changed importer maps to a bundle, otherwise
+ * the full workspace suite. Every ambiguity fails toward full.
+ */
+function makeLockfileRouter(changedPaths, scriptSourceDir) {
+  return (plan, facts) => {
+    plan.addSurface("workspace");
+    plan.addPreflight(
+      "pnpm install --frozen-lockfile",
+      "workspace dependency/config changed",
+    );
+    plan.addCommand(
+      "node scripts/alerts/check-peg-registry-integrity.mjs",
+      "root lockfile changed (peg registry authority dependency)",
+    );
+
+    const classifier = join(scriptSourceDir, "gate", "lockfile-scope.mjs");
+    if (!existsSync(classifier)) {
+      // Fail-toward-full is right for an ambiguous lockfile and WRONG for a
+      // classifier the gate cannot find: that failure is invisible, and every
+      // lockfile change would silently widen while the run read as slow.
+      const error = new Error(
+        `lockfile scope classifier could not be loaded from ${classifier}`,
+      );
+      error.exitCode = 2;
+      throw error;
+    }
+
+    const importers = scopedImporters(facts, classifier);
+    const lockfileOnly =
+      changedPaths.includes("pnpm-lock.yaml") &&
+      !changedPaths.some((path) => MANIFEST_CLASS.some((r) => r.test(path)));
+
+    if (
+      lockfileOnly &&
+      importers !== null &&
+      importers.every((importer) => importer in LOCKFILE_IMPORTER_BUNDLES)
+    ) {
+      plan.addCommand("pnpm skew:check", "lockfile change scoped to importers");
+      plan.addCommand(
+        "pnpm lockfile:lint",
+        "lockfile change scoped to importers",
+      );
+      for (const importer of importers) {
+        LOCKFILE_IMPORTER_BUNDLES[importer](
+          plan,
+          `lockfile importer ${importer} changed`,
+        );
+      }
+      return;
+    }
+
+    verbs.addWorkspaceQualityCommands(
+      plan,
+      "workspace dependency/config changed",
+    );
+    verbs.addAdrReminder(
+      plan,
+      "workspace membership/policy changed — ADR reminder (a new package likely needs an ADR)",
+      facts,
+    );
+  };
+}
+
+/** Changed importer keys, or null when the change is not scopable. */
+function scopedImporters(facts, classifier) {
+  const base = gitShow(facts, `${facts.baseRef}:pnpm-lock.yaml`);
+  if (base === null) return null;
+  const head =
+    facts.headRef === "HEAD" && facts.pathExistsInWorktree("pnpm-lock.yaml")
+      ? readFileSync(join(facts.repoRoot, "pnpm-lock.yaml"))
+      : gitShow(facts, `${facts.headRef}:pnpm-lock.yaml`);
+  if (head === null) return null;
+
+  const dir = mkdtempSync(join(tmpdir(), "gate-lockfile-"));
+  try {
+    const basePath = join(dir, "base");
+    const headPath = join(dir, "head");
+    writeFileSync(basePath, base);
+    writeFileSync(headPath, head);
+    const result = execFileSync("node", [classifier, basePath, headPath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return result.split("\n").filter((line) => line !== "");
+  } catch {
+    return null;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function gitShow(facts, spec) {
+  try {
+    return execFileSync("git", ["-C", facts.repoRoot, "show", spec], {
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 256 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether any changed path is routing-sensitive, per the documentation
+ * navigation evaluation's own classifier.
+ *
+ * The gate resolves this helper from `$script_source_dir` and exits 3 when it
+ * cannot, because a classifier the gate cannot find fails invisibly — the
+ * `--check-fixtures` command simply stops being scheduled. Same rule here.
+ */
+export async function routingSensitivePathsChanged(
+  changedPaths,
+  scriptSourceDir,
+) {
+  const classifier = join(
+    scriptSourceDir,
+    "docs",
+    "docs-navigation-eval-helpers.mjs",
+  );
+  let isRoutingSensitivePath;
+  try {
+    ({ isRoutingSensitivePath } = await import(pathToFileURL(classifier).href));
+  } catch (error) {
+    const failure = new Error(
+      `routing classifier could not be loaded from ${classifier}: ${error.message}`,
+    );
+    failure.exitCode = 3;
+    throw failure;
+  }
+  if (typeof isRoutingSensitivePath !== "function") {
+    const failure = new Error(
+      `${classifier} does not export isRoutingSensitivePath`,
+    );
+    failure.exitCode = 3;
+    throw failure;
+  }
+  return changedPaths.some((path) => isRoutingSensitivePath(path) === true);
+}
+
+/** Build the plan. Exported so tests and the parity harness can call it directly. */
+export function buildPlan({ changedPaths, facts, routingSensitive = false }) {
+  const plan = new Plan();
+  const context = {
+    plan,
+    routeLockfileChange: makeLockfileRouter(
+      changedPaths,
+      facts.scriptSourceDir,
+    ),
+  };
+
+  routeChangedPaths(ROUTING_PLAN, changedPaths, facts, context);
+
+  // Post-loop sweeps, before the four post-passes.
+  if (facts.isRealTree) {
+    plan.addCommand(
+      "pnpm tf:test",
+      "non-empty change set validates production infrastructure contract",
+    );
+  }
+  if (routingSensitive) {
+    plan.addCommand(
+      "pnpm docs:navigation-eval -- --check-fixtures",
+      "routing-sensitive source changed",
+    );
+  }
+
+  addTrunkCheckCommand(plan, changedPaths, facts);
+  sortCodegenCommands(plan);
+  compactTurboQualityCommands(plan);
+  applyScopedTestCommands(plan, changedPaths, facts);
+  return plan;
+}
+
+/** The plan as the TSV record stream the gate reads back. */
+export function formatPlan(plan) {
+  const lines = [];
+  for (const surface of plan.surfaces) lines.push(`surface\t${surface}`);
+  for (const entry of plan.checklists) {
+    lines.push(`checklist\t${entry.checklist}\t${entry.reason}`);
+  }
+  for (const bucket of BUCKETS) {
+    for (const entry of plan.buckets.get(bucket)) {
+      lines.push(`${bucket}\t${entry.command}\t${entry.reason}`);
+    }
+  }
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -29,10 +29,10 @@
 
 import { execFileSync } from "node:child_process";
 import {
-  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -118,6 +118,15 @@ const LOCKFILE_IMPORTER_BUNDLES = {
   },
 };
 
+/** `[[ -f <path> ]]`: a regular file, following symlinks. */
+const isRegularFile = (path) => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
+
 /** Workspace-manifest-class paths whose presence disqualifies lockfile scoping. */
 const MANIFEST_CLASS = [
   /^package\.json$/,
@@ -149,7 +158,9 @@ function makeLockfileRouter(changedPaths, scriptSourceDir) {
     );
 
     const classifier = join(scriptSourceDir, "gate", "lockfile-scope.mjs");
-    if (!existsSync(classifier)) {
+    // `[[ ! -f "$lockfile_scope_path" ]]` — a directory by that name is not a
+    // classifier the gate could run either.
+    if (!isRegularFile(classifier)) {
       // Fail-toward-full is right for an ambiguous lockfile and WRONG for a
       // classifier the gate cannot find: that failure is invisible, and every
       // lockfile change would silently widen while the run read as slow.
@@ -201,7 +212,7 @@ function scopedImporters(facts, classifier) {
   const base = gitShow(facts, `${facts.baseRef}:pnpm-lock.yaml`);
   if (base === null) return null;
   const head =
-    facts.headRef === "HEAD" && facts.pathExistsInWorktree("pnpm-lock.yaml")
+    facts.headRef === "HEAD" && facts.pathIsFile("pnpm-lock.yaml")
       ? readFileSync(join(facts.repoRoot, "pnpm-lock.yaml"))
       : gitShow(facts, `${facts.headRef}:pnpm-lock.yaml`);
   if (head === null) return null;

--- a/scripts/gate/mapping/facts.mjs
+++ b/scripts/gate/mapping/facts.mjs
@@ -9,18 +9,23 @@
  * testable and what lets the parity harness feed it the same inputs the gate
  * had.
  *
- * FAIL-CLOSED IS THE HOUSE RULE. Every ambiguity here resolves toward MORE
- * work, never less: an unreadable manifest classifies as `workspace` (the full
- * suite), an unresolvable ref becomes a sentinel rather than an empty string,
- * and a missing classifier is an error rather than a shrug. A fact that fails
- * quietly produces a smaller plan, which is the one outcome the gate must never
- * reach.
+ * FAIL-CLOSED IS THE HOUSE RULE, and it has two distinct shapes. An AMBIGUOUS
+ * fact resolves toward more work: an unreadable root manifest classifies as
+ * `workspace`, the full suite, and an unresolvable ref becomes a sentinel
+ * rather than an empty string. A BROKEN fact refuses outright: an invalid
+ * Terraform registry throws rather than routing zero stacks, because "no
+ * registered stacks" and "the registry is corrupt" are the same empty list to
+ * every consumer downstream. A fact that fails quietly produces a smaller plan,
+ * which is the one outcome the gate must never reach.
  */
 
 import { execFileSync } from "node:child_process";
 import {
+  accessSync,
+  constants,
   existsSync,
   lstatSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   statSync,
@@ -147,6 +152,100 @@ function jsonChangePaths(base, head) {
   return changes;
 }
 
+/**
+ * Absolute paths of every symlink under `dir`, at any depth.
+ *
+ * Mirrors `find <dir> -type l`: the link's own entry is what is reported, and
+ * the walk does not descend through one (`Dirent.isDirectory()` is false for a
+ * symlink, exactly as `find` without `-L` behaves).
+ */
+function findSymlinks(dir) {
+  const found = [];
+  const stack = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      // `find … 2>/dev/null || true` — an unreadable directory is skipped.
+      continue;
+    }
+    for (const entry of entries) {
+      const absolute = join(current, entry.name);
+      if (entry.isSymbolicLink()) found.push(absolute);
+      else if (entry.isDirectory()) stack.push(absolute);
+    }
+  }
+  return found.sort();
+}
+
+/** The registry's text when the gate's `[[ -r ]]` would pass, else null. */
+function readRegistryText(registry) {
+  try {
+    accessSync(registry, constants.R_OK);
+  } catch {
+    return null;
+  }
+  try {
+    return readFileSync(registry, "utf8");
+  } catch {
+    // Readable a moment ago and unreadable now: refuse rather than route an
+    // empty stack list, which is the same direction as a parse failure.
+    throw registryRefusal();
+  }
+}
+
+const registryRefusal = () => {
+  const error = new Error(
+    "failed to load Terraform stack paths from terraform.stacks.json",
+  );
+  error.exitCode = 2;
+  return error;
+};
+
+/**
+ * The registry's stack paths, validated exactly as the gate validates them.
+ *
+ * Transcribed from `agent-quality-gate.sh:265-292`. Every rejection there is
+ * `exit 2`, so every rejection here throws.
+ */
+function validateStackPaths(text) {
+  if (text === null) return [];
+  let registry;
+  try {
+    registry = JSON.parse(text);
+  } catch {
+    throw registryRefusal();
+  }
+  if (
+    !isRecord(registry) ||
+    registry.version !== 1 ||
+    !Array.isArray(registry.stacks)
+  ) {
+    throw registryRefusal();
+  }
+  const paths = registry.stacks.map((stack) =>
+    isRecord(stack) ? stack.path : undefined,
+  );
+  if (
+    paths.length === 0 ||
+    paths.some(
+      (stackPath) =>
+        typeof stackPath !== "string" ||
+        !/^[A-Za-z0-9._/-]+$/u.test(stackPath) ||
+        stackPath.startsWith("/") ||
+        stackPath
+          .split("/")
+          .some((segment) => ["", ".", ".."].includes(segment)),
+    ) ||
+    new Set(paths).size !== paths.length
+  ) {
+    throw registryRefusal();
+  }
+  return paths;
+}
+
 export class Facts {
   constructor(options) {
     this.repoRoot = options.repoRoot;
@@ -176,8 +275,28 @@ export class Facts {
   }
   #baseOid;
 
+  /** `[[ -e "$path" ]]`: the path exists, following symlinks. */
   pathExistsInWorktree(path) {
     return existsSync(join(this.repoRoot, path));
+  }
+
+  /**
+   * `[[ -f "$path" ]]`: the path is a REGULAR file, following symlinks.
+   *
+   * Not `existsSync`, which is `-e`. The two disagree on exactly the shapes a
+   * repository can hold: a directory, a symlink to a directory, and a gitlink
+   * (`160000`, a submodule, which is a directory in the working tree) all
+   * exist and are not regular files. `[[ -f ]]` is false for each, so the
+   * guarded command is not scheduled, and a guard that answered `-e` would
+   * schedule `bash -n <directory>` — a command the gate never emits.
+   */
+  pathIsFile(path) {
+    try {
+      return statSync(join(this.repoRoot, path)).isFile();
+    } catch {
+      // A dangling symlink or an unreadable parent: `[[ -f ]]` is false too.
+      return false;
+    }
   }
 
   /**
@@ -205,21 +324,27 @@ export class Facts {
     );
   }
 
-  /** Repo-relative resolved targets of every directory symlink under scripts/. */
+  /**
+   * Repo-relative resolved targets of every directory symlink under scripts/.
+   *
+   * The source is the WORKING TREE, not git's index: the gate runs
+   * `find "$repo_root/scripts" -type l` and keeps the links that resolve to a
+   * directory inside the repository. Reading git's index instead would miss an
+   * untracked directory symlink that the gate sees — and missing one means the
+   * suites beneath it stop being routed, which is a smaller plan.
+   *
+   * `find` without `-L` does not descend through symlinks, so neither does
+   * this walk.
+   */
   get scriptsSymlinkTargets() {
     if (this.#symlinkTargets === undefined) {
       this.#symlinkTargets = [];
       const scriptsDir = join(this.repoRoot, "scripts");
       if (this.isRealTree && existsSync(scriptsDir)) {
-        const listed = git(this.repoRoot, ["ls-files", "-s", "scripts"]) ?? "";
         const rootPhysical = realpathSync(this.repoRoot);
-        for (const line of listed.split("\n")) {
-          // Mode 120000 is a symlink in git's index.
-          if (!line.startsWith("120000")) continue;
-          const path = line.split("\t")[1];
-          if (path === undefined) continue;
-          const absolute = join(this.repoRoot, path);
+        for (const absolute of findSymlinks(scriptsDir)) {
           try {
+            // `-d` follows the link; only a directory exposes a suite tree.
             if (!statSync(absolute).isDirectory()) continue;
             const target = realpathSync(absolute);
             const rel = relative(rootPhysical, target);
@@ -227,7 +352,8 @@ export class Facts {
               continue;
             this.#symlinkTargets.push(rel.split(sep).join("/"));
           } catch {
-            // A dangling or unreadable link exposes no suite tree.
+            // A dangling or unreadable link exposes no suite tree, and the
+            // gate's own `cd "$link" && pwd -P || continue` skips it too.
           }
         }
       }
@@ -236,24 +362,23 @@ export class Facts {
   }
   #symlinkTargets;
 
-  /** Registered Terraform stack paths, from the registry rather than from paths. */
+  /**
+   * Registered Terraform stack paths, from the registry rather than from paths.
+   *
+   * ABSENT AND INVALID ARE DIFFERENT ANSWERS, and the gate already separates
+   * them (`agent-quality-gate.sh:263-302`). A registry that is not readable is
+   * a repository without one — the fixture repos the gate's own unit tests run
+   * against — and routes no stack-specific validation. A registry that IS
+   * readable but does not parse, or holds a shape the gate rejects, is a
+   * REFUSAL: the gate prints `failed to load Terraform stack paths` and exits
+   * 2. Returning `[]` there would silently drop `terraform validate` for every
+   * registered stack while the run still printed "All mapped commands passed."
+   */
   get terraformStackPaths() {
     if (this.#stackPaths === undefined) {
-      this.#stackPaths = [];
-      const registry = join(this.repoRoot, "terraform.stacks.json");
-      if (existsSync(registry)) {
-        try {
-          const parsed = JSON.parse(readFileSync(registry, "utf8"));
-          for (const stack of parsed.stacks ?? []) {
-            if (typeof stack.path === "string")
-              this.#stackPaths.push(stack.path);
-          }
-        } catch {
-          // An unreadable registry routes no stack-specific validation, which
-          // is what the gate does too — the unconditional `pnpm tf:test` sweep
-          // still runs.
-        }
-      }
+      this.#stackPaths = validateStackPaths(
+        readRegistryText(join(this.repoRoot, "terraform.stacks.json")),
+      );
     }
     return this.#stackPaths;
   }
@@ -280,7 +405,8 @@ export class Facts {
     if (baseText === null) return "workspace";
 
     let headText;
-    if (this.headRef === "HEAD" && this.pathExistsInWorktree("package.json")) {
+    // `[[ "$head_ref" == "HEAD" && -f "$path" ]]`, the gate's own test.
+    if (this.headRef === "HEAD" && this.pathIsFile("package.json")) {
       headText = readFileSync(join(this.repoRoot, "package.json"), "utf8");
     } else {
       headText = git(this.repoRoot, ["show", `${this.headRef}:package.json`]);

--- a/scripts/gate/mapping/facts.mjs
+++ b/scripts/gate/mapping/facts.mjs
@@ -348,8 +348,15 @@ export class Facts {
             if (!statSync(absolute).isDirectory()) continue;
             const target = realpathSync(absolute);
             const rel = relative(rootPhysical, target);
-            if (rel === "" || rel.startsWith("..") || rel.startsWith(sep))
-              continue;
+            // `..name` is a directory whose NAME starts with two dots, not a
+            // path that climbs out of the repository — and the gate, which
+            // tests `case "$target/" in "$repo_root"/*`, accepts it. Rejecting
+            // every `..` prefix drops a routing pattern the gate has, which is
+            // a smaller plan. Only `..` itself and a `../` prefix leave the
+            // tree.
+            const escapes =
+              rel === ".." || rel.startsWith(`..${sep}`) || rel.startsWith(sep);
+            if (rel === "" || escapes) continue;
             this.#symlinkTargets.push(rel.split(sep).join("/"));
           } catch {
             // A dangling or unreadable link exposes no suite tree, and the

--- a/scripts/gate/mapping/facts.mjs
+++ b/scripts/gate/mapping/facts.mjs
@@ -262,7 +262,7 @@ export class Facts {
   /**
    * How the root `package.json` changed, as one of the four closed classes.
    *
-   * Anything unreadable or unparseable is `workspace`, which is the widest
+   * Anything unreadable or unparsable is `workspace`, which is the widest
    * answer — the full suite.
    */
   rootPackageJsonClass() {

--- a/scripts/gate/mapping/facts.mjs
+++ b/scripts/gate/mapping/facts.mjs
@@ -1,0 +1,325 @@
+/**
+ * The repository facts the routing consults that are not the changed-path list.
+ *
+ * Everything here is something the bash gate reads from the tree or from git at
+ * run time: whether a path exists, what the base ref resolves to, which
+ * `scripts/` symlinks resolve where, which Terraform stacks are registered, and
+ * how the root manifest changed. Keeping them behind one object means the
+ * engine is a pure function of (changed paths, facts) — which is what makes it
+ * testable and what lets the parity harness feed it the same inputs the gate
+ * had.
+ *
+ * FAIL-CLOSED IS THE HOUSE RULE. Every ambiguity here resolves toward MORE
+ * work, never less: an unreadable manifest classifies as `workspace` (the full
+ * suite), an unresolvable ref becomes a sentinel rather than an empty string,
+ * and a missing classifier is an error rather than a shrug. A fact that fails
+ * quietly produces a smaller plan, which is the one outcome the gate must never
+ * reach.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const git = (repoRoot, args) => {
+  try {
+    return execFileSync("git", ["-C", repoRoot, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+};
+
+/** The dev-metadata pointers a manifest change may touch without escalating. */
+const DEV_METADATA = [
+  /^\/devDependencies$/,
+  /^\/devDependencies\//,
+  /^\/name$/,
+  /^\/description$/,
+  /^\/license$/,
+  /^\/keywords$/,
+  /^\/keywords\//,
+  /^\/author$/,
+  /^\/author\//,
+  /^\/repository$/,
+  /^\/repository\//,
+  /^\/bugs$/,
+  /^\/bugs\//,
+  /^\/homepage$/,
+];
+
+/**
+ * The root `package.json` script names that count as TOOLING rather than as
+ * package scripts. A manifest whose only changes are these is safe to route to
+ * the tooling checks instead of the full workspace suite.
+ *
+ * Transcribed from the gate's own `case` list; `check-sentry-suites-in-ci-gate-probe.mjs`
+ * pins the closed verdict set this feeds.
+ */
+const TOOLING_SCRIPT_POINTERS = new Set(
+  [
+    "agent:quality-gate",
+    "agent:quality-gate:test",
+    "agent:prewarm",
+    "agent:prewarm:test",
+    "agent:review-materiality",
+    "agent:review-materiality:test",
+    "agent:context-check",
+    "agent:context-budget",
+    "agent:context-budget:test",
+    "docs:index",
+    "docs:index:test",
+    "docs:audit",
+    "docs:audit:test",
+    "docs:garden",
+    "docs:garden:test",
+    "docs:navigation-eval",
+    "docs:navigation-eval:test",
+    "agent:autoreview",
+    "issue:board",
+    "issue:board:test",
+    "issue:claim",
+    "issue:review",
+    "issue:release",
+    "sentry:ingest",
+    "sentry:ingest:test",
+    "sentry:digest",
+    "sentry:digest:test",
+    "sentry:project",
+    "sentry:project:test",
+    "sentry:brief",
+    "sentry:brief:test",
+    "sentry:autofix:select",
+    "sentry:autofix:select:test",
+    "sentry:autofix:finalize:test",
+    "sentry:autofix:run-record:test",
+    "sentry:archive",
+    "sentry:archive:test",
+    "sentry:broker:test",
+    "sentry:requeue:test",
+    "pr:feedback-state",
+    "pr:feedback-state:test",
+    "pr:ready-state",
+    "pr:ready-state:test",
+    "tf",
+    "tf:test",
+    "alerts:rules:lint",
+    "alerts:rules:lint:test",
+    "lockfile:lint",
+    "lockfile:lint:test",
+    "skew:check",
+    "skew:check:test",
+    "override:prune-report",
+    "override:prune-report:test",
+    "adr:check",
+    "adr:check:test",
+    "sanitize:test",
+  ].map((name) => `/scripts/${name}`),
+);
+
+const escapePointer = (part) => part.replace(/~/g, "~0").replace(/\//g, "~1");
+const isRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+/** JSON-pointer paths that differ between two parsed objects, sorted per key. */
+function jsonChangePaths(base, head) {
+  const changes = [];
+  const walk = (a, b, path) => {
+    if (Object.is(a, b)) return;
+    if (isRecord(a) && isRecord(b)) {
+      const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+      for (const key of keys)
+        walk(a[key], b[key], `${path}/${escapePointer(key)}`);
+      return;
+    }
+    if (JSON.stringify(a) !== JSON.stringify(b)) changes.push(path || "/");
+  };
+  walk(base, head, "");
+  return changes;
+}
+
+export class Facts {
+  constructor(options) {
+    this.repoRoot = options.repoRoot;
+    this.baseRef = options.baseRef;
+    this.headRef = options.headRef;
+    this.changedPathsFile = options.changedPathsFile;
+    this.fullLocalTests = options.fullLocalTests === true;
+    // The gate fences repository-specific routing behind this, so its own unit
+    // tests — which run against stub fixture repositories — do not inherit it.
+    this.isRealTree = options.isRealTree === true;
+    this.scriptSourceDir = options.scriptSourceDir;
+    this.#rootPackageJsonClass = null;
+  }
+
+  /** `git rev-parse` of the base ref, or the gate's sentinel when unresolvable. */
+  get baseOid() {
+    if (this.#baseOid === undefined) {
+      const resolved = git(this.repoRoot, [
+        "rev-parse",
+        "--verify",
+        `${this.baseRef}^{commit}`,
+      ]);
+      this.#baseOid =
+        resolved === null ? `__unresolved__:${this.baseRef}` : resolved.trim();
+    }
+    return this.#baseOid;
+  }
+  #baseOid;
+
+  pathExistsInWorktree(path) {
+    return existsSync(join(this.repoRoot, path));
+  }
+
+  /**
+   * Whether the path is a symlink in the working tree.
+   *
+   * `lstat`, not `stat`: the arm exists precisely because a link's own entry is
+   * what changed, and following it would answer about the target instead.
+   */
+  pathIsSymlink(path) {
+    try {
+      return lstatSync(join(this.repoRoot, path)).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Whether a path exists in the HEAD state: the working tree when head is
+   * HEAD (so uncommitted edits count), otherwise the ref via git.
+   */
+  pathExistsAtHead(path) {
+    if (this.headRef === "HEAD") return this.pathExistsInWorktree(path);
+    return (
+      git(this.repoRoot, ["cat-file", "-e", `${this.headRef}:${path}`]) !== null
+    );
+  }
+
+  /** Repo-relative resolved targets of every directory symlink under scripts/. */
+  get scriptsSymlinkTargets() {
+    if (this.#symlinkTargets === undefined) {
+      this.#symlinkTargets = [];
+      const scriptsDir = join(this.repoRoot, "scripts");
+      if (this.isRealTree && existsSync(scriptsDir)) {
+        const listed = git(this.repoRoot, ["ls-files", "-s", "scripts"]) ?? "";
+        const rootPhysical = realpathSync(this.repoRoot);
+        for (const line of listed.split("\n")) {
+          // Mode 120000 is a symlink in git's index.
+          if (!line.startsWith("120000")) continue;
+          const path = line.split("\t")[1];
+          if (path === undefined) continue;
+          const absolute = join(this.repoRoot, path);
+          try {
+            if (!statSync(absolute).isDirectory()) continue;
+            const target = realpathSync(absolute);
+            const rel = relative(rootPhysical, target);
+            if (rel === "" || rel.startsWith("..") || rel.startsWith(sep))
+              continue;
+            this.#symlinkTargets.push(rel.split(sep).join("/"));
+          } catch {
+            // A dangling or unreadable link exposes no suite tree.
+          }
+        }
+      }
+    }
+    return this.#symlinkTargets;
+  }
+  #symlinkTargets;
+
+  /** Registered Terraform stack paths, from the registry rather than from paths. */
+  get terraformStackPaths() {
+    if (this.#stackPaths === undefined) {
+      this.#stackPaths = [];
+      const registry = join(this.repoRoot, "terraform.stacks.json");
+      if (existsSync(registry)) {
+        try {
+          const parsed = JSON.parse(readFileSync(registry, "utf8"));
+          for (const stack of parsed.stacks ?? []) {
+            if (typeof stack.path === "string")
+              this.#stackPaths.push(stack.path);
+          }
+        } catch {
+          // An unreadable registry routes no stack-specific validation, which
+          // is what the gate does too — the unconditional `pnpm tf:test` sweep
+          // still runs.
+        }
+      }
+    }
+    return this.#stackPaths;
+  }
+  #stackPaths;
+
+  /**
+   * How the root `package.json` changed, as one of the four closed classes.
+   *
+   * Anything unreadable or unparseable is `workspace`, which is the widest
+   * answer — the full suite.
+   */
+  rootPackageJsonClass() {
+    if (this.#rootPackageJsonClass !== null) return this.#rootPackageJsonClass;
+    this.#rootPackageJsonClass = this.#classifyRootPackageJson();
+    return this.#rootPackageJsonClass;
+  }
+  #rootPackageJsonClass;
+
+  #classifyRootPackageJson() {
+    const baseText = git(this.repoRoot, [
+      "show",
+      `${this.baseRef}:package.json`,
+    ]);
+    if (baseText === null) return "workspace";
+
+    let headText;
+    if (this.headRef === "HEAD" && this.pathExistsInWorktree("package.json")) {
+      headText = readFileSync(join(this.repoRoot, "package.json"), "utf8");
+    } else {
+      headText = git(this.repoRoot, ["show", `${this.headRef}:package.json`]);
+      if (headText === null) return "workspace";
+    }
+
+    let changes;
+    try {
+      changes = jsonChangePaths(JSON.parse(baseText), JSON.parse(headText));
+    } catch {
+      return "workspace";
+    }
+    if (changes.length === 0) return "workspace";
+
+    let toolingScript = false;
+    let nonToolingScript = false;
+    let nonScript = false;
+    let devMetadata = false;
+    let nonDevMetadata = false;
+
+    for (const change of changes) {
+      if (TOOLING_SCRIPT_POINTERS.has(change)) {
+        toolingScript = true;
+      } else if (change === "/scripts" || change.startsWith("/scripts/")) {
+        nonToolingScript = true;
+      } else if (DEV_METADATA.some((pattern) => pattern.test(change))) {
+        nonScript = true;
+        devMetadata = true;
+      } else {
+        nonScript = true;
+        nonDevMetadata = true;
+      }
+    }
+
+    if (toolingScript && !nonToolingScript && !nonScript) {
+      return "root-tooling-scripts";
+    }
+    if (toolingScript || nonToolingScript) return "package-scripts";
+    if (devMetadata && !nonDevMetadata) return "workspace-dev-metadata";
+    return "workspace";
+  }
+}

--- a/scripts/gate/mapping/plan.mjs
+++ b/scripts/gate/mapping/plan.mjs
@@ -1,0 +1,143 @@
+/**
+ * The command plan the routing builds up: four ordered buckets, two ordered
+ * sets, and the global flags the routing mutates as it goes.
+ *
+ * This is the Node half of what `agent-quality-gate.sh` does with six bash
+ * arrays. Every rule here mirrors one the gate already has, and the ones that
+ * look arbitrary are the ones that matter:
+ *
+ *   - Dedupe is on the command STRING, and the FIRST reason registered wins.
+ *     `production-infra-identity-contract/routing.test.mjs` asserts on a reason
+ *     string, so "first wins" is a contract rather than an implementation
+ *     detail.
+ *   - Two command pairs share one dedupe KEY, so the pnpm alias and the direct
+ *     bash entry point never schedule the same suite twice.
+ *   - `prepend` puts a command at the HEAD of the quality bucket. Trunk uses it,
+ *     and it runs after everything else has been added, so the head is the only
+ *     position that makes it first.
+ *   - Buckets are emitted preflight → codegen → post-codegen → quality, which is
+ *     the order `write_command_plan` writes and the freshness stamp hashes.
+ */
+
+/**
+ * The two commands that are the same suite reached two ways.
+ *
+ * `add_command` deduplicates on this key, not on the raw string, so a change
+ * touching both the alias and the script schedules one run rather than two.
+ */
+const DEDUPE_ALIASES = new Map([
+  ["pnpm agent:quality-gate:test", "agent-quality-gate.test"],
+  ["bash scripts/agent-quality-gate.test.sh", "agent-quality-gate.test"],
+  ["pnpm agent:autoreview:test", "agent-autoreview.test"],
+  ["bash scripts/agent-autoreview.test.sh", "agent-autoreview.test"],
+]);
+
+/** The dedupe identity of a command string. */
+export const commandDedupeKey = (command) =>
+  DEDUPE_ALIASES.get(command) ?? command;
+
+/** The buckets, in the order the plan is written and hashed. */
+export const BUCKETS = Object.freeze([
+  "preflight",
+  "codegen",
+  "post-codegen",
+  "quality",
+]);
+
+export class Plan {
+  constructor() {
+    /** @type {Map<string, {command: string, reason: string}[]>} */
+    this.buckets = new Map(BUCKETS.map((bucket) => [bucket, []]));
+    /** @type {string[]} */
+    this.surfaces = [];
+    /** @type {{checklist: string, reason: string}[]} */
+    this.checklists = [];
+    // Set by any route that escalates to the whole workspace. It disables
+    // scoped tests for the entire run, so it is a property of the run rather
+    // than of the arm that set it.
+    this.sawWorkspaceEscalation = false;
+    // Packages whose coverage floor is standing in for a dependency-bump
+    // regression check; scoping must not narrow those.
+    this.lockfileScopedPackages = new Set();
+    this.packageScriptRiskChanged = false;
+  }
+
+  #has(bucket, command) {
+    const key = commandDedupeKey(command);
+    return this.buckets
+      .get(bucket)
+      .some((entry) => commandDedupeKey(entry.command) === key);
+  }
+
+  /** Append to a bucket unless an equivalent command is already there. */
+  add(bucket, command, reason) {
+    if (!this.buckets.has(bucket)) {
+      throw new Error(`unknown command bucket \`${bucket}\``);
+    }
+    if (this.#has(bucket, command)) return;
+    this.buckets.get(bucket).push({ command, reason });
+  }
+
+  addCommand(command, reason) {
+    this.add("quality", command, reason);
+  }
+
+  addPreflight(command, reason) {
+    this.add("preflight", command, reason);
+  }
+
+  addCodegen(command, reason) {
+    this.add("codegen", command, reason);
+  }
+
+  addPostCodegen(command, reason) {
+    this.add("post-codegen", command, reason);
+  }
+
+  /**
+   * Put a command at the head of the quality bucket.
+   *
+   * Trunk is prepended after every other command has been added, which is the
+   * only way it ends up first. Prepending something already present is a no-op
+   * rather than a move — the same as the gate's `prepend_command`.
+   */
+  prependCommand(command, reason) {
+    if (this.#has("quality", command)) return;
+    this.buckets.get("quality").unshift({ command, reason });
+  }
+
+  addSurface(surface) {
+    if (!this.surfaces.includes(surface)) this.surfaces.push(surface);
+  }
+
+  /** Checklists deduplicate on the path alone; the first reason wins. */
+  addChecklist(checklist, reason) {
+    if (this.checklists.some((entry) => entry.checklist === checklist)) return;
+    this.checklists.push({ checklist, reason });
+  }
+
+  markLockfileScopedPackage(packageName) {
+    this.lockfileScopedPackages.add(packageName);
+  }
+
+  isLockfileScopedPackage(packageName) {
+    return this.lockfileScopedPackages.has(packageName);
+  }
+
+  /** The quality bucket, for the post-passes that rewrite it in place. */
+  get quality() {
+    return this.buckets.get("quality");
+  }
+
+  set quality(entries) {
+    this.buckets.set("quality", entries);
+  }
+
+  get codegen() {
+    return this.buckets.get("codegen");
+  }
+
+  set codegen(entries) {
+    this.buckets.set("codegen", entries);
+  }
+}

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -1,0 +1,272 @@
+/**
+ * The four whole-set passes that run AFTER every changed path has been routed.
+ *
+ * They are separate from the verbs because they cannot be decided per path:
+ * each reads the complete changed set or the complete command list. Their order
+ * is fixed and is itself contract — Trunk is prepended first so it lands at the
+ * head, codegen is sorted before the plan is written, Turbo compaction rewrites
+ * the quality bucket, and scoped tests rewrite it again afterwards using the
+ * final escalation flag.
+ *
+ *   addTrunkCheckCommand → sortCodegenCommands → compactTurbo → applyScopedTests
+ */
+
+import { shellQuote } from "./shell-quote.mjs";
+
+// ── 1. Trunk ───────────────────────────────────────────────────────────────
+
+/**
+ * Patterns that force a full-repo Trunk scan. A changed path that no longer
+ * exists forces one too: a targeted invocation naming a deleted file fails, so
+ * the whole-repo scan is the fail-safe answer.
+ */
+const TRUNK_FULL_SCAN = [
+  /^\.trunk\//,
+  /^tools\/trunk$/,
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^pnpm-workspace\.yaml$/,
+  /^patches\//,
+  /^\.npmrc$/,
+  /\/\.npmrc$/,
+  /^pnpmfile\.cjs$/,
+  /^\.pnpmfile\.cjs$/,
+  /^\.node-version$/,
+  /\/package\.json$/,
+];
+
+export function addTrunkCheckCommand(plan, changedPaths, facts) {
+  const missing = changedPaths.some(
+    (path) => !facts.pathExistsInWorktree(path),
+  );
+  const forcesFull =
+    missing ||
+    changedPaths.some((path) => TRUNK_FULL_SCAN.some((r) => r.test(path)));
+
+  if (forcesFull) {
+    plan.prependCommand(
+      "./tools/trunk check --all",
+      "changed paths require full-repo Trunk checks",
+    );
+  } else if (changedPaths.length > 0) {
+    plan.prependCommand(
+      `./tools/trunk check ${changedPaths.map(shellQuote).join(" ")}`,
+      "changed existing paths should pass targeted Trunk checks",
+    );
+  } else {
+    plan.prependCommand(
+      "./tools/trunk check --all",
+      "changed paths could not be mapped to targeted Trunk checks",
+    );
+  }
+
+  // A .shellcheckrc edit only lints itself under a targeted run, so force a
+  // repo-wide ShellCheck-only pass. Prepended after the scan above, so it ends
+  // up ahead of it.
+  if (changedPaths.includes(".shellcheckrc")) {
+    plan.prependCommand(
+      "./tools/trunk check --all --filter=shellcheck",
+      "ShellCheck config changed; re-validate every script it governs",
+    );
+  }
+}
+
+// ── 2. Codegen order ───────────────────────────────────────────────────────
+
+/**
+ * Every Envio codegen variant overwrites the same generated package, so when
+ * several are scheduled mainnet must run LAST — the package checks that follow
+ * validate the normally-linked package. Known commands come first in this
+ * order; anything unrecognised keeps its relative position after them.
+ */
+const KNOWN_CODEGEN_ORDER = [
+  "pnpm dashboard:codegen",
+  "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen",
+  "pnpm --filter @mento-protocol/indexer-envio indexer:reserve-yield:test",
+  "pnpm indexer:testnet:codegen",
+  "pnpm indexer:codegen",
+];
+
+export function sortCodegenCommands(plan) {
+  const entries = plan.codegen;
+  const sorted = [];
+  for (const known of KNOWN_CODEGEN_ORDER) {
+    const found = entries.find((entry) => entry.command === known);
+    if (found !== undefined) sorted.push(found);
+  }
+  for (const entry of entries) {
+    if (!KNOWN_CODEGEN_ORDER.includes(entry.command)) sorted.push(entry);
+  }
+  plan.codegen = sorted;
+}
+
+// ── 3. Turbo compaction ────────────────────────────────────────────────────
+
+const TURBO_COMMAND =
+  /^pnpm exec turbo run (\S+) --filter=(@mento-protocol\/\S+) --cache=local:rw$/;
+
+/**
+ * Coalesce same-task Turbo invocations into one command with several filters.
+ *
+ * The compacted command takes the POSITION of the first invocation of that
+ * task, and its reason is the `; `-joined list of the distinct reasons that
+ * contributed, in first-seen order. Both are what the gate produces and what
+ * the suite asserts on.
+ */
+export function compactTurboQualityCommands(plan) {
+  /** @type {Map<string, {packages: string[], reasons: string[]}>} */
+  const groups = new Map();
+  const slots = [];
+
+  for (const entry of plan.quality) {
+    const match = TURBO_COMMAND.exec(entry.command);
+    if (match === null) {
+      slots.push({ kind: "plain", entry });
+      continue;
+    }
+    const [, task, packageName] = match;
+    if (groups.has(task)) {
+      const group = groups.get(task);
+      if (!group.packages.includes(packageName))
+        group.packages.push(packageName);
+      if (!group.reasons.includes(entry.reason))
+        group.reasons.push(entry.reason);
+      continue;
+    }
+    groups.set(task, { packages: [packageName], reasons: [entry.reason] });
+    slots.push({ kind: "turbo", task });
+  }
+
+  plan.quality = slots.map((slot) => {
+    if (slot.kind === "plain") return slot.entry;
+    const group = groups.get(slot.task);
+    const filters = group.packages.map((name) => ` --filter=${name}`).join("");
+    return {
+      command: `pnpm exec turbo run ${slot.task}${filters} --cache=local:rw`,
+      reason: group.reasons.join("; "),
+    };
+  });
+}
+
+// ── 4. Scoped tests ────────────────────────────────────────────────────────
+
+/** Package → importer directory. An unmapped package can never be scoped. */
+const SCOPED_PACKAGE_DIR = new Map([
+  ["@mento-protocol/ui-dashboard", "ui-dashboard"],
+  ["@mento-protocol/indexer-envio", "indexer-envio"],
+  ["@mento-protocol/metrics-bridge", "metrics-bridge"],
+  ["@mento-protocol/integration-probes", "integration-probes"],
+  ["@mento-protocol/governance-watchdog", "governance-watchdog"],
+  [
+    "@mento-protocol/alerts-onchain-event-handler",
+    "alerts/infra/onchain-event-handler",
+  ],
+  ["@mento-protocol/alerts-oncall-announcer", "alerts/infra/oncall-announcer"],
+]);
+
+/**
+ * True when a package-relative path is NOT production source.
+ *
+ * Every ambiguity answers "not source", which disqualifies the package and
+ * leaves its full coverage floor in place. `vitest related` follows the import
+ * graph, so anything a test might read through the filesystem instead — YAML,
+ * JSON, CSS, assets — has to fail toward the full suite.
+ */
+export function scopedIsNonSourcePath(path) {
+  const patterns = [
+    /\.test\./,
+    /\.spec\./,
+    /^__tests__\//,
+    /\/__tests__\//,
+    /^tests?\//,
+    /\/tests?\//,
+    /^vitest\.config\./,
+    /\/vitest\.config\./,
+    /^vitest\..*\.config\./,
+    /\/vitest\..*\.config\./,
+    /^vitest\.hermetic-setup\.ts$/,
+    /\/vitest\.hermetic-setup\.ts$/,
+    /^tsconfig/,
+    /\/tsconfig/,
+    /^package\.json$/,
+    /\/package\.json$/,
+    /\.graphql$/,
+    /^__generated__\//,
+    /\/__generated__\//,
+    /^generated\//,
+    /\/generated\//,
+    /\.gen\.ts$/,
+    /^fixtures\//,
+    /\/fixtures\//,
+    /^__fixtures__\//,
+    /\/__fixtures__\//,
+  ];
+  if (patterns.some((pattern) => pattern.test(path))) return true;
+  return !/\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(path);
+}
+
+/**
+ * True when any changed path anywhere disables scoping for the whole run.
+ *
+ * Test infrastructure changes which tests run for unrelated source, and
+ * `shared-config/**` can regress any consumer through the dependency graph that
+ * `vitest related` does not follow from the changed file.
+ */
+export function scopedTestInfraChanged(changedPaths) {
+  const patterns = [
+    /^scripts\/envio-schema-stubs\.graphql$/,
+    /^shared-config\//,
+    /^vitest\.hermetic-setup\.ts$/,
+    /\/vitest\.hermetic-setup\.ts$/,
+    /^vitest\.config\./,
+    /\/vitest\.config\./,
+    /^vitest\..*\.config\./,
+    /\/vitest\..*\.config\./,
+    /\/tests?\/setup\//,
+  ];
+  return changedPaths.some((path) => patterns.some((r) => r.test(path)));
+}
+
+const SCOPED_TARGET =
+  /^pnpm --filter (@mento-protocol\/[a-z-]+) test:coverage$/;
+
+export function applyScopedTestCommands(plan, changedPaths, facts) {
+  if (facts.fullLocalTests) return;
+  if (plan.sawWorkspaceEscalation) return;
+  if (changedPaths.length > 15) return;
+  if (scopedTestInfraChanged(changedPaths)) return;
+
+  plan.quality = plan.quality.map((entry) => {
+    const match = SCOPED_TARGET.exec(entry.command);
+    if (match === null) return entry;
+    const packageName = match[1];
+
+    // shared-config's blast radius is the reason it keeps its full suite.
+    if (packageName === "@mento-protocol/config") return entry;
+    // A lockfile importer bump means the coverage floor is standing in for the
+    // dependency-bump regression check; an unrelated small edit must not narrow
+    // it to that edit's related tests.
+    if (plan.isLockfileScopedPackage(packageName)) return entry;
+
+    const packageDir = SCOPED_PACKAGE_DIR.get(packageName);
+    if (packageDir === undefined) return entry;
+
+    const files = [];
+    for (const path of changedPaths) {
+      if (!path.startsWith(`${packageDir}/`)) continue;
+      const relative = path.slice(packageDir.length + 1);
+      if (scopedIsNonSourcePath(relative)) return entry;
+      // A deleted path, or the old side of a rename, makes `vitest related`
+      // find zero tests silently — which would skip the coverage floor rather
+      // than fail toward it.
+      if (!facts.pathExistsAtHead(path)) return entry;
+      files.push(relative);
+    }
+    if (files.length === 0) return entry;
+
+    return {
+      command: `pnpm --filter ${packageName} exec vitest related --run ${files.map(shellQuote).join(" ")}`,
+      reason: `${entry.reason} (scoped-tests)`,
+    };
+  });
+}

--- a/scripts/gate/mapping/route.mjs
+++ b/scripts/gate/mapping/route.mjs
@@ -1,0 +1,236 @@
+/**
+ * Walk the routing table over a changed-path set and build the command plan.
+ *
+ * This is the control flow the gate's thirteen `case` statements express, run
+ * as data instead. The rules it has to keep are the ones D5a's table made
+ * explicit and the equality test pins:
+ *
+ *   - Every GROUP runs for every path. Groups do not shadow one another.
+ *   - Within a group the FIRST matching arm wins and no later arm in that group
+ *     runs. That is why arm order is routing.
+ *   - A `realTreeOnly` group is skipped entirely against a stub fixture
+ *     repository, because those repositories own neither the suites nor the
+ *     symlinks it enumerates.
+ *   - A `dynamic` group's patterns are built from an engine-computed set, and
+ *     its arm carries `stop: true` so it fires once per path rather than once
+ *     per member.
+ *
+ * An unknown verb, guard, dispatch subject or dynamic source THROWS. The caller
+ * turns that into a refusal, because a mapper that skipped what it did not
+ * understand would emit a smaller plan and the gate would run fewer checks and
+ * still exit 0.
+ */
+
+import { PATH_TOKEN } from "../routing-table/gate-arms.mjs";
+import { casePatternToRegExp } from "../routing-table/pattern.mjs";
+import { shellQuote } from "./shell-quote.mjs";
+import * as verbs from "./verbs.mjs";
+
+/** Verb name → implementation. Every name the table may hold appears here. */
+const VERBS = {
+  add_command: (plan, args) => plan.addCommand(args[0], args[1]),
+  add_preflight_command: (plan, args) => plan.addPreflight(args[0], args[1]),
+  add_surface: (plan, args) => plan.addSurface(args[0]),
+  add_checklist: (plan, args) => plan.addChecklist(args[0], args[1]),
+  add_adr_reminder: (plan, args, facts) =>
+    verbs.addAdrReminder(plan, args[0], facts),
+  add_turbo_package_task: (plan, args) =>
+    plan.addCommand(verbs.turboLocalCacheCommand(args[0], args[1]), args[2]),
+  add_package_quality_commands: (plan, args) =>
+    verbs.addPackageQualityCommands(plan, args[0], args[1]),
+  add_package_vitest_typecheck_commands: (plan, args) =>
+    verbs.addPackageVitestTypecheckCommands(plan, args[0], args[1]),
+  add_workspace_quality_commands: (plan, args) =>
+    verbs.addWorkspaceQualityCommands(plan, args[0]),
+  add_dashboard_quality_commands: (plan, args) =>
+    verbs.addDashboardQualityCommands(plan, args[0]),
+  add_aegis_quality_commands: (plan, args) =>
+    verbs.addAegisQualityCommands(plan, args[0]),
+  add_alerts_oncall_quality_commands: (plan, args) =>
+    verbs.addAlertsOncallQualityCommands(plan, args[0]),
+  add_root_tooling_package_script_checks: (plan, args) =>
+    verbs.addRootToolingPackageScriptChecks(plan, args[0]),
+  add_terraform_validate_commands: (plan, args) =>
+    verbs.addTerraformValidateCommands(plan, args[0], args[1]),
+  add_registered_terraform_validate_commands: (plan, args, facts) =>
+    verbs.addRegisteredTerraformValidateCommands(plan, args[0], facts),
+  add_sentry_suite_gate_commands: (plan, args) =>
+    verbs.addSentrySuiteGateCommands(plan, args[0]),
+  add_ui_react_doctor_diff: (plan, args, facts) =>
+    verbs.addUiReactDoctorDiff(plan, args[0], facts),
+  add_ui_react_doctor_full_score: (plan, args) =>
+    verbs.addUiReactDoctorFullScore(plan, args[0]),
+  add_ui_mutation_baseline: (plan, args) =>
+    verbs.addUiMutationBaseline(plan, args[0]),
+  add_ui_size_limit: (plan, args) => verbs.addUiSizeLimit(plan, args[0]),
+  add_bridge_mutation_baseline: (plan, args) =>
+    verbs.addBridgeMutationBaseline(plan, args[0]),
+  add_indexer_mutation_baseline: (plan, args) =>
+    verbs.addIndexerMutationBaseline(plan, args[0]),
+  add_dashboard_codegen: (plan, args) =>
+    verbs.addDashboardCodegen(plan, args[0]),
+  add_all_indexer_codegen: (plan, args) =>
+    verbs.addAllIndexerCodegen(plan, args[0]),
+  add_indexer_mainnet_codegen: (plan, args) =>
+    verbs.addIndexerMainnetCodegen(plan, args[0]),
+  add_indexer_testnet_codegen: (plan, args) =>
+    verbs.addIndexerTestnetCodegen(plan, args[0]),
+  add_bridge_codegen_then_restore_mainnet: (plan, args) =>
+    verbs.addBridgeCodegenThenRestoreMainnet(plan, args[0]),
+  add_reserve_yield_codegen_then_restore_mainnet: (plan, args) =>
+    verbs.addReserveYieldCodegenThenRestoreMainnet(plan, args[0]),
+  route_lockfile_change: (plan, args, facts, context) =>
+    context.routeLockfileChange(plan, facts),
+};
+
+/** Compiled patterns are reused across the whole run; there are ~470 of them. */
+const compiled = new Map();
+const matches = (pattern, path) => {
+  if (!compiled.has(pattern))
+    compiled.set(pattern, casePatternToRegExp(pattern));
+  return compiled.get(pattern).test(path);
+};
+
+const substitute = (pattern, value) =>
+  pattern.replace(/\$\{[a-z_][a-z_0-9]*\}/, value);
+
+function evaluateGuard(guard, path, facts) {
+  if (guard === "pathIsFile") return facts.pathExistsInWorktree(path);
+  if (guard === "pathIsSymlink") return facts.pathIsSymlink(path);
+  if (guard === "realTreeOnly") return facts.isRealTree;
+  if (guard === "nonEmpty") return facts.terraformStackPaths.length > 0;
+  if (guard !== null && typeof guard === "object" && "pathEquals" in guard) {
+    return path === guard.pathEquals;
+  }
+  throw new Error(`unknown routing guard ${JSON.stringify(guard)}`);
+}
+
+/** Apply one arm's effects. Returns true when the arm asked routing to stop. */
+function applyEffects(effects, plan, path, facts, context) {
+  for (const effect of effects) {
+    if (effect.kind === "break") return true;
+
+    if (effect.kind === "set") {
+      if (effect.name === "package_script_risk_changed") {
+        plan.packageScriptRiskChanged = true;
+      } else if (effect.name === "root_package_json_class") {
+        // Reading it is what memoizes it; the dispatch below consults the same
+        // cached answer.
+        facts.rootPackageJsonClass();
+      } else {
+        throw new Error(`unknown assignment \`${effect.name}\``);
+      }
+      continue;
+    }
+
+    if (effect.kind === "when") {
+      if (evaluateGuard(effect.guard, path, facts)) {
+        if (applyEffects(effect.effects, plan, path, facts, context))
+          return true;
+      }
+      continue;
+    }
+
+    if (effect.kind === "dispatch") {
+      const subject =
+        effect.subject === "path" ? path : facts.rootPackageJsonClass();
+      if (
+        effect.subject !== "path" &&
+        effect.subject !== "root_package_json_class"
+      ) {
+        throw new Error(`unknown dispatch subject \`${effect.subject}\``);
+      }
+      for (const arm of effect.arms) {
+        if (!arm.patterns.some((pattern) => matches(pattern, subject)))
+          continue;
+        if (applyEffects(arm.effects, plan, path, facts, context)) return true;
+        break; // first match wins
+      }
+      continue;
+    }
+
+    if (effect.kind !== "call") {
+      throw new Error(`unknown routing effect kind \`${effect.kind}\``);
+    }
+    const implementation = VERBS[effect.verb];
+    if (implementation === undefined) {
+      throw new Error(`no implementation for routing verb \`${effect.verb}\``);
+    }
+    // The changed path reaches a templated command through this one token, and
+    // it arrives `printf %q`-quoted because that is what `quote_path` does.
+    // The arms that carry it are guarded on the file existing.
+    const args = effect.args.map((argument) =>
+      argument.includes(PATH_TOKEN)
+        ? argument.split(PATH_TOKEN).join(shellQuote(path))
+        : argument,
+    );
+    implementation(plan, args, facts, context);
+  }
+  return false;
+}
+
+/** Route one changed path through every group, in order. */
+function routePath(groups, plan, path, facts, context) {
+  for (const group of groups) {
+    if (group.realTreeOnly && !facts.isRealTree) continue;
+
+    if (group.dynamic !== null) {
+      const members =
+        group.dynamic === "scriptsSymlinkTargets"
+          ? facts.scriptsSymlinkTargets
+          : group.dynamic === "registeredTerraformStacks"
+            ? facts.terraformStackPaths
+            : null;
+      if (members === null) {
+        throw new Error(`unknown dynamic pattern source \`${group.dynamic}\``);
+      }
+      if (group.requiresNonEmpty && members.length === 0) continue;
+      // One arm, one substitution per member, stopping at the first hit —
+      // the `break` inside the gate's `for` loop.
+      for (const member of members) {
+        let stopped = false;
+        for (const arm of group.arms) {
+          const armMatches = arm.patterns.some((pattern) =>
+            matches(substitute(pattern, member), path),
+          );
+          if (!armMatches) continue;
+          stopped = applyEffects(
+            arm.effects.map((effect) => substituteArgs(effect, member)),
+            plan,
+            path,
+            facts,
+            context,
+          );
+          break;
+        }
+        if (stopped) break;
+      }
+      continue;
+    }
+
+    for (const arm of group.arms) {
+      if (!arm.patterns.some((pattern) => matches(pattern, path))) continue;
+      applyEffects(arm.effects, plan, path, facts, context);
+      break; // first match wins
+    }
+  }
+}
+
+/** Replace a dynamic group's placeholder inside effect arguments. */
+function substituteArgs(effect, member) {
+  if (effect.kind !== "call") return effect;
+  return {
+    ...effect,
+    args: effect.args.map((argument) =>
+      /^\$\{[a-z_][a-z_0-9]*\}$/.test(argument) ? member : argument,
+    ),
+  };
+}
+
+export function routeChangedPaths(groups, changedPaths, facts, context) {
+  const plan = context.plan;
+  for (const path of changedPaths) {
+    routePath(groups, plan, path, facts, context);
+  }
+  return plan;
+}

--- a/scripts/gate/mapping/route.mjs
+++ b/scripts/gate/mapping/route.mjs
@@ -95,7 +95,10 @@ const substitute = (pattern, value) =>
   pattern.replace(/\$\{[a-z_][a-z_0-9]*\}/, value);
 
 function evaluateGuard(guard, path, facts) {
-  if (guard === "pathIsFile") return facts.pathExistsInWorktree(path);
+  // `[[ -f ]]`, not `[[ -e ]]`: a directory, a symlink to a directory and a
+  // gitlink all exist without being regular files, and the gate does not
+  // schedule `bash -n` or `node --check` against any of them.
+  if (guard === "pathIsFile") return facts.pathIsFile(path);
   if (guard === "pathIsSymlink") return facts.pathIsSymlink(path);
   if (guard === "realTreeOnly") return facts.isRealTree;
   if (guard === "nonEmpty") return facts.terraformStackPaths.length > 0;

--- a/scripts/gate/mapping/shell-quote.mjs
+++ b/scripts/gate/mapping/shell-quote.mjs
@@ -16,7 +16,7 @@
  *   unescaped   A-Z a-z 0-9 and . / - _ # ~ = : @ % +   (and any byte >= 0x80)
  *   escaped     space ' " $ * [ ] ( ) & ; | \ ! , ^ { } < > ?
  *   empty       ''
- *   control     ANSI-C form, e.g. a newline gives $'a\nb'
+ *   control     ANSI-C form, e.g. a newline gives $'a\nb' and ESC gives $'a\Eb'
  *
  * `#` and `~` are NOT escaped mid-string, which is the detail a hand-written
  * "escape anything unusual" implementation gets wrong; `,` and `^` ARE, which
@@ -50,7 +50,15 @@ const tildeIsAmbiguous = (value, index) =>
   value[index] === "~" &&
   (index === 0 || value[index - 1] === "=" || value[index - 1] === ":");
 
-/** The ANSI-C escapes bash emits inside `$'…'`. */
+/**
+ * The ANSI-C escapes bash emits inside `$'…'`.
+ *
+ * ESC is the one that is not guessable from the C escape table: bash's
+ * `ansic_quote` carries `case ESC: c = 'E'`, so 0x1b comes back as `\E` rather
+ * than as the octal `\033` every other unnamed control character gets.
+ * Measured on 3.2.57 and 5.3.15 — both agree. A byte >= 0x80 is NOT octal-
+ * escaped in this mode; it passes through, also measured on both.
+ */
 const ANSI_C = new Map([
   ["\x07", "\\a"],
   ["\b", "\\b"],
@@ -59,6 +67,7 @@ const ANSI_C = new Map([
   ["\r", "\\r"],
   ["\t", "\\t"],
   ["\v", "\\v"],
+  ["\x1b", "\\E"],
   ["\\", "\\\\"],
   ["'", "\\'"],
 ]);

--- a/scripts/gate/mapping/shell-quote.mjs
+++ b/scripts/gate/mapping/shell-quote.mjs
@@ -10,7 +10,8 @@
  * a plan whose stamp never matches and whose parity run reds.
  *
  * MEASURED, not inferred, on `/bin/bash` 3.2.57 and `/opt/homebrew/bin/bash`
- * 5.3.15 — both agree exactly:
+ * 5.3.15 over every printable ASCII character in seven positions — alone, at
+ * the start, at the end, mid-word, and after `=`, `:` and `/`:
  *
  *   unescaped   A-Z a-z 0-9 and . / - _ # ~ = : @ % +   (and any byte >= 0x80)
  *   escaped     space ' " $ * [ ] ( ) & ; | \ ! , ^ { } < > ?
@@ -20,11 +21,34 @@
  * `#` and `~` are NOT escaped mid-string, which is the detail a hand-written
  * "escape anything unusual" implementation gets wrong; `,` and `^` ARE, which
  * is the detail a "shell metacharacters only" implementation gets wrong.
+ *
+ * TWO CHARACTERS DEPEND ON POSITION, and the measurement is the only way to
+ * know it:
+ *
+ *   - A LEADING `#` is escaped by both builds — `#file` gives `\#file`. It has
+ *     to be: an unescaped `#` opening a word comments out the rest of the
+ *     command.
+ *   - A `~` where a tilde expansion could START — index 0, or straight after
+ *     `=` or `:` — is escaped by 5.3.15 and left alone by 3.2.57. The two
+ *     builds DISAGREE, so there is no single string to emit, and `shellQuote`
+ *     refuses rather than guessing. See the refusal below.
+ *
  * `shell-quote.test.mjs` asks bash itself rather than trusting this comment.
  */
 
 /** Characters bash leaves alone inside `%q`. */
 const SAFE = /[A-Za-z0-9._/\-#~=:@%+]/;
+
+/**
+ * True where a `~` could begin a tilde expansion, and the supported bash
+ * builds therefore answer differently.
+ *
+ * Measured: `~`, `~x`, `a=~b` and `a:~b` are escaped by 5.3.15 and untouched by
+ * 3.2.57, while `a~b`, `x~` and `a/~b` are untouched by both.
+ */
+const tildeIsAmbiguous = (value, index) =>
+  value[index] === "~" &&
+  (index === 0 || value[index - 1] === "=" || value[index - 1] === ":");
 
 /** The ANSI-C escapes bash emits inside `$'…'`. */
 const ANSI_C = new Map([
@@ -53,6 +77,19 @@ const isControl = (character) => {
 export function shellQuote(value) {
   if (value === "") return "''";
 
+  // REFUSE rather than pick a side. The gate's own quoting is whatever bash is
+  // running it, so a guess here is a command string that matches the gate on
+  // one machine and not on another — a plan whose freshness stamp never lands
+  // and whose parity is a coin flip. No path in this repository holds one.
+  for (let index = 0; index < value.length; index += 1) {
+    if (!tildeIsAmbiguous(value, index)) continue;
+    const error = new Error(
+      `cannot reproduce printf %q for ${JSON.stringify(value)}: bash 3.2 leaves a leading-position \`~\` alone and bash 5.3 escapes it, so the quoted form depends on which bash runs the gate`,
+    );
+    error.exitCode = 2;
+    throw error;
+  }
+
   // A control character forces the whole word into ANSI-C quoting; bash does
   // not mix the two forms.
   if ([...value].some(isControl)) {
@@ -70,10 +107,14 @@ export function shellQuote(value) {
   }
 
   let quoted = "";
+  let first = true;
   for (const character of value) {
     // Anything outside ASCII is passed through, matching both measured builds.
-    const passthrough = SAFE.test(character) || character.codePointAt(0) > 0x7f;
+    const safe = SAFE.test(character) || character.codePointAt(0) > 0x7f;
+    // A `#` opening the word is the one SAFE character that is not safe there.
+    const passthrough = safe && !(first && character === "#");
     quoted += passthrough ? character : `\\${character}`;
+    first = false;
   }
   return quoted;
 }

--- a/scripts/gate/mapping/shell-quote.mjs
+++ b/scripts/gate/mapping/shell-quote.mjs
@@ -1,0 +1,79 @@
+/**
+ * Bash's `printf %q`, reproduced.
+ *
+ * Several routed commands interpolate a changed path — `bash -n {path}`,
+ * `node --check {path}`, the targeted Trunk invocation, the ADR reminder's
+ * `--changed-paths-file` — and the gate builds every one of them through
+ * `quote_path`, which is `printf %q`. The command string is what the freshness
+ * stamp hashes and what the self-test asserts on, so "close enough" quoting is
+ * a different command: a plan that differs from the gate's by one backslash is
+ * a plan whose stamp never matches and whose parity run reds.
+ *
+ * MEASURED, not inferred, on `/bin/bash` 3.2.57 and `/opt/homebrew/bin/bash`
+ * 5.3.15 — both agree exactly:
+ *
+ *   unescaped   A-Z a-z 0-9 and . / - _ # ~ = : @ % +   (and any byte >= 0x80)
+ *   escaped     space ' " $ * [ ] ( ) & ; | \ ! , ^ { } < > ?
+ *   empty       ''
+ *   control     ANSI-C form, e.g. a newline gives $'a\nb'
+ *
+ * `#` and `~` are NOT escaped mid-string, which is the detail a hand-written
+ * "escape anything unusual" implementation gets wrong; `,` and `^` ARE, which
+ * is the detail a "shell metacharacters only" implementation gets wrong.
+ * `shell-quote.test.mjs` asks bash itself rather than trusting this comment.
+ */
+
+/** Characters bash leaves alone inside `%q`. */
+const SAFE = /[A-Za-z0-9._/\-#~=:@%+]/;
+
+/** The ANSI-C escapes bash emits inside `$'…'`. */
+const ANSI_C = new Map([
+  ["\x07", "\\a"],
+  ["\b", "\\b"],
+  ["\f", "\\f"],
+  ["\n", "\\n"],
+  ["\r", "\\r"],
+  ["\t", "\\t"],
+  ["\v", "\\v"],
+  ["\\", "\\\\"],
+  ["'", "\\'"],
+]);
+
+const isControl = (character) => {
+  const code = character.codePointAt(0);
+  return code < 0x20 || code === 0x7f;
+};
+
+/**
+ * Quote one string the way `printf %q` would.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function shellQuote(value) {
+  if (value === "") return "''";
+
+  // A control character forces the whole word into ANSI-C quoting; bash does
+  // not mix the two forms.
+  if ([...value].some(isControl)) {
+    let body = "";
+    for (const character of value) {
+      if (ANSI_C.has(character)) {
+        body += ANSI_C.get(character);
+      } else if (isControl(character)) {
+        body += `\\${character.codePointAt(0).toString(8).padStart(3, "0")}`;
+      } else {
+        body += character;
+      }
+    }
+    return `$'${body}'`;
+  }
+
+  let quoted = "";
+  for (const character of value) {
+    // Anything outside ASCII is passed through, matching both measured builds.
+    const passthrough = SAFE.test(character) || character.codePointAt(0) > 0x7f;
+    quoted += passthrough ? character : `\\${character}`;
+  }
+  return quoted;
+}

--- a/scripts/gate/mapping/shell-quote.test.mjs
+++ b/scripts/gate/mapping/shell-quote.test.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * `shellQuote` against bash itself.
+ *
+ * It reimplements `printf %q`, which several routed commands depend on, and the
+ * command string is what the freshness stamp hashes — so a single wrong
+ * backslash is a plan that never matches the gate's. The rules are not
+ * guessable (`#` and `~` are left alone mid-string, `,` and `^` are not), so
+ * this asks the shell rather than asserting a table of remembered answers.
+ *
+ * Every installed bash is driven, because 3.2 is what the pre-push hook runs on
+ * a Mac and 5.x is what a developer's PATH usually has.
+ *
+ * Run: node --test scripts/gate/mapping/shell-quote.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+import { shellQuote } from "./shell-quote.mjs";
+
+/** Every distinct bash on this machine, by resolved path. */
+function bashInterpreters() {
+  const resolved = new Map();
+  for (const candidate of [
+    "/bin/bash",
+    "bash",
+    "/opt/homebrew/bin/bash",
+    "/usr/local/bin/bash",
+  ]) {
+    const found = spawnSync(
+      candidate,
+      ["-c", 'printf "%s %s" "$BASH" "$BASH_VERSION"'],
+      {
+        encoding: "utf8",
+        env: { PATH: process.env.PATH ?? "" },
+        timeout: 30_000,
+      },
+    );
+    if (found.error || found.status !== 0) continue;
+    const [path, version] = found.stdout.trim().split(" ");
+    if (path?.startsWith("/") && !resolved.has(path))
+      resolved.set(path, version);
+  }
+  return resolved;
+}
+
+/**
+ * The subjects. Deliberately heavy on the characters where a hand-written
+ * implementation goes wrong, plus the ordinary repo paths that must come back
+ * untouched — if those were escaped, every command in the plan would differ.
+ */
+const SUBJECTS = [
+  "scripts/agent-quality-gate.sh",
+  "ui-dashboard/src/lib/__generated__/graphql.ts",
+  "docs/notes/a-b_c.1.md",
+  "alerts/infra/oncall-announcer/vitest.config.ts",
+  "a b",
+  "a'b",
+  'a"b',
+  "a$b",
+  "a*b",
+  "a[b]",
+  "a(b)",
+  "a&b",
+  "a;b",
+  "a|b",
+  "a\\b",
+  "a!b",
+  "a#b",
+  "a~b",
+  "a=b",
+  "a:b",
+  "a@b",
+  "a%b",
+  "a+b",
+  "a,b",
+  "a^b",
+  "a{b}",
+  "a<b>",
+  "a?b",
+  "a`b",
+  "",
+  "ui-dashboard/src/app/pool/[poolId]/page.tsx",
+  "weird name with spaces.ts",
+];
+
+const interpreters = bashInterpreters();
+
+test("at least one bash was found to check against", () => {
+  assert.ok(interpreters.size > 0, "no usable bash on this machine");
+});
+
+for (const [bash, version] of interpreters) {
+  test(`shellQuote matches printf %q on ${bash} (${version})`, () => {
+    // One spawn for the whole corpus: the subjects go in on stdin, one per
+    // line, and come back `%q`-quoted in the same order.
+    const script = `
+      while IFS= read -r line; do printf '%q\\n' "$line"; done
+    `;
+    const output = execFileSync(bash, ["-c", script], {
+      input: `${SUBJECTS.join("\n")}\n`,
+      encoding: "utf8",
+    });
+    const expected = output.split("\n").slice(0, SUBJECTS.length);
+
+    const disagreements = [];
+    SUBJECTS.forEach((subject, index) => {
+      const mine = shellQuote(subject);
+      if (mine !== expected[index]) {
+        disagreements.push(
+          `${JSON.stringify(subject)}: bash ${JSON.stringify(expected[index])}, shellQuote ${JSON.stringify(mine)}`,
+        );
+      }
+    });
+    assert.deepEqual(
+      disagreements,
+      [],
+      `shellQuote disagrees with ${bash}:\n  - ${disagreements.join("\n  - ")}`,
+    );
+  });
+}
+
+test("ordinary repository paths are returned untouched", () => {
+  // The case that matters most in practice: if these were escaped, every
+  // templated command in the plan would differ from the gate's.
+  for (const path of [
+    "scripts/agent-quality-gate.sh",
+    "docs/adr/0069-gate-routing-table-as-data.md",
+    "indexer-envio/src/EventHandlers.ts",
+  ]) {
+    assert.equal(shellQuote(path), path);
+  }
+});

--- a/scripts/gate/mapping/shell-quote.test.mjs
+++ b/scripts/gate/mapping/shell-quote.test.mjs
@@ -105,6 +105,23 @@ const SUBJECTS = [
   "",
   "ui-dashboard/src/app/pool/[poolId]/page.tsx",
   "weird name with spaces.ts",
+  // The ANSI-C branch. Without these the whole `$'…'` form was asserted by a
+  // header comment and nothing else — which is how `\E` stayed wrong: bash
+  // gives ESC its own escape, where every other unnamed control character
+  // becomes octal.
+  "a\tb",
+  "a\x1bb",
+  "\x1b",
+  "a\x7fb",
+  "a\x01b",
+  "a\nb",
+  "a\rb",
+  "a\x07b",
+  "a\vb",
+  // A control character next to a byte >= 0x80: the pass-through half of the
+  // same branch, which is only visible once the word is in ANSI-C form.
+  "a\x1bé",
+  "aéb",
 ];
 
 const interpreters = bashInterpreters();
@@ -115,15 +132,18 @@ test("at least one bash was found to check against", () => {
 
 for (const [bash, version] of interpreters) {
   test(`shellQuote matches printf %q on ${bash} (${version})`, () => {
-    // One spawn for the whole corpus: the subjects go in on stdin, one per
-    // line, and come back `%q`-quoted in the same order.
-    const script = `
-      while IFS= read -r line; do printf '%q\\n' "$line"; done
-    `;
-    const output = execFileSync(bash, ["-c", script], {
-      input: `${SUBJECTS.join("\n")}\n`,
-      encoding: "utf8",
-    });
+    // One spawn for the whole corpus, with the subjects as POSITIONAL
+    // ARGUMENTS rather than stdin lines. The line-oriented `read -r` form this
+    // replaces could not carry a tab, an ESC or a newline, so it silently
+    // excluded every subject that reaches the ANSI-C branch.
+    //
+    // Splitting the output on newlines stays safe: `%q` escapes control
+    // characters, so no quoted form can contain a raw newline.
+    const output = execFileSync(
+      bash,
+      ["-c", 'printf "%q\\n" "$@"', bash, ...SUBJECTS],
+      { encoding: "utf8" },
+    );
     const expected = output.split("\n").slice(0, SUBJECTS.length);
 
     const disagreements = [];

--- a/scripts/gate/mapping/shell-quote.test.mjs
+++ b/scripts/gate/mapping/shell-quote.test.mjs
@@ -50,8 +50,29 @@ function bashInterpreters() {
  * The subjects. Deliberately heavy on the characters where a hand-written
  * implementation goes wrong, plus the ordinary repo paths that must come back
  * untouched — if those were escaped, every command in the plan would differ.
+ *
+ * POSITION IS PART OF THE CORPUS. An earlier version tested `a#b` and `a~b`
+ * and nothing else, which says nothing about `#file` — where both builds
+ * escape and an unescaped `#` would comment out the rest of the command. Every
+ * position-sensitive character now appears leading, trailing and mid-word.
  */
 const SUBJECTS = [
+  "#",
+  "#file",
+  "#!/bin/sh",
+  "x#",
+  "a/#b",
+  "a=#b",
+  "a:#b",
+  "-file",
+  "+file",
+  "=file",
+  ":file",
+  "%file",
+  "@file",
+  ".file",
+  "x~",
+  "a/~b",
   "scripts/agent-quality-gate.sh",
   "ui-dashboard/src/lib/__generated__/graphql.ts",
   "docs/notes/a-b_c.1.md",
@@ -121,6 +142,48 @@ for (const [bash, version] of interpreters) {
     );
   });
 }
+
+/** The tilde positions where a tilde expansion could start. */
+const AMBIGUOUS_TILDES = ["~", "~file", "~/x", "a=~b", "a:~b"];
+
+test("a tilde that could start an expansion is refused, not guessed", () => {
+  for (const subject of AMBIGUOUS_TILDES) {
+    assert.throws(
+      () => shellQuote(subject),
+      /bash 3\.2 leaves a leading-position/,
+      `expected a refusal for ${JSON.stringify(subject)}`,
+    );
+  }
+  // The other positions are not ambiguous and must still round-trip.
+  assert.equal(shellQuote("a~b"), "a~b");
+  assert.equal(shellQuote("x~"), "x~");
+  assert.equal(shellQuote("a/~b"), "a/~b");
+});
+
+test("the refusal is justified: the installed bash builds disagree", (t) => {
+  // The control for the test above. If this machine has only one bash
+  // generation there is nothing to compare, and the refusal rests on the
+  // measurement recorded in shell-quote.mjs instead of on this run.
+  const answers = new Map();
+  for (const [bash, version] of interpreters) {
+    const quoted = execFileSync(bash, ["-c", `printf '%q' "$1"`, bash, "~x"], {
+      encoding: "utf8",
+    });
+    answers.set(`${bash} (${version})`, quoted);
+  }
+  const distinct = new Set(answers.values());
+  if (distinct.size < 2) {
+    t.skip(
+      `only one answer for "~x" on this machine: ${[...answers].map(([k, v]) => `${k} -> ${JSON.stringify(v)}`).join(", ")}`,
+    );
+    return;
+  }
+  assert.deepEqual(
+    [...distinct].sort(),
+    ["\\~x", "~x"],
+    "the disagreement is the measured one — 3.2 leaves it, 5.x escapes it",
+  );
+});
 
 test("ordinary repository paths are returned untouched", () => {
   // The case that matters most in practice: if these were escaped, every

--- a/scripts/gate/mapping/verbs.mjs
+++ b/scripts/gate/mapping/verbs.mjs
@@ -1,0 +1,353 @@
+/**
+ * The 29 effect verbs, as the gate defines them.
+ *
+ * Each function here is the Node twin of one `add_*` helper in
+ * `scripts/agent-quality-gate.sh`. The bodies are transcriptions, not
+ * re-designs: the command strings, their order, the reason suffixes in
+ * parentheses, and which bucket each lands in are all contract. The parity
+ * harness compares this engine's plan against the live gate's, so a paraphrase
+ * shows up as a difference rather than as a nicer implementation.
+ *
+ * Two things are easy to get wrong and are called out where they happen:
+ * several bundles schedule a CODEGEN preflight before their quality commands,
+ * and several append a parenthesised suffix to the caller's reason. Both are
+ * load-bearing — the suffix reaches `routing.test.mjs`, and the codegen order
+ * reaches `sort_codegen_commands`.
+ */
+
+import { shellQuote } from "./shell-quote.mjs";
+
+/** `pnpm exec turbo run <task> --filter=<pkg> --cache=local:rw` */
+export const turboLocalCacheCommand = (packageName, taskName) =>
+  `pnpm exec turbo run ${taskName} --filter=${packageName} --cache=local:rw`;
+
+const addTurboPackageTask = (plan, packageName, taskName, reason) => {
+  plan.addCommand(turboLocalCacheCommand(packageName, taskName), reason);
+};
+
+const addTurboDashboardTask = (plan, taskName, reason) => {
+  addTurboPackageTask(plan, "@mento-protocol/ui-dashboard", taskName, reason);
+};
+
+// ── codegen ────────────────────────────────────────────────────────────────
+
+const addIndexerPostCodegenInstall = (plan) => {
+  plan.addPostCodegen(
+    "pnpm install --frozen-lockfile",
+    "link generated package after indexer codegen",
+  );
+};
+
+const addDashboardCodegenCommitCheck = (plan) => {
+  // Built by string concatenation in the gate; reproduced byte for byte,
+  // including the escaped inner quotes, because this whole thing is one
+  // command string the stamp hashes.
+  const command =
+    'if [[ -n "$(git status --porcelain -- ui-dashboard/src/lib/__generated__/graphql.ts)" ]]; then' +
+    " git status --short -- ui-dashboard/src/lib/__generated__/graphql.ts;" +
+    ' echo "Generated dashboard GraphQL types are not committed. Run pnpm dashboard:codegen and commit the result." >&2;' +
+    " exit 1; fi";
+  plan.addPostCodegen(
+    command,
+    "verify dashboard GraphQL generated output is committed",
+  );
+};
+
+export const addDashboardCodegen = (plan, reason) => {
+  plan.addCodegen("pnpm dashboard:codegen", reason);
+  addDashboardCodegenCommitCheck(plan);
+};
+
+export const addIndexerMainnetCodegen = (plan, reason) => {
+  plan.addCodegen("pnpm indexer:codegen", reason);
+  addIndexerPostCodegenInstall(plan);
+};
+
+export const addIndexerTestnetCodegen = (plan, reason) => {
+  plan.addCodegen("pnpm indexer:testnet:codegen", reason);
+  addIndexerPostCodegenInstall(plan);
+};
+
+export const addIndexerBridgeCodegen = (plan, reason) => {
+  plan.addCodegen(
+    "pnpm --filter @mento-protocol/indexer-envio indexer:bridge-only:codegen",
+    reason,
+  );
+  addIndexerPostCodegenInstall(plan);
+};
+
+export const addAllIndexerCodegen = (plan, reason) => {
+  addIndexerBridgeCodegen(plan, reason);
+  addIndexerTestnetCodegen(plan, reason);
+  addIndexerMainnetCodegen(plan, reason);
+};
+
+export const addBridgeCodegenThenRestoreMainnet = (plan, bridgeReason) => {
+  addIndexerBridgeCodegen(plan, bridgeReason);
+  addIndexerMainnetCodegen(
+    plan,
+    "restore full multichain generated package after non-mainnet codegen",
+  );
+};
+
+export const addReserveYieldCodegenThenRestoreMainnet = (plan, reason) => {
+  // Despite the name, this schedules no mainnet restore — the gate's own body
+  // does not either. Transcribed as it is, not as the name suggests.
+  plan.addCodegen(
+    "pnpm --filter @mento-protocol/indexer-envio indexer:reserve-yield:test",
+    reason,
+  );
+  addIndexerPostCodegenInstall(plan);
+};
+
+// ── package quality bundles ────────────────────────────────────────────────
+
+export const addPackageQualityCommands = (plan, packageName, reason) => {
+  // Both `tsc --noEmit` and the type-aware ESLint rules need the generated
+  // Envio types, so codegen is forced as a preflight for these two packages.
+  if (packageName === "@mento-protocol/indexer-envio") {
+    addIndexerMainnetCodegen(
+      plan,
+      `${reason} (codegen needed before indexer typecheck/lint)`,
+    );
+  } else if (packageName === "@mento-protocol/ui-dashboard") {
+    addDashboardCodegen(
+      plan,
+      `${reason} (codegen needed before dashboard typecheck/lint)`,
+    );
+  }
+  addTurboPackageTask(plan, packageName, "lint", reason);
+  addTurboPackageTask(plan, packageName, "typecheck", reason);
+  if (packageName === "@mento-protocol/metrics-bridge") {
+    plan.addCommand(`pnpm --filter ${packageName} build`, reason);
+  }
+  plan.addCommand(
+    `pnpm --filter ${packageName} test:coverage`,
+    `${reason} (coverage floor)`,
+  );
+  addTurboPackageTask(
+    plan,
+    packageName,
+    "knip",
+    `${reason} (knip: unused files/deps/exports)`,
+  );
+  plan.addCommand(
+    "pnpm code-health:deps",
+    `${reason} (dep-cruiser: cross-package boundaries + cycles)`,
+  );
+  plan.addChecklist(
+    "docs/pr-checklists/code-health.md",
+    `${reason} (code-health gates fire on this change)`,
+  );
+};
+
+export const addPackageVitestTypecheckCommands = (
+  plan,
+  packageName,
+  reason,
+) => {
+  if (packageName === "@mento-protocol/indexer-envio") {
+    addIndexerMainnetCodegen(
+      plan,
+      `${reason} (codegen needed before indexer typecheck)`,
+    );
+  }
+  addTurboPackageTask(plan, packageName, "typecheck", reason);
+  plan.addCommand(
+    `pnpm --filter ${packageName} test:coverage`,
+    `${reason} (coverage floor)`,
+  );
+};
+
+export const addDashboardQualityCommands = (plan, reason) => {
+  addPackageQualityCommands(plan, "@mento-protocol/ui-dashboard", reason);
+  plan.addCommand(
+    "pnpm --filter @mento-protocol/ui-dashboard exec playwright install chromium",
+    reason,
+  );
+  addTurboDashboardTask(plan, "test:browser", reason);
+};
+
+export const addAegisQualityCommands = (plan, reason) => {
+  addTurboPackageTask(plan, "@mento-protocol/aegis", "typecheck", reason);
+  plan.addCommand("pnpm --filter @mento-protocol/aegis build", reason);
+  addTurboPackageTask(plan, "@mento-protocol/aegis", "lint", reason);
+  addTurboPackageTask(
+    plan,
+    "@mento-protocol/aegis",
+    "knip",
+    `${reason} (knip: unused files/deps/exports)`,
+  );
+  plan.addCommand("pnpm --filter @mento-protocol/aegis test:cov", reason);
+  plan.addCommand("cd aegis && forge test", reason);
+  plan.addCommand(
+    "pnpm code-health:deps",
+    `${reason} (dep-cruiser: cross-package boundaries + cycles)`,
+  );
+  plan.addChecklist(
+    "docs/pr-checklists/code-health.md",
+    `${reason} (code-health gates fire on this change)`,
+  );
+};
+
+export const addAlertsOncallQualityCommands = (plan, reason) => {
+  const pkg = "@mento-protocol/alerts-oncall-announcer";
+  addTurboPackageTask(plan, pkg, "lint", reason);
+  addTurboPackageTask(plan, pkg, "typecheck", reason);
+  plan.addCommand(
+    `pnpm --filter ${pkg} test:coverage`,
+    `${reason} (coverage floor)`,
+  );
+  addTurboPackageTask(
+    plan,
+    pkg,
+    "knip",
+    `${reason} (knip: unused files/deps/exports)`,
+  );
+};
+
+// ── dashboard extras ───────────────────────────────────────────────────────
+
+export const addUiReactDoctorFullScore = (plan, reason) => {
+  addTurboDashboardTask(plan, "react-doctor:score", reason);
+};
+
+export const addUiReactDoctorDiff = (plan, reason, facts) => {
+  // Carries the base ref AND its resolved OID, both `%q`-quoted, so the Turbo
+  // cache key moves when the base moves.
+  const command =
+    `REACT_DOCTOR_BASE_REF=${shellQuote(facts.baseRef)}` +
+    ` REACT_DOCTOR_BASE_CACHE_KEY=${shellQuote(facts.baseOid)}` +
+    ` ${turboLocalCacheCommand("@mento-protocol/ui-dashboard", "react-doctor:diff")}`;
+  plan.addCommand(command, reason);
+};
+
+export const addUiMutationBaseline = (plan, reason) => {
+  plan.addCommand("pnpm dashboard:mutation", reason);
+};
+
+export const addUiSizeLimit = (plan, reason) => {
+  // The pinned deployment identity keeps the command hermetic under Trunk's
+  // stripped environment; it is part of the command string, not the env.
+  plan.addCommand(
+    `VERCEL_DEPLOYMENT_ID=local-quality-gate ${turboLocalCacheCommand("@mento-protocol/ui-dashboard", "size-limit")}`,
+    reason,
+  );
+};
+
+export const addBridgeMutationBaseline = (plan, reason) => {
+  plan.addCommand("pnpm bridge:mutation", reason);
+};
+
+export const addIndexerMutationBaseline = (plan, reason) => {
+  plan.addCommand("pnpm indexer:mutation", reason);
+};
+
+// ── workspace escalation ───────────────────────────────────────────────────
+
+export const addWorkspaceQualityCommands = (plan, reason) => {
+  // The flag is the point: it disables scoped tests for the whole run.
+  plan.sawWorkspaceEscalation = true;
+  plan.addCommand("pnpm skew:check", reason);
+  addAllIndexerCodegen(plan, reason);
+  // Deliberately the lightweight dashboard bundle, not the full one: the
+  // browser suite is high-cost and flaky under the sandbox, and CI runs it in
+  // its own job. A direct ui-dashboard/* change still gets the full bundle.
+  addPackageQualityCommands(plan, "@mento-protocol/ui-dashboard", reason);
+  addUiReactDoctorFullScore(plan, reason);
+  addUiSizeLimit(plan, reason);
+  addPackageQualityCommands(plan, "@mento-protocol/indexer-envio", reason);
+  addPackageQualityCommands(plan, "@mento-protocol/metrics-bridge", reason);
+  addPackageQualityCommands(plan, "@mento-protocol/integration-probes", reason);
+  addPackageQualityCommands(plan, "@mento-protocol/config", reason);
+  addPackageQualityCommands(
+    plan,
+    "@mento-protocol/governance-watchdog",
+    reason,
+  );
+  addAegisQualityCommands(plan, reason);
+};
+
+// ── terraform ──────────────────────────────────────────────────────────────
+
+export const addTerraformValidateCommands = (plan, module, reason) => {
+  const dataDir = `${module}/.terraform-agent-gate`;
+  plan.addCommand(
+    `TF_DATA_DIR=${dataDir} node scripts/terraform/terraform-fmt-check.mjs ${shellQuote(module)}`,
+    reason,
+  );
+  plan.addCommand(
+    `TF_DATA_DIR=${dataDir} terraform -chdir=${module} init -backend=false -input=false`,
+    reason,
+  );
+  plan.addCommand(
+    `TF_DATA_DIR=${dataDir} terraform -chdir=${module} validate -no-color`,
+    reason,
+  );
+};
+
+export const addRegisteredTerraformValidateCommands = (plan, reason, facts) => {
+  for (const stackPath of facts.terraformStackPaths) {
+    addTerraformValidateCommands(plan, stackPath, reason);
+  }
+};
+
+// ── misc ───────────────────────────────────────────────────────────────────
+
+export const addAdrReminder = (plan, reason, facts) => {
+  const command =
+    "node scripts/pr/check-adr-reminder.mjs" +
+    ` --base ${shellQuote(facts.baseRef)} --head ${shellQuote(facts.headRef)}` +
+    ` --include-untracked --changed-paths-file ${shellQuote(facts.changedPathsFile)}`;
+  plan.addCommand(command, reason);
+};
+
+export const addSentrySuiteGateCommands = (plan, reason) => {
+  plan.addCommand(
+    "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry/gate/sentry-suite-gate.test.mjs",
+    reason,
+  );
+  plan.addCommand(
+    "/usr/bin/env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry/gate/sentry-suite-gate.mjs",
+    `${reason} (validate the committed manifest against the real suites)`,
+  );
+};
+
+/** The suites a root tooling-script change re-runs, in the gate's order. */
+const ROOT_TOOLING_SCRIPT_COMMANDS = [
+  "node scripts/check-agent-quality-gate-package-scripts.mjs",
+  "bash scripts/agent-quality-gate.test.sh",
+  "node scripts/gate/agent-prewarm.test.mjs",
+  "node scripts/pr/review-materiality.test.mjs",
+  "node scripts/pr/agent-issue-board.test.mjs",
+  "pnpm sentry:ingest:test",
+  "pnpm sentry:digest:test",
+  "pnpm sentry:project:test",
+  "pnpm sentry:brief:test",
+  "pnpm sentry:autofix:select:test",
+  "pnpm sentry:autofix:finalize:test",
+  "pnpm sentry:archive:test",
+  "pnpm sentry:broker:test",
+  "pnpm sentry:requeue:test",
+  "node scripts/sentry/ci-wiring/check-sentry-suites-in-ci.test.mjs",
+  "node scripts/pr/pr-feedback-state.test.mjs",
+  "node scripts/pr/pr-ready-state.test.mjs",
+  "node scripts/coderabbit-config.test.mjs",
+  "node scripts/terraform/terraform-fmt-check.test.mjs",
+  "node scripts/tf-stacks.test.mjs",
+  "node scripts/supply-chain/lockfile-lint.test.mjs",
+  "node scripts/supply-chain/version-skew-check.test.mjs",
+  "node scripts/supply-chain/override-prune-report.test.mjs",
+  "node scripts/pr/check-adr-reminder.test.mjs",
+  "node scripts/context/docs-index.test.mjs",
+  "node scripts/docs/docs-audit.test.mjs",
+  "node scripts/docs/docs-garden-issue.test.mjs",
+  "node scripts/docs/docs-navigation-eval.test.mjs",
+  "node scripts/context/agent-context-budget.test.mjs",
+];
+
+export const addRootToolingPackageScriptChecks = (plan, reason) => {
+  for (const command of ROOT_TOOLING_SCRIPT_COMMANDS) {
+    plan.addCommand(command, reason);
+  }
+};

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Differential parity: the Node mapping engine against the LIVE bash gate.
+ *
+ * A development tool for the D5b swap, deleted once the swap lands.
+ *
+ * DEVIATION FROM THE DESIGN, DELIBERATE. The design has this compare a gate
+ * pinned in a separate worktree against a swapped gate. That shape exists
+ * because it assumed the swap had already happened. Landing the engine INERT
+ * first makes a simpler and stronger comparison available: the bash arms are
+ * still the routing that runs, so the live gate IS the oracle, on the same tree
+ * and the same commit, with no pinned worktree to keep in step. Every
+ * difference is attributable to the engine rather than to a checkout skew.
+ *
+ * The observable is the gate's dry-run stdout — the routing contract two Node
+ * consumers already parse and 1,229 suite assertions already assert on.
+ *
+ * ZERO differences is the pass condition, and a green run is not believed until
+ * `--mutate` has been shown to red it.
+ *
+ * Usage:
+ *   node scripts/gate/routing-parity.mjs --corpus tracked --limit 200
+ *   node scripts/gate/routing-parity.mjs --mutate      # prove it can fail
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Facts } from "./mapping/facts.mjs";
+import { buildPlan, routingSensitivePathsChanged } from "./mapping.mjs";
+import { BUCKETS } from "./mapping/plan.mjs";
+
+const REPO = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * The gate's own dry-run stdout, reduced to the three observable sections.
+ *
+ * The header carries the base, the head and the Turbo cache directory, none of
+ * which is routing; the changed-path echo is the input. Surfaces and checklists
+ * are sets and are sorted; the command list keeps its order, because order is
+ * an invariant the plan and the stamp both depend on.
+ */
+/**
+ * Blank the changed-paths file each side happened to use.
+ *
+ * The ADR reminder embeds it, and the two sides legitimately differ: the gate
+ * writes its own randomized scratch file, the harness writes one of its own.
+ * `write_command_plan` already performs exactly this substitution before the
+ * freshness stamp hashes the plan, for the same reason — the execution path is
+ * not part of the routing. Anything else that differs is a real difference.
+ */
+const NORMALIZE_PATHS_FILE = /--changed-paths-file \S+/g;
+const normalize = (line) =>
+  line.replace(
+    NORMALIZE_PATHS_FILE,
+    "--changed-paths-file __CHANGED_PATHS_FILE__",
+  );
+
+function parseGateStdout(text) {
+  const surfaces = [];
+  const checklists = [];
+  const commands = [];
+  let section = null;
+  for (const line of text.split("\n")) {
+    if (line === "Detected surfaces:") {
+      section = "surface";
+      continue;
+    }
+    if (line === "Required checklist review:") {
+      section = "checklist";
+      continue;
+    }
+    if (line === "Mapped safe local commands:") {
+      section = "command";
+      continue;
+    }
+    if (line === "Changed paths:") {
+      section = "changed";
+      continue;
+    }
+    if (line === "") {
+      section = null;
+      continue;
+    }
+    if (section === null || !line.startsWith("- ")) continue;
+    const body = line.slice(2);
+    if (section === "surface") surfaces.push(body);
+    else if (section === "checklist") checklists.push(body);
+    else if (section === "command") commands.push(normalize(body));
+  }
+  return { surfaces: surfaces.sort(), checklists: checklists.sort(), commands };
+}
+
+/** The engine's plan in the same shape, so the two can be compared directly. */
+function planToObservable(plan) {
+  const commands = [];
+  for (const bucket of BUCKETS) {
+    for (const entry of plan.buckets.get(bucket)) {
+      commands.push(normalize(`${entry.command} (${entry.reason})`));
+    }
+  }
+  return {
+    surfaces: [...plan.surfaces].sort(),
+    checklists: plan.checklists
+      .map((entry) => `${entry.checklist} (${entry.reason})`)
+      .sort(),
+    commands,
+  };
+}
+
+function runGate(changedPaths, dir) {
+  const pathsFile = join(dir, "paths");
+  writeFileSync(pathsFile, `${changedPaths.join("\n")}\n`);
+  const stdout = execFileSync(
+    "bash",
+    [
+      join(REPO, "scripts/agent-quality-gate.sh"),
+      "--changed-paths-file",
+      pathsFile,
+      "--base",
+      "HEAD",
+    ],
+    {
+      cwd: REPO,
+      encoding: "utf8",
+      env: { ...process.env, AGENT_QUALITY_GATE_LOCK: "0" },
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  return { stdout, pathsFile };
+}
+
+async function runEngine(changedPaths, pathsFile) {
+  const scriptSourceDir = join(REPO, "scripts");
+  const facts = new Facts({
+    repoRoot: REPO,
+    baseRef: "HEAD",
+    headRef: "HEAD",
+    changedPathsFile: pathsFile,
+    isRealTree: true,
+    scriptSourceDir,
+  });
+  const routingSensitive = await routingSensitivePathsChanged(
+    changedPaths,
+    scriptSourceDir,
+  );
+  return planToObservable(buildPlan({ changedPaths, facts, routingSensitive }));
+}
+
+/** One line per difference, naming the path set and what moved. */
+function diff(label, gate, engine) {
+  const problems = [];
+  for (const field of ["surfaces", "checklists"]) {
+    const missing = gate[field].filter((x) => !engine[field].includes(x));
+    const extra = engine[field].filter((x) => !gate[field].includes(x));
+    for (const item of missing)
+      problems.push(`${label}: engine MISSING ${field} ${item}`);
+    for (const item of extra)
+      problems.push(`${label}: engine EXTRA ${field} ${item}`);
+  }
+  const n = Math.max(gate.commands.length, engine.commands.length);
+  for (let i = 0; i < n; i += 1) {
+    if (gate.commands[i] !== engine.commands[i]) {
+      problems.push(
+        `${label}: command[${i}]\n    gate:   ${gate.commands[i] ?? "(none)"}\n    engine: ${engine.commands[i] ?? "(none)"}`,
+      );
+      break;
+    }
+  }
+  return problems;
+}
+
+function corpusTracked(limit) {
+  const listed = execFileSync("git", ["-C", REPO, "ls-files"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const all = listed.split("\n").filter((p) => p !== "");
+  if (limit === null || limit >= all.length) return all;
+  // Deterministic spread rather than a random sample, so a re-run compares the
+  // same paths and a difference is reproducible.
+  const step = all.length / limit;
+  return Array.from({ length: limit }, (_, i) => all[Math.floor(i * step)]);
+}
+
+const argv = process.argv.slice(2);
+const option = (name, fallback) => {
+  const index = argv.indexOf(name);
+  return index === -1 ? fallback : argv[index + 1];
+};
+const limit = option("--limit", null);
+const mutate = argv.includes("--mutate");
+
+const paths = corpusTracked(limit === null ? null : Number(limit));
+const dir = mkdtempSync(join(tmpdir(), "routing-parity-"));
+let differences = 0;
+let compared = 0;
+
+try {
+  for (const path of paths) {
+    const set = [path];
+    const { stdout, pathsFile } = runGate(set, dir);
+    const gate = parseGateStdout(stdout);
+    const engine = await runEngine(set, pathsFile);
+    if (mutate) engine.commands.shift();
+    const problems = diff(path, gate, engine);
+    compared += 1;
+    if (problems.length > 0) {
+      differences += 1;
+      if (differences <= 15) console.log(problems.join("\n"));
+    }
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\ncompared ${compared} single-path sets; ${differences} differed`);
+if (mutate) {
+  console.log(
+    differences > 0
+      ? "MUTATION CONTROL FIRED: the harness can tell the two apart."
+      : "MUTATION CONTROL DID NOT FIRE — this harness proves nothing.",
+  );
+  process.exit(differences > 0 ? 0 : 1);
+}
+process.exit(differences === 0 ? 0 : 1);

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -35,6 +35,8 @@
  *                       commit
  *   --corpus fixture    a stub fixture repository, where the gate is not in its
  *                       own tree and the repository-specific groups are skipped
+ *   --corpus symlink    a real directory symlink under scripts/, the dynamic
+ *                       pattern source no committed path can exercise
  *   --pass2             deprecated alias for `--corpus multi`
  *   --limit <n>         positive integer; sample the tracked corpus evenly
  *   --base <ref>        base ref for the corpora that do not supply their own
@@ -48,6 +50,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -633,6 +636,66 @@ function corpusFixture(dir) {
   ].map((set) => ({ ...set, repoRoot: fixture, baseRef: "HEAD" }));
 }
 
+/**
+ * Pass 6 — a real directory symlink under `scripts/`.
+ *
+ * `scriptsSymlinkTargets` is a DYNAMIC pattern source: the arms it feeds are
+ * built from whatever `find scripts -type l` resolves to, so with no directory
+ * symlink in the tree — and there is none today — the whole group is inert and
+ * every other corpus says nothing about it. The gate's own self-test creates
+ * one for the same reason.
+ *
+ * Two targets, because the containment rule is where this goes wrong: an
+ * ordinary directory, and one whose NAME begins with two dots. `path.relative`
+ * answers `..name` for the second, which a `startsWith("..")` test reads as
+ * "outside the repository" while the gate's prefix match accepts it
+ * (Codex 3838283142). That is a routing pattern the gate has and the engine
+ * does not, which is a smaller plan.
+ *
+ * Everything created here is removed in the same call, including on a throw.
+ */
+function corpusSymlink() {
+  const targets = [
+    { label: "plain", dir: ".routing-parity-target.tmp" },
+    { label: "dotdot-prefixed", dir: "..routing-parity-target.tmp" },
+  ];
+  const link = "scripts/.routing-parity-link.tmp";
+  const sets = [];
+  for (const { label, dir } of targets) {
+    sets.push({
+      label: `symlink-${label}-link-itself`,
+      paths: [link],
+      symlink: { dir, link },
+    });
+    sets.push({
+      label: `symlink-${label}-beneath-target`,
+      paths: [`${dir}/sentry-probe.test.mjs`],
+      symlink: { dir, link },
+    });
+    sets.push({
+      label: `symlink-${label}-unrelated-path`,
+      paths: ["ui-dashboard/src/lib/utils.ts"],
+      symlink: { dir, link },
+    });
+  }
+  return sets;
+}
+
+/** Create the symlink a `symlink` corpus set needs, and hand back its undo. */
+function withSymlink({ dir, link }) {
+  const targetPath = join(REPO, dir);
+  const linkPath = join(REPO, link);
+  rmSync(linkPath, { recursive: true, force: true });
+  rmSync(targetPath, { recursive: true, force: true });
+  mkdirSync(targetPath, { recursive: true });
+  writeFileSync(join(targetPath, "sentry-probe.test.mjs"), "// probe\n");
+  symlinkSync(targetPath, linkPath);
+  return () => {
+    rmSync(linkPath, { recursive: true, force: true });
+    rmSync(targetPath, { recursive: true, force: true });
+  };
+}
+
 /** A dangling commit whose tree is HEAD's with one top-level path replaced. */
 function baseCommitWith(dir, path, content) {
   const blobFile = join(dir, "blob");
@@ -684,7 +747,14 @@ function parseLimit(raw) {
   return value;
 }
 
-const CORPORA = new Set(["tracked", "multi", "synthetic", "base", "fixture"]);
+const CORPORA = new Set([
+  "tracked",
+  "multi",
+  "synthetic",
+  "base",
+  "fixture",
+  "symlink",
+]);
 const limit = parseLimit(option("--limit", null));
 const mutate = argv.includes("--mutate");
 const defaultBase = option("--base", "HEAD");
@@ -706,18 +776,28 @@ function buildWork() {
   if (corpus === "synthetic") return corpusSynthetic(corpusTracked(null));
   if (corpus === "base") return corpusBase(dir);
   if (corpus === "fixture") return corpusFixture(dir);
+  if (corpus === "symlink") return corpusSymlink();
   return corpusTracked(limit).map((path) => ({ label: path, paths: [path] }));
 }
 
 try {
-  for (const { label, paths: set, baseRef, repoRoot } of buildWork()) {
+  for (const { label, paths: set, baseRef, repoRoot, symlink } of buildWork()) {
     if (set.length === 0) continue;
     const base = baseRef ?? defaultBase;
     const root = repoRoot ?? REPO;
-    const { stdout, pathsFile } = runGate(set, dir, base, root);
-    const gate = parseGateStdout(stdout);
-    // The gate's normalized set, not the harness's raw one.
-    const engine = await runEngine(gate.changedPaths, pathsFile, base, root);
+    // A set that needs a symlink in the real tree owns it for exactly its own
+    // two runs, so a failure cannot leave one behind.
+    const undo = symlink === undefined ? () => {} : withSymlink(symlink);
+    let gate;
+    let engine;
+    try {
+      const run = runGate(set, dir, base, root);
+      gate = parseGateStdout(run.stdout);
+      // The gate's normalized set, not the harness's raw one.
+      engine = await runEngine(gate.changedPaths, run.pathsFile, base, root);
+    } finally {
+      undo();
+    }
     if (mutate) engine.commands.shift();
     const problems = diff(label, gate, engine);
     compared += 1;

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -46,6 +46,7 @@
 
 import { execFileSync } from "node:child_process";
 import {
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -608,9 +609,17 @@ function corpusFixture(dir) {
   // inside the outer gate run, since the mapping arm schedules this corpus —
   // and a global `core.hooksPath` or `init.templateDir` would run their hooks
   // against a repository that is not their work.
+  //
+  // An empty hooks directory rather than a verification bypass: this
+  // repository does not skip hooks, it points them at a directory that holds
+  // none. The directory lives outside the fixture so it can never become
+  // fixture content.
+  const emptyHooks = join(dir, "no-hooks");
+  mkdirSync(emptyHooks, { recursive: true });
   inFixture("config", "commit.gpgsign", "false");
+  inFixture("config", "core.hooksPath", emptyHooks);
   inFixture("add", "-A");
-  inFixture("commit", "--no-verify", "-qm", "fixture");
+  inFixture("commit", "-qm", "fixture");
 
   // Uncommitted, so `git show HEAD:package.json` and the working tree differ:
   // that diff is what the root-manifest classifier reads, and it makes the
@@ -699,20 +708,50 @@ function corpusSymlink() {
 function withSymlink({ dir, link }) {
   const targetPath = join(REPO, dir);
   const linkPath = join(REPO, link);
+
+  // REFUSE, never clear the way. These are fixed names in the developer's real
+  // repository, and an `rm -rf` of a path this run did not create would delete
+  // whatever happened to be sitting there. A leftover from a killed run is a
+  // thing to be told about, not something to silently overwrite.
+  for (const path of [targetPath, linkPath]) {
+    if (!pathPresent(path)) continue;
+    const error = new Error(
+      `${path} already exists; the symlink corpus creates its own probe paths and will not remove one it did not create. Remove it by hand if it is a leftover.`,
+    );
+    error.exitCode = 2;
+    throw error;
+  }
+
+  // Undo removes exactly what this call made, in reverse order, and nothing
+  // else — including when setup throws part-way and the caller never gets it.
+  const created = [];
   const undo = () => {
-    rmSync(linkPath, { recursive: true, force: true });
-    rmSync(targetPath, { recursive: true, force: true });
+    for (const path of [...created].reverse()) {
+      rmSync(path, { recursive: true, force: true });
+    }
+    created.length = 0;
   };
-  undo();
   try {
-    mkdirSync(targetPath, { recursive: true });
+    mkdirSync(targetPath);
+    created.push(targetPath);
     writeFileSync(join(targetPath, "sentry-probe.test.mjs"), "// probe\n");
     symlinkSync(targetPath, linkPath);
+    created.push(linkPath);
   } catch (error) {
     undo();
     throw error;
   }
   return undo;
+}
+
+/** Whether any entry sits at this path — a dangling symlink included. */
+function pathPresent(path) {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** A dangling commit whose tree is HEAD's with one top-level path replaced. */

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -63,6 +63,14 @@ function parseGateStdout(text) {
   const surfaces = [];
   const checklists = [];
   const commands = [];
+  // The gate's own normalized changed-path set, in ITS order. The gate applies
+  // `sed '/^$/d' | sort -u` to the input file, and that ordering is routing:
+  // `add_command` keeps the first reason it is given, so iterating the set in a
+  // different order produces the same commands with different reasons. Feeding
+  // the engine what the gate printed removes the question entirely — including
+  // the collation the gate's `sort` happened to use, which is locale-dependent
+  // and therefore not something this harness should try to reproduce.
+  const changedPaths = [];
   let section = null;
   for (const line of text.split("\n")) {
     if (line === "Detected surfaces:") {
@@ -90,8 +98,14 @@ function parseGateStdout(text) {
     if (section === "surface") surfaces.push(body);
     else if (section === "checklist") checklists.push(body);
     else if (section === "command") commands.push(normalize(body));
+    else if (section === "changed") changedPaths.push(body);
   }
-  return { surfaces: surfaces.sort(), checklists: checklists.sort(), commands };
+  return {
+    surfaces: surfaces.sort(),
+    checklists: checklists.sort(),
+    commands,
+    changedPaths,
+  };
 }
 
 /** The engine's plan in the same shape, so the two can be compared directly. */
@@ -186,6 +200,90 @@ function corpusTracked(limit) {
   return Array.from({ length: limit }, (_, i) => all[Math.floor(i * step)]);
 }
 
+/**
+ * Pass 2 — multi-path sets.
+ *
+ * Four behaviours are set-dependent and a single-path corpus cannot see any of
+ * them: the Trunk full-vs-targeted decision, the codegen sort (which only has
+ * something to sort when several variants are scheduled), Turbo compaction
+ * (which needs two packages sharing a task), and scoped tests (which have a
+ * 15-path threshold and four disqualifiers). Pass 1 proving zero differences
+ * says almost nothing about these, so this is where the post-passes are
+ * actually tested.
+ */
+function corpusMultiPath(tracked) {
+  const sets = [];
+  const pick = (source, count, seed) => {
+    // Deterministic, so a difference is reproducible on a re-run.
+    const chosen = [];
+    let cursor = seed;
+    for (let i = 0; i < count; i += 1) {
+      cursor = (cursor * 1103515245 + 12345) % 2147483648;
+      chosen.push(source[cursor % source.length]);
+    }
+    return [...new Set(chosen)];
+  };
+
+  for (const k of [2, 3, 5, 15, 16]) {
+    for (let seed = 1; seed <= 6; seed += 1) {
+      sets.push({
+        label: `random-k${k}-s${seed}`,
+        paths: pick(tracked, k, seed * 7919),
+      });
+    }
+  }
+
+  // Straddle each scoped-test disqualifier: the same base set with and without
+  // the one path that turns scoping off.
+  const base = [
+    "ui-dashboard/src/lib/utils.ts",
+    "indexer-envio/src/EventHandlers.ts",
+  ];
+  const straddles = {
+    "shared-config": "shared-config/src/index.ts",
+    "test-infra-hermetic": "ui-dashboard/vitest.hermetic-setup.ts",
+    "test-infra-config": "ui-dashboard/vitest.config.ts",
+    "schema-stub": "scripts/envio-schema-stubs.graphql",
+    "workspace-escalation": "package.json",
+    "lockfile-scoped": "pnpm-lock.yaml",
+    "non-source-in-package": "ui-dashboard/src/lib/types.json",
+    "test-file-in-package": "ui-dashboard/src/lib/utils.test.ts",
+  };
+  sets.push({ label: "straddle-base", paths: base });
+  for (const [name, extra] of Object.entries(straddles)) {
+    sets.push({ label: `straddle-${name}`, paths: [...base, extra] });
+  }
+
+  // The 15/16 threshold, exactly.
+  const dashboardFiles = tracked
+    .filter((p) => p.startsWith("ui-dashboard/src/") && p.endsWith(".ts"))
+    .slice(0, 16);
+  if (dashboardFiles.length === 16) {
+    sets.push({ label: "threshold-15", paths: dashboardFiles.slice(0, 15) });
+    sets.push({ label: "threshold-16", paths: dashboardFiles });
+  }
+
+  // Turbo compaction needs two packages sharing a task.
+  sets.push({
+    label: "turbo-compaction",
+    paths: [
+      "ui-dashboard/src/lib/utils.ts",
+      "metrics-bridge/src/index.ts",
+      "integration-probes/src/index.ts",
+    ],
+  });
+  // Several codegen variants at once, so the sort has something to order.
+  sets.push({
+    label: "codegen-sort",
+    paths: [
+      "indexer-envio/config.yaml",
+      "indexer-envio/config.testnet.yaml",
+      "ui-dashboard/src/lib/utils.ts",
+    ],
+  });
+  return sets;
+}
+
 const argv = process.argv.slice(2);
 const option = (name, fallback) => {
   const index = argv.indexOf(name);
@@ -199,14 +297,20 @@ const dir = mkdtempSync(join(tmpdir(), "routing-parity-"));
 let differences = 0;
 let compared = 0;
 
+const pass2 = argv.includes("--pass2");
+const work = pass2
+  ? corpusMultiPath(corpusTracked(null))
+  : paths.map((path) => ({ label: path, paths: [path] }));
+
 try {
-  for (const path of paths) {
-    const set = [path];
+  for (const { label, paths: set } of work) {
+    if (set.length === 0) continue;
     const { stdout, pathsFile } = runGate(set, dir);
     const gate = parseGateStdout(stdout);
-    const engine = await runEngine(set, pathsFile);
+    // The gate's normalized set, not the harness's raw one.
+    const engine = await runEngine(gate.changedPaths, pathsFile);
     if (mutate) engine.commands.shift();
-    const problems = diff(path, gate, engine);
+    const problems = diff(label, gate, engine);
     compared += 1;
     if (problems.length > 0) {
       differences += 1;

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -16,15 +16,40 @@
  * consumers already parse and 1,229 suite assertions already assert on.
  *
  * ZERO differences is the pass condition, and a green run is not believed until
- * `--mutate` has been shown to red it.
+ * `--mutate` has been shown to red it. An empty corpus is a FAILURE, not a
+ * pass: "compared 0 sets; 0 differed" is the shape of the bug this harness
+ * exists to catch, so it exits non-zero rather than reporting green.
  *
  * Usage:
- *   node scripts/gate/routing-parity.mjs --corpus tracked --limit 200
- *   node scripts/gate/routing-parity.mjs --mutate      # prove it can fail
+ *   node scripts/gate/routing-parity.mjs [--corpus <name>] [--limit <n>]
+ *                                        [--base <ref>] [--mutate]
+ *
+ *   --corpus tracked    one run per tracked path (default)
+ *   --corpus multi      multi-path sets — the four whole-set post-passes
+ *   --corpus synthetic  one built path per routing-table pattern no tracked
+ *                       path reaches, so an arm the tree cannot exercise is
+ *                       still compared
+ *   --corpus base       synthetic BASE COMMITS — the root-manifest classifier's
+ *                       four classes and the lockfile importer scoping, none of
+ *                       which is reachable while base and head are the same
+ *                       commit
+ *   --corpus fixture    a stub fixture repository, where the gate is not in its
+ *                       own tree and the repository-specific groups are skipped
+ *   --pass2             deprecated alias for `--corpus multi`
+ *   --limit <n>         positive integer; sample the tracked corpus evenly
+ *   --base <ref>        base ref for the corpora that do not supply their own
+ *                       (default HEAD)
+ *   --mutate            drop one engine command and require the harness to red
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,8 +57,18 @@ import { fileURLToPath } from "node:url";
 import { Facts } from "./mapping/facts.mjs";
 import { buildPlan, routingSensitivePathsChanged } from "./mapping.mjs";
 import { BUCKETS } from "./mapping/plan.mjs";
+import { ROUTING_GROUPS } from "./routing-table/index.mjs";
+import { walkArms } from "./routing-table/schema.mjs";
+import { isGlob } from "./routing-table/pattern.mjs";
 
 const REPO = fileURLToPath(new URL("../..", import.meta.url));
+
+const git = (args, input) =>
+  execFileSync("git", ["-C", REPO, ...args], {
+    encoding: "utf8",
+    input,
+    maxBuffer: 256 * 1024 * 1024,
+  });
 
 /**
  * The gate's own dry-run stdout, reduced to the three observable sections.
@@ -125,9 +160,11 @@ function planToObservable(plan) {
   };
 }
 
-function runGate(changedPaths, dir) {
+function runGate(changedPaths, dir, baseRef, repoRoot) {
   const pathsFile = join(dir, "paths");
   writeFileSync(pathsFile, `${changedPaths.join("\n")}\n`);
+  // The gate SCRIPT always comes from this checkout; only the repository it
+  // runs against moves. That is exactly the split `$script_source_dir` tests.
   const stdout = execFileSync(
     "bash",
     [
@@ -135,10 +172,10 @@ function runGate(changedPaths, dir) {
       "--changed-paths-file",
       pathsFile,
       "--base",
-      "HEAD",
+      baseRef,
     ],
     {
-      cwd: REPO,
+      cwd: repoRoot,
       encoding: "utf8",
       env: { ...process.env, AGENT_QUALITY_GATE_LOCK: "0" },
       maxBuffer: 64 * 1024 * 1024,
@@ -147,14 +184,16 @@ function runGate(changedPaths, dir) {
   return { stdout, pathsFile };
 }
 
-async function runEngine(changedPaths, pathsFile) {
+async function runEngine(changedPaths, pathsFile, baseRef, repoRoot) {
   const scriptSourceDir = join(REPO, "scripts");
   const facts = new Facts({
-    repoRoot: REPO,
-    baseRef: "HEAD",
+    repoRoot,
+    baseRef,
     headRef: "HEAD",
     changedPathsFile: pathsFile,
-    isRealTree: true,
+    // The gate's own test, evaluated here rather than assumed: repository-
+    // specific routing is fenced behind the gate living in the tree it checks.
+    isRealTree: scriptSourceDir === join(repoRoot, "scripts"),
     scriptSourceDir,
   });
   const routingSensitive = await routingSensitivePathsChanged(
@@ -284,31 +323,401 @@ function corpusMultiPath(tracked) {
   return sets;
 }
 
+/**
+ * Pass 3 — one built path per pattern the tracked tree cannot reach.
+ *
+ * The tracked corpus exercises an arm only if some committed file happens to
+ * match it. Measured on this tree, 225 of the table's 234 arms are reached that
+ * way and nine are not — a repository with no `.npmrc`, and a star-slash
+ * `package.json` arm that every earlier package arm claims first. An arm no
+ * corpus reaches is an arm the parity evidence says nothing about, so this
+ * builds a path for it.
+ *
+ * The pattern COMPILER is not what this tests — `pattern-oracle.test.mjs`
+ * already proves every pattern against real bash, matches and near misses
+ * both. This tests the arm's effects: the verbs, the reasons and the bucket
+ * the engine produces once the arm fires.
+ */
+function corpusSynthetic(tracked) {
+  const trackedSet = new Set(tracked);
+  const seen = new Set();
+  const sets = [];
+  for (const { subject, arm } of walkArms(ROUTING_GROUPS)) {
+    // A dispatch on the root-manifest class switches on a verdict string
+    // rather than a path; `--corpus base` is what reaches those arms.
+    if (subject !== "path") continue;
+    for (const pattern of arm.patterns) {
+      // A dynamic group's pattern carries a `${placeholder}` that only means
+      // something once a symlink target or a stack path is substituted in.
+      if (/\$\{[a-z_][a-z_0-9]*\}/.test(pattern)) continue;
+      // Two expansions of `*`, because segment COUNT is routing: a nested
+      // dispatch that tries `*/*/*` before `*` is only reached by the second
+      // one, and a `*` that always spans a separator would never get there.
+      for (const star of ["a/b", "a"]) {
+        const path = synthesizeMatch(pattern, star);
+        if (path === "" || trackedSet.has(path) || seen.has(path)) continue;
+        seen.add(path);
+        sets.push({
+          label: `synthetic:${pattern}${isGlob(pattern) ? "" : " (literal)"}`,
+          paths: [path],
+        });
+      }
+    }
+  }
+  return sets;
+}
+
+/**
+ * A path built to match a bash `case` pattern, expanding `*` as `star`.
+ *
+ * `a/b` is the expansion that matters most — `*` crosses `/` in a `case`
+ * pattern, and a synthetic match that never spans a separator would not
+ * exercise that. Same construction as `pattern-oracle.test.mjs`, which proves
+ * against bash that the paths it builds really do match.
+ */
+function synthesizeMatch(pattern, star) {
+  let path = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === "*") {
+      path += star;
+    } else if (character === "?") {
+      path += "c";
+    } else if (character === "[") {
+      const close = pattern.indexOf("]", index + 2);
+      if (close === -1) {
+        path += "[";
+        continue;
+      }
+      const member = [...pattern.slice(index + 1, close)].find(
+        (candidate) => !"!^-".includes(candidate),
+      );
+      path += member ?? "d";
+      index = close;
+    } else if (character === "\\") {
+      index += 1;
+      path += pattern[index] ?? "";
+    } else {
+      path += character;
+    }
+  }
+  return path;
+}
+
+/**
+ * Pass 4 — synthetic BASE COMMITS.
+ *
+ * Every other corpus runs with base and head at the same commit, which is what
+ * makes them cheap and reproducible — and which also makes two whole routing
+ * families unreachable, because both read the DIFF between base and head
+ * rather than the changed-path list:
+ *
+ *   - `classify_root_package_json_changes` has four classes, and an empty diff
+ *     is always `workspace`. Three classes, five dispatch arms and the
+ *     29-command `add_root_tooling_package_script_checks` verb never fire.
+ *   - `lockfile_scoped_importers` reports the importer keys that CHANGED, and
+ *     an empty diff reports none — so the scoped branch is entered with an
+ *     empty importer list and the whole importer→bundle map, including the
+ *     `mark_lockfile_scoped_package` calls that disable scoped tests, is never
+ *     reached.
+ *
+ * So build a base commit that differs from HEAD in exactly one engineered way,
+ * and run both sides against it. The commit is a dangling object written with
+ * `commit-tree`; nothing is checked out and no ref moves.
+ */
+function corpusBase(dir) {
+  const headPackageJson = readFileSync(join(REPO, "package.json"), "utf8");
+  const headLockfile = readFileSync(join(REPO, "pnpm-lock.yaml"), "utf8");
+  const withPackageJson = (mutate) => {
+    const parsed = JSON.parse(headPackageJson);
+    mutate(parsed);
+    return `${JSON.stringify(parsed, null, 2)}\n`;
+  };
+
+  const sets = [
+    {
+      label: "base-class-root-tooling-scripts",
+      paths: ["package.json"],
+      file: "package.json",
+      content: withPackageJson((p) => {
+        // A tooling script pointer and nothing else → root-tooling-scripts.
+        p.scripts["docs:index"] = `${p.scripts["docs:index"]} --parity-probe`;
+      }),
+    },
+    {
+      label: "base-class-package-scripts",
+      paths: ["package.json"],
+      file: "package.json",
+      // A script that is not on the tooling list → package-scripts.
+      content: withPackageJson((p) => {
+        p.scripts["parity-probe-script"] = "true";
+      }),
+    },
+    {
+      label: "base-class-workspace-dev-metadata",
+      paths: ["package.json"],
+      file: "package.json",
+      content: withPackageJson((p) => {
+        p.description = "parity probe";
+      }),
+    },
+    {
+      label: "base-class-workspace",
+      paths: ["package.json"],
+      file: "package.json",
+      content: withPackageJson((p) => {
+        p.packageManager = "pnpm@0.0.0";
+      }),
+    },
+  ];
+
+  // One mappable importer per bundle shape the map holds, plus the two
+  // fail-toward-full shapes.
+  for (const importer of [
+    "ui-dashboard",
+    "indexer-envio",
+    "shared-config",
+    "alerts/infra/oncall-announcer",
+  ]) {
+    const content = mutateImporter(headLockfile, importer);
+    if (content === null) continue;
+    sets.push({
+      label: `base-lockfile-importer-${importer}`,
+      paths: ["pnpm-lock.yaml"],
+      file: "pnpm-lock.yaml",
+      content,
+    });
+  }
+  const rootImporter = mutateImporter(headLockfile, ".");
+  if (rootImporter !== null) {
+    // The root importer maps to no bundle → fail toward the full suite.
+    sets.push({
+      label: "base-lockfile-importer-unmappable-root",
+      paths: ["pnpm-lock.yaml"],
+      file: "pnpm-lock.yaml",
+      content: rootImporter,
+    });
+  }
+  sets.push({
+    label: "base-lockfile-non-importer-section",
+    paths: ["pnpm-lock.yaml"],
+    file: "pnpm-lock.yaml",
+    // A top-level section outside `importers` → the classifier says "full".
+    content: headLockfile.replace(
+      /^lockfileVersion: .*$/m,
+      "lockfileVersion: '0.0'",
+    ),
+  });
+  // A lockfile change alongside a manifest-class path is not lockfile-only, so
+  // it must widen even though the importer diff is perfectly scopable.
+  const straddle = mutateImporter(headLockfile, "ui-dashboard");
+  if (straddle !== null) {
+    sets.push({
+      label: "base-lockfile-with-co-changed-manifest",
+      paths: ["pnpm-lock.yaml", "ui-dashboard/package.json"],
+      file: "pnpm-lock.yaml",
+      content: straddle,
+    });
+  }
+
+  return sets.map(({ label, paths, file, content }) => ({
+    label,
+    paths,
+    baseRef: baseCommitWith(dir, file, content),
+  }));
+}
+
+/**
+ * The head lockfile with one importer's first `specifier:` altered.
+ *
+ * A textual edit, not a YAML round-trip: re-dumping the document could move
+ * something outside `importers` and the classifier would answer "full" for a
+ * reason the probe never intended. Returns null when the importer is absent.
+ */
+function mutateImporter(lockfile, importer) {
+  const lines = lockfile.split("\n");
+  const start = lines.findIndex((line) => line === `  ${importer}:`);
+  if (start === -1) return null;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    // Still inside this importer's block?
+    if (/^ {0,2}\S/.test(lines[index])) return null;
+    const match = /^(\s+specifier: )(.*)$/.exec(lines[index]);
+    if (match === null) continue;
+    lines[index] = `${match[1]}${match[2]}-parity-probe`;
+    return lines.join("\n");
+  }
+  return null;
+}
+
+/**
+ * Pass 5 — a STUB FIXTURE REPOSITORY, where the gate is not in its own tree.
+ *
+ * Four routing effects are fenced behind
+ * `[[ "$script_source_dir" == "$repo_root/scripts" ]]` so the gate's own unit
+ * tests do not inherit them: the two Sentry arms, the symlink groups, and the
+ * unconditional `pnpm tf:test` sweep. Every other corpus here runs the gate on
+ * its own checkout, where that condition is true — so the engine's
+ * `isRealTree: false` branch, which SKIPS whole groups, had no comparison at
+ * all. A branch that only ever removes work is the one to check hardest.
+ *
+ * The fixture is the shape `agent-quality-gate.test.sh` builds: a throwaway git
+ * repository with a root manifest, invoked with the real gate script from this
+ * checkout.
+ */
+function corpusFixture(dir) {
+  const fixture = join(dir, "fixture");
+  const inFixture = (...args) =>
+    execFileSync("git", ["-C", fixture, ...args], { encoding: "utf8" });
+
+  mkdirSync(join(fixture, "ui-dashboard/src"), { recursive: true });
+  mkdirSync(join(fixture, "scripts"), { recursive: true });
+  mkdirSync(join(fixture, "terraform"), { recursive: true });
+  mkdirSync(join(fixture, "docs/notes"), { recursive: true });
+  writeFileSync(
+    join(fixture, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "routing-parity-fixture",
+        private: true,
+        scripts: {
+          "docs:index": "node scripts/context/docs-index.mjs",
+          build: "true",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(fixture, "ui-dashboard/src/x.ts"),
+    "export const x = 1;\n",
+  );
+  writeFileSync(join(fixture, "scripts/probe.sh"), "echo probe\n");
+  writeFileSync(join(fixture, "scripts/probe.mjs"), "export const y = 1;\n");
+  writeFileSync(join(fixture, "terraform/main.tf"), "# fixture\n");
+  writeFileSync(join(fixture, "docs/notes/a.md"), "# fixture\n");
+
+  inFixture("init", "-q");
+  inFixture("config", "user.email", "routing-parity@example.invalid");
+  inFixture("config", "user.name", "routing-parity");
+  inFixture("add", "-A");
+  inFixture("commit", "-qm", "fixture");
+
+  // Uncommitted, so `git show HEAD:package.json` and the working tree differ:
+  // that diff is what the root-manifest classifier reads, and it makes the
+  // fixture reach `root-tooling-scripts` without a synthetic base commit.
+  const manifest = JSON.parse(
+    readFileSync(join(fixture, "package.json"), "utf8"),
+  );
+  manifest.scripts["docs:index"] = "node scripts/context/docs-index.mjs --f";
+  writeFileSync(
+    join(fixture, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  return [
+    { label: "fixture-shell-script", paths: ["scripts/probe.sh"] },
+    { label: "fixture-script-module", paths: ["scripts/probe.mjs"] },
+    { label: "fixture-dashboard-source", paths: ["ui-dashboard/src/x.ts"] },
+    { label: "fixture-terraform", paths: ["terraform/main.tf"] },
+    { label: "fixture-docs-note", paths: ["docs/notes/a.md"] },
+    { label: "fixture-root-manifest", paths: ["package.json"] },
+    {
+      label: "fixture-sentry-suite",
+      paths: ["scripts/sentry/gate/sentry-probe.test.mjs"],
+    },
+    {
+      label: "fixture-multi",
+      paths: ["ui-dashboard/src/x.ts", "scripts/probe.sh", "docs/notes/a.md"],
+    },
+  ].map((set) => ({ ...set, repoRoot: fixture, baseRef: "HEAD" }));
+}
+
+/** A dangling commit whose tree is HEAD's with one top-level path replaced. */
+function baseCommitWith(dir, path, content) {
+  const blobFile = join(dir, "blob");
+  writeFileSync(blobFile, content);
+  const blob = git(["hash-object", "-w", "--path", path, blobFile]).trim();
+  const entries = git(["ls-tree", "HEAD"])
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => {
+      const [meta, name] = line.split("\t");
+      if (name !== path) return line;
+      return `${meta.split(" ")[0]} blob ${blob}\t${name}`;
+    });
+  const tree = git(["mktree"], `${entries.join("\n")}\n`).trim();
+  return git([
+    "commit-tree",
+    tree,
+    "-m",
+    "routing-parity synthetic base",
+  ]).trim();
+}
+
 const argv = process.argv.slice(2);
 const option = (name, fallback) => {
   const index = argv.indexOf(name);
   return index === -1 ? fallback : argv[index + 1];
 };
-const limit = option("--limit", null);
-const mutate = argv.includes("--mutate");
 
-const paths = corpusTracked(limit === null ? null : Number(limit));
+const fail = (message) => {
+  console.error(`routing-parity: ${message}`);
+  process.exit(2);
+};
+
+/**
+ * A limit that is not a positive integer is a REFUSAL, not a default.
+ *
+ * `--limit` with nothing after it makes `Number(undefined)` NaN, every
+ * comparison against NaN is false, and the corpus comes out empty — so the
+ * harness would compare nothing, report "0 differed" and exit 0. That is the
+ * "All 0 …" failure this harness was written to prevent, reproduced inside the
+ * harness itself.
+ */
+function parseLimit(raw) {
+  if (raw === null) return null;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    fail(`--limit requires a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return value;
+}
+
+const CORPORA = new Set(["tracked", "multi", "synthetic", "base", "fixture"]);
+const limit = parseLimit(option("--limit", null));
+const mutate = argv.includes("--mutate");
+const defaultBase = option("--base", "HEAD");
+if (defaultBase === undefined) fail("--base requires a ref");
+const corpus = argv.includes("--pass2")
+  ? "multi"
+  : (option("--corpus", "tracked") ?? "");
+if (!CORPORA.has(corpus)) {
+  fail(`--corpus must be one of ${[...CORPORA].join(", ")}, got "${corpus}"`);
+}
+
 const dir = mkdtempSync(join(tmpdir(), "routing-parity-"));
 let differences = 0;
 let compared = 0;
 
-const pass2 = argv.includes("--pass2");
-const work = pass2
-  ? corpusMultiPath(corpusTracked(null))
-  : paths.map((path) => ({ label: path, paths: [path] }));
+/** The work list: one entry per comparison, each with the base it runs at. */
+function buildWork() {
+  if (corpus === "multi") return corpusMultiPath(corpusTracked(null));
+  if (corpus === "synthetic") return corpusSynthetic(corpusTracked(null));
+  if (corpus === "base") return corpusBase(dir);
+  if (corpus === "fixture") return corpusFixture(dir);
+  return corpusTracked(limit).map((path) => ({ label: path, paths: [path] }));
+}
 
 try {
-  for (const { label, paths: set } of work) {
+  for (const { label, paths: set, baseRef, repoRoot } of buildWork()) {
     if (set.length === 0) continue;
-    const { stdout, pathsFile } = runGate(set, dir);
+    const base = baseRef ?? defaultBase;
+    const root = repoRoot ?? REPO;
+    const { stdout, pathsFile } = runGate(set, dir, base, root);
     const gate = parseGateStdout(stdout);
     // The gate's normalized set, not the harness's raw one.
-    const engine = await runEngine(gate.changedPaths, pathsFile);
+    const engine = await runEngine(gate.changedPaths, pathsFile, base, root);
     if (mutate) engine.commands.shift();
     const problems = diff(label, gate, engine);
     compared += 1;
@@ -321,7 +730,13 @@ try {
   rmSync(dir, { recursive: true, force: true });
 }
 
-console.log(`\ncompared ${compared} single-path sets; ${differences} differed`);
+console.log(`\ncompared ${compared} ${corpus} sets; ${differences} differed`);
+// A harness that compared nothing has proven nothing, whatever the difference
+// count says.
+if (compared === 0) {
+  console.log("EMPTY CORPUS — this run proves nothing.");
+  process.exit(2);
+}
 if (mutate) {
   console.log(
     differences > 0

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -603,8 +603,14 @@ function corpusFixture(dir) {
   inFixture("init", "-q");
   inFixture("config", "user.email", "routing-parity@example.invalid");
   inFixture("config", "user.name", "routing-parity");
+  // Signing and hooks are the developer's, not this probe's. A global
+  // `commit.gpgsign` would ask a pinentry for a throwaway fixture commit —
+  // inside the outer gate run, since the mapping arm schedules this corpus —
+  // and a global `core.hooksPath` or `init.templateDir` would run their hooks
+  // against a repository that is not their work.
+  inFixture("config", "commit.gpgsign", "false");
   inFixture("add", "-A");
-  inFixture("commit", "-qm", "fixture");
+  inFixture("commit", "--no-verify", "-qm", "fixture");
 
   // Uncommitted, so `git show HEAD:package.json` and the working tree differ:
   // that diff is what the root-manifest classifier reads, and it makes the
@@ -681,19 +687,32 @@ function corpusSymlink() {
   return sets;
 }
 
-/** Create the symlink a `symlink` corpus set needs, and hand back its undo. */
+/**
+ * Create the symlink a `symlink` corpus set needs, and hand back its undo.
+ *
+ * SETUP CLEANS UP AFTER ITSELF. The caller only receives the undo once every
+ * step has succeeded, so a throw in between — a filesystem or sandbox that
+ * refuses `symlink(2)`, a transient `EEXIST` — would otherwise leave a probe
+ * directory at the root of the tree the outer gate is checking. Everything
+ * here is removed before the throw is re-raised.
+ */
 function withSymlink({ dir, link }) {
   const targetPath = join(REPO, dir);
   const linkPath = join(REPO, link);
-  rmSync(linkPath, { recursive: true, force: true });
-  rmSync(targetPath, { recursive: true, force: true });
-  mkdirSync(targetPath, { recursive: true });
-  writeFileSync(join(targetPath, "sentry-probe.test.mjs"), "// probe\n");
-  symlinkSync(targetPath, linkPath);
-  return () => {
+  const undo = () => {
     rmSync(linkPath, { recursive: true, force: true });
     rmSync(targetPath, { recursive: true, force: true });
   };
+  undo();
+  try {
+    mkdirSync(targetPath, { recursive: true });
+    writeFileSync(join(targetPath, "sentry-probe.test.mjs"), "// probe\n");
+    symlinkSync(targetPath, linkPath);
+  } catch (error) {
+    undo();
+    throw error;
+  }
+  return undo;
 }
 
 /** A dangling commit whose tree is HEAD's with one top-level path replaced. */
@@ -710,8 +729,11 @@ function baseCommitWith(dir, path, content) {
       return `${meta.split(" ")[0]} blob ${blob}\t${name}`;
     });
   const tree = git(["mktree"], `${entries.join("\n")}\n`).trim();
+  // `--no-gpg-sign`: this is a dangling probe object in the developer's REAL
+  // repository, and `commit-tree` honours `commit.gpgsign` too.
   return git([
     "commit-tree",
+    "--no-gpg-sign",
     tree,
     "-m",
     "routing-parity synthetic base",

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -318,7 +318,7 @@ export const AGENT_MODULE_ARMS = [
     ],
   },
   {
-    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. When the gate is flipped to read the engine's plan, this arm gains the self-test the way the routing-table arm already has it.",
+    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. The quoting test alone would leave routing, facts, verbs, ordering, compaction and scoped-test selection unchecked (Codex 3838109001), so the two CHEAP parity corpora run too: `fixture` (2s) covers the branch that skips repository-specific groups, and `multi` (57s) is where the four whole-set post-passes are actually exercised. The tracked, synthetic and base corpora are a 35-minute run and stay a per-PR step. When the gate is flipped to read the engine's plan the harness is deleted, and this arm gains the self-test the way the routing-table arm already has it (issue 2020).",
     patterns: [
       "scripts/gate/mapping.mjs",
       "scripts/gate/mapping/*.mjs",
@@ -328,6 +328,16 @@ export const AGENT_MODULE_ARMS = [
       {
         command: "node --test scripts/gate/mapping/shell-quote.test.mjs",
         reason: "gate mapping engine changed",
+      },
+      {
+        command: "node scripts/gate/routing-parity.mjs --corpus fixture",
+        reason:
+          "gate mapping engine changed (parity against the live arms, fixture repository)",
+      },
+      {
+        command: "node scripts/gate/routing-parity.mjs --corpus multi",
+        reason:
+          "gate mapping engine changed (parity against the live arms, whole-set post-passes)",
       },
     ],
   },

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -318,7 +318,7 @@ export const AGENT_MODULE_ARMS = [
     ],
   },
   {
-    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. The quoting test alone would leave routing, facts, verbs, ordering, compaction and scoped-test selection unchecked (Codex 3838109001), so the two CHEAP parity corpora run too: `fixture` (2s) covers the branch that skips repository-specific groups, and `multi` (57s) is where the four whole-set post-passes are actually exercised. The tracked, synthetic and base corpora are a 35-minute run and stay a per-PR step. When the gate is flipped to read the engine's plan the harness is deleted, and this arm gains the self-test the way the routing-table arm already has it (issue 2020).",
+    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. The quoting test alone would leave routing, facts, verbs, ordering, compaction and scoped-test selection unchecked (Codex 3838109001), so the three CHEAP parity corpora run too: `fixture` (2s) covers the branch that skips repository-specific groups, `symlink` (6s) covers the dynamic pattern source no committed path can reach — it is the corpus that caught the `..`-prefixed target bug — and `multi` (57s) is where the four whole-set post-passes are actually exercised. The tracked, synthetic and base corpora are a 35-minute run and stay a per-PR step. When the gate is flipped to read the engine's plan the harness is deleted, and this arm gains the self-test the way the routing-table arm already has it (issue 2020).",
     patterns: [
       "scripts/gate/mapping.mjs",
       "scripts/gate/mapping/*.mjs",
@@ -333,6 +333,11 @@ export const AGENT_MODULE_ARMS = [
         command: "node scripts/gate/routing-parity.mjs --corpus fixture",
         reason:
           "gate mapping engine changed (parity against the live arms, fixture repository)",
+      },
+      {
+        command: "node scripts/gate/routing-parity.mjs --corpus symlink",
+        reason:
+          "gate mapping engine changed (parity against the live arms, scripts/ symlink source)",
       },
       {
         command: "node scripts/gate/routing-parity.mjs --corpus multi",

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -318,6 +318,20 @@ export const AGENT_MODULE_ARMS = [
     ],
   },
   {
+    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. When the gate is flipped to read the engine's plan, this arm gains the self-test the way the routing-table arm already has it.",
+    patterns: [
+      "scripts/gate/mapping.mjs",
+      "scripts/gate/mapping/*.mjs",
+      "scripts/gate/routing-parity.mjs",
+    ],
+    effects: [
+      {
+        command: "node --test scripts/gate/mapping/shell-quote.test.mjs",
+        reason: "gate mapping engine changed",
+      },
+    ],
+  },
+  {
     why: "The bash-from-Node machinery. Its own suite already runs, because check-sentry-suites-in-ci.test.mjs imports it and the coverage arm routes that. What was missing is the OTHER consumer: ADR 0069's routing-table suite drives `runProbeShell`/`probeDirs` for the /bin/bash pattern oracle and `bashFunctionSource` for the implementation-signature pin. A change to the probe environment or to the end-of-function scan changes what both of those prove, and nothing said so.",
     patterns: [
       "scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs",


### PR DESCRIPTION
## The Problem

- D5a made the gate's routing data, but the routing that *runs* is still 1,400
  lines of bash `case` arms. Nothing consumes the table.
- Swapping the gate to a Node mapper is the step where routing stops being bash,
  and its failure mode is the one this whole track exists to remove: a mapper
  that maps fewer commands, exits 0, and prints "All mapped commands passed."
- That swap is only safe once there is evidence the two agree.

## The Solution

- `scripts/gate/mapping.mjs` and its helpers: changed paths + repo facts in,
  command plan out — the 29 effect verbs, the four whole-set post-passes, both
  classifiers, the two engine-computed pattern sources, the guards, and the four
  ordered buckets.
- `scripts/gate/routing-parity.mjs` compares that engine against the **live bash
  gate** and reports zero differences over six corpora that together reach every
  arm in the routing table and both dynamic pattern sources.
- **Nothing is wired.** The bash arms are still the routing that runs. A gate run
  on this branch is what it was before it.

## Details

**This is D5b part 1 of 2, and the split is the point.** The design has the
parity harness compare a pinned pre-swap worktree against an already-swapped
gate. That shape only exists because it assumed the swap had happened. Landing
the engine inert first makes a simpler and stronger comparison available: the
bash arms are still live, so the gate **is** the oracle — same tree, same
commit, no pinned worktree to keep in step, and every difference attributable to
the engine rather than to checkout skew. It also means every commit here is
additive, and the irreversible-feeling step lands separately with its own
evidence.

**What the engine implements.** The verbs are transcriptions, not re-designs —
command strings, ordering, the parenthesised reason suffixes, and which bucket
each lands in are all contract that `routing.test.mjs` and the freshness stamp
depend on. Dedupe keeps the first reason and aliases the two alias/script pairs.
The four post-passes run in the fixed order Trunk → codegen sort → Turbo
compaction → scoped tests, because the last two read state the earlier ones set.

**`printf %q` is reproduced, not approximated — and position is part of it.**
Several routed commands interpolate a changed path, and the command string is
what the stamp hashes. Measured on bash 3.2.57 and 5.3.15 across every
printable ASCII character in seven positions: `#` and `~` are left alone
mid-string while `,` and `^` are escaped, which is exactly the split a
hand-written "escape anything unusual" version gets wrong. Two characters turn
on position, and only the measurement says so:

- a **leading** `#` is escaped by both builds, and has to be — an unescaped `#`
  opening a word comments out the rest of the command, so `bash -n #file` would
  have run `bash -n` with no argument;
- a `~` where a tilde expansion could start — index 0, or straight after `=` or
  `:` — is escaped by 5.3.15 and left alone by 3.2.57. There is no single
  correct string, so `shellQuote` **refuses**. A guess matches the gate on one
  machine and not on another: a freshness stamp that never lands and a parity
  result that depends on which bash ran.

`shell-quote.test.mjs` asks every installed bash rather than asserting
remembered answers, now with every position-sensitive character leading,
trailing and mid-word, plus a control that asks the installed builds whether
they really do disagree about `~x`.

**Fail-closed, and the direction is checked one source at a time.** An unknown
verb, guard, dispatch subject or dynamic source throws. A missing lockfile
classifier is exit 2 and a missing routing classifier is exit 3, both matching
the gate — because those failures are invisible otherwise: the narrowing simply
stops happening and the run reads as slow rather than broken. Three fact
sources moved this round:

- `terraform.stacks.json` is a **refusal**, not an empty list. The gate
  separates absent from invalid (`agent-quality-gate.sh:263-302`): no registry
  is a fixture repository, an unparsable or unsafe registry is `exit 2`. The
  engine now transcribes the same validation — version, non-empty, path safety,
  uniqueness — and throws with `exitCode 2`. Returning `[]` there dropped
  `terraform validate` for every registered stack silently.
- The `scripts/` symlink targets are read from the **working tree**, matching
  the gate's `find scripts -type l`, rather than from git's index. An untracked
  directory symlink is one the gate sees and the index does not, and missing it
  drops the Sentry routing for everything beneath it.
- `pathIsFile` is a regular-file test, matching `[[ -f ]]`. `existsSync` is
  `[[ -e ]]`, which is true for a directory, a directory symlink and a gitlink.
- A symlink target whose NAME starts with two dots — `..tools` — is inside the
  repository, and the gate's prefix match accepts it. Rejecting every `..`
  prefix dropped a routing pattern the gate has.

An unreadable root manifest still classifies as `workspace` — the full suite —
because that is what the gate does and it is the wide answer.

**The parity gap the corpora had, found by measuring rather than by reading.**
Every set in the original harness ran with base and head at the same commit, on
this checkout, against whatever the tree happens to hold. Four families of
routing were unreachable that way.

**Two read the base↔head diff** rather than the changed-path list:

- `classify_root_package_json_changes` has four classes, and an empty diff is
  always `workspace`. Three classes, five dispatch arms and the 29-command
  `add_root_tooling_package_script_checks` verb never fired.
- `lockfile_scoped_importers` reports the importers that *changed*, and an empty
  diff reports none — so the scoped branch was entered with an empty importer
  list, and the whole importer→bundle map, including the
  `mark_lockfile_scoped_package` calls that disable scoped tests, was never
  reached.

**The third is the repository-specific fence.** Four routing effects are gated
on `[[ "$script_source_dir" == "$repo_root/scripts" ]]` so the gate's own unit
tests do not inherit them — the two Sentry arms, the symlink groups and the
unconditional `pnpm tf:test` sweep. Every set ran the gate on its own checkout,
where that is true, so the engine's `isRealTree: false` branch — a branch whose
only effect is to SKIP groups — had no comparison at all.

**The fourth is a dynamic pattern source with no members.**
`scriptsSymlinkTargets` builds its arms from `find scripts -type l`, and this
repository has no directory symlink, so that group was inert in every set. It is
where the `..`-prefixed containment bug was hiding.
(`registeredTerraformStacks`, the other dynamic source, has six members with
tracked paths beneath them, so pass 1 already reached it.)

Measured against the table: the tracked corpus reaches **225 of 234** arms. The
nine it cannot reach are those five class-dispatch arms, the `.npmrc` family
(this repo has no `.npmrc`), and a `package.json`-under-any-directory arm that
every earlier package arm claims first. Four new corpora close all four
families: the same measurement now reports **234 of 234**, and both dynamic
sources are exercised.

## Validation

**Parity, six corpora, zero differences, each proven falsifiable.**

| Corpus | Sets | Differences | What only it covers |
| --- | --- | --- | --- |
| `tracked` | 2,272 | **0** | every tracked path, one per run |
| `multi` | 43 | **0** | the four whole-set post-passes |
| `synthetic` | 235 | **0** | arms no tracked path reaches |
| `base` | 11 | **0** | the four root-manifest classes; lockfile importer scoping |
| `fixture` | 8 | **0** | the gate running outside its own tree |
| `symlink` | 6 | **0** | the `scripts/` directory-symlink pattern source |

2,575 comparisons in total. `--mutate` drops one command from the engine's plan
and the harness reds (`MUTATION CONTROL FIRED`) on every corpus, every set. A
green run was not believed before that.

`--corpus base` builds a dangling commit with `commit-tree` whose tree is HEAD's
with one blob replaced, then runs both sides against it. Each set was checked to
reach the branch it was built for rather than assumed to: the four manifest
classes produce 33 / 57 / 13 / 30 commands with distinct reason strings, the
four mappable importers take the scoped route with their own bundle, and the
three fail-toward-full shapes (root importer, non-importer section, co-changed
manifest) widen.

`--corpus fixture` builds a throwaway git repository the shape
`agent-quality-gate.test.sh` builds and invokes this checkout's gate against it,
so `$script_source_dir` and `$repo_root/scripts` differ. Its positive control is
the sweep: every fixture plan lacks the unconditional `pnpm tf:test` that every
real-tree plan carries.

`--corpus symlink` creates a directory symlink under `scripts/` for the duration
of each set and removes it again, the way the gate self-test does, with two
targets: an ordinary name and a `..`-prefixed one. It red on
`symlink-dotdot-prefixed-beneath-target` before the containment fix and is green
after — the negative control for both the bug and the corpus.

Of the twenty-five new sets, twenty-four matched on the first run: the gap was
missing evidence rather than a defect everywhere except the symlink containment
rule, which no corpus could previously see.

**The gate now runs the cheap corpora itself.** The arm that fires for
`scripts/gate/mapping*` scheduled only the shell-quoting unit test, which
imports nothing from the engine — routing, facts, verbs, ordering, compaction
and scoped-test selection could all regress with the gate still green. It now
runs `fixture` (2s), `symlink` (6s) and `multi` (57s) as well. The tracked,
synthetic and base corpora are a 35-minute run and stay a per-PR step.

**Review findings, and the control for each.**

- *Terraform registry fails open.* Eight corruption shapes — unparsable, wrong
  version, non-array `stacks`, empty `stacks`, absolute path, traversal path,
  duplicate paths, non-string path — now refuse on **both** sides: gate `exit 2`,
  engine `throw` with `exitCode 2`. The unmodified registry is the positive
  control: gate `exit 0`, engine six stacks.
- *`--limit` NaN produced an empty corpus and exit 0.* A bare `--limit`, `0`,
  `1.5` and `abc` are now `exit 2`, and so are an unknown `--corpus`, a bare
  `--corpus` and a bare `--base`. Separately, `compared === 0` exits 2 with
  "EMPTY CORPUS — this run proves nothing", proven by forcing the corpus empty
  and watching the harness go from exit 0 to exit 2.
- *`pathIsFile` versus `[[ -f ]]`.* Five shapes built in a scratch worktree —
  regular file, directory, directory symlink, dangling symlink, file symlink —
  agree three ways: real bash, the gate's plan, the engine's plan. The tree has
  no committed `.sh` directory or gitlink today, so the divergence was latent;
  `existsSync` on a `.sh` directory returns true where `[[ -f ]]` returns false,
  which would have scheduled `bash -n <directory>`.
- *Usage block and summary line.* `--corpus` is now read and validated,
  `--pass2` is documented as its alias, `--base` is documented and threaded
  through both sides, and the summary names the corpus it compared.

**Quoting, measured rather than remembered.** 658 subjects — every printable
ASCII character alone, leading, trailing, mid-word, and after `=`, `:` and `/` —
against both installed bash builds: 0 mismatches, and the only four cases where
the builds disagree with each other are the four the engine refuses.

The ANSI-C branch was measured separately after the second review round found it
untested: bash gives ESC its own escape (`$'a\Eb'`) where every other unnamed
control character becomes octal, and the engine was emitting `$'a\033b'`. The
oracle could not have caught it — it fed subjects through `read -r`, one per
line, so a tab, an ESC or a newline could never be a subject and the whole
`$'…'` form was asserted by a header comment. Subjects now go in as positional
arguments and the corpus carries tab, ESC, DEL, newline, CR, BEL, VT and a
control character beside a non-ASCII byte. Negative control: removing the ESC
entry reds both builds on exactly the three ESC subjects.

**The probes do not touch the developer's tree or config.** `--corpus symlink`
cleans up inside its own setup, so a filesystem that refuses `symlink(2)` cannot
leave a probe directory at the repository root; and the fixture and base corpora
pin `commit.gpgsign=false`, `--no-verify` and `--no-gpg-sign`, so a global
signing or hooks configuration cannot ask a pinentry for a throwaway probe
commit from inside a gate run.

**Commands:** `pnpm gate:routing-table:test` (62/62, equality against the arms
still green), `node --test scripts/gate/mapping/shell-quote.test.mjs` (6/6 across
both bash builds), `pnpm lint:scripts`, `GATE_TEST_FOCUS=routing-sources`, full
gate green at the pre-push hook's exact form.

**Review rounds.** Four bot threads addressed and resolved. The codex autoreview
engine raised three findings across successive rounds — the `%q` leading-`#`
escape, the gate arm that validated nothing, and the `..`-prefixed symlink
target — each verified against the code and fixed. The claude engine then raised
three more: the ESC escape and its untested branch (fixed), the probe cleanup
and git-config hygiene above (fixed), and a claim that bytes >= 0x80 are
octal-escaped inside ANSI-C quoting, which measurement refuted — both builds
pass them through, and a subject now pins that.

## Deferrals

Part 2 carries the swap itself and everything that only makes sense with it,
tracked in #2020:

- #2020 — the gate calling the mapper and reading the plan back as TSV.
- #2020 — engine unit tests beyond `shellQuote`, and the routing-sources
  self-test assertion for the engine arm.
- #2020 — the stdout-format contract assertion for `agent-prewarm.mjs`.
- #2020 — `implementation_signature()` entries and `turbo.json` inputs for the
  engine. Deliberately *not* added here, because the engine is not yet an input
  to any gate decision and pinning it now would invalidate every warm stamp for
  no behavioural reason.
- #2020 — harvesting the `run_gate` argument sets from the self-test as a
  further parity corpus.
- #2020 — deleting the harness, which happens once the swap lands.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals.
- [x] Architecture decision? ADR 0069 already records this seam; this PR
      implements it and changes no decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quality-gate routing (command selection, lockfile scoping, fail-closed classifiers) but does not wire the engine into live runs; bash `case` arms remain the authority.
> 
> **Overview**
> Lands **D5b part 1**: a Node mapping engine that turns changed paths + repo facts into the same command plan the bash quality gate already emits — **without wiring it**. Live routing is still the bash `case` arms.
> 
> `buildPlan` walks `ROUTING_PLAN`, applies the 29 effect verbs, then the four post-passes (Trunk, codegen sort, Turbo compaction, scoped tests). Fail-closed: unknown verbs/guards throw; unreadable facts widen to the full workspace suite rather than shrinking the plan.
> 
> `routing-parity.mjs` diffs the engine against the live gate on the same tree (single-path + multi-path corpora, with a `--mutate` control). Mapping-engine path changes now schedule `shell-quote.test.mjs`, which checks `printf %q` against installed bash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af2fdfb613a724a3ec3ce57ff5ebfe4e2689195. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent quality-gate routing based on changed files and repository state.
  * Added safe scoped testing and validation, with automatic escalation to full-workspace checks when needed.
  * Improved command planning, ordering, deduplication, code generation sequencing, and shell-safe path handling.

* **Tests**
  * Added routing parity checks across fixture, symlink, and multi-path scenarios.
  * Added comprehensive shell-quoting compatibility coverage.
  * Routing changes now automatically schedule the relevant verification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
