### PR TITLE
feat(scripts): the quality gate routes from the Node mapping engine, behind an in-production parity guard (D5b part 2)

### DIFF
--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -3,7 +3,7 @@ title: scripts/ may use module subdirectories; basenames and pinned paths are th
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-20
+last_verified: 2026-08-22
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -309,6 +309,12 @@ routing, not procedure.
    by `gate-equality.test.mjs`, which fails if only one side moved — so the sweep
    is not done until both are repointed. Every module in that directory is also
    an `implementation_signature()` entry, with the same `__missing__` freeze.
+   Since D5b part 2 there is a third side: `scripts/gate/mapping.mjs` and
+   `scripts/gate/mapping/` build the plan the gate actually uses, and the gate
+   resolves the mapper from `$script_source_dir` in one more literal. Those
+   modules carry the same signature and `turbo.json` pins, and a move that
+   misses the mapper refuses the run outright rather than going quiet — the gate
+   checks for it before it calls it.
 10. `forbidden_sources` in `docs/evals/documentation-navigation-fixtures.json`
     names the navigation evaluation's own implementation, so a run cannot read
     the answers out of it. `validateFixtureSuite` checks those paths for

--- a/docs/adr/0069-gate-routing-table-as-data.md
+++ b/docs/adr/0069-gate-routing-table-as-data.md
@@ -3,7 +3,7 @@ title: The quality gate's routing table is data, compiled by the repo's own bash
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-21
+last_verified: 2026-08-22
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -13,9 +13,12 @@ garden_lane: adrs-architecture
 
 # ADR 0069 — the quality gate's routing table is data, compiled by the repo's own bash-`case` translator
 
-**Status:** Active (Aug 2026). First implementation PR: the D5a step of
+**Status:** Active (Aug 2026). Implemented across three PRs of
 [issue 1877](https://github.com/mento-protocol/monitoring-monorepo/issues/1877)'s
-deferred track.
+deferred D5 track: D5a made the table data, D5b landed the Node mapping engine
+and proved it at parity, and D5b part 2 made it the routing behind an
+in-production parity guard. D5c retires the bash arms after the soak
+([issue 2020](https://github.com/mento-protocol/monitoring-monorepo/issues/2020)).
 
 **Scope:** ci/process
 
@@ -165,6 +168,33 @@ or reorders an arm and does not touch the data. It also runs in the required
 the local pre-push gate is the thing a contributor can bypass, and a table that
 has drifted from the arms fails nowhere at all.
 
+### 4. D5b part 2: the engine becomes the routing, behind a guard that runs in production
+
+The gate no longer builds its plan from the `case` arms. It runs
+`scripts/gate/mapping.mjs` once per run, reads the plan back as the TSV
+`write_command_plan` already emits, and uses that. The arms still execute, and
+the gate **refuses the whole run if the two plans differ by one byte** — every
+record, in order, including the two run-scoped flags the routing sets.
+
+That guard is the point of the split. The parity harness proved agreement over
+a corpus; this proves it over whatever a contributor actually changed, on every
+run, on every machine. It is also what makes the step reversible without a
+revert: a divergence stops the run rather than silently picking a winner, and
+the arms are still sitting there.
+
+Every failure around the seam is a refusal, because the failure mode this whole
+track exists to remove is a plan that came out smaller and still exited 0: a
+mapper that cannot be found, exits non-zero, emits nothing, emits a record the
+gate cannot parse, or names a bucket that does not exist. Measured, each of
+those refuses with exit 2 (evidence below).
+
+**Why the arms stay for a soak rather than going in the same PR.** The engine's
+plan is now hashed into the freshness stamp and executed. The arms cost nothing
+but wall-clock, and while they run, every gate invocation anyone makes is
+another parity sample on a path set nobody thought to put in a corpus. D5c
+deletes the arms, the comparison, and the harness together, once the soak has
+produced no refusal.
+
 ### The new data is a pinned trust surface
 
 Six pins land with the table:
@@ -244,6 +274,45 @@ gate is not a trust root.
 
 ## Consequences
 
+- **Routing is Node now, and the pins moved with it.** `implementation_signature()`
+  gained the seven engine modules, the two engine test files and the harness;
+  `turbo.json` gained `scripts/gate/mapping.mjs` and `scripts/gate/mapping/**`
+  at all three sites that already carried the table. A missing entry freezes the
+  stamp, which is the ADR 0064 failure, and it is now load-bearing for code that
+  decides what runs rather than for data nothing consumed.
+- **The soak costs wall-clock; D5c pays it back with interest.** Measured on a
+  representative 24-path change set, dry run: pre-swap 10.2s, post-swap 11.1s
+  (the arms and the engine both run, plus the comparison), and 0.7s with the
+  arms disabled — the D5c projection, measured rather than estimated, by
+  starving the bash loop in a throwaway copy. The bash routing costs ~0.42s per
+  changed path; the engine maps the same 24 paths in 0.12s including Node
+  startup. On a single-path change the difference is noise (0.47s → 0.64s).
+  So the swap is slightly slower today and roughly **14× faster on a 24-path
+  change once D5c lands**.
+- **The dry-run stdout did not move.** Byte-identical before and after on the
+  24-path set and on a workspace-escalating set, after the
+  `__CHANGED_PATHS_FILE__` substitution `write_command_plan` already applies —
+  the only raw difference is the randomized scratch path, which differs between
+  two runs of the _same_ gate. The freshness stamp therefore hashes identically,
+  and the two Node consumers that parse that stdout keep parsing it.
+- **The parity harness survives the swap, and changes job.** The design had it
+  deleted here. It is kept, because after the swap its own comparison is
+  circular — the gate's plan IS the engine's — while its seven corpora are now
+  the only way to drive the _in-gate_ guard across 2,905 path sets in one
+  command. It reports a gate refusal as the difference it is instead of dying on
+  it. It goes at D5c with the arms and the guard, since all three are one
+  mechanism.
+- **The engine's behaviour is pinned by its own tests, not only by the arms.**
+  `scripts/gate/mapping/engine.test.mjs` covers dedupe and first-reason-wins, the
+  alias pairs, prepend, bucket order, the four post-passes including the 15/16
+  scoped-test threshold and every disqualifier, and the root-manifest
+  classifier's four classes. Without it, D5c would delete the only thing pinning
+  those rules in the same commit that removes the arms.
+- **`agent:prewarm` now has an end-to-end contract test.** It parses the gate's
+  dry-run stdout and no-ops silently when the format drifts; the command lines
+  are produced by a different program than the header literals it was pinned
+  against, so the test now runs the real gate and requires a non-empty
+  extraction.
 - **`scripts/gate/routing-table/` is a new pinned surface.** Every `scripts/`
   move must now update the data as well as the arms, and ADR 0064's sweep
   checklist gains it. A missing `implementation_signature()` entry freezes the
@@ -306,7 +375,9 @@ gate is not a trust root.
   — 13 top-level `case` statements, 53 counting nested, 232 arms, 478 distinct
   patterns of which 362 are glob-free, 29 verbs.
 - Paired-arm rationale, verbatim in the source: `agent-quality-gate.sh:3802-3834`.
-- `implementation_signature()`: `agent-quality-gate.sh:4667`.
+- `implementation_signature()`: `agent-quality-gate.sh:4912`. The list grew at
+  D5b part 2 — seven engine modules, two engine test files and the parity
+  harness — which is why the line moved from `4667`.
 - Routing consumers: `scripts/gate/agent-prewarm.mjs:37`;
   `scripts/production-infra-identity-contract/routing.test.mjs:127`.
 - Bash-from-Node machinery reused by the oracle:

--- a/docs/adr/0069-gate-routing-table-as-data.md
+++ b/docs/adr/0069-gate-routing-table-as-data.md
@@ -298,7 +298,7 @@ gate is not a trust root.
 - **The parity harness survives the swap, and changes job.** The design had it
   deleted here. It is kept, because after the swap its own comparison is
   circular — the gate's plan IS the engine's — while its seven corpora are now
-  the only way to drive the _in-gate_ guard across 2,905 path sets in one
+  the only way to drive the _in-gate_ guard across 2,906 path sets in one
   command. It reports a gate refusal as the difference it is instead of dying on
   it. It goes at D5c with the arms and the guard, since all three are one
   mechanism.
@@ -375,9 +375,11 @@ gate is not a trust root.
   — 13 top-level `case` statements, 53 counting nested, 232 arms, 478 distinct
   patterns of which 362 are glob-free, 29 verbs.
 - Paired-arm rationale, verbatim in the source: `agent-quality-gate.sh:3802-3834`.
-- `implementation_signature()`: `agent-quality-gate.sh:4912`. The list grew at
-  D5b part 2 — seven engine modules, two engine test files and the parity
-  harness — which is why the line moved from `4667`.
+- `implementation_signature()`: `agent-quality-gate.sh:4923`, measured at D5b
+  part 2. The list grew there — seven engine modules, two engine test files and
+  the parity harness — which is why the line moved from `4667`. Both suites
+  locate the function by NAME rather than by line, so this citation is a reading
+  aid and not a pin.
 - Routing consumers: `scripts/gate/agent-prewarm.mjs:37`;
   `scripts/production-infra-identity-contract/routing.test.mjs:127`.
 - Bash-from-Node machinery reused by the oracle:

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -75,8 +75,10 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `docs/docs-navigation-eval-helpers.mjs` and `gate/lockfile-scope.mjs` to
   `$script_source_dir` in three literals, not stub `$repo_root`. Repoint all
   three (ADR 0064).
-- **Gate routing-table pins.** Every `gate/routing-table/*.mjs` module is an
-  `implementation_signature()` and `turbo.json` entry
+- **Gate routing and mapping pins.** Every `gate/routing-table/*.mjs`,
+  `gate/mapping*.mjs` and `gate/routing-parity.mjs` is an
+  `implementation_signature()` and `turbo.json` entry. The engine is the routing
+  now, so a missing pin freezes the stamp for code that picks what runs
   ([ADR 0069](../docs/adr/0069-gate-routing-table-as-data.md)).
 - **Evaluation fixture forbidden lists.** `forbidden_sources` in
   `docs/evals/documentation-navigation-fixtures.json` names the navigation

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -75,10 +75,10 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `docs/docs-navigation-eval-helpers.mjs` and `gate/lockfile-scope.mjs` to
   `$script_source_dir` in three literals, not stub `$repo_root`. Repoint all
   three (ADR 0064).
-- **Gate routing and mapping pins.** Every `gate/routing-table/*.mjs`,
-  `gate/mapping*.mjs` and `gate/routing-parity.mjs` is an
-  `implementation_signature()` and `turbo.json` entry. The engine is the routing
-  now, so a missing pin freezes the stamp for code that picks what runs
+- **Gate routing and mapping pins.** Every `gate/routing-table/*.mjs` and
+  `gate/mapping*.mjs` is an `implementation_signature()` and `turbo.json` entry;
+  `gate/routing-parity.mjs` is signature-only (a mapped command, not a Turbo
+  input). A missing pin freezes the stamp for routing code
   ([ADR 0069](../docs/adr/0069-gate-routing-table-as-data.md)).
 - **Evaluation fixture forbidden lists.** `forbidden_sources` in
   `docs/evals/documentation-navigation-fixtures.json` names the navigation

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4027,6 +4027,9 @@ while IFS= read -r path; do
           # deleted, and this arm gains the self-test the way the routing-table
           # arm already has it.
           add_command "node --test scripts/gate/mapping/shell-quote.test.mjs" "gate mapping engine changed"
+          add_command "node --test scripts/gate/mapping/engine.test.mjs" "gate mapping engine changed (behaviour the arms will stop pinning at D5c)"
+          add_command "pnpm agent:quality-gate:test" "gate mapping engine produces the stdout the gate suite asserts on"
+          add_command "node scripts/gate/agent-prewarm.test.mjs" "gate mapping engine produces the stdout agent:prewarm parses"
           add_command "node scripts/gate/routing-parity.mjs --corpus fixture" "gate mapping engine changed (parity against the live arms, fixture repository)"
           add_command "node scripts/gate/routing-parity.mjs --corpus symlink" "gate mapping engine changed (parity against the live arms, scripts/ symlink source)"
           add_command "node scripts/gate/routing-parity.mjs --corpus multi" "gate mapping engine changed (parity against the live arms, whole-set post-passes)"
@@ -4699,6 +4702,166 @@ sort_codegen_commands
 compact_turbo_quality_commands
 apply_scoped_test_commands
 
+# ── D5b part 2: the Node mapping engine is the routing ──────────────────────
+#
+# Everything above this line is the bash `case` arms, and they still run. What
+# changes here is which plan the gate USES: the mapper's. The arms become a
+# cross-check, and the gate REFUSES the whole run if the two plans differ by one
+# byte. That is parity in production rather than parity in a harness, and it is
+# what makes the swap reversible — a divergence stops the run instead of
+# silently choosing a winner.
+#
+# D5c deletes the arms and this comparison once the soak is clean. ADR 0069.
+#
+# EVERY failure below is a refusal. A mapper that crashes, exits non-zero,
+# prints something unparsable, names a bucket that does not exist, or emits
+# nothing at all must not leave the gate running on a partial plan: fewer mapped
+# commands still print "All mapped commands passed."
+plan_records_from_bash() {
+  local entry
+  printf 'flag\tpackage_script_risk_changed\t%s\n' "$package_script_risk_changed"
+  printf 'flag\tsaw_workspace_escalation\t%s\n' "$saw_workspace_escalation"
+  for entry in "${surfaces[@]+"${surfaces[@]}"}"; do
+    printf 'surface\t%s\n' "$entry"
+  done
+  for entry in "${checklists[@]+"${checklists[@]}"}"; do
+    printf 'checklist\t%s\t%s\n' "${entry%%|*}" "${entry#*|}"
+  done
+  for entry in "${preflight_commands[@]+"${preflight_commands[@]}"}"; do
+    printf 'preflight\t%s\t%s\n' "${entry%%|*}" "${entry#*|}"
+  done
+  for entry in "${codegen_commands[@]+"${codegen_commands[@]}"}"; do
+    printf 'codegen\t%s\t%s\n' "${entry%%|*}" "${entry#*|}"
+  done
+  for entry in "${post_codegen_commands[@]+"${post_codegen_commands[@]}"}"; do
+    printf 'post-codegen\t%s\t%s\n' "${entry%%|*}" "${entry#*|}"
+  done
+  for entry in "${quality_commands[@]+"${quality_commands[@]}"}"; do
+    printf 'quality\t%s\t%s\n' "${entry%%|*}" "${entry#*|}"
+  done
+}
+
+mapper_path="$script_source_dir/gate/mapping.mjs"
+# Checked before the call, and separately from a run failure: a mapper the gate
+# cannot find is a repointing mistake, not a routing result, and it must not
+# read as one.
+if [[ ! -f "$mapper_path" ]]; then
+  echo "error: gate mapping engine could not be loaded from ${mapper_path}" >&2
+  echo "       scripts/agent-quality-gate.sh runs this module at pre-push time; moving it requires repointing that path in the same commit." >&2
+  exit 2
+fi
+
+mapper_args=(
+  "$mapper_path"
+  --repo-root "$repo_root"
+  --changed-paths-file "$changed_paths_file"
+  --base "$base_ref"
+  --head "$head_ref"
+  --script-source-dir "$script_source_dir"
+)
+if [[ "$script_source_dir" == "$repo_root/scripts" ]]; then
+  mapper_args+=(--real-tree)
+fi
+if [[ "$full_local_tests" == "1" || "$full_local_tests" == "true" ]]; then
+  mapper_args+=(--full-local-tests)
+fi
+
+mapper_plan_file="$(make_tmpfile)"
+mapper_status=0
+node "${mapper_args[@]}" > "$mapper_plan_file" || mapper_status=$?
+if [[ "$mapper_status" -ne 0 ]]; then
+  echo "error: gate mapping engine failed (exit ${mapper_status}); refusing to run on a plan it did not produce" >&2
+  exit "$mapper_status"
+fi
+if [[ ! -s "$mapper_plan_file" ]]; then
+  echo "error: gate mapping engine produced an empty plan; refusing to run" >&2
+  exit 2
+fi
+
+engine_preflight_commands=()
+engine_codegen_commands=()
+engine_post_codegen_commands=()
+engine_quality_commands=()
+engine_checklists=()
+engine_surfaces=()
+engine_package_script_risk_changed=false
+mapper_record=""
+mapper_rest=""
+mapper_field=""
+while IFS= read -r mapper_record; do
+  [[ -n "$mapper_record" ]] || continue
+  mapper_rest="${mapper_record#*$'\t'}"
+  case "$mapper_record" in
+    flag$'\t'*)
+      mapper_field="${mapper_rest%%$'\t'*}"
+      case "${mapper_field}=${mapper_rest#*$'\t'}" in
+        package_script_risk_changed=true) engine_package_script_risk_changed=true ;;
+        package_script_risk_changed=false) ;;
+        # Accepted and compared, not stored: its only reader already ran. An
+        # unrecognised VALUE still falls through to the refusal below.
+        saw_workspace_escalation=true | saw_workspace_escalation=false) ;;
+        *)
+          echo "error: gate mapping engine emitted an unknown flag record: ${mapper_record}" >&2
+          exit 2
+          ;;
+      esac
+      ;;
+    surface$'\t'*) engine_surfaces+=("$mapper_rest") ;;
+    checklist$'\t'*)
+      engine_checklists+=("${mapper_rest%%$'\t'*}|${mapper_rest#*$'\t'}")
+      ;;
+    preflight$'\t'*)
+      engine_preflight_commands+=("${mapper_rest%%$'\t'*}|${mapper_rest#*$'\t'}")
+      ;;
+    codegen$'\t'*)
+      engine_codegen_commands+=("${mapper_rest%%$'\t'*}|${mapper_rest#*$'\t'}")
+      ;;
+    post-codegen$'\t'*)
+      engine_post_codegen_commands+=("${mapper_rest%%$'\t'*}|${mapper_rest#*$'\t'}")
+      ;;
+    quality$'\t'*)
+      engine_quality_commands+=("${mapper_rest%%$'\t'*}|${mapper_rest#*$'\t'}")
+      ;;
+    *)
+      echo "error: gate mapping engine emitted an unparsable record: ${mapper_record}" >&2
+      exit 2
+      ;;
+  esac
+done < "$mapper_plan_file"
+
+# The transitional guard. Order matters on both sides — the buckets, the
+# surfaces and the checklists all print and hash in sequence — so this is a
+# byte comparison of the whole plan, not a set comparison.
+bash_plan_file="$(make_tmpfile)"
+plan_records_from_bash > "$bash_plan_file"
+if ! diff -u "$bash_plan_file" "$mapper_plan_file" > "$bash_plan_file.diff" 2>&1; then
+  echo "error: the gate mapping engine and the bash routing arms disagree." >&2
+  echo "       This is the D5c soak guard: the run is refused rather than run on either plan." >&2
+  echo "       -bash +engine:" >&2
+  sed 's/^/       /' "$bash_plan_file.diff" >&2
+  rm -f "$bash_plan_file.diff"
+  exit 2
+fi
+rm -f "$bash_plan_file.diff"
+
+# The engine's plan is the plan. Assigned from its records rather than left as
+# the bash arrays, so that when D5c deletes the arms nothing downstream moves.
+preflight_commands=("${engine_preflight_commands[@]+"${engine_preflight_commands[@]}"}")
+codegen_commands=("${engine_codegen_commands[@]+"${engine_codegen_commands[@]}"}")
+post_codegen_commands=("${engine_post_codegen_commands[@]+"${engine_post_codegen_commands[@]}"}")
+quality_commands=("${engine_quality_commands[@]+"${engine_quality_commands[@]}"}")
+checklists=("${engine_checklists[@]+"${engine_checklists[@]}"}")
+surfaces=("${engine_surfaces[@]+"${engine_surfaces[@]}"}")
+# This one is still read below, by the refusal that stops a run whose package
+# manifests or lockfile changed, so it has to cross the seam.
+package_script_risk_changed="$engine_package_script_risk_changed"
+# `saw_workspace_escalation` deliberately does NOT get assigned here. Its only
+# reader is `scoped_tests_enabled`, which ran in the post-passes above, so an
+# assignment at this point would be dead code that reads like a live flag. It is
+# still carried across the seam and compared, because a disagreement about it
+# means the two sides escalated differently even where the command lists happen
+# to match.
+
 hash_sha256() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$@"
