### PR TITLE
fix(autoreview): include split review signals runtime

### DIFF
--- a/docs/adr/0065-scripts-file-size-watchlist-scope.md
+++ b/docs/adr/0065-scripts-file-size-watchlist-scope.md
@@ -3,7 +3,7 @@ title: scripts/ is inside the file-size watchlist, with named-mechanism exemptio
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-18
+last_verified: 2026-08-23
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -104,10 +104,12 @@ is the largest example and stays in the report: it is the entire subject of
 which decomposes it into sourced helper modules, so exempting it would suppress
 exactly the row that already has an owner. `pr-ready-state{,-core}.mjs` sit
 behind `materialize_feedback_runtime`'s two basename lists, required and
-optional, which already prove themselves extensible: `pr-feedback-state-claude.mjs`
-is the optional entry, and the D3 move (issue 1877) added a location resolver
-under both lists without touching either name. Two appendable arrays are not the
-six-list materializer above it. For
+optional, which already prove themselves extensible.
+`pr-feedback-state-claude.mjs` and `pr-ready-state-review-signals.mjs` are
+version-split optional entries, so coherent snapshots from before either split
+still work. The D3 move (issue 1877) added a location resolver under both lists
+without changing their names. Two appendable arrays are not the six-list
+materializer above it. For
 `deploy-staging-{contract,callsite-discovery}.mjs` only the _test_ is the
 callsite contract's single self-scan exclusion. All four stay measured. A file
 the reorganization already brought under the cap carries no entry.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -61,11 +61,11 @@ stay with their domain.
 `scripts/` has twelve path-pin classes. Move each pin with its file in the
 same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
 
-- **Autoreview runtime materialization.** `agent-autoreview.sh` pins sibling
-  runtime in Perl lists and `runtime_paths`; feedback helpers use `origin/main`.
-  Move feedback paths in three merges: add copies and a dual-path fallback;
-  repoint consumers; remove old paths and fallback when no pre-move wrapper
-  remains (ADR 0064).
+- **Autoreview runtime pins.** `agent-autoreview.sh` pins sibling runtime and
+  optional `pr-feedback-state-claude.mjs` and
+  `pr-ready-state-review-signals.mjs`; feedback blobs use `origin/main`. Move
+  feedback paths in three merges: add copies/fallback; repoint; remove old paths
+  after no pre-move wrapper remains (ADR 0064).
 - **Gate routing pins.** The gate excludes stub-repo tests with
   `$script_source_dir == $repo_root/scripts`, and pairs
   `bootstrap/codex-cloud-setup.{sh,test.sh}` for offline tests. It routes

