### PR TITLE
fix(sentry): project local config verdicts to work issues

### DIFF
--- a/.github/workflows/sentry-triage-agent.yml
+++ b/.github/workflows/sentry-triage-agent.yml
@@ -917,7 +917,7 @@ jobs:
           # the newest "Regressed in Sentry (last seen " reopen comment counts,
           # so a stale pre-regression verdict never re-labels a regressed
           # issue), validates the verdict against the closed four-value enum,
-          # and emits {"verdict","label","projectable","shed","architecturalHold"}
+          # and emits {"verdict","label","projectable","projectionDestination","shed","architecturalHold"}
           # JSON (on a local code-fix + fix_scope:architectural verdict `label`
           # is the two-name comma list and architecturalHold is true). The comment
           # body is agent-authored from untrusted Sentry data — it is only ever
@@ -928,10 +928,10 @@ jobs:
           # omits the required `human_question` field is treated exactly like an
           # invalid verdict (same fail-loud + retry) so a lazy, non-decision
           # escalation never lands a label — see the verdict contract in
-          # docs/notes/sentry-triage-pipeline.md. `projectable` (actionable
-          # verdict + allowlisted EXTERNAL owning repo) tells the close step
-          # whether this stub is settled here or deferred to the serialized
-          # `project` job.
+          # docs/notes/sentry-triage-pipeline.md. `projectable` remains the
+          # external-only capability. `projectionDestination` tells the close
+          # step whether this stub is settled here or deferred to the
+          # serialized `project` job, including exact local config work.
           parse_file="${RUNNER_TEMP}/verdict-parse.json"
           # Plain scripts/ is correct HERE and nowhere else in this file: this
           # job has its own runner and its own pristine checkout, which the
@@ -948,6 +948,11 @@ jobs:
           verdict=$(jq -r '.verdict' "${parse_file}")
           label=$(jq -r '.label' "${parse_file}")
           projectable=$(jq -r '.projectable' "${parse_file}")
+          projection_destination=$(jq -r '.projectionDestination' "${parse_file}")
+          if ! [[ "${projection_destination}" =~ ^(external|local-config|none)$ ]]; then
+            echo "::error::projectionDestination for issue #${QUEUE_ISSUE_NUMBER} is '${projection_destination}', not a closed destination; leaving sentry:needs-triage in place for retry."
+            exit 1
+          fi
           # `shed` is every OTHER verdict label, comma-joined, from the same
           # parser (#1745). The select job admits any OPEN numeric issue, so a
           # human re-dispatching an answered escalation hands this step a stub
@@ -1089,6 +1094,7 @@ jobs:
             echo "verdict=${verdict}"
             echo "label=${label}"
             echo "projectable=${projectable}"
+            echo "projection_destination=${projection_destination}"
             echo "architectural_hold=${architectural_hold}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -1183,8 +1189,9 @@ jobs:
       # -----------------------------------------------------------------------
       # Queue hygiene (#1338/#1354): a verdicted queue issue is a closed ledger
       # entry, not an archive record. This step settles every bucket EXCEPT two
-      # that stay OPEN: actionable EXTERNAL verdicts, which are deferred (left
-      # open, verdict-labeled) to the serialized `project` job below — projection
+      # that stay OPEN: routed actionable verdicts, which are deferred (left
+      # open, verdict-labeled) to the serialized `project` job below. External
+      # projection and exact local config work both serialize there.
       # and its close must run one-at-a-time to kill the same-run duplicate-family
       # race, and the projection PAT must never reach these matrix jobs — and
       # local architectural code-fix (#1812), which stays open under
@@ -1201,14 +1208,15 @@ jobs:
           VERDICT: ${{ steps.verdict.outputs.verdict }}
           VERDICT_LABEL: ${{ steps.verdict.outputs.label }}
           PROJECTABLE: ${{ steps.verdict.outputs.projectable }}
+          PROJECTION_DESTINATION: ${{ steps.verdict.outputs.projection_destination }}
           ARCHITECTURAL_HOLD: ${{ steps.verdict.outputs.architectural_hold }}
         run: |
           set -euo pipefail
           projection_note=""
           case "${VERDICT}" in
             code-fix | config-fix)
-              if [ "${PROJECTABLE}" = "true" ]; then
-                echo "Issue #${QUEUE_ISSUE_NUMBER} has an actionable external verdict; leaving it open for the serialized project job."
+              if [ "${PROJECTION_DESTINATION}" = "external" ] || [ "${PROJECTION_DESTINATION}" = "local-config" ]; then
+                echo "Issue #${QUEUE_ISSUE_NUMBER} has an actionable ${PROJECTION_DESTINATION} verdict; leaving it open for the serialized project job."
                 exit 0
               fi
               # Architectural hold (#1812): a LOCAL code-fix whose fix_scope is
@@ -1267,7 +1275,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # project: SERIALIZED verdict projection (deterministic, no LLM — ADR 0038).
   # Runs ONCE per triage run, after every matrix job settles, and processes the
-  # batch's actionable EXTERNAL verdicts one at a time via the script's --batch
+  # batch's routed actionable verdicts one at a time via the script's --batch
   # mode (single node process, shared in-run registry). Serialization is the
   # point:
   #   - Two duplicate-family SHORT-IDs in one batch could otherwise both pass
@@ -1283,7 +1291,8 @@ jobs:
   #   - if: always() + count gate (like the digest): failed matrix jobs leave
   #     their stubs on sentry:needs-triage, which --batch skips; the rest of
   #     the batch still projects.
-  # Per-row outcomes: projected/reused stubs are closed here with the
+  # External and exact local-config routes reach this job. Per-row
+  # projected/reused stubs are closed here with the
   # projected URL in the fixed closing comment; skipped-no-token (main) closes
   # with the visible "not provisioned" note; failed rows re-queue through the
   # single chokepoint's workflow CLI (restore sentry:needs-triage, shed the
@@ -1314,7 +1323,7 @@ jobs:
         with:
           node-version-file: .node-version
 
-      - name: Project actionable external verdicts (serialized)
+      - name: Project actionable verdicts (serialized)
         env:
           GH_TOKEN: ${{ github.token }}
           # The ONLY place in this workflow the cross-repo projection PAT is

--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -3,7 +3,7 @@ title: Central Sentry triage plane with owning-repo verdict projection
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-21
+last_verified: 2026-08-23
 scope: ci/process
 date: 2026-07
 doc_type: adr
@@ -77,11 +77,13 @@ deterministic step.**
   job — the matrix jobs hosting the LLM agent never see it. For a `code-fix` /
   `config-fix` verdict whose destination is `external`, it files an issue in
   that repo. For `local-config`, it files a local work issue with
-  `agent-ready` using the ambient workflow token. Both routes label the stub
-  `sentry:projected`, comment the projected URL, and close the stub. A closed
-  local match repairs `agent-ready` and conflicting lifecycle labels before it
-  reopens, so a failed repair stays retryable; an open match keeps its
-  lifecycle. The matrix settles all `none` destinations and
+  `agent-ready` using the ambient workflow token. Immediately before a local
+  create or closed-match repair, the route ensures the canonical shared
+  `agent-ready` definition exists without force-editing existing metadata. Both
+  routes label the stub `sentry:projected`, comment the projected URL, and close
+  the stub. A closed local match repairs `agent-ready` and conflicting lifecycle
+  labels before it reopens, so a failed repair stays retryable; an open match
+  keeps its lifecycle. The matrix settles all `none` destinations and
   `upstream-transient` stubs, but leaves TWO classes OPEN: `needs-human`, and a local `code-fix` whose
   `fix_scope` is `architectural` — open human design work held under
   `sentry:fix-scope-architectural` and excluded from the autofix candidate window

--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -77,13 +77,14 @@ deterministic step.**
   job — the matrix jobs hosting the LLM agent never see it. For a `code-fix` /
   `config-fix` verdict whose destination is `external`, it files an issue in
   that repo. For `local-config`, it files a local work issue with
-  `agent-ready` using the ambient workflow token. Immediately before a local
-  create or closed-match repair, the route ensures the canonical shared
-  `agent-ready` definition exists without force-editing existing metadata. Both
-  routes label the stub `sentry:projected`, comment the projected URL, and close
-  the stub. A closed local match repairs `agent-ready` and conflicting lifecycle
-  labels before it reopens, so a failed repair stays retryable; an open match
-  keeps its lifecycle. The matrix settles all `none` destinations and
+  `agent-ready` using the ambient workflow token. Before a local create, the
+  route ensures only the canonical shared `agent-ready` definition. Before a
+  closed-match repair, it ensures all four canonical lifecycle label definitions
+  named by the edit. Neither path force-edits existing metadata. Both routes label the stub
+  `sentry:projected`, comment the projected URL, and close the stub. A closed
+  local match restores `agent-ready`, removes `agent-active`, `in-pr`, and
+  `needs-grooming`, and then reopens. A failed repair stays retryable; an open
+  match keeps its lifecycle. The matrix settles all `none` destinations and
   `upstream-transient` stubs, but leaves TWO classes OPEN: `needs-human`, and a local `code-fix` whose
   `fix_scope` is `architectural` — open human design work held under
   `sentry:fix-scope-architectural` and excluded from the autofix candidate window

--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -3,7 +3,7 @@ title: Central Sentry triage plane with owning-repo verdict projection
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-21
 scope: ci/process
 date: 2026-07
 doc_type: adr
@@ -67,24 +67,30 @@ deterministic step.**
 - **Verdict projection (deterministic, no LLM, SERIALIZED).** A dedicated
   `project` job in `.github/workflows/sentry-triage-agent.yml`, driven by
   `scripts/sentry/triage/sentry-triage-project.mjs --batch`, runs after the whole triage
-  matrix and processes the batch's actionable external verdicts one at a time
-  in one process. Serialization plus an in-run registry kills the
+  matrix and processes the batch's routed actionable verdicts one at a time in
+  one process. The closed destination enum is `external`, `local-config`, or
+  `none`: external is an allowlisted owning repo; local-config is only an exact
+  local `config-fix`; local code-fix and unrecognised repositories are none.
+  `projectable` remains external-only. Serialization plus an in-run registry kills the
   duplicate-family double-file race (a just-created issue is not searchable
   for seconds-to-minutes), and it confines the projection token to this one
   job — the matrix jobs hosting the LLM agent never see it. For a `code-fix` /
-  `config-fix` verdict whose `affected_repo` is an EXTERNAL owning repo, it
-  files an issue in that repo, labels the stub `sentry:projected`, comments
-  the projected URL, and closes the stub. The matrix settles local actionable
-  and `upstream-transient` stubs and defers external actionable stubs to this
-  job, but leaves TWO classes OPEN: `needs-human`, and a local `code-fix` whose
+  `config-fix` verdict whose destination is `external`, it files an issue in
+  that repo. For `local-config`, it files a local work issue with
+  `agent-ready` using the ambient workflow token. Both routes label the stub
+  `sentry:projected`, comment the projected URL, and close the stub. A closed
+  local match repairs `agent-ready` and conflicting lifecycle labels before it
+  reopens, so a failed repair stays retryable; an open match keeps its
+  lifecycle. The matrix settles all `none` destinations and
+  `upstream-transient` stubs, but leaves TWO classes OPEN: `needs-human`, and a local `code-fix` whose
   `fix_scope` is `architectural` — open human design work held under
   `sentry:fix-scope-architectural` and excluded from the autofix candidate window
   at query time (issue #1812), so projection and queue-hygiene work must not
   auto-close it. `needs-human` and `upstream-transient` are never projected.
 - **The trust boundary is a fixed allowlist plus authorship.** `affected_repo`
   is untrusted agent text, validated against exactly `frontend-monorepo`,
-  `mento-analytics-api`, `minipay-dapp`; anything else (including this repo) is a
-  no-op with a `::warning::`. Only verdict comments authored by the pipeline's
+  `mento-analytics-api`, `minipay-dapp`; this repo is a local-config candidate
+  only for `config-fix`; anything else is a no-op with a `::warning::`. Only verdict comments authored by the pipeline's
   own Actions bot are honored (this repo is public — a drive-by commenter must
   not drive labels, closes, or cross-repo writes), and labeling and projection
   share ONE parser (`--parse-only`) so they can never disagree about a verdict.
@@ -94,8 +100,10 @@ deterministic step.**
   mention-defang) and multi-line fields fenced. Idempotent by Sentry SHORT-ID
   (a hidden back-link marker anchored to the body's leading marker block,
   searched across all states, with a genuine match also required to be
-  authored by the projector identity itself; a closed match is reopened so
-  regressions resurface) so re-runs and regressions never duplicate — and
+  authored by the projector identity itself. Local issues use the exact
+  `app/github-actions` issue-author fence, while comment surfaces use the
+  trusted `github-actions` or `github-actions[bot]` comment fence; a closed
+  match is reopened so regressions resurface) so re-runs and regressions never duplicate — and
   verdict-declared duplicates coalesce onto one owning-repo issue. The new
   SHORT-ID persists as a projector-authored alias comment, while the serialized
   in-run registry prevents discovery races instead of filing one issue per