@@ -4761,6 +4924,16 @@ implementation_signature() {
     scripts/check-agent-quality-gate-package-scripts.mjs \
     scripts/docs/docs-navigation-eval-helpers.mjs \
     scripts/gate/lockfile-scope.mjs \
+    scripts/gate/mapping.mjs \
+    scripts/gate/mapping/facts.mjs \
+    scripts/gate/mapping/plan.mjs \
+    scripts/gate/mapping/post-passes.mjs \
+    scripts/gate/mapping/route.mjs \
+    scripts/gate/mapping/shell-quote.mjs \
+    scripts/gate/mapping/shell-quote.test.mjs \
+    scripts/gate/mapping/verbs.mjs \
+    scripts/gate/mapping/engine.test.mjs \
+    scripts/gate/routing-parity.mjs \
     scripts/gate/routing-table/arms-agent-modules.mjs \
     scripts/gate/routing-table/arms-alerts.mjs \
     scripts/gate/routing-table/arms-packages.mjs \

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -4771,7 +4771,11 @@ mapper_status=0
 node "${mapper_args[@]}" > "$mapper_plan_file" || mapper_status=$?
 if [[ "$mapper_status" -ne 0 ]]; then
   echo "error: gate mapping engine failed (exit ${mapper_status}); refusing to run on a plan it did not produce" >&2
-  exit "$mapper_status"
+  # Exit 2, not the mapper's own code. 2 is this gate's refusal status, and the
+  # bash routing classifier already collapses its own 3 into a 2 the same way
+  # (`:2010`). Forwarding 1 or 3 here would make a mapper crash look like a
+  # different class of failure to anything reading the gate's status.
+  exit 2
 fi
 if [[ ! -s "$mapper_plan_file" ]]; then
   echo "error: gate mapping engine produced an empty plan; refusing to run" >&2

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -2070,6 +2070,51 @@ assert_contains "error: lockfile scope classifier could not be loaded from"
 assert_not_contains "lockfile change scoped to importers"
 assert_not_contains "- cd aegis && forge test (workspace dependency/config changed)"
 
+# The mapping engine is the routing now (ADR 0069, D5b part 2), so a gate that
+# cannot find it must refuse rather than fall back to the bash arms it still
+# carries. That fallback is the tempting bug: the arms are RIGHT THERE, and
+# using them would look like resilience while quietly returning the gate to a
+# routing path nothing checks any more.
+#
+# Same mirror trick as the classifier case above, one level deeper: every
+# scripts/ entry is symlinked, and `gate` is rebuilt as a real directory whose
+# contents are symlinks minus mapping.mjs.
+mapper_missing_dir="$(mktemp -d)"
+for mapper_sibling in "$repo_root"/scripts/*; do
+  mapper_sibling_name="$(basename "$mapper_sibling")"
+  if [[ "$mapper_sibling_name" != "gate" ]]; then
+    ln -s "$mapper_sibling" "$mapper_missing_dir/$mapper_sibling_name"
+  fi
+done
+mkdir -p "$mapper_missing_dir/gate"
+for mapper_gate_entry in "$repo_root"/scripts/gate/*; do
+  mapper_gate_entry_name="$(basename "$mapper_gate_entry")"
+  if [[ "$mapper_gate_entry_name" != "mapping.mjs" ]]; then
+    ln -s "$mapper_gate_entry" "$mapper_missing_dir/gate/$mapper_gate_entry_name"
+  fi
+done
+mapper_missing_repo="$(mktemp -d)"
+(
+  cd "$mapper_missing_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf '{ "name": "fixture" }\n' > package.json
+  git add package.json
+  git commit -qm init
+  printf 'export const changed = 1;\n' > changed.mjs
+  set +e
+  bash "$mapper_missing_dir/agent-quality-gate.sh" --base HEAD > "$output_file" 2>&1
+  printf '%s\n' "$?" > exit-code
+  set -e
+)
+mapper_missing_exit="$(cat "$mapper_missing_repo/exit-code")"
+rm -rf "$mapper_missing_dir" "$mapper_missing_repo"
+[[ "$mapper_missing_exit" -eq 2 ]] ||
+  fail "missing gate mapping engine exited $mapper_missing_exit instead of 2"
+assert_contains "error: gate mapping engine could not be loaded from"
+assert_not_contains "Mapped safe local commands:"
+
 run_gate "indexer-envio/package.json"
 assert_contains "- docs/pr-checklists/stateful-data-ui.md (indexer data flow changed)"
 assert_occurrences 1 "- pnpm install --frozen-lockfile (link generated package after indexer codegen)"
@@ -3849,11 +3894,19 @@ if [[ -f "$counter_file" ]]; then
 fi
 printf '%s\n' "$((count + 1))" > "$counter_file"
 STUB
+  # The stub exists to make the MAPPED commands free, not to break the gate's
+  # own Node helpers. Those are the `--input-type=module` heredocs and, since
+  # D5b part 2, the mapping engine the gate runs to build its plan at all — a
+  # stubbed-out mapper produces an empty plan and the gate refuses the run,
+  # which is the guard working, not the fixture.
   cat > bin/node <<'STUB'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "--input-type=module" ]]; then
   exec "${REAL_NODE:?}" "$@"
 fi
+case "${1:-}" in
+  *"/scripts/gate/mapping.mjs") exec "${REAL_NODE:?}" "$@" ;;
+esac
 exit 0
 STUB
   cat > bin/pnpm <<'STUB'

--- a/scripts/gate/agent-prewarm.test.mjs
+++ b/scripts/gate/agent-prewarm.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   extractTurboCacheDir,
   extractTurboPrewarmCommands,
@@ -173,6 +175,53 @@ assert.deepEqual(extractTurboPrewarmCommands(gateContractOutput), [
 assert.equal(
   extractTurboCacheDir(gateContractOutput),
   "/home/agent/.cache/turbo-monitoring-monorepo",
+);
+
+// ── The end-to-end contract, against the gate that actually runs ────────────
+//
+// Everything above rebuilds the stdout shape from literals in the gate source.
+// That catches a renamed header and nothing else. Since D5b part 2 the command
+// LINES come from the Node mapping engine rather than from bash `printf`s, so
+// the shape this parser depends on — `- <command> (<reason>)`, Turbo commands
+// carrying `--filter=` and `--cache=local:rw`, a blank line ending the block —
+// is now produced by a different program than the one the literals live in.
+//
+// The failure mode is silence: a drifted format makes `extractTurboPrewarmCommands`
+// return `[]`, and prewarm reports success having warmed nothing. So run the
+// real gate and require a real, non-empty extraction.
+const realGateOutput = execFileSync(
+  "bash",
+  [
+    fileURLToPath(new URL("../agent-quality-gate.sh", import.meta.url)),
+    "--changed-paths-file",
+    "/dev/stdin",
+    "--base",
+    "HEAD",
+  ],
+  {
+    cwd: fileURLToPath(new URL("../..", import.meta.url)),
+    input: "ui-dashboard/src/lib/utils.ts\n",
+    encoding: "utf8",
+    env: { ...process.env, AGENT_QUALITY_GATE_LOCK: "0" },
+    maxBuffer: 64 * 1024 * 1024,
+  },
+);
+
+const realCommands = extractTurboPrewarmCommands(realGateOutput);
+assert.ok(
+  realCommands.length > 0,
+  "extractTurboPrewarmCommands found NO Turbo commands in a real gate dry run; " +
+    "the stdout format drifted and agent:prewarm would warm nothing while reporting success",
+);
+assert.ok(
+  realCommands.includes(
+    "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  ),
+  `a dashboard source change must still yield the dashboard lint task; got ${JSON.stringify(realCommands)}`,
+);
+assert.ok(
+  realCommands.every((command) => command.endsWith("--cache=local:rw")),
+  "every extracted command must still carry the local cache flag prewarm relies on",
 );
 
 console.log("agent prewarm tests passed");

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -7,11 +7,11 @@
  * `write_command_plan` already emits, plus two further sections for the
  * surfaces and checklists the gate prints.
  *
- * NOT YET WIRED INTO THE GATE. D5b lands this inert and proves it against the
- * live bash routing with the parity harness first; the gate is flipped to read
- * from it only once that parity is zero with a proven mutation control. Until
- * then the bash `case` arms are still the routing that runs, and this module
- * changes nothing about a gate run.
+ * THIS IS THE ROUTING THAT RUNS. D5b part 2 flipped the gate to build its plan
+ * from this module's output. The bash `case` arms still execute alongside it
+ * for the D5c soak, and the gate REFUSES the whole run if the two plans differ
+ * by one byte — parity in production, not parity in a harness. D5c retires the
+ * arms once the soak is clean.
  *
  * FAIL CLOSED. Any unknown verb, guard, dispatch subject or dynamic source
  * throws, and this exits non-zero with the reason. The one outcome that must
@@ -34,12 +34,14 @@ import {
   rmSync,
   statSync,
   writeFileSync,
+  writeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { ROUTING_PLAN } from "./routing-table/index.mjs";
+import { Facts } from "./mapping/facts.mjs";
 import { Plan, BUCKETS } from "./mapping/plan.mjs";
 import { routeChangedPaths } from "./mapping/route.mjs";
 import {
@@ -280,7 +282,22 @@ export async function routingSensitivePathsChanged(
     failure.exitCode = 3;
     throw failure;
   }
-  return changedPaths.some((path) => isRoutingSensitivePath(path) === true);
+  let sensitive = false;
+  for (const path of changedPaths) {
+    const verdict = isRoutingSensitivePath(path);
+    // The gate accepts only `true` or `false` from this classifier and exits 2
+    // on anything else. Reading a non-boolean as falsey here would drop
+    // `--check-fixtures` from the plan, which is the smaller-plan direction.
+    if (typeof verdict !== "boolean") {
+      const failure = new Error(
+        `${classifier} returned a non-boolean for ${JSON.stringify(path)}`,
+      );
+      failure.exitCode = 2;
+      throw failure;
+    }
+    if (verdict) sensitive = true;
+  }
+  return sensitive;
 }
 
 /** Build the plan. Exported so tests and the parity harness can call it directly. */
@@ -317,9 +334,27 @@ export function buildPlan({ changedPaths, facts, routingSensitive = false }) {
   return plan;
 }
 
-/** The plan as the TSV record stream the gate reads back. */
+/**
+ * The plan as the TSV record stream the gate reads back.
+ *
+ * ORDER IS THE CONTRACT, in both directions: the gate prints surfaces,
+ * checklists and each bucket in exactly this sequence, and `write_command_plan`
+ * hashes the bucket records in exactly this sequence. A reordering here is a
+ * different stamp and a different stdout for two Node consumers that parse it.
+ *
+ * The `flag` records carry the two run-scoped booleans the routing sets that
+ * are not commands. `package_script_risk_changed` gates the gate's refusal to
+ * run at all, so the swap has to carry it across the seam or that refusal
+ * quietly stops happening.
+ */
 export function formatPlan(plan) {
   const lines = [];
+  lines.push(
+    `flag\tpackage_script_risk_changed\t${plan.packageScriptRiskChanged === true}`,
+  );
+  lines.push(
+    `flag\tsaw_workspace_escalation\t${plan.sawWorkspaceEscalation === true}`,
+  );
   for (const surface of plan.surfaces) lines.push(`surface\t${surface}`);
   for (const entry of plan.checklists) {
     lines.push(`checklist\t${entry.checklist}\t${entry.reason}`);
@@ -329,5 +364,84 @@ export function formatPlan(plan) {
       lines.push(`${bucket}\t${entry.command}\t${entry.reason}`);
     }
   }
-  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * The command-line entry point the gate calls, once per run.
+ *
+ * Every failure path here is a REFUSAL with a non-zero exit and a reason on
+ * stderr. The gate turns any non-zero exit into a refusal of the whole run,
+ * because the alternative — a mapper that fails and lets the run continue on
+ * whatever it managed to emit — is the smaller plan this rewrite exists to
+ * prevent.
+ */
+async function main(argv) {
+  const option = (name) => {
+    const index = argv.indexOf(name);
+    if (index === -1) return null;
+    const value = argv[index + 1];
+    if (value === undefined) {
+      throw Object.assign(new Error(`${name} requires a value`), {
+        exitCode: 2,
+      });
+    }
+    return value;
+  };
+
+  const required = (name) => {
+    const value = option(name);
+    if (value === null) {
+      throw Object.assign(new Error(`${name} is required`), { exitCode: 2 });
+    }
+    return value;
+  };
+
+  const repoRoot = required("--repo-root");
+  const changedPathsFile = required("--changed-paths-file");
+  const scriptSourceDir = required("--script-source-dir");
+  const facts = new Facts({
+    repoRoot,
+    baseRef: required("--base"),
+    headRef: required("--head"),
+    changedPathsFile,
+    isRealTree: argv.includes("--real-tree"),
+    fullLocalTests: argv.includes("--full-local-tests"),
+    scriptSourceDir,
+  });
+
+  // The gate's already-normalized set: `sed '/^$/d' | sort -u` has run, and
+  // that ordering is routing, because `add_command` keeps the FIRST reason it
+  // is given. Re-deriving it here would be guessing at the collation the
+  // gate's `sort` used.
+  const changedPaths = readFileSync(changedPathsFile, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line !== "");
+  if (changedPaths.length === 0) {
+    throw Object.assign(
+      new Error(`${changedPathsFile} holds no changed paths`),
+      { exitCode: 2 },
+    );
+  }
+
+  const routingSensitive = await routingSensitivePathsChanged(
+    changedPaths,
+    scriptSourceDir,
+  );
+  process.stdout.write(
+    formatPlan(buildPlan({ changedPaths, facts, routingSensitive })),
+  );
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = await main(process.argv.slice(2));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // writeSync, not console.error: `process.exit` drops whatever is still
+    // queued on an async stderr, and the gate runs this under a pipe.
+    writeSync(2, `agent quality gate mapper: ${message}\n`);
+    process.exit(typeof error?.exitCode === "number" ? error.exitCode : 1);
+  }
 }

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -31,6 +31,7 @@ import { execFileSync } from "node:child_process";
 import {
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -434,7 +435,32 @@ async function main(argv) {
   return 0;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+/**
+ * Whether this module was RUN rather than imported.
+ *
+ * Not a string comparison against `process.argv[1]`. Node resolves the main
+ * entry to its realpath before building `import.meta.url`, and leaves
+ * `process.argv[1]` as the path it was handed — so the naive comparison is
+ * false for every invocation that reaches this file through a symlink. Measured:
+ * the gate's own suite builds `scripts/` mirrors out of symlinks, macOS `/tmp`
+ * is a symlink to `/private/tmp`, and a checkout under a symlinked home is
+ * ordinary. In all of those `main()` never ran, the mapper exited 0 having
+ * written nothing, and the gate refused every run with "produced an empty plan"
+ * — fail-closed, but pointing at the engine instead of at the path.
+ */
+function invokedAsScript() {
+  const entry = process.argv[1];
+  if (entry === undefined) return false;
+  const here = fileURLToPath(import.meta.url);
+  if (entry === here) return true;
+  try {
+    return realpathSync(entry) === realpathSync(here);
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript()) {
   try {
     process.exitCode = await main(process.argv.slice(2));
   } catch (error) {

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -19,10 +19,21 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { bashFunctionSource } from "../../sentry/ci-wiring/check-sentry-suites-in-ci-gate-extract.mjs";
 
 import { Facts } from "./facts.mjs";
 import { BUCKETS, Plan, commandDedupeKey } from "./plan.mjs";
@@ -683,6 +694,123 @@ test("a tooling script plus anything else is no longer tooling-only", () => {
     assert.equal(classOf(dir), "package-scripts");
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── The CLI seam ───────────────────────────────────────────────────────────
+
+const REPO = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** Run the mapper the way the gate does, from `entry`. */
+function runMapper(entry, scriptSourceDir) {
+  const dir = mkdtempSync(join(tmpdir(), "engine-cli-"));
+  const pathsFile = join(dir, "paths");
+  writeFileSync(pathsFile, "ui-dashboard/src/lib/utils.ts\n");
+  try {
+    return execFileSync(
+      "node",
+      [
+        entry,
+        "--repo-root",
+        REPO,
+        "--changed-paths-file",
+        pathsFile,
+        "--base",
+        "HEAD",
+        "--head",
+        "HEAD",
+        "--script-source-dir",
+        scriptSourceDir,
+        "--real-tree",
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("the mapper runs when reached through a SYMLINK, not only by its real path", () => {
+  // `process.argv[1] === fileURLToPath(import.meta.url)` is false for every
+  // symlinked invocation, because Node realpaths the entry for `import.meta.url`
+  // and leaves argv alone. The module then imports, runs nothing, exits 0 with
+  // no output — and the gate refuses every run with "produced an empty plan".
+  // The gate's own suite builds `scripts/` mirrors out of symlinks, and macOS
+  // `/tmp` is one, so this is the ordinary case rather than an exotic one.
+  const real = fileURLToPath(new URL("../mapping.mjs", import.meta.url));
+  const direct = runMapper(real, join(REPO, "scripts"));
+  assert.ok(direct.includes("\tpnpm "), "the control run produced no plan");
+
+  const mirror = mkdtempSync(join(tmpdir(), "engine-mirror-"));
+  try {
+    mkdirSync(join(mirror, "gate"));
+    for (const entry of readdirSync(join(REPO, "scripts"))) {
+      if (entry === "gate") continue;
+      symlinkSync(join(REPO, "scripts", entry), join(mirror, entry));
+    }
+    for (const entry of readdirSync(join(REPO, "scripts/gate"))) {
+      symlinkSync(
+        join(REPO, "scripts/gate", entry),
+        join(mirror, "gate", entry),
+      );
+    }
+    const throughLink = runMapper(join(mirror, "gate/mapping.mjs"), mirror);
+    assert.equal(
+      throughLink,
+      direct,
+      "a symlinked invocation must produce the same plan, not an empty one",
+    );
+  } finally {
+    rmSync(mirror, { recursive: true, force: true });
+  }
+});
+
+// ── The signature pin, enumerated ──────────────────────────────────────────
+
+const SIGNATURE_ENTRIES = (() => {
+  const source = bashFunctionSource(
+    readFileSync(join(REPO, "scripts/agent-quality-gate.sh"), "utf8"),
+    "implementation_signature",
+    "scripts/agent-quality-gate.sh",
+  );
+  const entries = source
+    .split(/\s+/)
+    .filter((word) => word.startsWith("scripts/") || word.endsWith(".json"));
+  // Sanity: if the span parsed wrongly every assertion below is vacuous.
+  assert.ok(
+    entries.includes("scripts/agent-quality-gate.sh"),
+    `parsed ${entries.length} signature entries without the gate itself; the span was read wrongly`,
+  );
+  return entries;
+})();
+
+const ENGINE_MODULES = readdirSync(fileURLToPath(new URL(".", import.meta.url)))
+  .filter((name) => name.endsWith(".mjs"))
+  .sort();
+
+test("implementation_signature() lists every mapping-engine module", () => {
+  // The same load-bearing pin the routing table has, and it matters more here:
+  // an entry the signature cannot `stat` hashes as `__missing__` and FREEZES
+  // the signature, so `--skip-if-fresh` reuses a stale stamp — for the code
+  // that now decides which commands run at all.
+  assert.ok(ENGINE_MODULES.length > 0, "found no engine modules to check");
+  for (const module of ENGINE_MODULES) {
+    assert.ok(
+      SIGNATURE_ENTRIES.includes(`scripts/gate/mapping/${module}`),
+      `implementation_signature() does not list scripts/gate/mapping/${module}; a missing entry freezes the freshness signature`,
+    );
+  }
+});
+
+test("implementation_signature() lists no mapping-engine module that is gone", () => {
+  const prefix = "scripts/gate/mapping/";
+  for (const entry of SIGNATURE_ENTRIES.filter((path) =>
+    path.startsWith(prefix),
+  )) {
+    assert.ok(
+      ENGINE_MODULES.includes(entry.slice(prefix.length)),
+      `implementation_signature() still lists ${entry}, which no longer exists; a stale entry hashes as __missing__ forever`,
+    );
   }
 });
 

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+/**
+ * The mapping engine's own unit tests.
+ *
+ * WHY THESE EXIST SEPARATELY FROM THE PARITY CORPORA. The corpora compare the
+ * engine against the bash arms, so they answer "do the two agree" and nothing
+ * else. Once D5c deletes the arms there is no oracle left, and the behaviours
+ * below — which reason survives a dedupe, where a compacted Turbo command
+ * lands, which of four disqualifiers switched scoped tests off — become
+ * unpinned in the same commit that removes the thing pinning them. These tests
+ * are what survives that deletion.
+ *
+ * They test BEHAVIOUR, not transcription: each one asserts a rule the runbook
+ * states, and each was checked to fail under the mutation that breaks that rule
+ * (recorded in the D5b part 2 PR).
+ *
+ * Run: node --test scripts/gate/mapping/engine.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { Facts } from "./facts.mjs";
+import { BUCKETS, Plan, commandDedupeKey } from "./plan.mjs";
+import {
+  addTrunkCheckCommand,
+  applyScopedTestCommands,
+  compactTurboQualityCommands,
+  scopedIsNonSourcePath,
+  scopedTestInfraChanged,
+  sortCodegenCommands,
+} from "./post-passes.mjs";
+import * as verbs from "./verbs.mjs";
+
+/** The subset of Facts the post-passes and verbs actually consult. */
+function stubFacts(overrides = {}) {
+  const present = new Set(overrides.presentPaths ?? []);
+  return {
+    isRealTree: true,
+    fullLocalTests: false,
+    baseRef: "origin/main",
+    baseOid: "0123456789abcdef0123456789abcdef01234567",
+    headRef: "HEAD",
+    changedPathsFile: "/tmp/changed-paths",
+    repoRoot: "/repo",
+    pathExistsInWorktree: (path) => present.has(path),
+    pathIsFile: (path) => present.has(path),
+    pathExistsAtHead: (path) => present.has(path),
+    terraformStackPaths: [],
+    ...overrides,
+  };
+}
+
+const commandsOf = (plan, bucket = "quality") =>
+  plan.buckets.get(bucket).map((entry) => entry.command);
+const reasonOf = (plan, command, bucket = "quality") =>
+  plan.buckets.get(bucket).find((entry) => entry.command === command)?.reason;
+
+// ── Plan: dedupe, reasons, order ───────────────────────────────────────────
+
+test("dedupe keeps the FIRST reason, not the last", () => {
+  const plan = new Plan();
+  plan.addCommand("pnpm lint", "first reason");
+  plan.addCommand("pnpm lint", "second reason");
+  assert.deepEqual(commandsOf(plan), ["pnpm lint"]);
+  // routing.test.mjs asserts on reason strings, so "first wins" is contract.
+  assert.equal(reasonOf(plan, "pnpm lint"), "first reason");
+});
+
+test("the two alias pairs share one dedupe key", () => {
+  for (const [alias, direct] of [
+    ["pnpm agent:quality-gate:test", "bash scripts/agent-quality-gate.test.sh"],
+    ["pnpm agent:autoreview:test", "bash scripts/agent-autoreview.test.sh"],
+  ]) {
+    assert.equal(
+      commandDedupeKey(alias),
+      commandDedupeKey(direct),
+      `${alias} and ${direct} must dedupe together`,
+    );
+    const plan = new Plan();
+    plan.addCommand(alias, "alias first");
+    plan.addCommand(direct, "direct second");
+    assert.deepEqual(
+      commandsOf(plan),
+      [alias],
+      "the same suite reached two ways must schedule once",
+    );
+  }
+});
+
+test("an unrelated command is not deduped away", () => {
+  const plan = new Plan();
+  plan.addCommand("pnpm lint", "a");
+  plan.addCommand("pnpm typecheck", "b");
+  assert.deepEqual(commandsOf(plan), ["pnpm lint", "pnpm typecheck"]);
+});
+
+test("dedupe is per bucket, not global", () => {
+  const plan = new Plan();
+  plan.addPreflight("pnpm install --frozen-lockfile", "preflight");
+  plan.addCommand("pnpm install --frozen-lockfile", "quality");
+  assert.deepEqual(commandsOf(plan, "preflight"), [
+    "pnpm install --frozen-lockfile",
+  ]);
+  assert.deepEqual(commandsOf(plan, "quality"), [
+    "pnpm install --frozen-lockfile",
+  ]);
+});
+
+test("prepend puts a command at the head, and re-prepending is a no-op", () => {
+  const plan = new Plan();
+  plan.addCommand("second", "b");
+  plan.prependCommand("first", "a");
+  assert.deepEqual(commandsOf(plan), ["first", "second"]);
+  plan.prependCommand("second", "moved?");
+  assert.deepEqual(
+    commandsOf(plan),
+    ["first", "second"],
+    "prepending an existing command must not move it",
+  );
+});
+
+test("checklists dedupe on the path alone, first reason wins", () => {
+  const plan = new Plan();
+  plan.addChecklist("docs/pr-checklists/code-health.md", "first");
+  plan.addChecklist("docs/pr-checklists/code-health.md", "second");
+  assert.deepEqual(plan.checklists, [
+    { checklist: "docs/pr-checklists/code-health.md", reason: "first" },
+  ]);
+});
+
+test("surfaces dedupe and keep insertion order", () => {
+  const plan = new Plan();
+  plan.addSurface("scripts");
+  plan.addSurface("ui-dashboard");
+  plan.addSurface("scripts");
+  assert.deepEqual(plan.surfaces, ["scripts", "ui-dashboard"]);
+});
+
+test("the bucket order is preflight, codegen, post-codegen, quality", () => {
+  // The gate prints and the freshness stamp hashes in this order.
+  assert.deepEqual(BUCKETS, [
+    "preflight",
+    "codegen",
+    "post-codegen",
+    "quality",
+  ]);
+});
+
+test("an unknown bucket throws rather than being dropped", () => {
+  const plan = new Plan();
+  assert.throws(
+    () => plan.add("nonsense", "cmd", "reason"),
+    /unknown command bucket/,
+  );
+});
+
+// ── Verbs ──────────────────────────────────────────────────────────────────
+
+test("a Turbo package task carries the local cache flag", () => {
+  assert.equal(
+    verbs.turboLocalCacheCommand("@mento-protocol/ui-dashboard", "lint"),
+    "pnpm exec turbo run lint --filter=@mento-protocol/ui-dashboard --cache=local:rw",
+  );
+});
+
+test("the package quality bundle keeps its command set and order", () => {
+  const plan = new Plan();
+  verbs.addPackageQualityCommands(plan, "@mento-protocol/metrics-bridge", "r");
+  assert.deepEqual(commandsOf(plan), [
+    "pnpm exec turbo run lint --filter=@mento-protocol/metrics-bridge --cache=local:rw",
+    "pnpm exec turbo run typecheck --filter=@mento-protocol/metrics-bridge --cache=local:rw",
+    "pnpm --filter @mento-protocol/metrics-bridge build",
+    "pnpm --filter @mento-protocol/metrics-bridge test:coverage",
+    "pnpm exec turbo run knip --filter=@mento-protocol/metrics-bridge --cache=local:rw",
+    "pnpm code-health:deps",
+  ]);
+  assert.equal(
+    reasonOf(
+      plan,
+      "pnpm --filter @mento-protocol/metrics-bridge test:coverage",
+    ),
+    "r (coverage floor)",
+    "the coverage floor carries its own reason suffix",
+  );
+});
+
+test("the indexer bundle forces mainnet codegen as a preflight", () => {
+  const plan = new Plan();
+  verbs.addPackageQualityCommands(plan, "@mento-protocol/indexer-envio", "r");
+  assert.ok(
+    commandsOf(plan, "codegen").includes("pnpm indexer:codegen"),
+    "typecheck and lint both need .envio/types.d.ts to exist first",
+  );
+});
+
+test("react-doctor:diff carries the base ref AND its resolved oid", () => {
+  const plan = new Plan();
+  const facts = stubFacts();
+  verbs.addUiReactDoctorDiff(plan, "r", facts);
+  const [command] = commandsOf(plan);
+  assert.match(command, /^REACT_DOCTOR_BASE_REF=origin\/main /);
+  assert.ok(
+    command.includes(`REACT_DOCTOR_BASE_CACHE_KEY=${facts.baseOid}`),
+    "the Turbo cache key must move when the base moves",
+  );
+});
+
+test("the ADR reminder is fed the gate's own base, head and path set", () => {
+  const plan = new Plan();
+  verbs.addAdrReminder(plan, "r", stubFacts());
+  const [command] = commandsOf(plan);
+  assert.ok(command.startsWith("node scripts/pr/check-adr-reminder.mjs"));
+  assert.ok(command.includes("--base origin/main --head HEAD"));
+  assert.ok(command.includes("--include-untracked --changed-paths-file"));
+});
+
+test("the Sentry suite gate schedules BOTH commands, neither substituting", () => {
+  const plan = new Plan();
+  verbs.addSentrySuiteGateCommands(plan, "r");
+  const commands = commandsOf(plan);
+  assert.equal(commands.length, 2);
+  assert.ok(
+    commands.every((command) => command.includes("env -u NODE_OPTIONS")),
+  );
+  assert.ok(
+    commands.some((command) => command.endsWith("sentry-suite-gate.test.mjs")),
+  );
+  assert.ok(
+    commands.some((command) => command.endsWith("sentry-suite-gate.mjs")),
+  );
+});
+
+test("registered Terraform stacks route from the registry, not from paths", () => {
+  const plan = new Plan();
+  const facts = stubFacts({
+    terraformStackPaths: ["terraform", "alerts/rules"],
+  });
+  verbs.addRegisteredTerraformValidateCommands(plan, "r", facts);
+  const commands = commandsOf(plan);
+  assert.ok(commands.some((command) => command.includes("terraform")));
+  assert.ok(commands.some((command) => command.includes("alerts/rules")));
+});
+
+test("workspace escalation sets the flag that disables scoped tests", () => {
+  const plan = new Plan();
+  assert.equal(plan.sawWorkspaceEscalation, false);
+  verbs.addWorkspaceQualityCommands(plan, "workspace changed");
+  assert.equal(
+    plan.sawWorkspaceEscalation,
+    true,
+    "the flag is the point: it is a property of the run, not of one arm",
+  );
+});
+
+test("the root tooling bundle schedules the whole suite list", () => {
+  const plan = new Plan();
+  verbs.addRootToolingPackageScriptChecks(plan, "r");
+  const commands = commandsOf(plan);
+  assert.ok(
+    commands.length > 20,
+    `expected the full list, got ${commands.length}`,
+  );
+  assert.ok(commands.includes("bash scripts/agent-quality-gate.test.sh"));
+  assert.ok(commands.includes("node scripts/pr/pr-ready-state.test.mjs"));
+});
+
+// ── Post-pass 1: Trunk ─────────────────────────────────────────────────────
+
+test("a path that no longer exists forces a full-repo Trunk scan", () => {
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["deleted/file.ts"],
+    stubFacts({ presentPaths: [] }),
+  );
+  assert.deepEqual(commandsOf(plan), ["./tools/trunk check --all"]);
+  assert.equal(
+    reasonOf(plan, "./tools/trunk check --all"),
+    "changed paths require full-repo Trunk checks",
+  );
+});
+
+test("existing ordinary paths get a targeted Trunk scan", () => {
+  const plan = new Plan();
+  const paths = ["a/one.ts", "b/two.ts"];
+  addTrunkCheckCommand(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(commandsOf(plan), ["./tools/trunk check a/one.ts b/two.ts"]);
+});
+
+test("a config path in the full-scan list forces full even when it exists", () => {
+  for (const path of [
+    ".trunk/trunk.yaml",
+    "tools/trunk",
+    "package.json",
+    "pnpm-lock.yaml",
+    "ui-dashboard/package.json",
+    ".npmrc",
+    ".node-version",
+  ]) {
+    const plan = new Plan();
+    addTrunkCheckCommand(plan, [path], stubFacts({ presentPaths: [path] }));
+    assert.deepEqual(
+      commandsOf(plan),
+      ["./tools/trunk check --all"],
+      `${path} governs the whole repo, so a targeted scan would lint only itself`,
+    );
+  }
+});
+
+test("a .shellcheckrc edit adds a repo-wide ShellCheck-only pass, ahead of the rest", () => {
+  const plan = new Plan();
+  const paths = [".shellcheckrc", "scripts/a.sh"];
+  addTrunkCheckCommand(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.equal(
+    commandsOf(plan)[0],
+    "./tools/trunk check --all --filter=shellcheck",
+    "prepended last, so it must end up first",
+  );
+});
+
+test("Trunk is prepended, so it runs before commands added earlier", () => {
+  const plan = new Plan();
+  plan.addCommand("pnpm lint", "earlier");
+  const paths = ["a/one.ts"];
+  addTrunkCheckCommand(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(commandsOf(plan), [
+    "./tools/trunk check a/one.ts",
+    "pnpm lint",
+  ]);
+});
+
+// ── Post-pass 2: codegen order ─────────────────────────────────────────────
+
+test("mainnet codegen sorts LAST, because every variant overwrites the same package", () => {
+  const plan = new Plan();
+  verbs.addIndexerMainnetCodegen(plan, "mainnet");
+  verbs.addIndexerTestnetCodegen(plan, "testnet");
+  verbs.addDashboardCodegen(plan, "dashboard");
+  sortCodegenCommands(plan);
+  const order = commandsOf(plan, "codegen");
+  assert.equal(
+    order[order.length - 1],
+    "pnpm indexer:codegen",
+    "the package checks that follow validate the normally-linked package",
+  );
+  assert.ok(
+    order.indexOf("pnpm dashboard:codegen") <
+      order.indexOf("pnpm indexer:testnet:codegen"),
+    "known commands keep the fixed relative order",
+  );
+});
+
+test("an unrecognised codegen command keeps its position after the known ones", () => {
+  const plan = new Plan();
+  plan.addCodegen("pnpm indexer:codegen", "mainnet");
+  plan.addCodegen("pnpm something:new", "unknown");
+  sortCodegenCommands(plan);
+  assert.deepEqual(commandsOf(plan, "codegen"), [
+    "pnpm indexer:codegen",
+    "pnpm something:new",
+  ]);
+});
+
+// ── Post-pass 3: Turbo compaction ──────────────────────────────────────────
+
+test("same-task Turbo commands coalesce into one invocation", () => {
+  const plan = new Plan();
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/a", "lint"),
+    "a changed",
+  );
+  plan.addCommand("pnpm middle", "unrelated");
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/b", "lint"),
+    "b changed",
+  );
+  compactTurboQualityCommands(plan);
+  assert.deepEqual(commandsOf(plan), [
+    "pnpm exec turbo run lint --filter=@mento-protocol/a --filter=@mento-protocol/b --cache=local:rw",
+    "pnpm middle",
+  ]);
+  assert.equal(
+    reasonOf(
+      plan,
+      "pnpm exec turbo run lint --filter=@mento-protocol/a --filter=@mento-protocol/b --cache=local:rw",
+    ),
+    "a changed; b changed",
+    "the reasons join in first-seen order",
+  );
+});
+
+test("compaction takes the position of the FIRST invocation of that task", () => {
+  const plan = new Plan();
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/a", "lint"),
+    "a",
+  );
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/a", "typecheck"),
+    "a",
+  );
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/b", "lint"),
+    "b",
+  );
+  compactTurboQualityCommands(plan);
+  assert.match(commandsOf(plan)[0], /turbo run lint /);
+  assert.match(commandsOf(plan)[1], /turbo run typecheck /);
+});
+
+test("a repeated package on one task is listed once", () => {
+  const plan = new Plan();
+  plan.addCommand(
+    verbs.turboLocalCacheCommand("@mento-protocol/a", "lint"),
+    "first",
+  );
+  plan.quality.push({
+    command: verbs.turboLocalCacheCommand("@mento-protocol/a", "lint"),
+    reason: "duplicate slipped past dedupe",
+  });
+  compactTurboQualityCommands(plan);
+  assert.deepEqual(commandsOf(plan), [
+    "pnpm exec turbo run lint --filter=@mento-protocol/a --cache=local:rw",
+  ]);
+});
+
+test("a non-Turbo command is left exactly as it was", () => {
+  const plan = new Plan();
+  plan.addCommand("pnpm code-health:deps", "r");
+  compactTurboQualityCommands(plan);
+  assert.deepEqual(commandsOf(plan), ["pnpm code-health:deps"]);
+});
+
+// ── Post-pass 4: scoped tests ──────────────────────────────────────────────
+
+const COVERAGE = "pnpm --filter @mento-protocol/ui-dashboard test:coverage";
+const scopedPlan = () => {
+  const plan = new Plan();
+  plan.addCommand(COVERAGE, "ui-dashboard changed (coverage floor)");
+  return plan;
+};
+
+test("a small production-source change narrows to vitest related", () => {
+  const plan = scopedPlan();
+  const paths = ["ui-dashboard/src/lib/utils.ts"];
+  applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(commandsOf(plan), [
+    "pnpm --filter @mento-protocol/ui-dashboard exec vitest related --run src/lib/utils.ts",
+  ]);
+  assert.match(commandsOf(plan)[0], /vitest related/);
+});
+
+test("the threshold is 15 paths: 15 scopes, 16 does not", () => {
+  for (const [count, expectScoped] of [
+    [15, true],
+    [16, false],
+  ]) {
+    const plan = scopedPlan();
+    const paths = Array.from(
+      { length: count },
+      (_, index) => `ui-dashboard/src/lib/f${index}.ts`,
+    );
+    applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+    const scoped = commandsOf(plan)[0].includes("vitest related");
+    assert.equal(
+      scoped,
+      expectScoped,
+      `${count} changed paths should ${expectScoped ? "" : "not "}scope`,
+    );
+  }
+});
+
+test("each disqualifier switches scoping off for the whole run", () => {
+  const base = ["ui-dashboard/src/lib/utils.ts"];
+  const disqualifiers = {
+    "shared-config blast radius": "shared-config/src/index.ts",
+    "hermetic test setup": "ui-dashboard/vitest.hermetic-setup.ts",
+    "vitest config": "ui-dashboard/vitest.config.ts",
+    "schema stub": "scripts/envio-schema-stubs.graphql",
+    "test setup dir": "ui-dashboard/test/setup/globals.ts",
+  };
+  for (const [name, extra] of Object.entries(disqualifiers)) {
+    const plan = scopedPlan();
+    const paths = [...base, extra];
+    applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+    assert.deepEqual(
+      commandsOf(plan),
+      [COVERAGE],
+      `${name} must leave the full coverage floor in place`,
+    );
+  }
+});
+
+test("a workspace escalation anywhere in the run disables scoping", () => {
+  const plan = scopedPlan();
+  plan.sawWorkspaceEscalation = true;
+  const paths = ["ui-dashboard/src/lib/utils.ts"];
+  applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(commandsOf(plan), [COVERAGE]);
+});
+
+test("a lockfile-scoped package keeps its full coverage floor", () => {
+  const plan = scopedPlan();
+  plan.markLockfileScopedPackage("@mento-protocol/ui-dashboard");
+  const paths = ["ui-dashboard/src/lib/utils.ts"];
+  applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(
+    commandsOf(plan),
+    [COVERAGE],
+    "the floor is standing in for the dependency-bump regression check",
+  );
+});
+
+test("--full-local-tests forces the full suite", () => {
+  const plan = scopedPlan();
+  const paths = ["ui-dashboard/src/lib/utils.ts"];
+  applyScopedTestCommands(
+    plan,
+    paths,
+    stubFacts({ presentPaths: paths, fullLocalTests: true }),
+  );
+  assert.deepEqual(commandsOf(plan), [COVERAGE]);
+});
+
+test("a deleted path in the package leaves the floor, because vitest related finds nothing", () => {
+  const plan = scopedPlan();
+  const paths = [
+    "ui-dashboard/src/lib/utils.ts",
+    "ui-dashboard/src/lib/gone.ts",
+  ];
+  applyScopedTestCommands(
+    plan,
+    paths,
+    // Present in the worktree listing but absent at head: a deletion, or the
+    // old side of a rename.
+    stubFacts({ presentPaths: ["ui-dashboard/src/lib/utils.ts"] }),
+  );
+  assert.deepEqual(commandsOf(plan), [COVERAGE]);
+});
+
+test("shared-config never scopes even when it is the only change", () => {
+  const plan = new Plan();
+  const command = "pnpm --filter @mento-protocol/config test:coverage";
+  plan.addCommand(command, "shared-config changed (coverage floor)");
+  const paths = ["shared-config/src/index.ts"];
+  applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(commandsOf(plan), [command]);
+});
+
+test("a non-source path inside the package disqualifies it", () => {
+  const plan = scopedPlan();
+  const paths = [
+    "ui-dashboard/src/lib/utils.ts",
+    "ui-dashboard/src/lib/data.json",
+  ];
+  applyScopedTestCommands(plan, paths, stubFacts({ presentPaths: paths }));
+  assert.deepEqual(
+    commandsOf(plan),
+    [COVERAGE],
+    "a test may read it through the filesystem, which vitest related cannot follow",
+  );
+});
+
+test("scopedIsNonSourcePath answers for the shapes the runbook lists", () => {
+  for (const path of [
+    "src/a.test.ts",
+    "src/a.spec.tsx",
+    "__tests__/a.ts",
+    "test/a.ts",
+    "vitest.config.ts",
+    "tsconfig.json",
+    "package.json",
+    "schema.graphql",
+    "__generated__/graphql.ts",
+    "src/a.gen.ts",
+    "fixtures/a.ts",
+    "src/styles.css",
+    "src/data.yaml",
+  ]) {
+    assert.equal(
+      scopedIsNonSourcePath(path),
+      true,
+      `${path} is not production source`,
+    );
+  }
+  for (const path of ["src/a.ts", "src/a.tsx", "src/a.mjs", "lib/b.cjs"]) {
+    assert.equal(
+      scopedIsNonSourcePath(path),
+      false,
+      `${path} IS production source`,
+    );
+  }
+});
+
+test("scopedTestInfraChanged sees infra anywhere in the set", () => {
+  assert.equal(scopedTestInfraChanged(["ui-dashboard/src/a.ts"]), false);
+  assert.equal(
+    scopedTestInfraChanged(["ui-dashboard/src/a.ts", "shared-config/src/b.ts"]),
+    true,
+  );
+});
+
+// ── Facts: the root-manifest classifier ────────────────────────────────────
+
+/** A throwaway repo whose HEAD package.json differs from its worktree copy. */
+function manifestRepo(mutate) {
+  const dir = mkdtempSync(join(tmpdir(), "engine-facts-"));
+  const git = (...args) =>
+    execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+  const manifest = {
+    name: "fixture",
+    private: true,
+    description: "fixture",
+    scripts: { "docs:index": "node a.mjs", build: "true" },
+    dependencies: { left: "1.0.0" },
+    devDependencies: { right: "1.0.0" },
+  };
+  mkdirSync(join(dir, "empty-hooks"), { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  git("init", "-q");
+  git("config", "user.email", "engine-test@example.invalid");
+  git("config", "user.name", "engine test");
+  git("config", "commit.gpgsign", "false");
+  git("config", "core.hooksPath", join(dir, "empty-hooks"));
+  git("add", "-A");
+  git("commit", "-qm", "fixture");
+  mutate(manifest);
+  writeFileSync(
+    join(dir, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return dir;
+}
+
+const classOf = (dir) =>
+  new Facts({
+    repoRoot: dir,
+    baseRef: "HEAD",
+    headRef: "HEAD",
+    changedPathsFile: join(dir, "paths"),
+    isRealTree: false,
+    scriptSourceDir: join(dir, "scripts"),
+  }).rootPackageJsonClass();
+
+test("the root manifest classifies into its four closed classes", () => {
+  const cases = [
+    // A tooling script pointer and nothing else.
+    [(m) => (m.scripts["docs:index"] = "node b.mjs"), "root-tooling-scripts"],
+    // A script that is not on the tooling list.
+    [(m) => (m.scripts.build = "false"), "package-scripts"],
+    // Descriptive metadata only.
+    [(m) => (m.description = "changed"), "workspace-dev-metadata"],
+    [(m) => (m.devDependencies.right = "2.0.0"), "workspace-dev-metadata"],
+    // Anything else is the full workspace suite.
+    [(m) => (m.dependencies.left = "2.0.0"), "workspace"],
+    // No change at all is also the widest answer.
+    [() => {}, "workspace"],
+  ];
+  for (const [mutate, expected] of cases) {
+    const dir = manifestRepo(mutate);
+    try {
+      assert.equal(classOf(dir), expected);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("a tooling script plus anything else is no longer tooling-only", () => {
+  const dir = manifestRepo((m) => {
+    m.scripts["docs:index"] = "node b.mjs";
+    m.dependencies.left = "2.0.0";
+  });
+  try {
+    assert.equal(classOf(dir), "package-scripts");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unparsable manifest widens to the full workspace suite", () => {
+  const dir = manifestRepo(() => {});
+  try {
+    writeFileSync(join(dir, "package.json"), "{ not json");
+    assert.equal(
+      classOf(dir),
+      "workspace",
+      "an ambiguous fact resolves toward MORE work",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/gate/mapping/shell-quote.mjs
+++ b/scripts/gate/mapping/shell-quote.mjs
@@ -13,7 +13,7 @@
  * 5.3.15 over every printable ASCII character in seven positions — alone, at
  * the start, at the end, mid-word, and after `=`, `:` and `/`:
  *
- *   unescaped   A-Z a-z 0-9 and . / - _ # ~ = : @ % +   (and any byte >= 0x80)
+ *   unescaped   A-Z a-z 0-9 and . / - _ # ~ = : @ % +
  *   escaped     space ' " $ * [ ] ( ) & ; | \ ! , ^ { } < > ?
  *   empty       ''
  *   control     ANSI-C form, e.g. a newline gives $'a\nb' and ESC gives $'a\Eb'
@@ -33,6 +33,14 @@
  *     builds DISAGREE, so there is no single string to emit, and `shellQuote`
  *     refuses rather than guessing. See the refusal below.
  *
+ * A byte >= 0x80 is the same shape of problem one level out: the answer depends
+ * on the LOCALE, not on the build. Measured, `printf %q` of `aéb` gives
+ * `$'a\303\251b'` under `LC_ALL=C` and `aéb` under `LC_ALL=en_US.UTF-8` on both
+ * builds — and with the locale unset, 3.2.57 escapes where 5.3.15 does not. The
+ * gate's own pre-push hook runs with a stripped environment, so both answers
+ * are reachable on one machine. `shellQuote` refuses those too. No tracked path
+ * in this repository carries a non-ASCII byte.
+ *
  * `shell-quote.test.mjs` asks bash itself rather than trusting this comment.
  */
 
@@ -50,14 +58,22 @@ const tildeIsAmbiguous = (value, index) =>
   value[index] === "~" &&
   (index === 0 || value[index - 1] === "=" || value[index - 1] === ":");
 
+/** The one shape of failure this module has: two answers, so neither. */
+const refusal = (value, why) => {
+  const error = new Error(
+    `cannot reproduce printf %q for ${JSON.stringify(value)}: ${why}`,
+  );
+  error.exitCode = 2;
+  return error;
+};
+
 /**
  * The ANSI-C escapes bash emits inside `$'…'`.
  *
  * ESC is the one that is not guessable from the C escape table: bash's
  * `ansic_quote` carries `case ESC: c = 'E'`, so 0x1b comes back as `\E` rather
  * than as the octal `\033` every other unnamed control character gets.
- * Measured on 3.2.57 and 5.3.15 — both agree. A byte >= 0x80 is NOT octal-
- * escaped in this mode; it passes through, also measured on both.
+ * Measured on 3.2.57 and 5.3.15 — both agree, in both locales.
  */
 const ANSI_C = new Map([
   ["\x07", "\\a"],
@@ -87,16 +103,23 @@ export function shellQuote(value) {
   if (value === "") return "''";
 
   // REFUSE rather than pick a side. The gate's own quoting is whatever bash is
-  // running it, so a guess here is a command string that matches the gate on
-  // one machine and not on another — a plan whose freshness stamp never lands
-  // and whose parity is a coin flip. No path in this repository holds one.
+  // running it, under whatever locale it inherited, so a guess here is a
+  // command string that matches the gate on one machine and not on another — a
+  // plan whose freshness stamp never lands and whose parity is a coin flip. No
+  // path in this repository holds either shape.
   for (let index = 0; index < value.length; index += 1) {
-    if (!tildeIsAmbiguous(value, index)) continue;
-    const error = new Error(
-      `cannot reproduce printf %q for ${JSON.stringify(value)}: bash 3.2 leaves a leading-position \`~\` alone and bash 5.3 escapes it, so the quoted form depends on which bash runs the gate`,
-    );
-    error.exitCode = 2;
-    throw error;
+    if (tildeIsAmbiguous(value, index)) {
+      throw refusal(
+        value,
+        "bash 3.2 leaves a leading-position `~` alone and bash 5.3 escapes it, so the quoted form depends on which bash runs the gate",
+      );
+    }
+    if (value.codePointAt(index) > 0x7f) {
+      throw refusal(
+        value,
+        "a byte >= 0x80 is octal-escaped under LC_ALL=C and passed through under a UTF-8 locale, so the quoted form depends on the environment the gate inherited",
+      );
+    }
   }
 
   // A control character forces the whole word into ANSI-C quoting; bash does

--- a/scripts/gate/mapping/shell-quote.test.mjs
+++ b/scripts/gate/mapping/shell-quote.test.mjs
@@ -118,10 +118,6 @@ const SUBJECTS = [
   "a\rb",
   "a\x07b",
   "a\vb",
-  // A control character next to a byte >= 0x80: the pass-through half of the
-  // same branch, which is only visible once the word is in ANSI-C form.
-  "a\x1bé",
-  "aéb",
 ];
 
 const interpreters = bashInterpreters();
@@ -139,12 +135,25 @@ for (const [bash, version] of interpreters) {
     //
     // Splitting the output on newlines stays safe: `%q` escapes control
     // characters, so no quoted form can contain a raw newline.
-    const output = execFileSync(
-      bash,
-      ["-c", 'printf "%q\\n" "$@"', bash, ...SUBJECTS],
-      { encoding: "utf8" },
+    // BOTH LOCALES. `printf %q` is locale-sensitive, and the pre-push hook runs
+    // the gate with a stripped environment while a developer's shell is UTF-8 —
+    // so a corpus that inherits one locale pins half the behaviour and reds in
+    // the other half's environment. Everything left in SUBJECTS must be
+    // locale-independent; the bytes that are not are refused, below.
+    const perLocale = ["C", "en_US.UTF-8"].map((locale) =>
+      execFileSync(bash, ["-c", 'printf "%q\\n" "$@"', bash, ...SUBJECTS], {
+        encoding: "utf8",
+        env: { ...process.env, LC_ALL: locale },
+      })
+        .split("\n")
+        .slice(0, SUBJECTS.length),
     );
-    const expected = output.split("\n").slice(0, SUBJECTS.length);
+    assert.deepEqual(
+      perLocale[0],
+      perLocale[1],
+      `${bash} answers differently under LC_ALL=C and LC_ALL=en_US.UTF-8 for a subject in this corpus; such a subject cannot be reproduced and belongs in the refusal test`,
+    );
+    const expected = perLocale[0];
 
     const disagreements = [];
     SUBJECTS.forEach((subject, index) => {
@@ -178,6 +187,38 @@ test("a tilde that could start an expansion is refused, not guessed", () => {
   assert.equal(shellQuote("a~b"), "a~b");
   assert.equal(shellQuote("x~"), "x~");
   assert.equal(shellQuote("a/~b"), "a/~b");
+});
+
+test("a byte >= 0x80 is refused, because the answer is the locale's", (t) => {
+  for (const subject of ["aéb", "é", "a\x1bé", "ünïcödé/path.ts"]) {
+    assert.throws(
+      () => shellQuote(subject),
+      /byte >= 0x80 is octal-escaped under LC_ALL=C/,
+      `expected a refusal for ${JSON.stringify(subject)}`,
+    );
+  }
+
+  // The control: the locales really do disagree, on every installed build.
+  const answers = new Set();
+  for (const [bash] of interpreters) {
+    for (const locale of ["C", "en_US.UTF-8"]) {
+      answers.add(
+        execFileSync(bash, ["-c", 'printf "%q" "$1"', bash, "aéb"], {
+          encoding: "utf8",
+          env: { ...process.env, LC_ALL: locale },
+        }),
+      );
+    }
+  }
+  if (answers.size < 2) {
+    t.skip(`only one answer for "aéb" on this machine: ${[...answers]}`);
+    return;
+  }
+  assert.deepEqual(
+    [...answers].sort(),
+    ["$'a\\303\\251b'", "aéb"],
+    "the disagreement is the measured one — C octal-escapes, UTF-8 passes through",
+  );
 });
 
 test("the refusal is justified: the installed bash builds disagree", (t) => {

--- a/scripts/gate/routing-parity.mjs
+++ b/scripts/gate/routing-parity.mjs
@@ -37,6 +37,8 @@
  *                       own tree and the repository-specific groups are skipped
  *   --corpus symlink    a real directory symlink under scripts/, the dynamic
  *                       pattern source no committed path can exercise
+ *   --corpus self-test   every literal run_gate argument set in the gate's own
+ *                       9-minute suite, harvested from its source
  *   --pass2             deprecated alias for `--corpus multi`
  *   --limit <n>         positive integer; sample the tracked corpus evenly
  *   --base <ref>        base ref for the corpora that do not supply their own
@@ -169,23 +171,37 @@ function runGate(changedPaths, dir, baseRef, repoRoot) {
   writeFileSync(pathsFile, `${changedPaths.join("\n")}\n`);
   // The gate SCRIPT always comes from this checkout; only the repository it
   // runs against moves. That is exactly the split `$script_source_dir` tests.
-  const stdout = execFileSync(
-    "bash",
-    [
-      join(REPO, "scripts/agent-quality-gate.sh"),
-      "--changed-paths-file",
+  try {
+    const stdout = execFileSync(
+      "bash",
+      [
+        join(REPO, "scripts/agent-quality-gate.sh"),
+        "--changed-paths-file",
+        pathsFile,
+        "--base",
+        baseRef,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: { ...process.env, AGENT_QUALITY_GATE_LOCK: "0" },
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    return { stdout, pathsFile, refusal: null };
+  } catch (error) {
+    // A REFUSAL IS THE SIGNAL NOW, not a crash. Since the swap the gate builds
+    // its plan from the engine and cross-checks it against the bash arms, so a
+    // non-zero exit here is the in-gate parity guard firing — which is exactly
+    // what these corpora exist to drive. Report it as the difference it is
+    // rather than dying on the first one.
+    const stderr = String(error.stderr ?? "").trim();
+    return {
+      stdout: String(error.stdout ?? ""),
       pathsFile,
-      "--base",
-      baseRef,
-    ],
-    {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: { ...process.env, AGENT_QUALITY_GATE_LOCK: "0" },
-      maxBuffer: 64 * 1024 * 1024,
-    },
-  );
-  return { stdout, pathsFile };
+      refusal: `gate exited ${error.status}: ${stderr.split("\n").slice(0, 12).join("\n")}`,
+    };
+  }
 }
 
 async function runEngine(changedPaths, pathsFile, baseRef, repoRoot) {
@@ -652,6 +668,60 @@ function corpusFixture(dir) {
 }
 
 /**
+ * Pass 7 — the argument sets the gate's own self-test drives.
+ *
+ * 350 `run_gate` calls, each a path set some assertion was written for: the
+ * odd shapes, the deliberate near-misses, the multi-path sets that exercise a
+ * specific post-pass. They are the corpus with the most intent behind it,
+ * because a human wrote each one to pin something.
+ *
+ * Harvested from the suite source rather than by instrumenting `run_gate` at
+ * runtime: the suite takes nine minutes and the sets are literal arguments, so
+ * reading them is both faster and reproducible. A call whose arguments are not
+ * literals (three today, built from shell variables) is skipped rather than
+ * guessed at — the skip count is reported so it cannot quietly grow.
+ */
+function corpusSelfTest() {
+  const suite = readFileSync(
+    join(REPO, "scripts/agent-quality-gate.test.sh"),
+    "utf8",
+  );
+  const sets = [];
+  const seen = new Set();
+  let skipped = 0;
+  for (const line of suite.split("\n")) {
+    const match = /^\s*run_gate\s+(.+?)\s*$/.exec(line);
+    if (match === null) continue;
+    const argumentText = match[1];
+    // Only fully literal, double-quoted arguments. Anything carrying a `$` is
+    // a shell expansion this harness cannot resolve without running the suite.
+    if (argumentText.includes("$")) {
+      skipped += 1;
+      continue;
+    }
+    const paths = [...argumentText.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+    if (paths.length === 0 || paths.some((path) => path === "")) {
+      skipped += 1;
+      continue;
+    }
+    const key = paths.join(" ");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sets.push({ label: `self-test:${paths.join(",").slice(0, 80)}`, paths });
+  }
+  if (sets.length === 0) {
+    // The "All 0 …" shape: a changed helper name would silently empty this.
+    throw new Error(
+      "harvested no run_gate argument sets from agent-quality-gate.test.sh",
+    );
+  }
+  console.log(
+    `self-test corpus: ${sets.length} distinct sets harvested, ${skipped} non-literal calls skipped`,
+  );
+  return sets;
+}
+
+/**
  * Pass 6 — a real directory symlink under `scripts/`.
  *
  * `scriptsSymlinkTargets` is a DYNAMIC pattern source: the arms it feeds are
@@ -815,6 +885,7 @@ const CORPORA = new Set([
   "base",
   "fixture",
   "symlink",
+  "self-test",
 ]);
 const limit = parseLimit(option("--limit", null));
 const mutate = argv.includes("--mutate");
@@ -838,6 +909,7 @@ function buildWork() {
   if (corpus === "base") return corpusBase(dir);
   if (corpus === "fixture") return corpusFixture(dir);
   if (corpus === "symlink") return corpusSymlink();
+  if (corpus === "self-test") return corpusSelfTest();
   return corpusTracked(limit).map((path) => ({ label: path, paths: [path] }));
 }
 
@@ -851,17 +923,26 @@ try {
     const undo = symlink === undefined ? () => {} : withSymlink(symlink);
     let gate;
     let engine;
+    let refusal = null;
     try {
       const run = runGate(set, dir, base, root);
-      gate = parseGateStdout(run.stdout);
-      // The gate's normalized set, not the harness's raw one.
-      engine = await runEngine(gate.changedPaths, run.pathsFile, base, root);
+      refusal = run.refusal;
+      if (refusal === null) {
+        gate = parseGateStdout(run.stdout);
+        // The gate's normalized set, not the harness's raw one.
+        engine = await runEngine(gate.changedPaths, run.pathsFile, base, root);
+      }
     } finally {
       undo();
     }
+    compared += 1;
+    if (refusal !== null) {
+      differences += 1;
+      if (differences <= 15) console.log(`${label}: REFUSED\n    ${refusal}`);
+      continue;
+    }
     if (mutate) engine.commands.shift();
     const problems = diff(label, gate, engine);
-    compared += 1;
     if (problems.length > 0) {
       differences += 1;
       if (differences <= 15) console.log(problems.join("\n"));

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -318,7 +318,7 @@ export const AGENT_MODULE_ARMS = [
     ],
   },
   {
-    why: "The Node mapping engine (ADR 0069, D5b) and the parity harness that proves it against these arms. Nothing consults the engine yet — the `case` arms are still the routing that runs — so this routes the engine's own checks rather than the gate self-test. The quoting test alone would leave routing, facts, verbs, ordering, compaction and scoped-test selection unchecked (Codex 3838109001), so the three CHEAP parity corpora run too: `fixture` (2s) covers the branch that skips repository-specific groups, `symlink` (6s) covers the dynamic pattern source no committed path can reach — it is the corpus that caught the `..`-prefixed target bug — and `multi` (57s) is where the four whole-set post-passes are actually exercised. The tracked, synthetic and base corpora are a 35-minute run and stay a per-PR step. When the gate is flipped to read the engine's plan the harness is deleted, and this arm gains the self-test the way the routing-table arm already has it (issue 2020).",
+    why: "The Node mapping engine (ADR 0069) and the harness that drives the parity corpora against it. Since D5b part 2 this IS the routing: the gate builds its plan from the engine and refuses the run if the bash `case` arms disagree by one byte, so a change here changes what every gate run does. The arm therefore carries the gate self-test and the prewarm contract as well as the engine's own unit tests — the suite's 1,229 assertions are assertions about this module's output now. It also runs the three CHEAP parity corpora: `fixture` (2s) covers the branch that skips repository-specific groups, `symlink` (6s) covers the dynamic pattern source no committed path can reach, and `multi` (57s) is where the four whole-set post-passes are exercised. The tracked, synthetic, base and self-test corpora are a 40-minute run and stay a per-PR step. D5c deletes the arms, the in-gate comparison and the harness together (issue 2020).",
     patterns: [
       "scripts/gate/mapping.mjs",
       "scripts/gate/mapping/*.mjs",
@@ -328,6 +328,20 @@ export const AGENT_MODULE_ARMS = [
       {
         command: "node --test scripts/gate/mapping/shell-quote.test.mjs",
         reason: "gate mapping engine changed",
+      },
+      {
+        command: "node --test scripts/gate/mapping/engine.test.mjs",
+        reason:
+          "gate mapping engine changed (behaviour the arms will stop pinning at D5c)",
+      },
+      {
+        command: "pnpm agent:quality-gate:test",
+        reason:
+          "gate mapping engine produces the stdout the gate suite asserts on",
+      },
+      {
+        command: "node scripts/gate/agent-prewarm.test.mjs",
+        reason: "gate mapping engine produces the stdout agent:prewarm parses",
       },
       {
         command: "node scripts/gate/routing-parity.mjs --corpus fixture",

--- a/turbo.json
+++ b/turbo.json
@@ -96,6 +96,8 @@
         "$TURBO_ROOT$/scripts/agent-quality-gate.sh",
         "$TURBO_ROOT$/scripts/agent-quality-gate.test.sh",
         "$TURBO_ROOT$/scripts/gate/routing-table/**",
+        "$TURBO_ROOT$/scripts/gate/mapping.mjs",
+        "$TURBO_ROOT$/scripts/gate/mapping/**",
         "$TURBO_ROOT$/turbo.json"
       ],
       "env": ["VERCEL_ENV", "VERCEL_DEPLOYMENT_ID", "VERCEL_GIT_COMMIT_SHA"],
@@ -159,6 +161,8 @@
         "$TURBO_ROOT$/scripts/agent-quality-gate.sh",
         "$TURBO_ROOT$/scripts/agent-quality-gate.test.sh",
         "$TURBO_ROOT$/scripts/gate/routing-table/**",
+        "$TURBO_ROOT$/scripts/gate/mapping.mjs",
+        "$TURBO_ROOT$/scripts/gate/mapping/**",
         "$TURBO_ROOT$/turbo.json"
       ],
       "outputs": []
@@ -201,6 +205,8 @@
         "$TURBO_ROOT$/scripts/agent-quality-gate.sh",
         "$TURBO_ROOT$/scripts/agent-quality-gate.test.sh",
         "$TURBO_ROOT$/scripts/gate/routing-table/**",
+        "$TURBO_ROOT$/scripts/gate/mapping.mjs",
+        "$TURBO_ROOT$/scripts/gate/mapping/**",
         "$TURBO_ROOT$/turbo.json"
       ],
       "env": [


### PR DESCRIPTION
## The Problem

- D5b part 1 landed the mapping engine inert and proved it at parity, but the
  routing that ran was still 1,400 lines of bash `case` arms. Nothing consumed
  the engine.
- The swap's failure mode is the one this whole track exists to remove: a mapper
  that maps fewer commands, exits 0, and prints "All mapped commands passed."
- Parity proven over a corpus is not parity proven over whatever a contributor
  actually changed.

## The Solution

- The gate runs `scripts/gate/mapping.mjs` **once per run**, reads the plan back
  as the TSV `write_command_plan` already emits, and uses it. That plan is what
  gets printed, hashed into the freshness stamp, and executed.
- The bash `case` arms still run, and the gate **refuses the whole run if the two
  plans differ by one byte** — parity in production, not parity in a harness.
  D5c deletes the arms, the comparison and the harness together.
- Everything the arms were pinning gets its own pin first: engine unit tests, a
  prewarm stdout contract, the signature and Turbo entries, and a seventh parity
  corpus harvested from the gate's own suite.

## Details

**The seam.** After the bash loop and the four post-passes, the gate calls the
mapper with the changed-paths file it already normalized, the base, the head,
`$script_source_dir`, and two flags (`--real-tree`, `--full-local-tests`). The
mapper writes `flag`, `surface`, `checklist` and bucket records; the gate parses
them into arrays, compares them against the arms' plan rendered in the same
shape, and only then assigns them over the live arrays. Order is compared, not
just membership: the buckets, the surfaces and the checklists all print and hash
in sequence.

**Every edge around the seam is a refusal, and each was measured.** A mapper the
gate cannot find, one that exits non-zero, one that emits nothing, one that emits
a record the gate cannot parse, one that names a bucket that does not exist — and
any disagreement with the arms, in either direction. The `package_script_risk_changed`
flag crosses the seam too, because it gates the gate's refusal to run at all and
would otherwise quietly stop being set.

**Why the arms stay.** They cost wall-clock and nothing else, and while they run,
every gate invocation anyone makes is another parity sample on a path set nobody
thought to put in a corpus. The step is also reversible without a revert: a
divergence stops the run rather than picking a winner.

**What the engine now needs that it did not need while inert.** Its behaviour was
pinned only by the arms it was compared against, so D5c would have deleted the
last thing pinning it in the same commit that removed them.
`scripts/gate/mapping/engine.test.mjs` pins the rules directly: dedupe and
first-reason-wins, the two alias pairs, prepend-after-add, bucket order, the four
post-passes including the 15/16 scoped-test threshold and every disqualifier, and
the root-manifest classifier's four classes.

`agent-prewarm.mjs` parses the gate's dry-run stdout and no-ops silently when the
format drifts. Its contract test rebuilt that stdout from literals in the gate
source — but the command lines now come from a different program than those
literals live in, so the test now runs the real gate and requires a non-empty
extraction.

## Validation

**Parity, seven corpora, driving the in-gate guard across every path set.**

| Corpus | Sets | Refusals |
| --- | --- | --- |
| `tracked` | 2,273 | **0** |
| `multi` | 43 | **0** |
| `synthetic` | 235 | **0** |
| `base` | 11 | **0** |
| `fixture` | 8 | **0** |
| `symlink` | 6 | **0** |
| `self-test` | 330 | **0** |

2,906 path sets, no refusal. Since the swap the harness's own diff is
circular — the gate's plan IS the engine's — so the signal is the gate's exit
code: a refusal is the guard firing, and the harness now reports it as the
difference it is instead of dying on it.

**The guard's negative control, five shapes, each proven to land.**

| Mutation | Result |
| --- | --- |
| engine drops one command (the smaller-plan direction) | refused, exit 2 |
| engine adds one command | refused, exit 2 |
| engine changes one reason string only | refused, exit 2 |
| mapper exits non-zero | refused, exit 2 |
| mapper emits an unknown bucket | refused, exit 2 |
| unmutated baseline | exit 0 |

**Engine unit tests: 46 tests, 18 mutation controls, 0 uncaught.** Each mutation
breaks one documented rule — last-reason-wins, a split alias pair, prepend
appending, reordered buckets, a missing path no longer forcing a full Trunk scan,
mainnet codegen no longer sorting last, compaction dropping its joined reasons,
the threshold moving 15→16, a lockfile-scoped package losing its floor, test-infra
no longer disqualifying, a deleted path no longer disqualifying, the tooling class
losing its exclusivity, an unparsable manifest no longer widening, react-doctor
dropping its base oid, the escalation flag never being set. Every one reds the
suite; the baseline is green before and after.

**The prewarm contract catches real drift.** Dropping `--cache=local:rw` from the
engine's Turbo command takes the test from exit 0 to exit 1.

**The dry-run stdout did not move.** Byte-identical pre-swap and post-swap on a
24-path set spanning every surface, and on a workspace-escalating set, after the
`__CHANGED_PATHS_FILE__` substitution `write_command_plan` already applies. The
only raw difference is the randomized scratch path — which differs between two
runs of the *same* gate. The freshness stamp therefore hashes identically.

**Performance, measured three ways.**

| Change set | pre-swap | post-swap (soak) | D5c projection |
| --- | --- | --- | --- |
| 24 paths | 10.2s | 11.1s | **0.71s** |
| 1 path (workspace escalation) | 0.47s | 0.64s | 0.52s |

The bash routing costs ~0.42s per changed path; the engine maps all 24 in 0.12s
including Node startup. The projection is measured, not estimated: a throwaway
copy of the gate with the bash loop starved and the comparison disabled still
produces a plan, and that is what D5c leaves behind. So the soak is ~0.9s slower
on a 24-path change and D5c is roughly **14× faster** on one.

**Review rounds.** The codex engine found the parity harness pinned into
`implementation_signature()` and into `scripts/AGENTS.md`'s claim but not into
`turbo.json`; the claim was wrong rather than the pin, since the harness is a
mapped command and not an input to `build`, `size-limit` or `test:browser` —
listing it there would bust the dashboard build cache for a dev tool those tasks
never read. The claude engine then found three, all real and all fixed:

1. **The mapper never ran through a symlink.** `process.argv[1] === fileURLToPath(import.meta.url)`
   is false for every symlinked invocation, because Node realpaths the entry for
   `import.meta.url` and leaves argv alone. Measured: the module imported, ran
   nothing, exited 0 with no plan, and the gate refused *every* run with
   "produced an empty plan". The gate's own suite builds `scripts/` mirrors out
   of symlinks and macOS `/tmp` is one, so this was the ordinary case. Now
   compared by realpath, with a test that runs the mapper through a symlinked
   mirror and requires the same plan.
2. **The seam forwarded the mapper's exit code** (1, 2 or 3) where the ADR and
   the four sibling refusals all promise 2. Now 2, the way the bash routing
   classifier already collapses its own 3.
3. **Nothing enumerated `scripts/gate/mapping/*.mjs` against the signature**,
   unlike `routing-table/`, whose suite checks both directions. A new engine
   module would have been a Turbo input and silently absent from the stamp.
   Both directions are checked now.

Three further mutation controls cover those: reverting the symlink guard,
dropping a module from the signature, and leaving a stale entry in it each red
the suite.

**The pre-push hook caught one more, and it was a claim rather than a bug in
the swap.** `printf %q` of a byte >= 0x80 is LOCALE-sensitive: measured, `aéb`
is `$'a\303\251b'` under `LC_ALL=C` and `aéb` under `LC_ALL=en_US.UTF-8` on
both builds, and with the locale unset 3.2.57 escapes where 5.3.15 does not.
The hook strips the environment while a developer's shell is UTF-8, so both
answers are reachable on one machine. `shellQuote` had claimed the pass-through
as measured fact — measured, but only in a UTF-8 shell. It now refuses those
bytes for the same reason it refuses a leading `~`. The corpus had the same
blind spot and now drives every subject under both locales and asserts they
agree, so a subject whose answer depends on the environment cannot sit in it.
Both suites pass under an inherited environment, `env -i`, `LC_ALL=C` and
`LC_ALL=en_US.UTF-8`. No tracked path carries a non-ASCII byte.

**The gate suite caught one real consequence of the swap.** Its stubbed `node`
forwarded only `--input-type=module`, so the mapper was stubbed out, produced
nothing, and the gate refused. The guard was right and the fixture was written
for a gate with no Node routing; the stub now forwards the mapper too.

**Commands:** `pnpm gate:routing-table:test` 62/62 (the equality test still holds
the table against the arms), `node --test scripts/gate/mapping/engine.test.mjs`
43/43, `node --test scripts/gate/mapping/shell-quote.test.mjs` 6/6,
`node scripts/gate/agent-prewarm.test.mjs`, `GATE_TEST_FOCUS=routing-sources`,
full gate green at the pre-push hook's exact form, `pnpm lint:scripts`.

## Deferrals

- #2020 — D5c: delete the bash `case` arms, the in-gate comparison and
  `scripts/gate/routing-parity.mjs`. They are one mechanism and they go together,
  after the soak. **The soak starts at this PR's merge date.**

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The Solution is plain English and understandable before reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals.
- [x] Architecture decision? ADR 0069 records the seam and gains a decision
      section and consequences for the swap, the guard, the harness's changed
      job and the measured performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This swaps the pre-push quality gate’s live routing from bash `case` arms to the Node mapping engine. A mapper or parity-guard bug can refuse every run or, after D5c, change which checks actually execute.
> 
> **Overview**
> The quality gate now **uses** `scripts/gate/mapping.mjs` as routing: it runs the mapper once, parses the TSV plan, and executes that plan (including `package_script_risk_changed`). Bash `case` arms still run, but only as a soak cross-check — any one-byte plan mismatch, missing mapper, empty/unparsable output, or unknown record **refuses the whole run with exit 2**. D5c will drop the arms, comparison, and harness together.
> 
> Pins and tests move with the swap so D5c does not delete the only oracle. Engine modules land in `implementation_signature()` and `turbo.json`; `engine.test.mjs` pins dedupe, post-passes, scoped-test rules, and the root-manifest classifier; `agent-prewarm` now dry-runs the real gate. The parity harness treats in-gate refusals as diffs and adds a `self-test` corpus harvested from `run_gate` arguments.
> 
> `shellQuote` now refuses non-ASCII bytes (locale-dependent `printf %q`) and leading-`~` ambiguity. Mapper CLI detection uses `realpath` so symlink invocations (the gate suite’s normal case) actually emit a plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d876be8380282f0eb36e90ef38538cb5cdc7bc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Node-based routing engine to generate and validate quality-gate plans.
  * Added prewarm validation for expected Turbo commands and cache settings.
  * Added parity checks to identify differences between routing implementations.

* **Bug Fixes**
  * Quality checks now fail safely when routing data is missing, invalid, empty, or inconsistent.
  * Improved shell-quoting safeguards for ambiguous tilde usage and non-ASCII input.

* **Tests**
  * Expanded coverage for routing, plan generation, parity checks, prewarming, and shell quoting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->