--- a/scripts/agent-autoreview.sh
+++ b/scripts/agent-autoreview.sh
@@ -4325,6 +4325,7 @@ materialize_feedback_runtime() {
   )
   local optional_runtime_names=(
     pr-feedback-state-claude.mjs
+    pr-ready-state-review-signals.mjs
   )
   local runtime_names=()
   local runtime_paths=()

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6000,7 +6000,8 @@ run_feedback_runtime_aggregate_regression() {
     pr-feedback-state-claude.mjs \
     pr-ready-state.mjs \
     pr-ready-state-core.mjs \
-    pr-ready-state-format.mjs; do
+    pr-ready-state-format.mjs \
+    pr-ready-state-review-signals.mjs; do
     printf 'export {};\n' >"$review_repo/scripts/pr/$runtime_file"
   done
   commit_review_repo "$review_repo" init

--- a/scripts/agent-autoreview.test.sh
+++ b/scripts/agent-autoreview.test.sh
@@ -6040,6 +6040,108 @@ run_feedback_runtime_aggregate_regression() {
   fi
 }
 
+run_feedback_runtime_version_split_regression() {
+  local review_repo="$tmp_dir/feedback-runtime-version-split"
+  local post_split_bundle="$tmp_dir/feedback-runtime-post-split-bundle"
+  local pre_split_bundle="$tmp_dir/feedback-runtime-pre-split-bundle"
+  local missing_sibling_bundle="$tmp_dir/feedback-runtime-missing-sibling-bundle"
+  local pre_split_oid
+  local post_split_oid
+  local missing_sibling_oid
+  local runtime_file
+
+  init_review_repo "$review_repo"
+  git -C "$review_repo" remote add origin \
+    https://github.com/mento-protocol/monitoring-monorepo.git
+  mkdir -p "$review_repo/scripts/pr"
+  printf 'base\n' >"$review_repo/README.md"
+  cat >"$review_repo/scripts/pr/pr-feedback-state.mjs" <<'FEEDBACK_RUNTIME'
+#!/usr/bin/env node
+import { runtimeVersion } from "./pr-ready-state-core.mjs";
+process.stdout.write(
+  `{"findings":[],"testEvidence":{"runtimeVersion":"${runtimeVersion}"}}\n`,
+);
+FEEDBACK_RUNTIME
+  for runtime_file in \
+    pr-feedback-state-core.mjs \
+    pr-ready-state.mjs \
+    pr-ready-state-format.mjs; do
+    printf 'export {};\n' >"$review_repo/scripts/pr/$runtime_file"
+  done
+  printf 'export const runtimeVersion = "pre-split";\n' \
+    >"$review_repo/scripts/pr/pr-ready-state-core.mjs"
+  commit_review_repo "$review_repo" "pre-split feedback runtime"
+  pre_split_oid="$(git -C "$review_repo" rev-parse HEAD)"
+
+  cat >"$review_repo/scripts/pr/pr-ready-state-core.mjs" <<'POST_SPLIT_CORE'
+import { reviewSignalsVersion } from "./pr-ready-state-review-signals.mjs";
+export const runtimeVersion = `post-split:${reviewSignalsVersion}`;
+POST_SPLIT_CORE
+  printf 'export const reviewSignalsVersion = "present";\n' \
+    >"$review_repo/scripts/pr/pr-ready-state-review-signals.mjs"
+  commit_review_repo "$review_repo" "post-split feedback runtime"
+  post_split_oid="$(git -C "$review_repo" rev-parse HEAD)"
+
+  git -C "$review_repo" rm scripts/pr/pr-ready-state-review-signals.mjs \
+    >/dev/null
+  commit_review_repo "$review_repo" "drop post-split feedback sibling"
+  missing_sibling_oid="$(git -C "$review_repo" rev-parse HEAD)"
+
+  git -C "$review_repo" switch -c feature "$pre_split_oid" >/dev/null 2>&1
+  printf 'feature\n' >"$review_repo/feature.txt"
+  commit_review_repo "$review_repo" feature
+
+  git -C "$review_repo" update-ref \
+    refs/remotes/origin/main \
+    "$post_split_oid"
+  (
+    cd "$review_repo"
+    run_adapter \
+      --prepare-bundle-dir "$post_split_bundle" \
+      --mode branch \
+      --base "$pre_split_oid" \
+      --feedback-pr 1299
+  )
+  expect_file_contains \
+    "$post_split_bundle/feedback-state.json" \
+    '"runtimeVersion":"post-split:present"'
+  expect_empty_stderr
+
+  git -C "$review_repo" update-ref \
+    refs/remotes/origin/main \
+    "$pre_split_oid"
+  (
+    cd "$review_repo"
+    run_adapter \
+      --prepare-bundle-dir "$pre_split_bundle" \
+      --mode branch \
+      --base "$pre_split_oid" \
+      --feedback-pr 1299
+  )
+  expect_file_contains \
+    "$pre_split_bundle/feedback-state.json" \
+    '"runtimeVersion":"pre-split"'
+  expect_empty_stderr
+
+  git -C "$review_repo" update-ref \
+    refs/remotes/origin/main \
+    "$missing_sibling_oid"
+  (
+    cd "$review_repo"
+    run_adapter_expect_failure \
+      --prepare-bundle-dir "$missing_sibling_bundle" \
+      --mode branch \
+      --base "$pre_split_oid" \
+      --feedback-pr 1299
+  )
+  expect_stderr_contains "ERR_MODULE_NOT_FOUND"
+  expect_stderr_contains "pr-ready-state-review-signals.mjs"
+  if [[ -e "$missing_sibling_bundle" ]]; then
+    printf 'bundle was published without the post-split feedback sibling\n' >&2
+    exit 1
+  fi
+}
+
 # The feedback runtime lives only under scripts/pr/ (issue 1877, track D3), and
 # the wrapper reads every helper blob from the protected origin/main snapshot.
 # Two properties matter now the move is complete: the helpers resolve and run
@@ -8532,6 +8634,7 @@ run_bundle_integrity_family() {
   run_deploy_directory_checklist_routing_regression
   run_prepared_untracked_symlink_regression
   run_feedback_runtime_aggregate_regression
+  run_feedback_runtime_version_split_regression
   run_feedback_runtime_location_regression
   run_large_untracked_bound_regression
   run_aggregate_untracked_bound_regression


### PR DESCRIPTION
## The Problem

- The protected autoreview wrapper copied `pr-ready-state-core.mjs` without its split `pr-ready-state-review-signals.mjs` dependency.
- Numeric PR feedback capture failed with `ERR_MODULE_NOT_FOUND` before it could publish a review bundle.
- Coherent protected snapshots from before the split still need to work without the new sibling.

## The Solution

Add `pr-ready-state-review-signals.mjs` to the explicit optional feedback-runtime list. Post-split snapshots now copy the complete dependency closure. Pre-split snapshots remain valid because the sibling is optional and their core is self-contained. Incomplete post-split snapshots still fail closed before bundle publication.

## Details

- Add regression coverage for coherent post-split, coherent pre-split, and missing post-split runtimes.
- Include both optional version-split siblings in the aggregate runtime-cap fixture.
- Keep the existing byte, mode, size, source-root, and trust checks unchanged.
- Update ADR 0065 and the scripts path-pin instructions for both version-split optional siblings.
- Review the runtime change with the protected pre-change runtime at `8dd37a0a903be2cf31d0f39e8f0c62ccc1fb78ec`.
- The protected pre-change wrapper cannot complete numeric feedback capture because that missing dependency is the defect fixed here. The pre-publication review therefore used the trusted source bundle without `--feedback-pr`. The independently reviewed fixed runtime then captured and verified numeric feedback against exact head `54c08de6186a665337d461ce9f6f03e74e3e9c89`.

## Validation

- `pnpm agent:quality-gate --run` — passed all mapped checks.
- `AUTOREVIEW_TEST_FOCUS=bundle-integrity /bin/bash scripts/agent-autoreview.test.sh` — passed.
- `AUTOREVIEW_TEST_FOCUS=suite /bin/bash scripts/agent-autoreview.test.sh --jobs 1` — passed all five families in 767 seconds.
- Trusted bundle manifest `8db18db8a0fd5e0b2840b75b3dd6397b4d83adcbf384e67d06d7fe111566bdb7` — matched before and after a fresh-context review; review verdict: PASS.
- Exact-head PR-feedback bundle manifest `3415fbadf58b28cc76472561f98fe8b50b9a189da2355a33a0875ffd29241c6f` — matched before and after a fresh-context review; review verdict: PASS with no findings.
- `./tools/trunk fmt` — no issues.
- `node scripts/context/docs-index.mjs --check` — passed.
- `node scripts/context/check-agent-context.mjs` — passed for 153 managed files.
- Claude Security scan: skipped because this Codex session does not provide the Claude Code plugin. The quality gate and trusted closeout review covered the protected review-runtime boundary.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0065 records the existing explicit path-pin policy and now covers both optional siblings.

Closes #2015