@@ -108,7 +116,8 @@ deterministic step.**
   projection step, never the triage agent; the agent's allowlist and permissions
   are untouched. It is also ref-gated to `main` (a branch `workflow_dispatch`
   runs branch-modified workflow code; durable Environment protection is #1289).
-  Absent PAT → graceful no-op. Cross-repo fix **PRs** remain a later phase
+  Absent PAT → graceful no-op for external routing only. Local config routing
+  uses the existing ambient workflow token. Cross-repo fix **PRs** remain a later phase
   (ADR 0036 Stage C Phase 3, tracked in #1279) — this ADR authorizes
   Issues-write only.
 
@@ -144,7 +153,7 @@ deterministic step.**
   fetched or copied. A leaked/wrong verdict can create a readable owning-repo
   issue (Issues-write) but cannot mutate code or Sentry.
 - Projection is idempotent across regressions: a reopened-then-re-triaged stub
-  reuses the existing owning-repo issue rather than filing a duplicate.
+  reuses the existing work issue rather than filing a duplicate.
 - Owning-repo issues are advisory; the fix still happens the normal way in that
   repo. Cross-repo fix-PR automation stays out of scope (Phase 3, #1279).
 - The queue-close comment for `code-fix`/`config-fix` now records the projection

--- a/docs/adr/0064-scripts-module-directories.md
+++ b/docs/adr/0064-scripts-module-directories.md
@@ -3,7 +3,7 @@ title: scripts/ may use module subdirectories; basenames and pinned paths are th
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-22
+last_verified: 2026-08-23
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -368,7 +368,8 @@ not only the arm of the consumer that happens to fail loudest.
   domain directories: five files beyond `production-infra-identity-contract/`
   read `hcl.mjs`; the ADR 0053 deploy-staging contract reads
   `workflow-yaml.mjs`; the lockfile-lint gate and the override prune advisor
-  both read `pnpm-override-selector.mjs`; the documentation garden and the
-  navigation-eval scheduler both read `gh-issue-lifecycle.mjs`.
+  both read `pnpm-override-selector.mjs`; the documentation garden, the
+  navigation-eval scheduler, and local Sentry projection read
+  `gh-issue-lifecycle.mjs`.
 - Programme tracking issue:
   <https://github.com/mento-protocol/monitoring-monorepo/issues/1877>.

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -3,7 +3,7 @@ title: Sentry Triage Pipeline
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-10
+last_verified: 2026-08-21
 scope: ci/process
 doc_type: runbook
 review_interval_days: 90
@@ -100,7 +100,7 @@ Adding a project means adding it to the allowlist, not only to Sentry.
 | Verdict              | `analytics-mento-org` (local)                                                                                                                                                                                                                     | Every other project (external)                        |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `code-fix`           | `fix_scope: mechanical` → **autofix-eligible**, closed ledger entry — the only path that writes code. `fix_scope: architectural` → **stays OPEN** under `sentry:fix-scope-architectural` (human design work, excluded from autofix at query time) | Projects an issue into the owning repo. Never autofix |
-| `config-fix`         | Record only: no projection (this repo is not an allowlisted target), no autofix                                                                                                                                                                   | Projects an issue into the owning repo                |
+| `config-fix`         | Projects a local work issue with `agent-ready`; no autofix                                                                                                                                                                                        | Projects an issue into the owning repo                |
 | `upstream-transient` | Closes. Nothing downstream                                                                                                                                                                                                                        | Same                                                  |
 | `needs-human`        | Stays open with a decision-ready brief                                                                                                                                                                                                            | Same                                                  |
 
@@ -385,7 +385,7 @@ The namespace is separate from the development backlog:
 | `sentry:verdict-config-fix`      | Configuration or infrastructure change is recommended                                         |
 | `sentry:verdict-upstream`        | Upstream or transient issue; no repo fix                                                      |
 | `sentry:verdict-needs-human`     | A human decision is required                                                                  |
-| `sentry:projected`               | An actionable external verdict was projected to its owning repo                               |
+| `sentry:projected`               | An external actionable verdict or local config-fix was projected to a work issue              |
 | `sentry:fix-scope-architectural` | Local code-fix, `fix_scope: architectural` — open human design work; autofix never selects it |
 | `sentry:approved-archive`        | Human approval to archive the Sentry issue                                                    |
 | `sentry:archived`                | Archive workflow settled the approved issue                                                   |
@@ -455,8 +455,9 @@ step's post-condition reread still counts exactly one label, because
 (`VERDICT_LABELS` filters on that prefix). The close step reads
 `architectural_hold` and leaves the stub open rather than closing it. So the
 "a verdicted queue issue is a closed ledger entry" invariant now has TWO open
-exceptions: an actionable EXTERNAL verdict (deferred to the project job) and a
-LOCAL architectural code-fix (held as human design work). The hold is never
+exceptions: a projectable destination (external actionable verdict or exact
+local `config-fix`, deferred to the project job) and a LOCAL architectural
+code-fix (held as human design work). The hold is never
 terminal: it is shed on regression and on any re-verdict
 (`REOPEN_SHED_LABELS`), and `shed` carries it exactly when the hold does not
 apply, so a re-dispatched stub whose scope flips to mechanical un-strands in the
@@ -929,7 +930,7 @@ the case the pipeline can detect on its own, a dead credential broker, the
 refusal is enforced deterministically in the comment wrapper
 ([above](#a-broker-that-dies-mid-agent-1956)).
 
-The deterministic parser accepts only comments from
+The deterministic parser accepts only comments from `github-actions` or
 `github-actions[bot]`. After a regression reopen, it accepts only a verdict
 newer than the latest pipeline-authored regression comment. It then applies
 the label and transition below:
@@ -938,7 +939,8 @@ the label and transition below:
 | -------------------------------- | ------------------------------------------------------------ | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `code-fix` (mechanical/external) | `sentry:verdict-code-fix`                                    | Close as completed                | Project to an allowlisted external repo, or leave a visible projection-skipped note; eligible local mechanical issues may later enter autofix |
 | `code-fix` (local architectural) | `sentry:verdict-code-fix` + `sentry:fix-scope-architectural` | **Keep open** (human design work) | Excluded from autofix at query time; re-triage to clear (#1812)                                                                               |
-| `config-fix`                     | `sentry:verdict-config-fix`                                  | Close as completed                | Project to an allowlisted external repo, or leave a visible projection-skipped note                                                           |
+| `config-fix` (external)          | `sentry:verdict-config-fix`                                  | Close as completed                | Project to an allowlisted external repo, or leave a visible projection-skipped note                                                           |
+| `config-fix` (local)             | `sentry:verdict-config-fix`                                  | Close after projection            | Create or reuse a local work issue with `agent-ready`; no projection PAT required                                                             |
 | `upstream-transient`             | `sentry:verdict-upstream`                                    | Close as completed                | None                                                                                                                                          |
 | `needs-human`                    | `sentry:verdict-needs-human`                                 | Keep open                         | Human answers the recorded question and decides the next action                                                                               |
 
@@ -1020,22 +1022,29 @@ the surviving archive-side route as well as the sweep's blind spot. It does not
 make the sweep able to see Sentry, and it is not a substitute for the fence: the
 digest, projection, and autofix consumers still read the fence.
 
-### External verdict projection
+### Verdict projection
 
-[ADR 0038](../adr/0038-sentry-central-plane-verdict-projection.md) limits projection to
-actionable `code-fix` and `config-fix` verdicts whose `affected_repo` is
-one of the script's allowlisted owning repositories. Projection runs
-serialized after the triage matrix so two related verdicts cannot race to
+[ADR 0038](../adr/0038-sentry-central-plane-verdict-projection.md) routes
+actionable verdicts through a closed destination enum. `external` is an
+allowlisted external owner. `local-config` is only a `config-fix` whose owning
+repo validation is exactly this repository. Every local `code-fix` and every
+unrecognised repo is `none`. `projectable` remains external-only. Projection
+runs serialized after the triage matrix so two related verdicts cannot race to
 create duplicate issues.
 
-The projector uses a fine-grained PAT with Issues read/write on only those
-repositories. It keys reuse to the Sentry short ID and the projector account's
-authorship. Rotating the token through a different account can break reuse and
-must be treated as a migration. On `main`, an absent
-`SENTRY_PROJECTION_TOKEN` makes projection a visible no-op and queue
-settlement continues. A non-`main` manual triage dispatch deliberately
-withholds the token; an actionable external verdict is re-queued and the job
-fails so the next `main` run can project it safely.
+The external projector uses a fine-grained PAT with Issues read/write on only
+those repositories. It keys reuse to the Sentry short ID and the projector
+account's authorship. Rotating the token through a different account can break
+reuse and must be treated as a migration. A local config route uses the
+ambient workflow token. It only matches local issues whose `gh issue list`
+author is `app/github-actions`, while marker comments use the trusted
+`github-actions` or `github-actions[bot]` comment fence. It creates a
+new issue with `agent-ready`; for a closed match, it restores that label and
+removes `agent-active`, `in-pr`, and `needs-grooming` before reopening it, so a
+failed repair stays retryable; it leaves an open match's lifecycle unchanged. On `main`, an absent
+`SENTRY_PROJECTION_TOKEN` makes only external projection a visible no-op. A
+non-`main` manual triage dispatch re-queues an external verdict for the next
+`main` run. Local config projection does not require the PAT.
 
 ### Local autofix PRs
 
@@ -1798,6 +1807,7 @@ To pause ingest/triage, autofix, or archive, set that stage's named
 `sentry_projection_token = ""` and reapply. Confirm the plan removes
 `SENTRY_PROJECTION_TOKEN`; subsequent external verdicts then record the
 visible projection-skipped outcome instead of creating owning-repo issues.
+Local config-fix projection remains available through the workflow token.
 Never widen the read-only token or reuse it for archive. Treat
 `CLAUDE_CODE_OAUTH_TOKEN` replacement as a shared-secret rotation and verify
 the existing Claude PR workflow after applying it.

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -1038,16 +1038,17 @@ account's authorship. Rotating the token through a different account can break
 reuse and must be treated as a migration. A local config route uses the
 ambient workflow token. It only matches local issues whose `gh issue list`
 author is `app/github-actions`, while marker comments use the trusted
-`github-actions` or `github-actions[bot]` comment fence. Immediately before it
-creates a local issue or repairs a closed match, it ensures the canonical shared
-`agent-ready` definition exists without force-editing existing metadata. It
+`github-actions` or `github-actions[bot]` comment fence. Before it creates a
+local issue, it ensures only the canonical shared `agent-ready` definition.
+Before it repairs a closed match, it ensures all four canonical lifecycle label
+definitions named by the edit. Neither path force-edits existing metadata. It
 creates a new issue with `agent-ready`. For a closed match, it restores that
-label and removes `agent-active`, `in-pr`, and `needs-grooming` before reopening
-it, so a failed repair stays retryable. It leaves an open match's lifecycle
-unchanged. On `main`, an absent `SENTRY_PROJECTION_TOKEN` makes only external
-projection a visible no-op. A
-non-`main` manual triage dispatch re-queues an external verdict for the next
-`main` run. Local config projection does not require the PAT.
+label and removes
+`agent-active`, `in-pr`, and `needs-grooming` before reopening it, so a failed
+repair stays retryable. It leaves an open match's lifecycle unchanged. On
+`main`, an absent `SENTRY_PROJECTION_TOKEN` makes only external projection a
+visible no-op. A non-`main` manual triage dispatch re-queues an external verdict
+for the next `main` run. Local config projection does not require the PAT.
 
 ### Local autofix PRs
 

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -3,7 +3,7 @@ title: Sentry Triage Pipeline
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-21
+last_verified: 2026-08-23
 scope: ci/process
 doc_type: runbook
 review_interval_days: 90
@@ -1038,11 +1038,14 @@ account's authorship. Rotating the token through a different account can break
 reuse and must be treated as a migration. A local config route uses the
 ambient workflow token. It only matches local issues whose `gh issue list`
 author is `app/github-actions`, while marker comments use the trusted
-`github-actions` or `github-actions[bot]` comment fence. It creates a
-new issue with `agent-ready`; for a closed match, it restores that label and
-removes `agent-active`, `in-pr`, and `needs-grooming` before reopening it, so a
-failed repair stays retryable; it leaves an open match's lifecycle unchanged. On `main`, an absent
-`SENTRY_PROJECTION_TOKEN` makes only external projection a visible no-op. A
+`github-actions` or `github-actions[bot]` comment fence. Immediately before it
+creates a local issue or repairs a closed match, it ensures the canonical shared
+`agent-ready` definition exists without force-editing existing metadata. It
+creates a new issue with `agent-ready`. For a closed match, it restores that
+label and removes `agent-active`, `in-pr`, and `needs-grooming` before reopening
+it, so a failed repair stays retryable. It leaves an open match's lifecycle
+unchanged. On `main`, an absent `SENTRY_PROJECTION_TOKEN` makes only external
+projection a visible no-op. A
 non-`main` manual triage dispatch re-queues an external verdict for the next
 `main` run. Local config projection does not require the PAT.
 

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -455,7 +455,7 @@ step's post-condition reread still counts exactly one label, because
 (`VERDICT_LABELS` filters on that prefix). The close step reads
 `architectural_hold` and leaves the stub open rather than closing it. So the
 "a verdicted queue issue is a closed ledger entry" invariant now has TWO open
-exceptions: a projectable destination (external actionable verdict or exact
+exceptions: a routed destination (external actionable verdict or exact
 local `config-fix`, deferred to the project job) and a LOCAL architectural
 code-fix (held as human design work). The hold is never
 terminal: it is shed on regression and on any re-verdict

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -49,8 +49,9 @@ stays flat under `alerts/infra/` ownership; ADR 0064 gives the lint reason.
 `workflow-yaml.mjs` for Actions and shell parsing,
 `pnpm-override-selector.mjs` for pnpm overrides, and
 `gh-issue-lifecycle.mjs` for shared GitHub issue and label mechanics.
-Documentation schedulers use the full lifecycle module; local Sentry projection
-uses its narrowed `agent-ready` ensure. ADR 0064 lists each reader.
+Documentation schedulers use this module. Local projection ensures only
+`agent-ready` on create and all lifecycle labels on closed repair. ADR 0064
+lists readers.
 `peg-policy-digest.mjs` is the one definition of the peg version-digest
 contract both peg validators check. Inventories, pinned hashes, and identities
 stay with their domain.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -45,13 +45,13 @@ subdirectories.
 pre-start path and eight docs name it. `redrive-onchain-deadletter.{mjs,test.mjs}`
 stays flat under `alerts/infra/` ownership; ADR 0064 gives the lint reason.
 
-`lib/` holds cores more than one cluster reads. `hcl.mjs` (Terraform HCL
-tokenizer and block extraction), `workflow-yaml.mjs` (Actions workflow and
-shell-run parsing), `pnpm-override-selector.mjs` (pnpm override selectors), and
-`gh-issue-lifecycle.mjs` (the `gh` runner, pagination guard, Documentation
-Garden workflow authorization, label bootstrap, and issue-queue arbitration).
-Cores stay outside domain directories; ADR 0064 records which clusters read
-each. `peg-policy-digest.mjs` is the one definition of the peg version-digest
+`lib/` holds cores that multiple clusters read: `hcl.mjs` for Terraform HCL,
+`workflow-yaml.mjs` for Actions and shell parsing,
+`pnpm-override-selector.mjs` for pnpm overrides, and
+`gh-issue-lifecycle.mjs` for shared GitHub issue and label mechanics.
+Documentation schedulers use the full lifecycle module; local Sentry projection
+uses its narrowed `agent-ready` ensure. ADR 0064 lists each reader.
+`peg-policy-digest.mjs` is the one definition of the peg version-digest
 contract both peg validators check. Inventories, pinned hashes, and identities
 stay with their domain.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -70,7 +70,9 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `bootstrap/codex-cloud-setup.{sh,test.sh}` for offline tests. It routes
   `sentry/autofix/sentry-autofix-refused-inventory.mjs` alone to
   `pnpm sentry:autofix:run-record:test` and
-  `pnpm sentry:autofix:finalize:test`.
+  `pnpm sentry:autofix:finalize:test`. The exact
+  `sentry/triage/sentry-triage-project-route.mjs` path routes to
+  `pnpm sentry:project:test` with the projection family.
 - **Gate runtime module pins.** Before `cd`, `agent-quality-gate.sh` loads
   `$script_source_dir/gate/run-handles.sh`; move it with its signature, self-test
   route, and missing-helper fixture. It also pins

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3970,7 +3970,7 @@ while IFS= read -r path; do
           add_command "pnpm sentry:archive:test" "Sentry needs-human brief helper changed"
           add_command "pnpm sentry:project:test" "Sentry needs-human brief helper changed"
           ;;
-        scripts/sentry/triage/sentry-triage-project.mjs|scripts/sentry/triage/sentry-triage-project-core.mjs|scripts/sentry/triage/sentry-triage-project-cli.mjs|scripts/sentry/triage/sentry-triage-label-ensure.mjs|scripts/sentry/triage/sentry-triage-project.test.mjs|scripts/sentry/triage/sentry-triage-text.mjs|scripts/sentry/triage/sentry-triage-projection.mjs|scripts/sentry/triage/sentry-triage-escalation-contract.mjs)
+        scripts/sentry/triage/sentry-triage-project.mjs|scripts/sentry/triage/sentry-triage-project-core.mjs|scripts/sentry/triage/sentry-triage-project-route.mjs|scripts/sentry/triage/sentry-triage-project-cli.mjs|scripts/sentry/triage/sentry-triage-label-ensure.mjs|scripts/sentry/triage/sentry-triage-project.test.mjs|scripts/sentry/triage/sentry-triage-text.mjs|scripts/sentry/triage/sentry-triage-projection.mjs|scripts/sentry/triage/sentry-triage-escalation-contract.mjs)
           # sentry-triage-project-cli.mjs (the argv surface) and
           # sentry-triage-label-ensure.mjs (the settlement label self-heal) were
           # split out of the entry module for the 1,000-line cap (#1827); both

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3847,10 +3847,11 @@ while IFS= read -r path; do
         scripts/lib/gh-issue-lifecycle.mjs)
           # The `gh` runner, pagination guard, Documentation Garden workflow
           # authorization, label bootstrap, and queue-state arbitration behind
-          # both scheduled issue automations. Neither suite covers the other's
-          # consumer, so a shared module belongs in both arms.
+          # both scheduled issue automations, plus the narrowed local Sentry
+          # projection label ensure. Each consumer suite must run here.
           add_command "pnpm docs:garden:test" "shared GitHub issue lifecycle module changed"
           add_command "pnpm docs:navigation-eval:test" "shared GitHub issue lifecycle module changed"
+          add_command "pnpm sentry:project:test" "shared GitHub issue lifecycle module changed"
           ;;
         scripts/context/agent-context-budget.mjs|scripts/context/agent-context-budget.test.mjs)
           add_command "pnpm agent:context-budget:test" "agent context budget helper changed"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4941,6 +4941,11 @@ assert_contains "- pnpm sentry:ingest:test (Sentry re-queue chokepoint changed)"
 run_gate "scripts/sentry/triage/sentry-triage-project.mjs"
 assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
 
+# The route module owns external-PAT versus local-config I/O. A route-only
+# edit must still run the projection contract suite.
+run_gate "scripts/sentry/triage/sentry-triage-project-route.mjs"
+assert_contains "- pnpm sentry:project:test (Sentry triage projection helper changed)"
+
 # The argv surface and the settlement label self-heal, split out of the entry
 # module for the 1,000-line hard cap (#1827). Both are reached only through that
 # leg, so an unrouted change to either would ship untested.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5544,6 +5544,7 @@ run_gate "scripts/lib/gh-issue-lifecycle.mjs"
 assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- pnpm docs:garden:test (shared GitHub issue lifecycle module changed)"
 assert_contains "- pnpm docs:navigation-eval:test (shared GitHub issue lifecycle module changed)"
+assert_contains "- pnpm sentry:project:test (shared GitHub issue lifecycle module changed)"
 
 run_gate "docs/evals/documentation-navigation-fixtures.json"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation contract changed)"

--- a/scripts/docs/docs-garden-issue.test.mjs
+++ b/scripts/docs/docs-garden-issue.test.mjs
@@ -28,6 +28,8 @@ import {
   assertAuthorizedGardenWorkflow,
   ensureLabelsExist,
   ghPaginate,
+  ISSUE_STATE_LABEL_DEFINITIONS,
+  LABEL_DEFINITIONS,
 } from "../lib/gh-issue-lifecycle.mjs";
 
 let passed = 0;
@@ -325,6 +327,18 @@ await test("label setup creates only missing labels and never force-edits shared
   assert.ok(creates.length > 0);
   assert.ok(!creates.some((args) => args.includes("agent-ready")));
   assert.ok(!creates.some((args) => args.includes("--force")));
+});
+
+await test("default label setup excludes unrelated issue-state labels", () => {
+  const issueStateNames = new Set(
+    ISSUE_STATE_LABEL_DEFINITIONS.map((definition) => definition.name),
+  );
+  assert.deepEqual(
+    LABEL_DEFINITIONS.filter((definition) =>
+      issueStateNames.has(definition.name),
+    ).map((definition) => definition.name),
+    [AGENT_READY_LABEL_DEFINITION.name],
+  );
 });
 
 await test("label setup can ensure one shared definition without touching unrelated labels", async () => {

--- a/scripts/docs/docs-garden-issue.test.mjs
+++ b/scripts/docs/docs-garden-issue.test.mjs
@@ -24,6 +24,7 @@ import {
   runDocsGardenIssue,
 } from "./docs-garden-issue.mjs";
 import {
+  AGENT_READY_LABEL_DEFINITION,
   assertAuthorizedGardenWorkflow,
   ensureLabelsExist,
   ghPaginate,
@@ -324,6 +325,36 @@ await test("label setup creates only missing labels and never force-edits shared
   assert.ok(creates.length > 0);
   assert.ok(!creates.some((args) => args.includes("agent-ready")));
   assert.ok(!creates.some((args) => args.includes("--force")));
+});
+
+await test("label setup can ensure one shared definition without touching unrelated labels", async () => {
+  const calls = [];
+  await ensureLabelsExist(
+    { repo: "owner/repo" },
+    {
+      definitions: [AGENT_READY_LABEL_DEFINITION],
+      runner: async (args) => {
+        calls.push(args);
+        if (args[0] === "api") return "[]";
+        return "";
+      },
+    },
+  );
+  const creates = calls.filter(
+    (args) => args[0] === "label" && args[1] === "create",
+  );
+  assert.equal(creates.length, 1);
+  assert.deepEqual(creates[0], [
+    "label",
+    "create",
+    AGENT_READY_LABEL_DEFINITION.name,
+    "--repo",
+    "owner/repo",
+    "--color",
+    AGENT_READY_LABEL_DEFINITION.color,
+    "--description",
+    AGENT_READY_LABEL_DEFINITION.description,
+  ]);
 });
 
 await test("an open occurrence remains the target even after the calendar advances", () => {

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -238,12 +238,16 @@ export const AGENT_MODULE_ARMS = [
     patterns: ["scripts/lib/gh-issue-lifecycle.mjs"],
     effects: [
       {
-        why: "The `gh` runner, pagination guard, Documentation Garden workflow authorization, label bootstrap, and queue-state arbitration behind both scheduled issue automations. Neither suite covers the other's consumer, so a shared module belongs in both arms.",
+        why: "The `gh` runner, pagination guard, Documentation Garden workflow authorization, label bootstrap, and queue-state arbitration behind both scheduled issue automations, plus the narrowed local Sentry projection label ensure. Each consumer suite must run here.",
         command: "pnpm docs:garden:test",
         reason: "shared GitHub issue lifecycle module changed",
       },
       {
         command: "pnpm docs:navigation-eval:test",
+        reason: "shared GitHub issue lifecycle module changed",
+      },
+      {
+        command: "pnpm sentry:project:test",
         reason: "shared GitHub issue lifecycle module changed",
       },
     ],

--- a/scripts/gate/routing-table/arms-sentry-modules.mjs
+++ b/scripts/gate/routing-table/arms-sentry-modules.mjs
@@ -97,6 +97,7 @@ export const SENTRY_MODULE_ARMS = [
     patterns: [
       "scripts/sentry/triage/sentry-triage-project.mjs",
       "scripts/sentry/triage/sentry-triage-project-core.mjs",
+      "scripts/sentry/triage/sentry-triage-project-route.mjs",
       "scripts/sentry/triage/sentry-triage-project-cli.mjs",
       "scripts/sentry/triage/sentry-triage-label-ensure.mjs",
       "scripts/sentry/triage/sentry-triage-project.test.mjs",

--- a/scripts/lib/gh-issue-lifecycle.mjs
+++ b/scripts/lib/gh-issue-lifecycle.mjs
@@ -1,6 +1,5 @@
 /**
- * Shared GitHub issue-queue lifecycle primitives for the scheduled
- * documentation automations.
+ * Shared GitHub issue-queue lifecycle primitives for scheduled automation.
  *
  * `docs-garden-issue.mjs` and `docs-navigation-eval.mjs` both keep at most one
  * open issue per cycle, and both reach that state the same way: one `gh`
@@ -10,8 +9,11 @@
  * the garden entrypoint — the only entrypoint-imports-entrypoint edge in
  * `scripts/` — and copied the rest. Both now read them from here.
  *
- * Callers own their own markers, metadata validation, and decision branches.
- * This module owns only what was byte-identical between them.
+ * The local Sentry projection route also reads the canonical `agent-ready`
+ * definition and calls the narrowed label ensure before it creates or repairs
+ * a local work issue. Callers own their markers, metadata validation, and
+ * decision branches. This module owns the shared lifecycle label definition
+ * and the mechanisms that were byte-identical between the documentation jobs.
  */
 
 import { spawn } from "node:child_process";
@@ -21,19 +23,21 @@ const GARDEN_OIDC_AUDIENCE = "mento-docs-garden";
 const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
 const GITHUB_OIDC_REQUEST_HOST_SUFFIX = ".actions.githubusercontent.com";
 
+export const AGENT_READY_LABEL_DEFINITION = {
+  name: "agent-ready",
+  color: "0e8a16",
+  description: "Scoped work ready for an agent to claim",
+};
+
 export const ISSUE_STATE_LABELS = [
   "needs-grooming",
-  "agent-ready",
+  AGENT_READY_LABEL_DEFINITION.name,
   "agent-active",
   "in-pr",
 ];
 
 export const LABEL_DEFINITIONS = [
-  {
-    name: "agent-ready",
-    color: "0e8a16",
-    description: "Scoped work ready for an agent to claim",
-  },
+  AGENT_READY_LABEL_DEFINITION,
   {
     name: "documentation",
     color: "0075ca",
@@ -236,12 +240,15 @@ export async function ghPaginate(
   return pages;
 }
 
-export async function ensureLabelsExist(options, { runner = runGh } = {}) {
+export async function ensureLabelsExist(
+  options,
+  { runner = runGh, definitions = LABEL_DEFINITIONS } = {},
+) {
   const pages = await ghPaginate(`repos/${options.repo}/labels`, { runner });
   const existing = new Set(
     pages.flat().map((label) => String(label?.name ?? "")),
   );
-  for (const label of LABEL_DEFINITIONS) {
+  for (const label of definitions) {
     if (existing.has(label.name)) continue;
     await runner([
       "label",

--- a/scripts/lib/gh-issue-lifecycle.mjs
+++ b/scripts/lib/gh-issue-lifecycle.mjs
@@ -9,11 +9,12 @@
  * the garden entrypoint — the only entrypoint-imports-entrypoint edge in
  * `scripts/` — and copied the rest. Both now read them from here.
  *
- * The local Sentry projection route also reads the canonical `agent-ready`
- * definition and calls the narrowed label ensure before it creates or repairs
- * a local work issue. Callers own their markers, metadata validation, and
- * decision branches. This module owns the shared lifecycle label definition
- * and the mechanisms that were byte-identical between the documentation jobs.
+ * The local Sentry projection route also reads the canonical issue-state label
+ * definitions. It uses the narrowed `agent-ready` definition before create and
+ * the full set before closed repair. Callers own their markers, metadata
+ * validation, and decision branches. This module owns the shared lifecycle
+ * label definitions and the mechanisms that were byte-identical between the
+ * documentation jobs.
  */
 
 import { spawn } from "node:child_process";
@@ -23,18 +24,43 @@ const GARDEN_OIDC_AUDIENCE = "mento-docs-garden";
 const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
 const GITHUB_OIDC_REQUEST_HOST_SUFFIX = ".actions.githubusercontent.com";
 
+export const NEEDS_GROOMING_LABEL_DEFINITION = {
+  name: "needs-grooming",
+  color: "d876e3",
+  description:
+    "Needs scope, acceptance criteria, or human decision before agent work",
+};
+
 export const AGENT_READY_LABEL_DEFINITION = {
   name: "agent-ready",
   color: "0e8a16",
-  description: "Scoped work ready for an agent to claim",
+  description: "Ready for an agent to implement",
 };
 
-export const ISSUE_STATE_LABELS = [
-  "needs-grooming",
-  AGENT_READY_LABEL_DEFINITION.name,
-  "agent-active",
-  "in-pr",
+export const AGENT_ACTIVE_LABEL_DEFINITION = {
+  name: "agent-active",
+  color: "ffd33d",
+  description:
+    "An agent has claimed this issue and is working before or while opening a PR",
+};
+
+export const IN_PR_LABEL_DEFINITION = {
+  name: "in-pr",
+  color: "fef2c0",
+  description:
+    "Implementation is open in a PR; do not pick up as new agent work",
+};
+
+export const ISSUE_STATE_LABEL_DEFINITIONS = [
+  NEEDS_GROOMING_LABEL_DEFINITION,
+  AGENT_READY_LABEL_DEFINITION,
+  AGENT_ACTIVE_LABEL_DEFINITION,
+  IN_PR_LABEL_DEFINITION,
 ];
+
+export const ISSUE_STATE_LABELS = ISSUE_STATE_LABEL_DEFINITIONS.map(
+  (label) => label.name,
+);
 
 export const LABEL_DEFINITIONS = [
   AGENT_READY_LABEL_DEFINITION,

--- a/scripts/sentry/gate/sentry-suite-manifest.json
+++ b/scripts/sentry/gate/sentry-suite-manifest.json
@@ -70,7 +70,7 @@
     },
     "scripts/sentry/triage/sentry-triage-project.test.mjs": {
       "reporter": "count-line",
-      "floor": 138,
+      "floor": 140,
       "reads": [".github/workflows/sentry-triage-agent.yml"]
     },
     "scripts/sentry/triage/sentry-triage-requeue.test.mjs": {

--- a/scripts/sentry/gate/sentry-suite-manifest.json
+++ b/scripts/sentry/gate/sentry-suite-manifest.json
@@ -70,7 +70,7 @@
     },
     "scripts/sentry/triage/sentry-triage-project.test.mjs": {
       "reporter": "count-line",
-      "floor": 112
+      "floor": 133
     },
     "scripts/sentry/triage/sentry-triage-requeue.test.mjs": {
       "reporter": "count-line",

--- a/scripts/sentry/gate/sentry-suite-manifest.json
+++ b/scripts/sentry/gate/sentry-suite-manifest.json
@@ -70,7 +70,8 @@
     },
     "scripts/sentry/triage/sentry-triage-project.test.mjs": {
       "reporter": "count-line",
-      "floor": 133
+      "floor": 138,
+      "reads": [".github/workflows/sentry-triage-agent.yml"]
     },
     "scripts/sentry/triage/sentry-triage-requeue.test.mjs": {
       "reporter": "count-line",

--- a/scripts/sentry/triage/sentry-triage-brief.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-brief.test.mjs
@@ -2171,6 +2171,7 @@ await test("the pipeline's shared modules stay under the file-size hard cap", ()
     "scripts/sentry/triage/sentry-triage-project.mjs",
     "scripts/sentry/triage/sentry-triage-project-cli.mjs",
     "scripts/sentry/triage/sentry-triage-project-core.mjs",
+    "scripts/sentry/triage/sentry-triage-project-route.mjs",
     "scripts/sentry/triage/sentry-triage-label-ensure.mjs",
     "scripts/sentry/triage/sentry-triage-escalation-contract.mjs",
     "scripts/sentry/triage/sentry-triage-text.mjs",

--- a/scripts/sentry/triage/sentry-triage-digest.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.mjs
@@ -12,11 +12,10 @@
  *      hypotheses, what was investigated, why it was escalated, plus links).
  *   2. 🤖 Autofixed                            (renders ONLY when fix-PR data
  *      exists — see the #1278 emission interface below).
- *   3. 📮 Routed to owning repo                (code/config-fix verdicts, each
- *      linking the PROJECTED owning-repo issue; falls back to the queue-issue
- *      verdict when projection was skipped — a LOCAL code-fix never projects,
- *      and one the autofix leg will never attempt is marked as such rather
- *      than left reading as handed to a team that does not exist).
+ *   3. 📮 Routed to work issue                 (code/config-fix verdicts, each
+ *      linking the projected work issue; it can be an external owning-repo
+ *      issue or a local config-fix issue. It falls back to the queue verdict
+ *      when projection was skipped. A local code-fix never projects.
  *   4. 🙅 Wontfix / transient                  (upstream-transient verdicts,
  *      each linking the rationale on the queue issue, with a nudge toward the
  *      existing `sentry:approved-archive` label flow for that stub).

--- a/scripts/sentry/triage/sentry-triage-digest.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-digest.test.mjs
@@ -763,9 +763,8 @@ await test("classifyIssue routes a re-triaged-architectural stub to Open design 
 });
 
 await test("classifyIssue picks up a projected-issue pointer for the routed link", () => {
-  // Only an EXTERNAL code-fix genuinely projects and routes; a local one holds
-  // under sentry:fix-scope-architectural in its own section (#1812), so this
-  // projected-pointer case uses an external owning repo.
+  // An external code-fix and an exact local config-fix both project. Local
+  // code-fix remains outside this route because it is autofix or design work.
   const entry = classifyIssue(
     issueFixture({
       labels: ["sentry-triage", "sentry:verdict-code-fix"],
@@ -782,6 +781,28 @@ await test("classifyIssue picks up a projected-issue pointer for the routed link
   );
   assertEqual(entry.section, "routed");
   assertEqual(entry.projectedUrl, PROJECTED_URL);
+});
+
+await test("classifyIssue routes a local config-fix to its projected local work issue", () => {
+  const localWorkUrl =
+    "https://github.com/mento-protocol/monitoring-monorepo/issues/99";
+  const entry = classifyIssue(
+    issueFixture({
+      labels: ["sentry-triage", "sentry:verdict-config-fix"],
+      comments: [
+        {
+          body: verdictComment({
+            verdict: "config-fix",
+            affectedRepo: "mento-protocol/monitoring-monorepo",
+          }),
+        },
+        { body: `${PROJECTED_COMMENT_PREFIX}${localWorkUrl}` },
+      ],
+    }),
+  );
+  assertEqual(entry.section, "routed");
+  assertEqual(entry.owningRepoIsLocal, true);
+  assertEqual(entry.projectedUrl, localWorkUrl);
 });
 
 await test("classifyIssue puts still-needs-triage issues in the failed bucket/section", () => {

--- a/scripts/sentry/triage/sentry-triage-project-cli.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-cli.mjs
@@ -26,10 +26,10 @@ export function usage() {
   return `Usage: pnpm sentry:project --issue <queue-issue-number> [options]
 
 Deterministically projects an actionable (code-fix/config-fix) triage verdict
-for an EXTERNAL owning repo into a human-readable issue in that repo, labels the
-queue stub ${PROJECTED_LABEL}, and comments the projected issue URL. Prints a
-single-line JSON result ({"status": "...", "url": "..."}) to stdout; diagnostics
-and workflow annotations go to stderr.
+to an allowlisted external owning repo or an exact local config-fix work issue,
+labels the queue stub ${PROJECTED_LABEL}, and comments the projected issue URL.
+Prints a single-line JSON result ({"status": "...", "url": "..."}) to stdout;
+diagnostics and workflow annotations go to stderr.
 
 Statuses: projected | reused | skipped-verdict | skipped-repo | skipped-no-token
 (batch rows additionally: skipped-state | failed)
@@ -45,9 +45,12 @@ Options:
   --issues <json>      JSON array of queue-issue numbers (batch mode).
   --repo <owner/name>  Repo the queue stub lives in (default: ${DEFAULT_REPO}).
   --parse-only         Resolve and print the validated verdict + mapped label +
-                       projectability + shed list + architecturalHold
-                       ({"verdict","label","projectable","shed","architecturalHold"}
-                       JSON) without projecting. \`label\` is a comma list on a
+                       external projectability + projection destination + shed
+                       list + architecturalHold
+                       ({"verdict","label","projectable","projectionDestination","shed","architecturalHold"}
+                       JSON) without projecting. \`projectable\` remains
+                       external-only; \`projectionDestination\` is external,
+                       local-config, or none. \`label\` is a comma list on a
                        local code-fix + fix_scope:architectural verdict (adds
                        sentry:fix-scope-architectural), and architecturalHold then
                        tells the close step to leave the stub open. Used by the
@@ -81,9 +84,10 @@ Options:
 
 Env:
   SENTRY_PROJECTION_TOKEN  Fine-grained PAT (Issues R/W on the three owning
-                           repos) for the cross-repo create/search. Absent ->
-                           graceful no-op (status skipped-no-token).
-  GH_TOKEN                 Ambient github.token for local queue-stub mutations.
+                           repos) for external create/search. Absent ->
+                           graceful no-op for external routing only.
+  GH_TOKEN                 Ambient github.token for queue stubs and local
+                           config-fix work issues.
 `;
 }
 

--- a/scripts/sentry/triage/sentry-triage-project-core.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-core.mjs
@@ -12,6 +12,7 @@
 
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const LOCAL_REPO = DEFAULT_REPO;
+
 export const VERDICT_MARKER = "<!-- sentry-triage-verdict:v1 -->";
 // Stage A posts this fixed prefix when a closed stub regresses; the regression
 // fence below rejects a verdict comment that is not strictly newer than it.

--- a/scripts/sentry/triage/sentry-triage-project-core.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-core.mjs
@@ -12,7 +12,6 @@
 
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const LOCAL_REPO = DEFAULT_REPO;
-
 export const VERDICT_MARKER = "<!-- sentry-triage-verdict:v1 -->";
 // Stage A posts this fixed prefix when a closed stub regresses; the regression
 // fence below rejects a verdict comment that is not strictly newer than it.
@@ -57,9 +56,10 @@ export const ARCHIVE_COMMENT_MARKER = "<!-- sentry-triage-archive:v1 -->";
 // in the queue (verdict contract).
 export const PROJECTABLE_VERDICTS = ["code-fix", "config-fix"];
 
-// The FIXED projection allowlist — the three external owning repos. Anything
-// else (including this repo, whose errors are fixed here, not projected) is a
-// no-op. This list is the whole trust boundary for the cross-repo write.
+// The FIXED external projection allowlist — the three external owning repos.
+// This repo is a local-config destination only for an exact `config-fix`; every
+// other non-allowlisted destination is a no-op. This list is the whole trust
+// boundary for the cross-repo write.
 export const ALLOWED_OWNING_REPOS = [
   "mento-protocol/frontend-monorepo",
   "mento-protocol/mento-analytics-api",

--- a/scripts/sentry/triage/sentry-triage-project-route.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-route.mjs
@@ -10,6 +10,7 @@ import { spawn } from "node:child_process";
 import {
   AGENT_READY_LABEL_DEFINITION,
   ensureLabelsExist,
+  ISSUE_STATE_LABEL_DEFINITIONS,
 } from "../../lib/gh-issue-lifecycle.mjs";
 import { PROJECTED_LABEL } from "./sentry-triage-project-core.mjs";
 import {
@@ -191,10 +192,10 @@ const REPROJECTION_REOPEN_COMMENT =
   "Reopened by the Mento Sentry triage pipeline: the underlying Sentry issue " +
   "regressed and was re-triaged as actionable.";
 
-// The local projection route consumes the dev-backlog lifecycle label. It
-// creates only a missing label from the shared canonical definition and never
-// force-edits existing shared metadata. The ensure is best-effort. The issue
-// mutation remains authoritative and fails loudly if the label is still absent.
+// Local create consumes only the agent-ready lifecycle label. It creates a
+// missing label from the shared canonical definition and never force-edits
+// existing shared metadata. The ensure is best-effort. The issue mutation
+// remains authoritative and fails loudly if the label is still absent.
 export async function ensureAgentReadyLabel(owningRun, owningRepo) {
   try {
     await ensureLabelsExist(
@@ -211,6 +212,22 @@ export async function ensureAgentReadyLabel(owningRun, owningRepo) {
   }
 }
 
+async function ensureIssueStateLabels(owningRun, owningRepo) {
+  try {
+    await ensureLabelsExist(
+      { repo: owningRepo },
+      {
+        runner: owningRun,
+        definitions: ISSUE_STATE_LABEL_DEFINITIONS,
+      },
+    );
+  } catch (error) {
+    process.stderr.write(
+      `warning: could not ensure issue-state labels: ${error.message}\n`,
+    );
+  }
+}
+
 export async function reopenProjectedIssue(
   owningRun,
   owningRepo,
@@ -221,7 +238,7 @@ export async function reopenProjectedIssue(
   // remains CLOSED so a retry runs this repair again instead of treating the
   // stale lifecycle as an already-open issue to preserve.
   if (restoreAgentReady) {
-    await ensureAgentReadyLabel(owningRun, owningRepo);
+    await ensureIssueStateLabels(owningRun, owningRepo);
     await owningRun([
       "issue",
       "edit",

--- a/scripts/sentry/triage/sentry-triage-project-route.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-route.mjs
@@ -7,12 +7,18 @@
 
 import { spawn } from "node:child_process";
 
+import {
+  AGENT_READY_LABEL_DEFINITION,
+  ensureLabelsExist,
+} from "../../lib/gh-issue-lifecycle.mjs";
 import { PROJECTED_LABEL } from "./sentry-triage-project-core.mjs";
 import {
   ALIAS_NOTE_PREFIX,
   bodyBacklinksShortId,
   commentBacklinksShortId,
 } from "./sentry-triage-projection.mjs";
+
+export const AGENT_READY_LABEL = AGENT_READY_LABEL_DEFINITION.name;
 
 // `projectable` remains the external-write capability. This closed routing
 // enum adds one exact local destination without widening that capability.
@@ -185,6 +191,26 @@ const REPROJECTION_REOPEN_COMMENT =
   "Reopened by the Mento Sentry triage pipeline: the underlying Sentry issue " +
   "regressed and was re-triaged as actionable.";
 
+// The local projection route consumes the dev-backlog lifecycle label. It
+// creates only a missing label from the shared canonical definition and never
+// force-edits existing shared metadata. The ensure is best-effort. The issue
+// mutation remains authoritative and fails loudly if the label is still absent.
+export async function ensureAgentReadyLabel(owningRun, owningRepo) {
+  try {
+    await ensureLabelsExist(
+      { repo: owningRepo },
+      {
+        runner: owningRun,
+        definitions: [AGENT_READY_LABEL_DEFINITION],
+      },
+    );
+  } catch (error) {
+    process.stderr.write(
+      `warning: could not ensure label ${AGENT_READY_LABEL}: ${error.message}\n`,
+    );
+  }
+}
+
 export async function reopenProjectedIssue(
   owningRun,
   owningRepo,
@@ -195,6 +221,7 @@ export async function reopenProjectedIssue(
   // remains CLOSED so a retry runs this repair again instead of treating the
   // stale lifecycle as an already-open issue to preserve.
   if (restoreAgentReady) {
+    await ensureAgentReadyLabel(owningRun, owningRepo);
     await owningRun([
       "issue",
       "edit",
@@ -202,7 +229,7 @@ export async function reopenProjectedIssue(
       "-R",
       owningRepo,
       "--add-label",
-      "agent-ready",
+      AGENT_READY_LABEL,
       "--remove-label",
       "agent-active,in-pr,needs-grooming",
     ]);

--- a/scripts/sentry/triage/sentry-triage-project-route.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-route.mjs
@@ -1,0 +1,307 @@
+/**
+ * GitHub route and I/O layer for Sentry verdict projection. The entry module
+ * owns mode orchestration. This module owns the bounded GitHub issue routes:
+ * external owning repos use the projection PAT; local config work uses the
+ * ambient Actions token.
+ */
+
+import { spawn } from "node:child_process";
+
+import { PROJECTED_LABEL } from "./sentry-triage-project-core.mjs";
+import {
+  ALIAS_NOTE_PREFIX,
+  bodyBacklinksShortId,
+  commentBacklinksShortId,
+} from "./sentry-triage-projection.mjs";
+
+// `projectable` remains the external-write capability. This closed routing
+// enum adds one exact local destination without widening that capability.
+export const PROJECTION_DESTINATIONS = {
+  EXTERNAL: "external",
+  LOCAL_CONFIG: "local-config",
+  NONE: "none",
+};
+
+// `gh issue list` reports workflow-created issues as the Actions App. Comments
+// use a separate fence because their API surface reports `github-actions` and
+// `github-actions[bot]` instead.
+export const WORKFLOW_ISSUE_AUTHOR = "app/github-actions";
+
+export function isWorkflowCreatedIssue(login) {
+  return login === WORKFLOW_ISSUE_AUTHOR;
+}
+
+export function projectionDestination(verdict, repoCheck) {
+  if (repoCheck?.projectable === true) {
+    return PROJECTION_DESTINATIONS.EXTERNAL;
+  }
+  if (verdict === "config-fix" && repoCheck?.reason === "local-repo") {
+    return PROJECTION_DESTINATIONS.LOCAL_CONFIG;
+  }
+  return PROJECTION_DESTINATIONS.NONE;
+}
+
+export function defaultRunGh(args, { token } = {}) {
+  return new Promise((resolve, reject) => {
+    const env = token ? { ...process.env, GH_TOKEN: token } : process.env;
+    const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"], env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      reject(new Error(`gh ${args.join(" ")} failed: ${err.message}`));
+    });
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(
+          new Error(
+            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+export async function readQueueIssue(localRun, repo, number) {
+  const stdout = await localRun([
+    "issue",
+    "view",
+    String(number),
+    "-R",
+    repo,
+    "--json",
+    "number,title,body,url,state,labels,comments",
+  ]);
+  const data = JSON.parse(stdout);
+  return {
+    number: data.number,
+    title: data.title ?? "",
+    body: data.body ?? "",
+    url: data.url ?? "",
+    state: String(data.state ?? "").toUpperCase(),
+    labels: (data.labels ?? [])
+      .map((label) => (typeof label === "string" ? label : label?.name))
+      .filter(Boolean),
+    comments: data.comments ?? [],
+  };
+}
+
+const FOOTER_SEARCH_PHRASE = "Sentry triage pipeline";
+
+export async function fetchProjectorLogin(owningRun) {
+  const stdout = await owningRun(["api", "user", "--jq", ".login"]);
+  const login = String(stdout ?? "").trim();
+  if (!login) {
+    throw new Error(
+      "Could not resolve the projection token's own user login (gh api user returned empty); refusing to match existing projections without an author identity.",
+    );
+  }
+  return login;
+}
+
+export async function findExistingProjection(
+  owningRun,
+  owningRepo,
+  shortId,
+  { isIssueAuthor, isCommentAuthor },
+) {
+  const stdout = await owningRun([
+    "issue",
+    "list",
+    "-R",
+    owningRepo,
+    "--state",
+    "all",
+    "--search",
+    `"${shortId}" "${FOOTER_SEARCH_PHRASE}" in:body,comments`,
+    "--json",
+    "number,url,body,state,author",
+    "--limit",
+    "200",
+  ]);
+  const items = stdout && stdout.trim() ? JSON.parse(stdout) : [];
+  const issueMatches = (Array.isArray(items) ? items : []).filter((item) =>
+    isIssueAuthor(item.author?.login ?? ""),
+  );
+  const toResult = (item) => ({
+    number: item.number,
+    url: item.url,
+    state: String(item.state ?? "").toUpperCase(),
+  });
+  const direct = issueMatches.find((item) =>
+    bodyBacklinksShortId(item.body, shortId),
+  );
+  if (direct) return toResult(direct);
+
+  const aliasStdout = await owningRun([
+    "issue",
+    "list",
+    "-R",
+    owningRepo,
+    "--state",
+    "all",
+    "--search",
+    `"${ALIAS_NOTE_PREFIX} ${shortId}" in:comments`,
+    "--json",
+    "number,url,state,author",
+    "--limit",
+    "200",
+  ]);
+  const aliasItems =
+    aliasStdout && aliasStdout.trim() ? JSON.parse(aliasStdout) : [];
+  const aliasCandidates = (Array.isArray(aliasItems) ? aliasItems : []).filter(
+    (item) => isIssueAuthor(item.author?.login ?? ""),
+  );
+  const MAX_CANDIDATE_READS = 10;
+  if (aliasCandidates.length > MAX_CANDIDATE_READS) {
+    throw new Error(
+      `Alias lookup for ${shortId} in ${owningRepo} returned ${aliasCandidates.length} projector-authored candidates (max ${MAX_CANDIDATE_READS}); refusing to risk missing the genuine alias — failing loud for retry.`,
+    );
+  }
+  for (const item of aliasCandidates) {
+    const hasAlias = await hasAliasComment(
+      owningRun,
+      owningRepo,
+      item.number,
+      shortId,
+      isCommentAuthor,
+    );
+    if (hasAlias) return toResult(item);
+  }
+  return null;
+}
+
+const REPROJECTION_REOPEN_COMMENT =
+  "Reopened by the Mento Sentry triage pipeline: the underlying Sentry issue " +
+  "regressed and was re-triaged as actionable.";
+
+export async function reopenProjectedIssue(
+  owningRun,
+  owningRepo,
+  existing,
+  { restoreAgentReady = false } = {},
+) {
+  // Repair the closed local issue before reopening it. If the edit fails, it
+  // remains CLOSED so a retry runs this repair again instead of treating the
+  // stale lifecycle as an already-open issue to preserve.
+  if (restoreAgentReady) {
+    await owningRun([
+      "issue",
+      "edit",
+      String(existing.number),
+      "-R",
+      owningRepo,
+      "--add-label",
+      "agent-ready",
+      "--remove-label",
+      "agent-active,in-pr,needs-grooming",
+    ]);
+  }
+  await owningRun([
+    "issue",
+    "reopen",
+    String(existing.number),
+    "-R",
+    owningRepo,
+  ]);
+  await owningRun([
+    "issue",
+    "comment",
+    String(existing.number),
+    "-R",
+    owningRepo,
+    "--body",
+    REPROJECTION_REOPEN_COMMENT,
+  ]);
+}
+
+export async function createProjectedIssue(
+  owningRun,
+  owningRepo,
+  title,
+  body,
+  { labels = [] } = {},
+) {
+  const args = [
+    "issue",
+    "create",
+    "-R",
+    owningRepo,
+    "--title",
+    title,
+    "--body",
+    body,
+  ];
+  for (const label of labels) args.push("--label", label);
+  const stdout = await owningRun(args);
+  const url = String(stdout).trim().split(/\s+/).filter(Boolean).pop();
+  if (!url || !/^https:\/\/github\.com\//.test(url)) {
+    throw new Error(
+      `gh issue create did not return a github.com URL (got: ${JSON.stringify(url)})`,
+    );
+  }
+  return url;
+}
+
+async function hasAliasComment(
+  owningRun,
+  owningRepo,
+  number,
+  shortId,
+  isCommentAuthor,
+) {
+  const stdout = await owningRun([
+    "issue",
+    "view",
+    String(number),
+    "-R",
+    owningRepo,
+    "--json",
+    "comments",
+  ]);
+  const comments = JSON.parse(stdout).comments ?? [];
+  return comments.some(
+    (comment) =>
+      isCommentAuthor(comment?.author?.login ?? "") &&
+      commentBacklinksShortId(comment?.body, shortId),
+  );
+}
+
+export async function markStubProjected(
+  localRun,
+  localRepo,
+  issue,
+  projectedUrl,
+  projectedCommentPrefix,
+) {
+  await localRun([
+    "issue",
+    "edit",
+    String(issue.number),
+    "-R",
+    localRepo,
+    "--add-label",
+    PROJECTED_LABEL,
+  ]);
+  if (!issue.labels.includes(PROJECTED_LABEL)) {
+    await localRun([
+      "issue",
+      "comment",
+      String(issue.number),
+      "-R",
+      localRepo,
+      "--body",
+      `${projectedCommentPrefix}${projectedUrl}`,
+    ]);
+  }
+}

--- a/scripts/sentry/triage/sentry-triage-project.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.mjs
@@ -116,8 +116,10 @@ import { parseArgs, usage } from "./sentry-triage-project-cli.mjs";
 // (the workflow restores needs-triage instead of closing).
 import { clearBriefComments } from "./sentry-triage-brief.mjs";
 import {
+  AGENT_READY_LABEL,
   createProjectedIssue,
   defaultRunGh,
+  ensureAgentReadyLabel,
   fetchProjectorLogin,
   findExistingProjection,
   markStubProjected,
@@ -532,8 +534,11 @@ export async function runProjection(options, deps = {}) {
     queueIssueUrl,
   });
 
+  if (localConfig) {
+    await ensureAgentReadyLabel(owningRun, owningRepo);
+  }
   const url = await createProjectedIssue(owningRun, owningRepo, title, body, {
-    labels: localConfig ? ["agent-ready"] : [],
+    labels: localConfig ? [AGENT_READY_LABEL] : [],
   });
   registerFamily({ number: Number(url.split("/").pop()), url });
   await markStubProjected(

--- a/scripts/sentry/triage/sentry-triage-project.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.mjs
@@ -3,10 +3,10 @@
  * Verdict projection leg of the Sentry triage pipeline (ADR 0036 Stage C,
  * refined by ADR 0038, docs/adr/0038-sentry-central-plane-verdict-projection.md):
  * a deterministic, no-LLM step that turns an ACTIONABLE triage verdict
- * (`code-fix` / `config-fix`) for an EXTERNAL owning repo into a proper,
- * human-readable issue in that repo, so product teams see findings where they
- * work. The central queue stub in this repo is a machine ledger; the projected
- * owning-repo issue is the human artifact.
+ * (`code-fix` / `config-fix`) into a proper, human-readable work issue. An
+ * allowlisted external owner uses the projection PAT. An exact local
+ * `config-fix` uses the ambient Actions token. The central queue stub is a
+ * machine ledger; the projected issue is the human artifact.
  *
  * This script is a PURE CONSUMER of the verdict contract in
  * docs/notes/sentry-triage-pipeline.md — it reads a queue stub's title/body and
@@ -14,11 +14,12 @@
  * Sentry, never runs an LLM, never touches the verdict/label logic. It slots in
  * AFTER the deterministic verdict-label step and BEFORE the queue-close step.
  *
- * Security posture (this leg crosses a repo boundary with a write token, so the
- * bar is higher than the read-only legs):
+ * Security posture (the external route crosses a repo boundary with a write
+ * token, so the bar is higher than the read-only legs):
  *   - `affected_repo` from the verdict yaml is UNTRUSTED agent-authored text.
- *     It is validated against a FIXED three-repo allowlist; anything else is a
- *     no-op with a `::warning::` (treated as this repo — no projection).
+ *     A fixed three-repo allowlist permits external projection. An exact local
+ *     `config-fix` routes to this repo with the ambient token. Every other
+ *     non-allowlisted or non-local destination is a no-op with a `::warning::`.
  *   - Only `code-fix` / `config-fix` verdicts project. `needs-human` and
  *     `upstream-transient` never leave the queue.
  *   - The projected issue body renders ONLY verdict-contract fields (already
@@ -33,14 +34,12 @@
  *     for an existing issue back-linking the same Sentry SHORT-ID (a hidden
  *     `<!-- sentry-projection:v1 SHORT-ID -->` marker), so a re-run — including
  *     after a regression reopen — never files a duplicate.
- *   - Token routing: the cross-repo create/search use the fine-grained
- *     `SENTRY_PROJECTION_TOKEN` PAT (Issues R/W on exactly the three owning
- *     repos); the local stub mutations use the ambient `GH_TOKEN`
- *     (github.token, issues:write on THIS repo). The PAT is never used for a
- *     local call and never reaches the triage agent (it is step-scoped env).
+ *   - Token routing: external create/search use the fine-grained
+ *     `SENTRY_PROJECTION_TOKEN` PAT. Local config work and queue-stub
+ *     mutations use the ambient `GH_TOKEN` (github.token, issues:write here).
+ *     The PAT never reaches the triage agent.
  */
 
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 // All pure logic — constants, neutralization, parsing, verdict selection,
@@ -54,6 +53,7 @@ import {
   FIX_SCOPE_ARCHITECTURAL,
   isValidShortId,
   MAX_DUPLICATE_LOOKUPS,
+  isTrustedComment,
   parseShortId,
   PRIOR_VERDICT_NONE,
   PRIOR_VERDICT_UNKNOWN,
@@ -81,12 +81,9 @@ export {
   leadingProjectionMarkers,
 } from "./sentry-triage-projection.mjs";
 import {
-  ALIAS_NOTE_PREFIX,
-  bodyBacklinksShortId,
   buildAliasComment,
   buildProjectedBody,
   buildProjectedTitle,
-  commentBacklinksShortId,
 } from "./sentry-triage-projection.mjs";
 import {
   FIX_SCOPE_ARCHITECTURAL_LABEL,
@@ -118,295 +115,28 @@ import { parseArgs, usage } from "./sentry-triage-project-cli.mjs";
 // projectable stub never carries a brief — and a failure marks the row failed
 // (the workflow restores needs-triage instead of closing).
 import { clearBriefComments } from "./sentry-triage-brief.mjs";
+import {
+  createProjectedIssue,
+  defaultRunGh,
+  fetchProjectorLogin,
+  findExistingProjection,
+  markStubProjected,
+  readQueueIssue,
+  reopenProjectedIssue,
+  projectionDestination,
+  WORKFLOW_ISSUE_AUTHOR,
+  isWorkflowCreatedIssue,
+} from "./sentry-triage-project-route.mjs";
+export {
+  PROJECTION_DESTINATIONS,
+  projectionDestination,
+} from "./sentry-triage-project-route.mjs";
 
 // ---------------------------------------------------------------------------
-// GitHub I/O (via `gh`, mirroring the ingest/digest scripts). `runGh` is
-// injectable for tests; the real one routes the fine-grained PAT to cross-repo
-// calls only via a per-call GH_TOKEN override.
+// GitHub routing lives in sentry-triage-project-route.mjs. The entry module
+// keeps the serialized orchestration and supplies the destination-specific
+// credential and author fences.
 // ---------------------------------------------------------------------------
-
-function defaultRunGh(args, { token } = {}) {
-  return new Promise((resolve, reject) => {
-    const env = token ? { ...process.env, GH_TOKEN: token } : process.env;
-    const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"], env });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk;
-    });
-    child.on("error", (err) => {
-      reject(new Error(`gh ${args.join(" ")} failed: ${err.message}`));
-    });
-    child.on("close", (status) => {
-      if (status !== 0) {
-        reject(
-          new Error(
-            `gh ${args.join(" ")} failed with exit ${status}:\n${stderr}`,
-          ),
-        );
-        return;
-      }
-      resolve(stdout);
-    });
-  });
-}
-
-async function readQueueIssue(localRun, repo, number) {
-  const stdout = await localRun([
-    "issue",
-    "view",
-    String(number),
-    "-R",
-    repo,
-    "--json",
-    "number,title,body,url,state,labels,comments",
-  ]);
-  const data = JSON.parse(stdout);
-  return {
-    number: data.number,
-    title: data.title ?? "",
-    body: data.body ?? "",
-    url: data.url ?? "",
-    state: String(data.state ?? "").toUpperCase(),
-    labels: (data.labels ?? [])
-      .map((label) => (typeof label === "string" ? label : label?.name))
-      .filter(Boolean),
-    comments: data.comments ?? [],
-  };
-}
-
-// Fixed, markup-free phrase from the projected-issue footer, ANDed with the
-// SHORT-ID in the idempotency pre-filter so only pipeline-filed issues
-// surface — a bare SHORT-ID substring could over-match in a busy repo and
-// push the real projected issue past the result cap.
-const FOOTER_SEARCH_PHRASE = "Sentry triage pipeline";
-
-/** The projector identity is the PAT's own user: only issues IT authored can
- * count as genuine projections. Resolved once per run via `gh api user` under
- * the projection token; empty/failed resolution throws (fail loud) rather
- * than falling back to an unauthenticated match. */
-async function fetchProjectorLogin(owningRun) {
-  const stdout = await owningRun(["api", "user", "--jq", ".login"]);
-  const login = String(stdout ?? "").trim();
-  if (!login) {
-    throw new Error(
-      "Could not resolve the projection token's own user login (gh api user returned empty); refusing to match existing projections without an author identity.",
-    );
-  }
-  return login;
-}
-
-async function findExistingProjection(
-  owningRun,
-  owningRepo,
-  shortId,
-  projectorLogin,
-) {
-  // `in:body,comments`: a SHORT-ID lives either in a primary projection's
-  // BODY (marker + visible fields) or in an alias COMMENT on a coalesced
-  // issue (buildAliasComment's visible note) — both carry the footer phrase.
-  const stdout = await owningRun([
-    "issue",
-    "list",
-    "-R",
-    owningRepo,
-    "--state",
-    "all",
-    "--search",
-    `"${shortId}" "${FOOTER_SEARCH_PHRASE}" in:body,comments`,
-    "--json",
-    "number,url,body,state,author",
-    "--limit",
-    "200",
-  ]);
-  const items = stdout && stdout.trim() ? JSON.parse(stdout) : [];
-  // Search is a coarse pre-filter (GitHub search may not index HTML-comment
-  // text, so the marker itself can't be the search term); the footer-phrase
-  // AND keeps it sharp and the 200 cap (matching the duplicate search) keeps
-  // it deep. The authoritative check is layered and author-verified — anyone
-  // with Issues access in the owning repo can pre-create marker-shaped
-  // content, and a hostile issue must not steal the projection slot (the
-  // stub would close "reused" pointing at attacker-controlled content):
-  //   1. the candidate ISSUE must be authored by the projector identity;
-  //   2. its body's leading marker block matches the SHORT-ID (primary
-  //      projection), OR a projector-authored alias comment does
-  //      (coalesced duplicate).
-  const authorMatched = (Array.isArray(items) ? items : []).filter(
-    (item) => (item.author?.login ?? "") === projectorLogin,
-  );
-  const toResult = (item) => ({
-    number: item.number,
-    url: item.url,
-    state: String(item.state ?? "").toUpperCase(),
-  });
-  // Cheap body-marker check across ALL author-matched candidates: the bodies
-  // are already in the search payload, so a genuine primary projection is
-  // found regardless of where best-match ranking placed it — other
-  // projector-authored issues legitimately mention this SHORT-ID in their
-  // rendered "Possible duplicates" lists, and any cap applied before this
-  // scan could rank those ahead of the real projection and miss it.
-  const direct = authorMatched.find((item) =>
-    bodyBacklinksShortId(item.body, shortId),
-  );
-  if (direct) return toResult(direct);
-
-  // Alias phase: a coalesced SHORT-ID lives in an alias COMMENT, not a body,
-  // so run a DEDICATED exact-phrase search (`"<prefix> <shortId>"` — the
-  // fixed lead-in buildAliasComment renders) that essentially only alias
-  // comments for this id can match; mere mentions of the id in rendered
-  // duplicate lists cannot. Candidates are author-filtered and their comments
-  // verified (the phrase alone is mimicable by anyone with Issues access).
-  // The per-candidate comments read is the expensive call, so the candidate
-  // set is bounded — but bounded by FAILING LOUD, never by truncating: a
-  // genuine alias must never be skipped because hostile mimics outranked it,
-  // so an implausible candidate count (> MAX_CANDIDATE_READS, when the
-  // genuine population per id is 0 or 1) aborts into the workflow's
-  // compensation path instead of risking a duplicate filing.
-  const aliasStdout = await owningRun([
-    "issue",
-    "list",
-    "-R",
-    owningRepo,
-    "--state",
-    "all",
-    "--search",
-    `"${ALIAS_NOTE_PREFIX} ${shortId}" in:comments`,
-    "--json",
-    "number,url,state,author",
-    "--limit",
-    "200",
-  ]);
-  const aliasItems =
-    aliasStdout && aliasStdout.trim() ? JSON.parse(aliasStdout) : [];
-  const aliasCandidates = (Array.isArray(aliasItems) ? aliasItems : []).filter(
-    (item) => (item.author?.login ?? "") === projectorLogin,
-  );
-  const MAX_CANDIDATE_READS = 10;
-  if (aliasCandidates.length > MAX_CANDIDATE_READS) {
-    throw new Error(
-      `Alias lookup for ${shortId} in ${owningRepo} returned ${aliasCandidates.length} projector-authored candidates (max ${MAX_CANDIDATE_READS}); refusing to risk missing the genuine alias — failing loud for retry.`,
-    );
-  }
-  for (const item of aliasCandidates) {
-    const hasAlias = await hasAliasComment(
-      owningRun,
-      owningRepo,
-      item.number,
-      shortId,
-      projectorLogin,
-    );
-    if (hasAlias) return toResult(item);
-  }
-  return null;
-}
-
-// Fixed, deterministic text — no agent-derived content.
-const REPROJECTION_REOPEN_COMMENT =
-  "Reopened by the Mento Sentry triage pipeline: the underlying Sentry issue " +
-  "regressed and was re-triaged as actionable.";
-
-/** A regression that re-projects onto a CLOSED owning-repo issue must
- * resurface for the product team — silently linking a closed issue would bury
- * the regression. Reopen it and leave a fixed comment (Issues R/W covers
- * both); a failure here rejects, landing in the workflow's loud compensation
- * path. */
-async function reopenProjectedIssue(owningRun, owningRepo, existing) {
-  await owningRun([
-    "issue",
-    "reopen",
-    String(existing.number),
-    "-R",
-    owningRepo,
-  ]);
-  await owningRun([
-    "issue",
-    "comment",
-    String(existing.number),
-    "-R",
-    owningRepo,
-    "--body",
-    REPROJECTION_REOPEN_COMMENT,
-  ]);
-}
-
-async function createProjectedIssue(owningRun, owningRepo, title, body) {
-  const stdout = await owningRun([
-    "issue",
-    "create",
-    "-R",
-    owningRepo,
-    "--title",
-    title,
-    "--body",
-    body,
-  ]);
-  const url = String(stdout).trim().split(/\s+/).filter(Boolean).pop();
-  if (!url || !/^https:\/\/github\.com\//.test(url)) {
-    throw new Error(
-      `gh issue create did not return a github.com URL (got: ${JSON.stringify(url)})`,
-    );
-  }
-  return url;
-}
-
-/** True when the owning-repo issue carries a genuine ALIAS for `shortId`: a
- * comment authored by the projector identity whose first line is the marker
- * (see buildAliasComment in the core module for why aliases are atomic
- * comment appends, never body edits). */
-async function hasAliasComment(
-  owningRun,
-  owningRepo,
-  number,
-  shortId,
-  projectorLogin,
-) {
-  const stdout = await owningRun([
-    "issue",
-    "view",
-    String(number),
-    "-R",
-    owningRepo,
-    "--json",
-    "comments",
-  ]);
-  const comments = JSON.parse(stdout).comments ?? [];
-  return comments.some(
-    (comment) =>
-      (comment?.author?.login ?? "") === projectorLogin &&
-      commentBacklinksShortId(comment?.body, shortId),
-  );
-}
-
-async function markStubProjected(localRun, localRepo, issue, projectedUrl) {
-  // Label is idempotent (`--add-label` no-ops if present). Only add the
-  // pointer comment when the stub is not already marked, so a re-run (e.g. the
-  // reused path after a partial earlier run) never duplicates the comment.
-  await localRun([
-    "issue",
-    "edit",
-    String(issue.number),
-    "-R",
-    localRepo,
-    "--add-label",
-    PROJECTED_LABEL,
-  ]);
-  if (!issue.labels.includes(PROJECTED_LABEL)) {
-    await localRun([
-      "issue",
-      "comment",
-      String(issue.number),
-      "-R",
-      localRepo,
-      "--body",
-      `${PROJECTED_COMMENT_PREFIX}${projectedUrl}`,
-    ]);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Orchestration. Dependency-injectable (`runGh`) so tests drive the full flow
@@ -416,11 +146,11 @@ async function markStubProjected(localRun, localRepo, issue, projectedUrl) {
 /**
  * `--parse-only` mode: resolve and emit the validated verdict + mapped label
  * for the workflow's deterministic LABEL step, so labeling and projection run
- * the exact same parser (see resolveVerdict), plus `projectable` — whether
- * this verdict is actionable AND its `affected_repo` is an allowlisted
- * EXTERNAL owning repo. The matrix close step uses `projectable` to decide
- * whether to close the stub itself (upstream/local/unrecognized) or defer it
- * to the serialized `project` job (external actionable). Read-only — one
+ * the exact same parser (see resolveVerdict), plus `projectable` and its
+ * closed projection destination. `projectable` remains external-only. The
+ * local-config destination is only for an exact local `config-fix`. The matrix
+ * close step uses the destination to decide whether to defer the stub to the
+ * serialized project job. Read-only — one
  * `gh issue view` with the ambient token; the projection PAT is never needed
  * here. Throws on missing/stale/invalid verdicts so the label step fails
  * loudly and leaves `sentry:needs-triage` in place for retry.
@@ -511,7 +241,14 @@ export async function runParseOnly(options, deps = {}) {
   const shedLabels = VERDICT_LABELS.filter((name) => name !== label);
   if (!architecturalHold) shedLabels.push(FIX_SCOPE_ARCHITECTURAL_LABEL);
   const shed = shedLabels.join(",");
-  return { verdict, label: addLabel, projectable, shed, architecturalHold };
+  return {
+    verdict,
+    label: addLabel,
+    projectable,
+    projectionDestination: projectionDestination(verdict, repoCheck),
+    shed,
+    architecturalHold,
+  };
 }
 
 /**
@@ -575,7 +312,6 @@ export async function runPriorVerdicts(options, deps = {}) {
 export async function runProjection(options, deps = {}) {
   const runGh = deps.runGh ?? defaultRunGh;
   const localRun = (args) => runGh(args, {});
-  const owningRun = (args) => runGh(args, { token: options.projectionToken });
 
   const issue = await readQueueIssue(
     localRun,
@@ -613,13 +349,14 @@ export async function runProjection(options, deps = {}) {
   if (repoCheck.warning) {
     process.stderr.write(`::warning::${repoCheck.warning}\n`);
   }
-  if (!repoCheck.projectable) {
+  const destination = projectionDestination(parsed.verdict, repoCheck);
+  if (destination === "none") {
     return { status: "skipped-repo", reason: repoCheck.reason };
   }
 
-  // Graceful no-op while the PAT is not provisioned: the queue-close step makes
-  // this visible (not silent) in the closing comment.
-  if (!options.projectionToken) {
+  // Graceful no-op only for an external route without its PAT. Local config
+  // projection uses the ambient Actions token and never needs this secret.
+  if (destination === "external" && !options.projectionToken) {
     process.stderr.write(
       "::notice::SENTRY_PROJECTION_TOKEN is not set; skipping cross-repo verdict projection (secret not yet provisioned).\n",
     );
@@ -627,6 +364,22 @@ export async function runProjection(options, deps = {}) {
   }
 
   const owningRepo = repoCheck.repo;
+  const localConfig = destination === "local-config";
+  const owningRun = localConfig
+    ? localRun
+    : (args) => runGh(args, { token: options.projectionToken });
+  const projectorLogin = localConfig
+    ? WORKFLOW_ISSUE_AUTHOR
+    : await fetchProjectorLogin(owningRun);
+  const authorFences = localConfig
+    ? {
+        isIssueAuthor: isWorkflowCreatedIssue,
+        isCommentAuthor: (login) => isTrustedComment({ author: { login } }),
+      }
+    : {
+        isIssueAuthor: (login) => login === projectorLogin,
+        isCommentAuthor: (login) => login === projectorLogin,
+      };
   const queueIssueUrl =
     issue.url ||
     `https://github.com/${options.localRepo}/issues/${options.queueIssue}`;
@@ -691,13 +444,10 @@ export async function runProjection(options, deps = {}) {
       options.localRepo,
       issue,
       fromRegistry.url,
+      PROJECTED_COMMENT_PREFIX,
     );
     return { status: "reused", url: fromRegistry.url };
   }
-
-  // Author identity for genuine-projection matching (see
-  // findExistingProjection): only issues the PAT's own user filed count.
-  const projectorLogin = await fetchProjectorLogin(owningRun);
 
   // Idempotency: reuse an existing projected issue (any state) that back-links
   // this SHORT-ID rather than filing a duplicate. A CLOSED one is reopened
@@ -706,14 +456,22 @@ export async function runProjection(options, deps = {}) {
     owningRun,
     owningRepo,
     shortId,
-    projectorLogin,
+    authorFences,
   );
   if (existing) {
     if (existing.state === "CLOSED") {
-      await reopenProjectedIssue(owningRun, owningRepo, existing);
+      await reopenProjectedIssue(owningRun, owningRepo, existing, {
+        restoreAgentReady: localConfig,
+      });
     }
     registerFamily({ number: existing.number, url: existing.url });
-    await markStubProjected(localRun, options.localRepo, issue, existing.url);
+    await markStubProjected(
+      localRun,
+      options.localRepo,
+      issue,
+      existing.url,
+      PROJECTED_COMMENT_PREFIX,
+    );
     return { status: "reused", url: existing.url };
   }
 
@@ -732,11 +490,13 @@ export async function runProjection(options, deps = {}) {
         owningRun,
         owningRepo,
         dupId,
-        projectorLogin,
+        authorFences,
       ));
     if (!dupExisting) continue;
     if (dupExisting.state === "CLOSED") {
-      await reopenProjectedIssue(owningRun, owningRepo, dupExisting);
+      await reopenProjectedIssue(owningRun, owningRepo, dupExisting, {
+        restoreAgentReady: localConfig,
+      });
     }
     // Persist the coalesced SHORT-ID into the idempotency index as ONE atomic
     // comment APPEND (marker-anchored alias comment — see buildAliasComment
@@ -754,6 +514,7 @@ export async function runProjection(options, deps = {}) {
       options.localRepo,
       issue,
       dupExisting.url,
+      PROJECTED_COMMENT_PREFIX,
     );
     return { status: "reused", url: dupExisting.url };
   }
@@ -771,9 +532,17 @@ export async function runProjection(options, deps = {}) {
     queueIssueUrl,
   });
 
-  const url = await createProjectedIssue(owningRun, owningRepo, title, body);
+  const url = await createProjectedIssue(owningRun, owningRepo, title, body, {
+    labels: localConfig ? ["agent-ready"] : [],
+  });
   registerFamily({ number: Number(url.split("/").pop()), url });
-  await markStubProjected(localRun, options.localRepo, issue, url);
+  await markStubProjected(
+    localRun,
+    options.localRepo,
+    issue,
+    url,
+    PROJECTED_COMMENT_PREFIX,
+  );
   return { status: "projected", url };
 }
 

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
 import { LABEL_TO_VERDICT } from "./sentry-triage-digest.mjs";
 import {
   FIX_SCOPE_ARCHITECTURAL_LABEL,
@@ -294,6 +295,68 @@ await test("projection destination table keeps external capability separate from
   }
 });
 
+await test("workflow defers local config projection before any close", () => {
+  const workflow = readFileSync(
+    new URL(
+      "../../../.github/workflows/sentry-triage-agent.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const parseStart = workflow.indexOf(
+    'parse_file="${RUNNER_TEMP}/verdict-parse.json"',
+  );
+  const parseEnd = workflow.indexOf(
+    "      - name: Render or clear the needs-human brief",
+    parseStart,
+  );
+  assert(
+    parseStart >= 0 && parseEnd > parseStart,
+    "verdict parse step missing",
+  );
+  const parseStep = workflow.slice(parseStart, parseEnd);
+  assert(
+    parseStep.includes("jq -r '.projectionDestination'"),
+    "parse step must read projectionDestination",
+  );
+  assert(
+    parseStep.includes(
+      'echo "projection_destination=${projection_destination}"',
+    ),
+    "parse step must serialize projection_destination",
+  );
+
+  const closeStart = workflow.indexOf(
+    "- name: Close queue stub (deterministic)",
+  );
+  const projectStart = workflow.indexOf(
+    "\n  # ---------------------------------------------------------------------------\n  # project:",
+    closeStart,
+  );
+  assert(closeStart >= 0 && projectStart > closeStart, "close step missing");
+  const closeStep = workflow.slice(closeStart, projectStart);
+  assert(
+    closeStep.includes(
+      "PROJECTION_DESTINATION: ${{ steps.verdict.outputs.projection_destination }}",
+    ),
+    "close step must consume projection_destination",
+  );
+  const localBranch = closeStep.indexOf(
+    '[ "${PROJECTION_DESTINATION}" = "external" ] || [ "${PROJECTION_DESTINATION}" = "local-config" ]',
+  );
+  const firstClose = closeStep.indexOf("gh issue close");
+  assert(localBranch >= 0, "close step must branch on local-config");
+  assert(
+    firstClose > localBranch,
+    "close command must follow destination branch",
+  );
+  const branchExit = closeStep.indexOf("exit 0", localBranch);
+  assert(
+    branchExit >= 0 && branchExit < firstClose,
+    "local-config must exit before any close mutation",
+  );
+});
+
 // A mock `gh` runner covering the calls runProjection makes. Records every call
 // with the token it was invoked under so token routing is assertable. `stubs`
 // (number -> queue issue) serves batch mode's per-issue ambient views.
@@ -312,16 +375,20 @@ function makeRunGh({
       return `${projectorLogin}\n`;
     }
     if (a0 === "issue" && a1 === "view") {
-      // A token means an OWNING-repo view (hasAliasComment's `--json
-      // comments` read); resolve it from the `existing` fixtures by issue
-      // number (each fixture may carry a `comments` array). Ambient views
-      // read the queue stub.
-      if (opts.token) {
+      // The full field set is the queue-stub read. The exact `comments` read
+      // is a projected-issue alias lookup, even when the projected issue is
+      // local. Keep these surfaces distinct so an accidental local PAT route
+      // cannot hide behind a fixture that returns the wrong object shape.
+      const jsonFields = args[args.indexOf("--json") + 1];
+      if (jsonFields === "comments") {
         const found = existing.find(
           (e) => String(e.number) === String(args[2]),
         );
         return JSON.stringify({ comments: found?.comments ?? [] });
       }
+      // Queue-stub reads always return the full issue fixture. This remains
+      // true even when a buggy caller passes a token, so the assertion on
+      // every local call catches that routing error directly.
       return JSON.stringify(stubs?.[String(args[2])] ?? issue);
     }
     if (a0 === "issue" && a1 === "list") {
@@ -1556,7 +1623,7 @@ await test("runProjection creates local config work with the ambient token and a
     {
       localRepo: "mento-protocol/monitoring-monorepo",
       queueIssue: 500,
-      projectionToken: "",
+      projectionToken: PAT,
     },
     { runGh },
   );
@@ -1604,7 +1671,7 @@ await test("runProjection reopens a closed local config work issue and restores 
     {
       localRepo: "mento-protocol/monitoring-monorepo",
       queueIssue: 500,
-      projectionToken: "",
+      projectionToken: PAT,
     },
     { runGh },
   );
@@ -1667,7 +1734,7 @@ await test("a failed local lifecycle repair remains retryable while the issue is
   const options = {
     localRepo: "mento-protocol/monitoring-monorepo",
     queueIssue: 500,
-    projectionToken: "",
+    projectionToken: PAT,
   };
 
   await assertRejects(
@@ -1723,14 +1790,142 @@ await test("runProjection preserves the lifecycle of an open local config work i
     {
       localRepo: "mento-protocol/monitoring-monorepo",
       queueIssue: 500,
-      projectionToken: "",
+      projectionToken: PAT,
     },
     { runGh },
   );
   assertEqual(result.status, "reused");
   assert(
+    !calls.some((c) => c.token),
+    "every local open-reuse call must use the ambient token, never the PAT",
+  );
+  assert(
     !calls.some((c) => c.args[1] === "edit" && c.args[2] === "42"),
     "an open local work issue must keep its existing lifecycle labels",
+  );
+});
+
+await test("runProjection reuses a local alias with ambient calls and trusted author fences", async () => {
+  const existing = [
+    {
+      number: 42,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/42",
+      body: `${buildProjectionMarker("OTHER-9")}\nrest of body`,
+      state: "OPEN",
+      author: { login: "app/github-actions" },
+      comments: [
+        {
+          body: buildAliasComment({
+            shortId: "APP-MENTO-ORG-12",
+            queueIssueUrl:
+              "https://github.com/mento-protocol/monitoring-monorepo/issues/500",
+            verdict: "config-fix",
+            confidence: "medium",
+            summary: "earlier local occurrence",
+            rootCause: "rc",
+            proposedAction: "pa",
+          }),
+          author: { login: "github-actions" },
+        },
+      ],
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({ issue, existing });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "reused");
+  assert(
+    calls.some(
+      (call) =>
+        call.args[0] === "issue" &&
+        call.args[1] === "view" &&
+        call.args.includes("--json") &&
+        call.args[call.args.indexOf("--json") + 1] === "comments" &&
+        call.token === null,
+    ),
+    "local alias comment reads must use the ambient token",
+  );
+  assert(
+    !calls.some((call) => call.token),
+    "every local alias reuse call must use the ambient token, never the PAT",
+  );
+});
+
+await test("a hostile local alias cannot capture the route", async () => {
+  const existing = [
+    {
+      number: 78,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/78",
+      body: `${buildProjectionMarker("OTHER-9")}\nrest of body`,
+      state: "OPEN",
+      author: { login: "app/github-actions" },
+      comments: [
+        {
+          body: buildAliasComment({
+            shortId: "APP-MENTO-ORG-12",
+            queueIssueUrl:
+              "https://github.com/mento-protocol/monitoring-monorepo/issues/500",
+            verdict: "config-fix",
+            confidence: "medium",
+            summary: "hostile local alias",
+            rootCause: "rc",
+            proposedAction: "pa",
+          }),
+          author: { login: "attacker" },
+        },
+      ],
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existing,
+    createdUrl:
+      "https://github.com/mento-protocol/monitoring-monorepo/issues/999",
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "projected");
+  assert(
+    calls.some((call) => call.args[0] === "issue" && call.args[1] === "create"),
+    "expected a new local issue after rejecting the hostile alias",
+  );
+  assert(
+    !calls.some((call) => call.token),
+    "every hostile-alias local call must use the ambient token, never the PAT",
   );
 });
 

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
 import { LABEL_TO_VERDICT } from "./sentry-triage-digest.mjs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   FIX_SCOPE_ARCHITECTURAL_LABEL,
   LABEL_DEFINITIONS,
@@ -344,17 +355,77 @@ await test("workflow defers local config projection before any close", () => {
   const localBranch = closeStep.indexOf(
     '[ "${PROJECTION_DESTINATION}" = "external" ] || [ "${PROJECTION_DESTINATION}" = "local-config" ]',
   );
+  const localBranchEnd = closeStep.indexOf("\n              fi", localBranch);
   const firstClose = closeStep.indexOf("gh issue close");
   assert(localBranch >= 0, "close step must branch on local-config");
+  assert(
+    localBranchEnd > localBranch,
+    "close step local-config branch must have a bounded shell body",
+  );
   assert(
     firstClose > localBranch,
     "close command must follow destination branch",
   );
   const branchExit = closeStep.indexOf("exit 0", localBranch);
   assert(
-    branchExit >= 0 && branchExit < firstClose,
+    branchExit >= 0 && branchExit < localBranchEnd && branchExit < firstClose,
     "local-config must exit before any close mutation",
   );
+
+  const runStart = closeStep.indexOf("\n        run: |\n");
+  assert(runStart >= 0, "close step run block missing");
+  const runLines = closeStep
+    .slice(runStart + "\n        run: |\n".length)
+    .split("\n");
+  const runBlock = [];
+  for (const line of runLines) {
+    if (line === "") {
+      runBlock.push("");
+      continue;
+    }
+    if (!line.startsWith("          ")) break;
+    runBlock.push(line.slice(10));
+  }
+  assert(runBlock.length > 0, "close step run block must contain shell");
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "sentry-project-workflow-"));
+  const ghStub = join(tempRoot, "gh");
+  const callsFile = join(tempRoot, "gh-calls");
+  // The temporary `gh` records every invocation. The local-config branch must
+  // exit before this stub can observe even an attempted close.
+  writeFileSync(ghStub, '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$GH_CALLS"\n');
+  chmodSync(ghStub, 0o755);
+  try {
+    const output = execFileSync(
+      "/bin/bash",
+      ["-euo", "pipefail", "-c", runBlock.join("\n")],
+      {
+        cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+        env: {
+          ...process.env,
+          PATH: `${tempRoot}:${process.env.PATH}`,
+          GH_CALLS: callsFile,
+          QUEUE_ISSUE_NUMBER: "500",
+          VERDICT: "config-fix",
+          VERDICT_LABEL: "sentry:verdict-config-fix",
+          PROJECTABLE: "false",
+          PROJECTION_DESTINATION: "local-config",
+          ARCHITECTURAL_HOLD: "false",
+          GITHUB_REPOSITORY: "mento-protocol/monitoring-monorepo",
+        },
+      },
+    ).toString();
+    assert(
+      output.includes("leaving it open for the serialized project job"),
+      "local-config branch must report deferral",
+    );
+    assert(
+      !existsSync(callsFile) || readFileSync(callsFile, "utf8") === "",
+      "local-config branch must not invoke gh, including issue close",
+    );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 // A mock `gh` runner covering the calls runProjection makes. Records every call
@@ -1868,6 +1939,67 @@ await test("runProjection reuses a local alias with ambient calls and trusted au
   );
 });
 
+await test("a hostile local issue author cannot capture a trusted direct marker", async () => {
+  const existing = [
+    {
+      number: 77,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/77",
+      body: `${buildProjectionMarker("APP-MENTO-ORG-12")}\nrest of body`,
+      state: "OPEN",
+      author: { login: "attacker" },
+      comments: [
+        {
+          body: buildAliasComment({
+            shortId: "APP-MENTO-ORG-12",
+            queueIssueUrl:
+              "https://github.com/mento-protocol/monitoring-monorepo/issues/500",
+            verdict: "config-fix",
+            confidence: "medium",
+            summary: "trusted comment on hostile issue",
+            rootCause: "rc",
+            proposedAction: "pa",
+          }),
+          author: { login: "github-actions" },
+        },
+      ],
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existing,
+    createdUrl:
+      "https://github.com/mento-protocol/monitoring-monorepo/issues/1000",
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "projected");
+  assert(
+    calls.some((call) => call.args[0] === "issue" && call.args[1] === "create"),
+    "expected a new local issue after rejecting the hostile direct-marker author",
+  );
+  assert(
+    !calls.some((call) => call.token),
+    "every hostile direct-marker local call must use the ambient token, never the PAT",
+  );
+});
+
 await test("a hostile local alias cannot capture the route", async () => {
   const existing = [
     {
@@ -1926,6 +2058,67 @@ await test("a hostile local alias cannot capture the route", async () => {
   assert(
     !calls.some((call) => call.token),
     "every hostile-alias local call must use the ambient token, never the PAT",
+  );
+});
+
+await test("a hostile local issue author cannot capture a trusted alias", async () => {
+  const existing = [
+    {
+      number: 78,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/78",
+      body: `${buildProjectionMarker("OTHER-9")}\nrest of body`,
+      state: "OPEN",
+      author: { login: "attacker" },
+      comments: [
+        {
+          body: buildAliasComment({
+            shortId: "APP-MENTO-ORG-12",
+            queueIssueUrl:
+              "https://github.com/mento-protocol/monitoring-monorepo/issues/500",
+            verdict: "config-fix",
+            confidence: "medium",
+            summary: "trusted alias on hostile issue",
+            rootCause: "rc",
+            proposedAction: "pa",
+          }),
+          author: { login: "github-actions[bot]" },
+        },
+      ],
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existing,
+    createdUrl:
+      "https://github.com/mento-protocol/monitoring-monorepo/issues/1001",
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "projected");
+  assert(
+    calls.some((call) => call.args[0] === "issue" && call.args[1] === "create"),
+    "expected a new local issue after rejecting the hostile alias author",
+  );
+  assert(
+    !calls.some((call) => call.token),
+    "every hostile alias local call must use the ambient token, never the PAT",
   );
 });
 

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -31,6 +31,8 @@ import {
   parseShortId,
   parseVerdictComment,
   PROJECTED_LABEL,
+  PROJECTION_DESTINATIONS,
+  projectionDestination,
   resolveVerdict,
   runEnsureLabels,
   runParseOnly,
@@ -46,6 +48,10 @@ import {
   VERDICT_MARKER,
   VERDICT_TO_LABEL,
 } from "./sentry-triage-project.mjs";
+import {
+  isWorkflowCreatedIssue,
+  WORKFLOW_ISSUE_AUTHOR,
+} from "./sentry-triage-project-route.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
 
 let passed = 0;
@@ -225,6 +231,68 @@ function queueIssue({
 // projected-issue fixtures carry it as their author.
 const PROJECTOR_LOGIN = "sentry-projector-bot";
 const PROJECTOR_AUTHOR = { login: PROJECTOR_LOGIN };
+
+await test("isWorkflowCreatedIssue accepts only the live Actions App issue author", () => {
+  assertEqual(WORKFLOW_ISSUE_AUTHOR, "app/github-actions");
+  assert(
+    isWorkflowCreatedIssue("app/github-actions"),
+    "expected the live gh issue list author to pass",
+  );
+  for (const author of [
+    "app/github-actions[bot]",
+    "github-actions",
+    "github-actions[bot]",
+    "app/github-actions-evil",
+    "attacker",
+  ]) {
+    assert(
+      !isWorkflowCreatedIssue(author),
+      `unexpected trusted workflow issue author: ${author}`,
+    );
+  }
+});
+
+await test("projection destination table keeps external capability separate from local config", () => {
+  const cases = [
+    [
+      "code-fix",
+      { projectable: true, reason: "allowed" },
+      PROJECTION_DESTINATIONS.EXTERNAL,
+    ],
+    [
+      "config-fix",
+      { projectable: true, reason: "allowed" },
+      PROJECTION_DESTINATIONS.EXTERNAL,
+    ],
+    [
+      "config-fix",
+      { projectable: false, reason: "local-repo" },
+      PROJECTION_DESTINATIONS.LOCAL_CONFIG,
+    ],
+    [
+      "code-fix",
+      { projectable: false, reason: "local-repo" },
+      PROJECTION_DESTINATIONS.NONE,
+    ],
+    [
+      "config-fix",
+      { projectable: false, reason: "unrecognized-repo" },
+      PROJECTION_DESTINATIONS.NONE,
+    ],
+    [
+      "needs-human",
+      { projectable: false, reason: "local-repo" },
+      PROJECTION_DESTINATIONS.NONE,
+    ],
+  ];
+  for (const [verdict, repoCheck, expected] of cases) {
+    assertEqual(
+      projectionDestination(verdict, repoCheck),
+      expected,
+      `${verdict}/${repoCheck.reason}`,
+    );
+  }
+});
 
 // A mock `gh` runner covering the calls runProjection makes. Records every call
 // with the token it was invoked under so token routing is assertable. `stubs`
@@ -1467,6 +1535,205 @@ await test("runProjection projects config-fix as well", async () => {
   );
 });
 
+await test("runProjection creates local config work with the ambient token and agent-ready", async () => {
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    createdUrl:
+      "https://github.com/mento-protocol/monitoring-monorepo/issues/999",
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: "",
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "projected");
+  const create = calls.find((c) => c.args[1] === "create");
+  assertEqual(create.token, null);
+  assertEqual(
+    create.args[create.args.indexOf("-R") + 1],
+    "mento-protocol/monitoring-monorepo",
+  );
+  assert(
+    create.args.includes("agent-ready"),
+    "expected local work issue ready",
+  );
+  assert(
+    !calls.some((c) => c.token),
+    "every local projection call must use the ambient token, never the PAT",
+  );
+});
+
+await test("runProjection reopens a closed local config work issue and restores agent-ready", async () => {
+  const existing = [
+    {
+      number: 42,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/42",
+      body: `${buildProjectionMarker("APP-MENTO-ORG-12")}\nrest of body`,
+      state: "CLOSED",
+      labels: ["agent-active", "in-pr", "needs-grooming"],
+      author: { login: "app/github-actions" },
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({ issue, existing });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: "",
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "reused");
+  const readyEdit = calls.find(
+    (c) => c.args[1] === "edit" && c.args[2] === "42",
+  );
+  assert(readyEdit?.args.includes("agent-ready"), "expected ready restore");
+  assertEqual(
+    readyEdit?.args[readyEdit.args.indexOf("--remove-label") + 1],
+    "agent-active,in-pr,needs-grooming",
+  );
+  assertEqual(readyEdit.token, null);
+  assert(
+    !calls.some((c) => c.token),
+    "every local closed-reuse call must use the ambient token, never the PAT",
+  );
+});
+
+await test("a failed local lifecycle repair remains retryable while the issue is closed", async () => {
+  const existing = [
+    {
+      number: 42,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/42",
+      body: `${buildProjectionMarker("APP-MENTO-ORG-12")}\nrest of body`,
+      state: "CLOSED",
+      labels: ["agent-active", "in-pr", "needs-grooming"],
+      author: { login: "app/github-actions" },
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const base = makeRunGh({ issue, existing });
+  let failLifecycleEdit = true;
+  const runGh = async (args, opts) => {
+    if (
+      failLifecycleEdit &&
+      args[0] === "issue" &&
+      args[1] === "edit" &&
+      args[2] === "42"
+    ) {
+      failLifecycleEdit = false;
+      throw new Error("gh issue edit failed: HTTP 500");
+    }
+    const result = await base.runGh(args, opts);
+    if (args[0] === "issue" && args[1] === "reopen" && args[2] === "42") {
+      existing[0].state = "OPEN";
+    }
+    return result;
+  };
+  const options = {
+    localRepo: "mento-protocol/monitoring-monorepo",
+    queueIssue: 500,
+    projectionToken: "",
+  };
+
+  await assertRejects(
+    runProjection(options, { runGh }),
+    /edit failed: HTTP 500/,
+  );
+  assertEqual(existing[0].state, "CLOSED");
+  assert(
+    !base.calls.some((call) => call.args[1] === "reopen"),
+    "a failed lifecycle repair must not reopen the issue",
+  );
+
+  const retryStart = base.calls.length;
+  const result = await runProjection(options, { runGh });
+  assertEqual(result.status, "reused");
+  assertEqual(existing[0].state, "OPEN");
+  const retryLifecycle = base.calls
+    .slice(retryStart)
+    .filter(
+      (call) =>
+        call.args[0] === "issue" &&
+        call.args[2] === "42" &&
+        ["edit", "reopen"].includes(call.args[1]),
+    )
+    .map((call) => call.args[1]);
+  assertDeepEqual(retryLifecycle, ["edit", "reopen"]);
+});
+
+await test("runProjection preserves the lifecycle of an open local config work issue", async () => {
+  const existing = [
+    {
+      number: 42,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/42",
+      body: `${buildProjectionMarker("APP-MENTO-ORG-12")}\nrest of body`,
+      state: "OPEN",
+      labels: ["agent-active"],
+      author: { login: "app/github-actions" },
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({ issue, existing });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: "",
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "reused");
+  assert(
+    !calls.some((c) => c.args[1] === "edit" && c.args[2] === "42"),
+    "an open local work issue must keep its existing lifecycle labels",
+  );
+});
+
 await test("runProjection is idempotent: reuses an existing OPEN back-linked issue without reopening", async () => {
   const existing = [
     {
@@ -2406,6 +2673,7 @@ await test("runParseOnly returns the validated verdict + mapped label + projecta
     verdict: "code-fix",
     label: "sentry:verdict-code-fix",
     projectable: true,
+    projectionDestination: PROJECTION_DESTINATIONS.EXTERNAL,
     // External allowlisted code-fix: no hold. The shed carries the architectural
     // label because the hold does NOT apply (it un-strands a re-dispatch).
     shed: "sentry:verdict-config-fix,sentry:verdict-upstream,sentry:verdict-needs-human,sentry:fix-scope-architectural",
@@ -2432,6 +2700,7 @@ await test("runParseOnly reports an actionable-but-local verdict as not projecta
   );
   assertEqual(result.projectable, false);
   assertEqual(result.verdict, "code-fix");
+  assertEqual(result.projectionDestination, PROJECTION_DESTINATIONS.NONE);
 });
 
 await test("runParseOnly maps upstream-transient to the asymmetric label", async () => {
@@ -2452,6 +2721,7 @@ await test("runParseOnly maps upstream-transient to the asymmetric label", async
     verdict: "upstream-transient",
     label: "sentry:verdict-upstream",
     projectable: false,
+    projectionDestination: PROJECTION_DESTINATIONS.NONE,
     shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-needs-human,sentry:fix-scope-architectural",
     architecturalHold: false,
   });
@@ -2648,6 +2918,7 @@ await test("runParseOnly accepts a needs-human verdict WITH human_question", asy
     verdict: "needs-human",
     label: "sentry:verdict-needs-human",
     projectable: false,
+    projectionDestination: PROJECTION_DESTINATIONS.NONE,
     shed: "sentry:verdict-code-fix,sentry:verdict-config-fix,sentry:verdict-upstream,sentry:fix-scope-architectural",
     architecturalHold: false,
   });
@@ -2753,6 +3024,11 @@ await test("runParseOnly does NOT hold a LOCAL architectural CONFIG-fix (verdict
   // config-fix carries no fix_scope contract; only code-fix holds.
   assertEqual(result.architecturalHold, false);
   assertEqual(result.label, "sentry:verdict-config-fix");
+  assertEqual(result.projectable, false);
+  assertEqual(
+    result.projectionDestination,
+    PROJECTION_DESTINATIONS.LOCAL_CONFIG,
+  );
   assert(
     result.shed.split(",").includes(FIX_SCOPE_ARCHITECTURAL_LABEL),
     "config-fix sheds the hold label (hold does not apply)",

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -65,6 +65,7 @@ import {
   WORKFLOW_ISSUE_AUTHOR,
 } from "./sentry-triage-project-route.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
+import { AGENT_READY_LABEL_DEFINITION } from "../../lib/gh-issue-lifecycle.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -435,15 +436,21 @@ function makeRunGh({
   issue,
   stubs = null,
   existing = [],
+  existingLabels = [AGENT_READY_LABEL_DEFINITION.name],
+  requireAgentReadyBeforeMutation = false,
   createdUrl = null,
   projectorLogin = PROJECTOR_LOGIN,
 } = {}) {
   const calls = [];
+  const repoLabels = [...existingLabels];
   const runGh = async (args, opts = {}) => {
     calls.push({ args, token: opts.token ?? null });
     const [a0, a1] = args;
     if (a0 === "api" && a1 === "user") {
       return `${projectorLogin}\n`;
+    }
+    if (a0 === "api" && a1.startsWith("repos/") && a1.includes("/labels?")) {
+      return JSON.stringify(repoLabels.map((name) => ({ name })));
     }
     if (a0 === "issue" && a1 === "view") {
       // The full field set is the queue-stub read. The exact `comments` read
@@ -480,6 +487,13 @@ function makeRunGh({
       return JSON.stringify(existing);
     }
     if (a0 === "issue" && a1 === "create") {
+      if (
+        requireAgentReadyBeforeMutation &&
+        args.includes(AGENT_READY_LABEL_DEFINITION.name) &&
+        !repoLabels.includes(AGENT_READY_LABEL_DEFINITION.name)
+      ) {
+        throw new Error("gh issue create failed: agent-ready label is absent");
+      }
       if (createdUrl == null)
         throw new Error("gh issue create failed: HTTP 403");
       return `${createdUrl}\n`;
@@ -488,10 +502,19 @@ function makeRunGh({
       a0 === "issue" &&
       (a1 === "edit" || a1 === "comment" || a1 === "reopen")
     ) {
+      if (
+        requireAgentReadyBeforeMutation &&
+        a1 === "edit" &&
+        args.includes(AGENT_READY_LABEL_DEFINITION.name) &&
+        !repoLabels.includes(AGENT_READY_LABEL_DEFINITION.name)
+      ) {
+        throw new Error("gh issue edit failed: agent-ready label is absent");
+      }
       return "";
     }
     if (a0 === "label" && a1 === "create") {
       // runProjectionBatch's idempotent self-heal of sentry:projected.
+      if (!repoLabels.includes(args[2])) repoLabels.push(args[2]);
       return "";
     }
     if (a0 === "api" && a1 === "-X" && args[2] === "DELETE") {
@@ -1671,9 +1694,84 @@ await test("runProjection projects config-fix as well", async () => {
     create.args[create.args.indexOf("-R") + 1],
     "mento-protocol/mento-analytics-api",
   );
+  assert(
+    !calls.some(
+      (call) =>
+        call.args[0] === "api" && String(call.args[1]).includes("/labels?"),
+    ),
+    "external projection must not ensure a local lifecycle label",
+  );
 });
 
 await test("runProjection creates local config work with the ambient token and agent-ready", async () => {
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existingLabels: [],
+    requireAgentReadyBeforeMutation: true,
+    createdUrl:
+      "https://github.com/mento-protocol/monitoring-monorepo/issues/999",
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "projected");
+  const labelCreate = calls.find(
+    (c) => c.args[0] === "label" && c.args[1] === "create",
+  );
+  const create = calls.find(
+    (c) => c.args[0] === "issue" && c.args[1] === "create",
+  );
+  assert(labelCreate, "expected agent-ready to be self-healed");
+  assertEqual(labelCreate.args[2], AGENT_READY_LABEL_DEFINITION.name);
+  assertEqual(
+    labelCreate.args[labelCreate.args.indexOf("--color") + 1],
+    AGENT_READY_LABEL_DEFINITION.color,
+  );
+  assertEqual(
+    labelCreate.args[labelCreate.args.indexOf("--description") + 1],
+    AGENT_READY_LABEL_DEFINITION.description,
+  );
+  assert(
+    !labelCreate.args.includes("--force"),
+    "shared lifecycle labels must not be force-edited",
+  );
+  assert(
+    calls.indexOf(labelCreate) < calls.indexOf(create),
+    "agent-ready must exist before the local issue is created",
+  );
+  assertEqual(labelCreate.token, null);
+  assertEqual(create.token, null);
+  assertEqual(
+    create.args[create.args.indexOf("-R") + 1],
+    "mento-protocol/monitoring-monorepo",
+  );
+  assert(
+    create.args.includes("agent-ready"),
+    "expected local work issue ready",
+  );
+  assert(
+    !calls.some((c) => c.token),
+    "every local projection call must use the ambient token, never the PAT",
+  );
+});
+
+await test("runProjection does not recreate an existing local agent-ready label", async () => {
   const issue = queueIssue({
     comments: [
       botComment(
@@ -1699,19 +1797,11 @@ await test("runProjection creates local config work with the ambient token and a
     { runGh },
   );
   assertEqual(result.status, "projected");
-  const create = calls.find((c) => c.args[1] === "create");
-  assertEqual(create.token, null);
-  assertEqual(
-    create.args[create.args.indexOf("-R") + 1],
-    "mento-protocol/monitoring-monorepo",
-  );
   assert(
-    create.args.includes("agent-ready"),
-    "expected local work issue ready",
-  );
-  assert(
-    !calls.some((c) => c.token),
-    "every local projection call must use the ambient token, never the PAT",
+    !calls.some(
+      (call) => call.args[0] === "label" && call.args[1] === "create",
+    ),
+    "an existing shared label must not be edited",
   );
 });
 
@@ -1737,7 +1827,12 @@ await test("runProjection reopens a closed local config work issue and restores 
       ),
     ],
   });
-  const { runGh, calls } = makeRunGh({ issue, existing });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existing,
+    existingLabels: [],
+    requireAgentReadyBeforeMutation: true,
+  });
   const result = await runProjection(
     {
       localRepo: "mento-protocol/monitoring-monorepo",
@@ -1747,8 +1842,23 @@ await test("runProjection reopens a closed local config work issue and restores 
     { runGh },
   );
   assertEqual(result.status, "reused");
+  const labelCreate = calls.find(
+    (c) => c.args[0] === "label" && c.args[1] === "create",
+  );
   const readyEdit = calls.find(
     (c) => c.args[1] === "edit" && c.args[2] === "42",
+  );
+  const reopen = calls.find(
+    (c) => c.args[1] === "reopen" && c.args[2] === "42",
+  );
+  assert(labelCreate, "expected agent-ready to be self-healed");
+  assert(
+    calls.indexOf(labelCreate) < calls.indexOf(readyEdit),
+    "agent-ready must exist before the lifecycle edit",
+  );
+  assert(
+    calls.indexOf(readyEdit) < calls.indexOf(reopen),
+    "the lifecycle edit must complete before reopen",
   );
   assert(readyEdit?.args.includes("agent-ready"), "expected ready restore");
   assertEqual(
@@ -1759,6 +1869,67 @@ await test("runProjection reopens a closed local config work issue and restores 
   assert(
     !calls.some((c) => c.token),
     "every local closed-reuse call must use the ambient token, never the PAT",
+  );
+});
+
+await test("runProjection self-heals agent-ready before reopening a closed local duplicate", async () => {
+  const existing = [
+    {
+      number: 42,
+      url: "https://github.com/mento-protocol/monitoring-monorepo/issues/42",
+      body: `${buildProjectionMarker("DUP-1")}\nrest of body`,
+      state: "CLOSED",
+      labels: ["agent-active"],
+      author: { login: "app/github-actions" },
+    },
+  ];
+  const issue = queueIssue({
+    comments: [
+      botComment(
+        verdictComment({
+          verdict: "config-fix",
+          affectedRepo: "mento-protocol/monitoring-monorepo",
+          duplicates: "[DUP-1]",
+        }),
+        "2026-07-17T10:00:00Z",
+      ),
+    ],
+  });
+  const { runGh, calls } = makeRunGh({
+    issue,
+    existing,
+    existingLabels: [],
+    requireAgentReadyBeforeMutation: true,
+  });
+  const result = await runProjection(
+    {
+      localRepo: "mento-protocol/monitoring-monorepo",
+      queueIssue: 500,
+      projectionToken: PAT,
+    },
+    { runGh },
+  );
+  assertEqual(result.status, "reused");
+  const labelCreate = calls.find(
+    (call) => call.args[0] === "label" && call.args[1] === "create",
+  );
+  const readyEdit = calls.find(
+    (call) => call.args[1] === "edit" && call.args[2] === "42",
+  );
+  const reopen = calls.find(
+    (call) => call.args[1] === "reopen" && call.args[2] === "42",
+  );
+  assert(labelCreate, "expected agent-ready to be self-healed");
+  assert(readyEdit, "expected the duplicate lifecycle to be repaired");
+  assert(reopen, "expected the duplicate issue to reopen");
+  assert(
+    calls.indexOf(labelCreate) < calls.indexOf(readyEdit) &&
+      calls.indexOf(readyEdit) < calls.indexOf(reopen),
+    "the label ensure and lifecycle repair must precede reopen",
+  );
+  assert(
+    !calls.some((call) => call.token),
+    "local duplicate reuse must use the ambient token",
   );
 });
 
@@ -1784,17 +1955,21 @@ await test("a failed local lifecycle repair remains retryable while the issue is
       ),
     ],
   });
-  const base = makeRunGh({ issue, existing });
-  let failLifecycleEdit = true;
+  const base = makeRunGh({
+    issue,
+    existing,
+    existingLabels: [],
+    requireAgentReadyBeforeMutation: true,
+  });
+  let failLabelInventory = true;
   const runGh = async (args, opts) => {
     if (
-      failLifecycleEdit &&
-      args[0] === "issue" &&
-      args[1] === "edit" &&
-      args[2] === "42"
+      failLabelInventory &&
+      args[0] === "api" &&
+      String(args[1]).includes("/labels?")
     ) {
-      failLifecycleEdit = false;
-      throw new Error("gh issue edit failed: HTTP 500");
+      failLabelInventory = false;
+      throw new Error("gh api labels failed: HTTP 500");
     }
     const result = await base.runGh(args, opts);
     if (args[0] === "issue" && args[1] === "reopen" && args[2] === "42") {
@@ -1810,9 +1985,13 @@ await test("a failed local lifecycle repair remains retryable while the issue is
 
   await assertRejects(
     runProjection(options, { runGh }),
-    /edit failed: HTTP 500/,
+    /edit failed: agent-ready label is absent/,
   );
   assertEqual(existing[0].state, "CLOSED");
+  assert(
+    base.calls.some((call) => call.args[1] === "edit" && call.args[2] === "42"),
+    "a label ensure failure must not suppress the authoritative lifecycle edit",
+  );
   assert(
     !base.calls.some((call) => call.args[1] === "reopen"),
     "a failed lifecycle repair must not reopen the issue",
@@ -1873,6 +2052,13 @@ await test("runProjection preserves the lifecycle of an open local config work i
   assert(
     !calls.some((c) => c.args[1] === "edit" && c.args[2] === "42"),
     "an open local work issue must keep its existing lifecycle labels",
+  );
+  assert(
+    !calls.some(
+      (call) =>
+        call.args[0] === "api" && String(call.args[1]).includes("/labels?"),
+    ),
+    "open local reuse must not mutate or ensure lifecycle labels",
   );
 });
 

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -65,7 +65,10 @@ import {
   WORKFLOW_ISSUE_AUTHOR,
 } from "./sentry-triage-project-route.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
-import { AGENT_READY_LABEL_DEFINITION } from "../../lib/gh-issue-lifecycle.mjs";
+import {
+  AGENT_READY_LABEL_DEFINITION,
+  ISSUE_STATE_LABEL_DEFINITIONS,
+} from "../../lib/gh-issue-lifecycle.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -437,7 +440,7 @@ function makeRunGh({
   stubs = null,
   existing = [],
   existingLabels = [AGENT_READY_LABEL_DEFINITION.name],
-  requireAgentReadyBeforeMutation = false,
+  requireLabelsBeforeMutation = false,
   createdUrl = null,
   projectorLogin = PROJECTOR_LOGIN,
 } = {}) {
@@ -487,12 +490,16 @@ function makeRunGh({
       return JSON.stringify(existing);
     }
     if (a0 === "issue" && a1 === "create") {
-      if (
-        requireAgentReadyBeforeMutation &&
-        args.includes(AGENT_READY_LABEL_DEFINITION.name) &&
-        !repoLabels.includes(AGENT_READY_LABEL_DEFINITION.name)
-      ) {
-        throw new Error("gh issue create failed: agent-ready label is absent");
+      if (requireLabelsBeforeMutation) {
+        const requestedLabels = args.flatMap((arg, index) =>
+          args[index - 1] === "--label" ? String(arg).split(",") : [],
+        );
+        const missing = requestedLabels.find(
+          (label) => !repoLabels.includes(label),
+        );
+        if (missing) {
+          throw new Error(`gh issue create failed: label ${missing} is absent`);
+        }
       }
       if (createdUrl == null)
         throw new Error("gh issue create failed: HTTP 403");
@@ -503,12 +510,21 @@ function makeRunGh({
       (a1 === "edit" || a1 === "comment" || a1 === "reopen")
     ) {
       if (
-        requireAgentReadyBeforeMutation &&
+        requireLabelsBeforeMutation &&
         a1 === "edit" &&
-        args.includes(AGENT_READY_LABEL_DEFINITION.name) &&
-        !repoLabels.includes(AGENT_READY_LABEL_DEFINITION.name)
+        args.includes(AGENT_READY_LABEL_DEFINITION.name)
       ) {
-        throw new Error("gh issue edit failed: agent-ready label is absent");
+        const requestedLabels = args.flatMap((arg, index) =>
+          ["--add-label", "--remove-label"].includes(args[index - 1])
+            ? String(arg).split(",")
+            : [],
+        );
+        const missing = requestedLabels.find(
+          (label) => !repoLabels.includes(label),
+        );
+        if (missing) {
+          throw new Error(`gh issue edit failed: label ${missing} is absent`);
+        }
       }
       return "";
     }
@@ -524,6 +540,37 @@ function makeRunGh({
     throw new Error(`unexpected gh call: ${args.join(" ")}`);
   };
   return { runGh, calls };
+}
+
+function assertLabelDefinitionsCreatedBefore(calls, definitions, mutation) {
+  assert(mutation, "expected the issue mutation after label setup");
+  const creates = calls.filter(
+    (call) => call.args[0] === "label" && call.args[1] === "create",
+  );
+  assertDeepEqual(
+    creates.map((call) => call.args[2]),
+    definitions.map((definition) => definition.name),
+  );
+  for (const [index, definition] of definitions.entries()) {
+    const create = creates[index];
+    assertEqual(
+      create.args[create.args.indexOf("--color") + 1],
+      definition.color,
+    );
+    assertEqual(
+      create.args[create.args.indexOf("--description") + 1],
+      definition.description,
+    );
+    assert(
+      !create.args.includes("--force"),
+      "shared lifecycle labels must not be force-edited",
+    );
+    assert(
+      calls.indexOf(create) < calls.indexOf(mutation),
+      `${definition.name} must exist before the issue mutation`,
+    );
+  }
+  return creates;
 }
 
 const PAT = "ghp_projection_token";
@@ -1718,7 +1765,7 @@ await test("runProjection creates local config work with the ambient token and a
   const { runGh, calls } = makeRunGh({
     issue,
     existingLabels: [],
-    requireAgentReadyBeforeMutation: true,
+    requireLabelsBeforeMutation: true,
     createdUrl:
       "https://github.com/mento-protocol/monitoring-monorepo/issues/999",
   });
@@ -1731,29 +1778,13 @@ await test("runProjection creates local config work with the ambient token and a
     { runGh },
   );
   assertEqual(result.status, "projected");
-  const labelCreate = calls.find(
-    (c) => c.args[0] === "label" && c.args[1] === "create",
-  );
   const create = calls.find(
     (c) => c.args[0] === "issue" && c.args[1] === "create",
   );
-  assert(labelCreate, "expected agent-ready to be self-healed");
-  assertEqual(labelCreate.args[2], AGENT_READY_LABEL_DEFINITION.name);
-  assertEqual(
-    labelCreate.args[labelCreate.args.indexOf("--color") + 1],
-    AGENT_READY_LABEL_DEFINITION.color,
-  );
-  assertEqual(
-    labelCreate.args[labelCreate.args.indexOf("--description") + 1],
-    AGENT_READY_LABEL_DEFINITION.description,
-  );
-  assert(
-    !labelCreate.args.includes("--force"),
-    "shared lifecycle labels must not be force-edited",
-  );
-  assert(
-    calls.indexOf(labelCreate) < calls.indexOf(create),
-    "agent-ready must exist before the local issue is created",
+  const [labelCreate] = assertLabelDefinitionsCreatedBefore(
+    calls,
+    [AGENT_READY_LABEL_DEFINITION],
+    create,
   );
   assertEqual(labelCreate.token, null);
   assertEqual(create.token, null);
@@ -1831,7 +1862,7 @@ await test("runProjection reopens a closed local config work issue and restores 
     issue,
     existing,
     existingLabels: [],
-    requireAgentReadyBeforeMutation: true,
+    requireLabelsBeforeMutation: true,
   });
   const result = await runProjection(
     {
@@ -1842,19 +1873,17 @@ await test("runProjection reopens a closed local config work issue and restores 
     { runGh },
   );
   assertEqual(result.status, "reused");
-  const labelCreate = calls.find(
-    (c) => c.args[0] === "label" && c.args[1] === "create",
-  );
   const readyEdit = calls.find(
     (c) => c.args[1] === "edit" && c.args[2] === "42",
   );
   const reopen = calls.find(
     (c) => c.args[1] === "reopen" && c.args[2] === "42",
   );
-  assert(labelCreate, "expected agent-ready to be self-healed");
-  assert(
-    calls.indexOf(labelCreate) < calls.indexOf(readyEdit),
-    "agent-ready must exist before the lifecycle edit",
+  assert(readyEdit, "expected the closed lifecycle to be repaired");
+  assertLabelDefinitionsCreatedBefore(
+    calls,
+    ISSUE_STATE_LABEL_DEFINITIONS,
+    readyEdit,
   );
   assert(
     calls.indexOf(readyEdit) < calls.indexOf(reopen),
@@ -1899,7 +1928,7 @@ await test("runProjection self-heals agent-ready before reopening a closed local
     issue,
     existing,
     existingLabels: [],
-    requireAgentReadyBeforeMutation: true,
+    requireLabelsBeforeMutation: true,
   });
   const result = await runProjection(
     {
@@ -1910,22 +1939,22 @@ await test("runProjection self-heals agent-ready before reopening a closed local
     { runGh },
   );
   assertEqual(result.status, "reused");
-  const labelCreate = calls.find(
-    (call) => call.args[0] === "label" && call.args[1] === "create",
-  );
   const readyEdit = calls.find(
     (call) => call.args[1] === "edit" && call.args[2] === "42",
   );
   const reopen = calls.find(
     (call) => call.args[1] === "reopen" && call.args[2] === "42",
   );
-  assert(labelCreate, "expected agent-ready to be self-healed");
   assert(readyEdit, "expected the duplicate lifecycle to be repaired");
+  assertLabelDefinitionsCreatedBefore(
+    calls,
+    ISSUE_STATE_LABEL_DEFINITIONS,
+    readyEdit,
+  );
   assert(reopen, "expected the duplicate issue to reopen");
   assert(
-    calls.indexOf(labelCreate) < calls.indexOf(readyEdit) &&
-      calls.indexOf(readyEdit) < calls.indexOf(reopen),
-    "the label ensure and lifecycle repair must precede reopen",
+    calls.indexOf(readyEdit) < calls.indexOf(reopen),
+    "the lifecycle repair must precede reopen",
   );
   assert(
     !calls.some((call) => call.token),
@@ -1959,7 +1988,7 @@ await test("a failed local lifecycle repair remains retryable while the issue is
     issue,
     existing,
     existingLabels: [],
-    requireAgentReadyBeforeMutation: true,
+    requireLabelsBeforeMutation: true,
   });
   let failLabelInventory = true;
   const runGh = async (args, opts) => {
@@ -1985,7 +2014,7 @@ await test("a failed local lifecycle repair remains retryable while the issue is
 
   await assertRejects(
     runProjection(options, { runGh }),
-    /edit failed: agent-ready label is absent/,
+    /edit failed: label agent-ready is absent/,
   );
   assertEqual(existing[0].state, "CLOSED");
   assert(
@@ -1998,19 +2027,39 @@ await test("a failed local lifecycle repair remains retryable while the issue is
   );
 
   const retryStart = base.calls.length;
+  const failedAttemptCalls = base.calls.slice(0, retryStart);
+  assert(
+    !failedAttemptCalls.some(
+      (call) => call.args[0] === "label" && call.args[1] === "create",
+    ),
+    "a failed label inventory must not claim that a label was created",
+  );
+  assert(
+    !failedAttemptCalls.some((call) => call.args[1] === "comment"),
+    "a failed lifecycle repair must not comment on the closed issue",
+  );
   const result = await runProjection(options, { runGh });
   assertEqual(result.status, "reused");
   assertEqual(existing[0].state, "OPEN");
-  const retryLifecycle = base.calls
-    .slice(retryStart)
+  const retryCalls = base.calls.slice(retryStart);
+  const retryEdit = retryCalls.find(
+    (call) => call.args[1] === "edit" && call.args[2] === "42",
+  );
+  assert(retryEdit, "expected the retry to repair the closed lifecycle");
+  assertLabelDefinitionsCreatedBefore(
+    retryCalls,
+    ISSUE_STATE_LABEL_DEFINITIONS,
+    retryEdit,
+  );
+  const retryLifecycle = retryCalls
     .filter(
       (call) =>
         call.args[0] === "issue" &&
         call.args[2] === "42" &&
-        ["edit", "reopen"].includes(call.args[1]),
+        ["edit", "reopen", "comment"].includes(call.args[1]),
     )
     .map((call) => call.args[1]);
-  assertDeepEqual(retryLifecycle, ["edit", "reopen"]);
+  assertDeepEqual(retryLifecycle, ["edit", "reopen", "comment"]);
 });
 
 await test("runProjection preserves the lifecycle of an open local config work issue", async () => {


### PR DESCRIPTION
## The Problem

- A `config-fix` verdict for this repository had no projection destination. The workflow closed the queue stub without creating durable work.
- Issue #1733 diagnosed a concrete dashboard Sentry filter change, but the prior close path dropped that work.

## The Solution

Local `config-fix` verdicts now create or reuse normal `agent-ready` issues in this repository with the ambient Actions token. Closed matches restore the ready lifecycle before reopen. Open matches keep their current lifecycle. External projection still uses the existing PAT and author fence. Local `code-fix` behavior does not change.

This source change does not backfill old verdicts. After merge, re-dispatch #1733 and verify its Actions-authored projected issue before closing #1761.

## Details

- Add a closed `local-config` projection destination without widening the external `projectable` capability.
- Defer local config settlement from the matrix to the serialized projection job.
- Match local projections only when the issue author is the GitHub Actions App. Keep the existing trusted comment-author fence for aliases.
- Split GitHub route and I/O code into `sentry-triage-project-route.mjs`.
- Ensure the canonical shared `agent-ready` label exists immediately before local create or closed-issue repair. Do not force-edit existing shared label metadata.
- Keep failed local lifecycle repairs closed and retryable.
- Route shared lifecycle-module changes through the documentation and Sentry projection suites.

## Validation

- `pnpm agent:quality-gate --run` — all 25 mapped commands passed. The push hook confirmed the successful gate stamp remained fresh for `b20bc8c8c0db02bd6710b2a9466fa3238a29640b`.
- Fresh-context cumulative source review — no source blocker across 20 files and about 1,025 non-test changed lines. The only handback is the required post-merge #1733 live proof.
- Deterministic autoreview — clean for the committed branch and the final working-tree increment.
- Browser verification — not applicable; this PR changes workflow and script behavior only.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? This refines ADR 0038 in place; it does not require a new ADR.

Refs #1761

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sentry queue settlement and GitHub issue create/reopen/label behavior, including local issue filing with the workflow token. External PAT routing is unchanged, but a routing bug could close stubs without work or reuse the wrong issue.
> 
> **Overview**
> Local `config-fix` verdicts no longer close as a ledger-only stub. They now project into a durable `agent-ready` work issue in this repo, using the ambient workflow token instead of the cross-repo PAT.
> 
> Adds a closed `projectionDestination` enum (`external` | `local-config` | `none`) while keeping `projectable` external-only. The matrix close step defers both external and local-config stubs to the serialized `project` job. Local reuse matches only Actions-App-authored issues; closed matches restore `agent-ready` and strip conflicting lifecycle labels *before* reopen so a failed repair stays retryable. Open matches keep their current lifecycle.
> 
> GitHub I/O moves into `sentry-triage-project-route.mjs`. Shared `agent-ready` is ensured from `gh-issue-lifecycle.mjs` without force-editing existing label metadata. Digest, ADR 0038, and the pipeline runbook treat local config work as a routed projection. Local `code-fix` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b20bc8c8c0db02bd6710b2a9466fa3238a29640b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local configuration-fix projections alongside external projections.
  * Added destination-aware verdict handling for external, local, and non-projectable outcomes.
  * Local projections can create or reuse work issues, restore labels, reopen issues, and mark queue items as projected.
  * Updated triage output and CLI guidance to clarify projection destinations and token usage.

* **Bug Fixes**
  * Improved duplicate detection, authorship validation, retry handling, and lifecycle-label recovery.

* **Documentation**
  * Updated architecture records, runbooks, and operator guidance.

* **Tests**
  * Expanded coverage for routing, projections, labels, authorship, and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->