### PR TITLE
feat(scripts): Arkham intel-marathon pass 2 — populatedTags fix, cross-chain discovery, quota-aware sweep

### DIFF
--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -59,14 +59,14 @@
     "file": "src/app/bridge-flows/opengraph-image.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'Card' has too many lines (129). Maximum allowed is 100.",
-    "line": 91,
+    "line": 92,
     "linePreview": " | function Card({ data }: { data: BridgeFlowsOgData | null }) { | // null → \"—\" (snapshot query failed); 0 → \"$0\" (genuinely no bridge"
   },
   {
     "file": "src/app/opengraph-image.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'Card' has too many lines (158). Maximum allowed is 100.",
-    "line": 93,
+    "line": 94,
     "linePreview": " | function Card({ data }: { data: HomepageOgData | null }) { | // null → \"—\" (unavailable); 0 → \"$0.00\" (real empty state)."
   },
   {
@@ -122,28 +122,28 @@
     "file": "src/app/pool/[poolId]/opengraph-image.tsx",
     "ruleId": "complexity",
     "message": "Function 'Card' has a complexity of 24. Maximum allowed is 15.",
-    "line": 214,
+    "line": 215,
     "linePreview": " | function Card({ data }: { data: PoolOgData | null }) { | const name = data?.name ?? \"Mento Pool\";"
   },
   {
     "file": "src/app/pool/[poolId]/opengraph-image.tsx",
     "ruleId": "max-lines-per-function",
     "message": "Function 'Card' has too many lines (121). Maximum allowed is 100.",
-    "line": 214,
+    "line": 215,
     "linePreview": " | function Card({ data }: { data: PoolOgData | null }) { | const name = data?.name ?? \"Mento Pool\";"
   },
   {
     "file": "src/app/pools/_components/pools-page-client.tsx",
     "ruleId": "complexity",
     "message": "Function 'PoolsContent' has a complexity of 26. Maximum allowed is 15.",
-    "line": 67,
+    "line": 70,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing page component owns network data, table controls, and degraded-count messaging. | function PoolsContent({ | initialNetworkData,"
   },
   {
     "file": "src/app/pools/_components/pools-page-client.tsx",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 24 to the 18 allowed.",
-    "line": 67,
+    "line": 70,
     "linePreview": "// eslint-disable-next-line max-lines-per-function -- Existing page component owns network data, table controls, and degraded-count messaging. | function PoolsContent({ | initialNetworkData,"
   },
   {
@@ -241,14 +241,14 @@
     "file": "src/components/pool-header/deviation-cell.tsx",
     "ruleId": "complexity",
     "message": "Function 'DeviationCell' has a complexity of 23. Maximum allowed is 15.",
-    "line": 27,
+    "line": 28,
     "linePreview": " | export function DeviationCell({ | pool,"
   },
   {
     "file": "src/components/pool-header/uptime-value.tsx",
     "ruleId": "complexity",
     "message": "Function 'UptimeValue' has a complexity of 29. Maximum allowed is 15.",
-    "line": 79,
+    "line": 81,
     "linePreview": " | export function UptimeValue({ pool }: { pool: Pool }) { | const isVirtual = isVirtualPool(pool);"
   },
   {
@@ -316,30 +316,16 @@
   },
   {
     "file": "src/lib/arkham.ts",
-    "ruleId": "complexity",
-    "message": "Function 'toAddressEntry' has a complexity of 28. Maximum allowed is 15.",
-    "line": 223,
-    "linePreview": "*/ | export function toAddressEntry( | data: ArkhamMultiChainResponse,"
-  },
-  {
-    "file": "src/lib/arkham.ts",
     "ruleId": "max-depth",
     "message": "Blocks are nested too deeply (5). Maximum allowed is 4.",
-    "line": 334,
+    "line": 313,
     "linePreview": "} catch (retryErr) { | if (retryErr instanceof ArkhamAuthError) throw retryErr; | results.push({"
   },
   {
     "file": "src/lib/arkham.ts",
     "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 21 to the 18 allowed.",
-    "line": 223,
-    "linePreview": "*/ | export function toAddressEntry( | data: ArkhamMultiChainResponse,"
-  },
-  {
-    "file": "src/lib/arkham.ts",
-    "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 30 to the 18 allowed.",
-    "line": 309,
+    "line": 288,
     "linePreview": " | export async function enrichBatch( | addresses: string[],"
   },
   {

--- a/ui-dashboard/eslint-baseline.json
+++ b/ui-dashboard/eslint-baseline.json
@@ -317,29 +317,29 @@
   {
     "file": "src/lib/arkham.ts",
     "ruleId": "complexity",
-    "message": "Function 'toAddressEntry' has a complexity of 31. Maximum allowed is 15.",
-    "line": 186,
+    "message": "Function 'toAddressEntry' has a complexity of 28. Maximum allowed is 15.",
+    "line": 223,
     "linePreview": "*/ | export function toAddressEntry( | data: ArkhamMultiChainResponse,"
   },
   {
     "file": "src/lib/arkham.ts",
     "ruleId": "max-depth",
     "message": "Blocks are nested too deeply (5). Maximum allowed is 4.",
-    "line": 299,
+    "line": 334,
     "linePreview": "} catch (retryErr) { | if (retryErr instanceof ArkhamAuthError) throw retryErr; | results.push({"
   },
   {
     "file": "src/lib/arkham.ts",
     "ruleId": "sonarjs/cognitive-complexity",
-    "message": "Refactor this function to reduce its Cognitive Complexity from 26 to the 18 allowed.",
-    "line": 186,
+    "message": "Refactor this function to reduce its Cognitive Complexity from 21 to the 18 allowed.",
+    "line": 223,
     "linePreview": "*/ | export function toAddressEntry( | data: ArkhamMultiChainResponse,"
   },
   {
     "file": "src/lib/arkham.ts",
     "ruleId": "sonarjs/cognitive-complexity",
     "message": "Refactor this function to reduce its Cognitive Complexity from 30 to the 18 allowed.",
-    "line": 274,
+    "line": 309,
     "linePreview": " | export async function enrichBatch( | addresses: string[],"
   },
   {

--- a/ui-dashboard/scripts/arkham-smoke-test.mjs
+++ b/ui-dashboard/scripts/arkham-smoke-test.mjs
@@ -88,10 +88,23 @@ async function main() {
   let label;
   let entity;
   let topPred;
+  // Tag shapes: `populatedTags[].id` is current (2026-08); `tags[].slug` is the
+  // field it replaced. Read both so the readout shows which one arrived.
+  const tagSet = new Set();
+  let populatedTagCount = 0;
+  let legacyTagCount = 0;
   for (const perChain of Object.values(data)) {
     const trimmed = perChain.arkhamLabel?.name?.trim();
     if (!label && trimmed) label = trimmed;
     if (!entity && perChain.arkhamEntity?.name) entity = perChain.arkhamEntity;
+    for (const t of perChain.populatedTags ?? []) {
+      populatedTagCount++;
+      if (t.id) tagSet.add(t.id);
+    }
+    for (const t of perChain.tags ?? []) {
+      legacyTagCount++;
+      if (t.slug) tagSet.add(t.slug);
+    }
     for (const p of perChain.entityPredictions ?? []) {
       if (p.confidence < HIGH_CONFIDENCE) continue;
       if (!topPred || p.confidence > topPred.confidence) topPred = p;
@@ -101,6 +114,10 @@ async function main() {
   console.log("\n→ Quality gate:");
   console.log(`  arkhamLabel: ${label ?? "(none)"}`);
   console.log(`  arkhamEntity: ${entity?.name ?? "(none)"}`);
+  console.log(
+    `  tags: ${tagSet.size === 0 ? "(none)" : Array.from(tagSet).join(", ")}` +
+      ` [populatedTags=${populatedTagCount} legacy tags=${legacyTagCount}]`,
+  );
   console.log(
     `  top prediction: ${topPred?.entityId ?? "(none)"} @ ${
       topPred ? `${(topPred.confidence * 100).toFixed(0)}%` : "—"

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -59,6 +59,17 @@ case "$STAGE" in
     ;;
 esac
 
+# mirror-to-blob reads only local .intel-marathon/*.jsonl plus Vercel Blob —
+# it must not die on missing Upstash credentials either.
+case "$STAGE" in
+  mirror-to-blob | mirror)
+    NEEDS_UPSTASH=0
+    ;;
+  *)
+    NEEDS_UPSTASH=1
+    ;;
+esac
+
 # Resolve one credential: keep the exported value, else read it from tfvars.
 # Returns non-zero when neither is available — with a named error unless the
 # caller passed `optional` (a dry run, where the credential is unused).
@@ -90,7 +101,7 @@ fi
 # Fetch the per-DB REST token from the Upstash mgmt API — skipped entirely when
 # both REST vars are already exported.
 if [ -z "${UPSTASH_REDIS_REST_URL:-}" ] || [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; then
-  if [ "$DRY_RUN" = "1" ]; then
+  if [ "$DRY_RUN" = "1" ] || [ "$NEEDS_UPSTASH" = "0" ]; then
     resolve UPSTASH_EMAIL upstash_email optional || true
     resolve UPSTASH_API_KEY upstash_api_key optional || true
   else

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
-# Marathon launcher: bootstraps credentials from terraform.tfvars + Upstash
-# mgmt API, exports env vars, exec's the requested stage script.
+# Marathon launcher: resolves credentials, exports env vars, exec's the
+# requested stage script.
+#
+# Credentials come from the environment first. Anything still unset is read
+# from terraform.tfvars (plus the Upstash mgmt API for the per-DB REST token),
+# which exists only in a full clone — git worktrees have no terraform/ tree, so
+# export the vars yourself there. A credential the stage needs and that is
+# neither exported nor extractable is a named, fatal error.
+#
+#   ARKHAM_API_KEY                      ← tfvars `arkham_api_key`
+#   UPSTASH_REDIS_REST_URL/_REST_TOKEN  ← Upstash mgmt API, itself authorized by
+#                                         tfvars `upstash_email`/`upstash_api_key`
+#
+# `tier1-bulk-enrich --dry-run` calls neither Arkham nor Upstash, so it runs
+# with no credentials at all.
 #
 # Usage:
 #   bash ui-dashboard/scripts/intel-marathon/run.sh baseline-snapshot
-#   bash ui-dashboard/scripts/intel-marathon/run.sh tier1-bulk-enrich --chain 42220
+#   bash ui-dashboard/scripts/intel-marathon/run.sh tier1-bulk-enrich --dry-run
+#   bash ui-dashboard/scripts/intel-marathon/run.sh tier1-bulk-enrich
 #   bash ui-dashboard/scripts/intel-marathon/run.sh tier2-light-forensic --limit 150
 #   bash ui-dashboard/scripts/intel-marathon/run.sh verify
 #   bash ui-dashboard/scripts/intel-marathon/run.sh upload-drafts
@@ -24,20 +38,59 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 TFVARS="$REPO_ROOT/terraform/terraform.tfvars"
 DB_ID="c687bf0d-f61f-498e-879a-016de335b4ce"
 
-# Read tfvars-managed credentials.
-extract() {
-  grep -E "^$1" "$TFVARS" | sed 's/.*= *"//;s/"$//'
-}
-ARKHAM_API_KEY=$(extract arkham_api_key)
-UPSTASH_EMAIL=$(extract upstash_email)
-UPSTASH_API_KEY=$(extract upstash_api_key)
+# A dry run touches neither Arkham nor Upstash — resolve credentials
+# best-effort so it works in a worktree with nothing exported.
+DRY_RUN=0
+for arg in "$@"; do
+  if [ "$arg" = "--dry-run" ]; then DRY_RUN=1; fi
+done
 
-# Fetch the per-DB REST token from the Upstash mgmt API.
-RESPONSE=$(curl -s -u "${UPSTASH_EMAIL}:${UPSTASH_API_KEY}" \
-  "https://api.upstash.com/v2/redis/database/${DB_ID}")
-UPSTASH_REDIS_REST_TOKEN=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['rest_token'])")
-UPSTASH_ENDPOINT=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['endpoint'])")
-UPSTASH_REDIS_REST_URL="https://${UPSTASH_ENDPOINT}"
+# Resolve one credential: keep the exported value, else read it from tfvars.
+# Returns non-zero when neither is available — with a named error unless the
+# caller passed `optional` (a dry run, where the credential is unused).
+resolve() {
+  local var="$1" tfkey="$2" optional="${3:-}" value
+  if [ -n "${!var:-}" ]; then return 0; fi
+  if [ -f "$TFVARS" ]; then
+    # grep exits 1 on no match; `|| true` keeps `set -e` from killing the run
+    # before the explicit error below.
+    value=$(grep -E "^$tfkey" "$TFVARS" | sed 's/.*= *"//;s/"$//' || true)
+    if [ -n "$value" ]; then
+      printf -v "$var" '%s' "$value"
+      return 0
+    fi
+  fi
+  if [ "$optional" != "optional" ]; then
+    echo "Missing $var: not exported, and not readable from $TFVARS (key: $tfkey)." >&2
+    echo "Export $var, or run from a clone that has terraform/terraform.tfvars." >&2
+  fi
+  return 1
+}
+
+if [ "$DRY_RUN" = "1" ]; then
+  resolve ARKHAM_API_KEY arkham_api_key optional || true
+else
+  resolve ARKHAM_API_KEY arkham_api_key
+fi
+
+# Fetch the per-DB REST token from the Upstash mgmt API — skipped entirely when
+# both REST vars are already exported.
+if [ -z "${UPSTASH_REDIS_REST_URL:-}" ] || [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; then
+  if [ "$DRY_RUN" = "1" ]; then
+    resolve UPSTASH_EMAIL upstash_email optional || true
+    resolve UPSTASH_API_KEY upstash_api_key optional || true
+  else
+    resolve UPSTASH_EMAIL upstash_email
+    resolve UPSTASH_API_KEY upstash_api_key
+  fi
+  if [ -n "${UPSTASH_EMAIL:-}" ] && [ -n "${UPSTASH_API_KEY:-}" ]; then
+    RESPONSE=$(curl -s -u "${UPSTASH_EMAIL}:${UPSTASH_API_KEY}" \
+      "https://api.upstash.com/v2/redis/database/${DB_ID}")
+    UPSTASH_REDIS_REST_TOKEN=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['rest_token'])")
+    UPSTASH_ENDPOINT=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['endpoint'])")
+    UPSTASH_REDIS_REST_URL="https://${UPSTASH_ENDPOINT}"
+  fi
+fi
 
 export ARKHAM_API_KEY UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN
 

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -99,8 +99,10 @@ else
 fi
 
 # Fetch the per-DB REST token from the Upstash mgmt API — skipped entirely when
-# both REST vars are already exported.
-if [ -z "${UPSTASH_REDIS_REST_URL:-}" ] || [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; then
+# both REST vars are already exported, and never attempted for stages that do
+# not read Upstash at all (a mgmt-API network failure would abort under
+# `set -e` before a Blob-only stage ever ran).
+if [ "$NEEDS_UPSTASH" = "1" ] && { [ -z "${UPSTASH_REDIS_REST_URL:-}" ] || [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; }; then
   if [ "$DRY_RUN" = "1" ] || [ "$NEEDS_UPSTASH" = "0" ]; then
     resolve UPSTASH_EMAIL upstash_email optional || true
     resolve UPSTASH_API_KEY upstash_api_key optional || true

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -57,7 +57,7 @@ resolve() {
   if [ -f "$TFVARS" ]; then
     # grep exits 1 on no match; `|| true` keeps `set -e` from killing the run
     # before the explicit error below.
-    value=$(grep -E "^${tfkey}[[:space:]]*=" "$TFVARS" | sed 's/.*= *"//;s/"$//' || true)
+    value=$(grep -E "^[[:space:]]*${tfkey}[[:space:]]*=" "$TFVARS" | sed 's/.*= *"//;s/"$//' || true)
     if [ -n "$value" ]; then
       printf -v "$var" '%s' "$value"
       return 0

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -12,8 +12,11 @@
 #   UPSTASH_REDIS_REST_URL/_REST_TOKEN  ← Upstash mgmt API, itself authorized by
 #                                         tfvars `upstash_email`/`upstash_api_key`
 #
-# `tier1-bulk-enrich --dry-run` calls neither Arkham nor Upstash, so it runs
-# with no credentials at all.
+# `tier1-bulk-enrich --dry-run` never calls Arkham, so it needs no
+# ARKHAM_API_KEY. It DOES still use Upstash when credentials resolve: the dry
+# run reads the `labels` hash so its tier sizes are real, and this launcher
+# still mints a REST token below when tfvars is readable. It writes nothing.
+# With no credentials at all the dry run works too, reporting tier 1 as 0.
 #
 # Usage:
 #   bash ui-dashboard/scripts/intel-marathon/run.sh baseline-snapshot

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -57,7 +57,7 @@ resolve() {
   if [ -f "$TFVARS" ]; then
     # grep exits 1 on no match; `|| true` keeps `set -e` from killing the run
     # before the explicit error below.
-    value=$(grep -E "^$tfkey" "$TFVARS" | sed 's/.*= *"//;s/"$//' || true)
+    value=$(grep -E "^${tfkey}[[:space:]]*=" "$TFVARS" | sed 's/.*= *"//;s/"$//' || true)
     if [ -n "$value" ]; then
       printf -v "$var" '%s' "$value"
       return 0

--- a/ui-dashboard/scripts/intel-marathon/run.sh
+++ b/ui-dashboard/scripts/intel-marathon/run.sh
@@ -48,6 +48,17 @@ for arg in "$@"; do
   if [ "$arg" = "--dry-run" ]; then DRY_RUN=1; fi
 done
 
+# Stages that never call Arkham (Upstash/Blob only) — the Arkham key is
+# resolved best-effort for them so a worktree without it can still run them.
+case "$STAGE" in
+  verify | verify-libs | inspect | measure | mirror-to-blob | mirror | migrate-rename | rename | upload-drafts | tier0)
+    NEEDS_ARKHAM=0
+    ;;
+  *)
+    NEEDS_ARKHAM=1
+    ;;
+esac
+
 # Resolve one credential: keep the exported value, else read it from tfvars.
 # Returns non-zero when neither is available — with a named error unless the
 # caller passed `optional` (a dry run, where the credential is unused).
@@ -70,7 +81,7 @@ resolve() {
   return 1
 }
 
-if [ "$DRY_RUN" = "1" ]; then
+if [ "$DRY_RUN" = "1" ] || [ "$NEEDS_ARKHAM" = "0" ]; then
   resolve ARKHAM_API_KEY arkham_api_key optional || true
 else
   resolve ARKHAM_API_KEY arkham_api_key

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 /**
- * Tier 1 — bulk Arkham sweep of every distinct address that has interacted
- * with Mento, via /intelligence/address_enriched/{addr}/all. Persists into
- * Upstash `labels` hash (source: "arkham").
+ * Tier 1 — bulk Arkham sweep of the distinct EXTERNAL-ACTOR addresses in the
+ * indexer's data, via /intelligence/address_enriched/{addr}/all. Persists
+ * into Upstash `labels` hash (source: "arkham").
  *
  * Discovery reads the indexer's PER-ADDRESS ROLLUP entities rather than raw
  * event tables: one row per address instead of one row per event, so a full
  * sweep costs ~80 Hasura pages instead of thousands. Rollups carry no chain
  * filter — Arkham keys on the address, and EVM addresses are chain-agnostic.
+ * This is narrower than the production cron's DISCOVERY_TARGETS by design:
+ * protocol actors (isProtocolActor), router/pool contract fields
+ * (SwapEvent.recipient/.txTo, RebalanceEvent.*, Pool.rebalancerAddress), and
+ * BridgeTransfer.recipient (≈ its senders) are deliberately excluded.
+ * A discovery source that errors ABORTS the run before any quota is spent —
+ * a partial set looks identical to full coverage afterwards; pass
+ * --allow-partial-discovery to proceed anyway.
  *
  * Enrichment order (cap-aware; the trial's Intel Label quota is the binding
  * constraint, not throughput):
@@ -64,6 +71,10 @@
  *   --limit N          cap the number of addresses enriched this run
  *   --quota-floor N    stop when Intel Label Remaining <= N (default 50)
  *   --no-refresh       skip step 1; only enrich addresses with no label
+ *   --allow-partial-discovery
+ *                      proceed even when a discovery source errored (the run
+ *                      normally aborts to avoid spending quota on a silently
+ *                      incomplete sweep)
  *   --chain <id>       output-file scope tag only (default "all"). Discovery
  *                      is cross-chain; pass this only to resume a prior
  *                      per-chain progress file.
@@ -96,6 +107,7 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 const refresh = !args.includes("--no-refresh");
+const allowPartialDiscovery = args.includes("--allow-partial-discovery");
 
 function flagValue(name) {
   const i = args.indexOf(name);
@@ -104,11 +116,25 @@ function flagValue(name) {
   return raw === undefined || raw.startsWith("--") ? undefined : raw;
 }
 
+/**
+ * Numeric flag with a hard parse failure. A typo'd `--quota-floor 5O` would
+ * otherwise become NaN, and every `remaining <= NaN` comparison is false — the
+ * quota brake would look configured and never fire.
+ */
+function numericFlag(name, fallback) {
+  const raw = flagValue(name);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(`Invalid ${name}: ${raw} (expected a non-negative number)`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 const scope = flagValue("--chain") ?? "all";
-const limitArg = flagValue("--limit") ? Number(flagValue("--limit")) : Infinity;
-const quotaFloor = flagValue("--quota-floor")
-  ? Number(flagValue("--quota-floor"))
-  : QUOTA_FLOOR_DEFAULT;
+const limitArg = numericFlag("--limit", Infinity);
+const quotaFloor = numericFlag("--quota-floor", QUOTA_FLOOR_DEFAULT);
 
 // Discovery is unauthenticated Hasura, so --dry-run needs no credentials.
 const required = dryRun
@@ -221,6 +247,7 @@ async function pageSource(source) {
 async function discoverAll() {
   console.log("→ Discovery from per-address rollups (all chains)...");
   const registry = new Map(); // address → { sources, volumeWei, nonBroker }
+  const failedSources = [];
   const perSource = {}; // "Table.field" → distinct address count
   for (const source of DISCOVERY_SOURCES) {
     for (const field of source.addressFields) {
@@ -261,10 +288,22 @@ async function discoverAll() {
       );
     } catch (err) {
       console.warn(`  ⚠ ${source.table}: ${err.message}`);
+      failedSources.push(source.table);
       for (const field of source.addressFields) {
         perSource[`${source.table}.${field}`] = `ERROR: ${err.message}`;
       }
     }
+  }
+  // A failed source silently shrinks the sweep — quota spent against an
+  // incomplete discovery set looks identical to full coverage afterwards.
+  // Abort instead, unless the caller explicitly accepted the gap.
+  if (failedSources.length > 0 && !allowPartialDiscovery) {
+    console.error(
+      `✗ Discovery incomplete — ${failedSources.length} source(s) failed: ` +
+        `${failedSources.join(", ")}. Re-run, or pass ` +
+        `--allow-partial-discovery to enrich the partial set anyway.`,
+    );
+    process.exit(1);
   }
   console.log(`→ Discovery total (deduped): ${registry.size} addresses`);
   return { registry, perSource };
@@ -463,16 +502,21 @@ function buildQueue(registry, existing) {
 // not to consume quota, but the numbers come from the API either way.
 //
 // Two sources, in precedence order. Response headers are authoritative and
-// per-request, so once any have been seen they own the values. The
+// per-request, so once they have been seen they own the values. The
 // /subscription/intel-usage body is the fallback: the headers are unverified,
 // and without a fallback a header-less API would leave `remaining` null and the
 // --quota-floor stop would never fire.
+//
+// Precedence is tracked per-field for `remaining`, not for the header set as a
+// whole: an API that sends Usage/Limit but no Remaining must not switch off the
+// body fallback, or `remaining` would stay null and the stop would never fire.
 const quota = {
   usage: null,
   limit: null,
   remaining: null,
   seen: false, // any source has reported numbers
   fromHeaders: false, // response headers have reported numbers at least once
+  remainingFromHeaders: false, // a header has reported Remaining specifically
 };
 
 const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
@@ -496,7 +540,10 @@ function noteQuotaHeaders(res) {
     remaining < quota.remaining;
   if (usage !== null) quota.usage = usage;
   if (limit !== null) quota.limit = limit;
-  if (remaining !== null) quota.remaining = remaining;
+  if (remaining !== null) {
+    quota.remaining = remaining;
+    quota.remainingFromHeaders = true;
+  }
   quota.seen = true;
   quota.fromHeaders = true;
   return dropped;
@@ -506,7 +553,7 @@ function quotaLine() {
   if (!quota.seen) return "quota not yet observed";
   return `usage=${quota.usage ?? "?"} limit=${quota.limit ?? "?"} remaining=${
     quota.remaining ?? "?"
-  } via=${quota.fromHeaders ? "headers" : "intel-usage"}`;
+  } via=${quota.remainingFromHeaders ? "headers" : "intel-usage"}`;
 }
 
 // Live body shape (probed 2026-08-24):
@@ -537,9 +584,10 @@ async function logIntelUsage(context) {
       return;
     }
     const body = await res.json();
-    // Headers win once seen. Otherwise every poll refreshes the body-derived
-    // numbers, so the --quota-floor stop stays live on a header-less API.
-    if (!quota.fromHeaders) {
+    // A Remaining header wins once seen. Until then every poll refreshes the
+    // body-derived numbers, so the --quota-floor stop stays live on an API that
+    // sends no Remaining header at all — or only Usage/Limit.
+    if (!quota.remainingFromHeaders) {
       const remaining = remainingFromUsageBody(body);
       if (remaining !== null) {
         quota.remaining = remaining;
@@ -606,16 +654,17 @@ function toAddressEntry(data) {
     !label && !entity && topPred
       ? `Arkham prediction (${Math.round(topPred.confidence * 100)}% confidence)`
       : undefined;
-  return {
+  // sanitizeEntry(), as the lib's toAddressEntry does — a NEW entry gets the
+  // same trim / case-insensitive tag dedup / length caps the dashboard's own
+  // writes get, not just the merged refresh path below.
+  return sanitizeEntry({
     name,
-    tags: Array.from(tagSet)
-      .slice(0, 20)
-      .map((t) => String(t).slice(0, 50)),
+    tags: Array.from(tagSet),
     notes: note,
     isPublic: false,
     source: "arkham",
     updatedAt: new Date().toISOString(),
-  };
+  });
 }
 
 // Entry-shape limits, mirroring ui-dashboard/src/lib/address-labels-shared.ts.

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -286,6 +286,10 @@ async function discoverAll() {
           capped ? " ⚠ HARD_PAGE_CAP hit — truncated" : ""
         }`,
       );
+      // A capped source is exactly as incomplete as an errored one — silently
+      // sweeping a truncated registry defeats the abort-on-partial-discovery
+      // guarantee this function otherwise enforces.
+      if (capped) failedSources.push(source.table);
     } catch (err) {
       console.warn(`  ⚠ ${source.table}: ${err.message}`);
       failedSources.push(source.table);
@@ -679,14 +683,19 @@ const AUTO_NOTE_PREFIX = "Arkham prediction (";
 // union of fresh + existing tags can exceed the cap.
 function sanitizeEntry(entry) {
   const seenTags = new Set();
-  const tags = entry.tags.slice(0, MAX_TAGS_COUNT).flatMap((raw) => {
-    const t = String(raw).trim().slice(0, MAX_TAG_LENGTH);
-    if (!t) return [];
-    const key = t.toLowerCase();
-    if (seenTags.has(key)) return [];
-    seenTags.add(key);
-    return [t];
-  });
+  // Dedupe/drop-blank BEFORE capping — otherwise a blank or duplicate tag
+  // early in the list consumes a slot in the 20-item cap that a later,
+  // genuinely unique tag never gets to fill.
+  const tags = entry.tags
+    .flatMap((raw) => {
+      const t = String(raw).trim().slice(0, MAX_TAG_LENGTH);
+      if (!t) return [];
+      const key = t.toLowerCase();
+      if (seenTags.has(key)) return [];
+      seenTags.add(key);
+      return [t];
+    })
+    .slice(0, MAX_TAGS_COUNT);
   const notes = entry.notes?.slice(0, MAX_NOTES_LENGTH);
   return {
     ...entry,
@@ -723,8 +732,12 @@ function buildWriteEntry(fresh, current) {
     return { ...fresh, createdAt: current?.createdAt ?? fresh.updatedAt };
   }
   const isAutoNote = current.notes?.startsWith(AUTO_NOTE_PREFIX) === true;
+  // Existing tags first: `current.tags` can carry Tier 2's forensic ctp:/type:
+  // tags (curated, one-shot) ahead of a bulk Arkham tag dump. Now that
+  // populatedTags can fill the 20-tag cap on its own, putting `fresh` first
+  // would let a routine refresh silently evict that curated content.
   const tags = withoutArkhamTags(
-    Array.from(new Set([...fresh.tags, ...(current.tags ?? [])])),
+    Array.from(new Set([...(current.tags ?? []), ...fresh.tags])),
   );
   return sanitizeEntry({
     name: fresh.name,
@@ -921,8 +934,17 @@ async function main() {
     const batch = pendingWrites.splice(0, pendingWrites.length);
     const news = batch.filter((w) => w.mode === "new");
     const refreshes = batch.filter((w) => w.mode === "refresh");
-    if (news.length > 0) await flushNewWrites(news);
-    if (refreshes.length > 0) await flushRefreshWrites(refreshes);
+    try {
+      if (news.length > 0) await flushNewWrites(news);
+      if (refreshes.length > 0) await flushRefreshWrites(refreshes);
+    } catch (err) {
+      // Put the batch back so the next flush retries it instead of dropping
+      // already-fetched, quality-gate-passed results. Each address already
+      // has a `{address, status}` line in progressFile from the per-address
+      // loop, so a write lost here would never be retried on resume.
+      pendingWrites.unshift(...batch);
+      throw err;
+    }
   }
 
   /** Halt on errors that every remaining address would hit too. */
@@ -1009,7 +1031,6 @@ async function main() {
       );
       appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
       recordResult(address, status, data);
-      if (pendingWrites.length >= HSET_BATCH) await flushWrites();
       if (dropped) console.log(`  quota ↓ after ${address}: ${quotaLine()}`);
     } catch (err) {
       await haltIfFatal(err.message);
@@ -1047,6 +1068,13 @@ async function main() {
         await noteFailure(err.message);
       }
     }
+    // Outside the Arkham try/catch above: a storage failure here is not an
+    // Arkham enrichment error and must not be absorbed by noteFailure() (which
+    // would reset consecutiveErrors on the next successful fetch and mask a
+    // sustained Upstash outage from the circuit breaker). Let it propagate to
+    // main().catch() and halt the run instead of grinding through the whole
+    // queue while silently writing nothing.
+    if (pendingWrites.length >= HSET_BATCH) await flushWrites();
     const done = i + 1;
     if (done % QUOTA_LOG_EVERY === 0) {
       await flushWrites();

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -75,6 +75,10 @@
  *                      proceed even when a discovery source errored (the run
  *                      normally aborts to avoid spending quota on a silently
  *                      incomplete sweep)
+ *   --allow-unknown-quota
+ *                      start even when the startup /subscription/intel-usage
+ *                      poll yielded no Remaining (the run normally refuses
+ *                      rather than sweep with no quota ceiling visible)
  *   --chain <id>       output-file scope tag only (default "all"). Discovery
  *                      is cross-chain; pass this only to resume a prior
  *                      per-chain progress file.
@@ -146,6 +150,12 @@ function numericFlag(name, fallback) {
   return parsed;
 }
 
+// `--chain` picks the progress/inventory filenames; silently falling back to
+// "all" on a missing value would resume the wrong file.
+if (args.includes("--chain") && flagValue("--chain") === undefined) {
+  console.error("Missing value for --chain (expected a scope tag)");
+  process.exit(1);
+}
 const scope = flagValue("--chain") ?? "all";
 const limitArg = numericFlag("--limit", Infinity);
 const quotaFloor = numericFlag("--quota-floor", QUOTA_FLOOR_DEFAULT);
@@ -884,6 +894,19 @@ async function main() {
   console.log(`→ ${candidates.length} addresses to enrich this run`);
 
   await logIntelUsage("start");
+  // Fail closed on unknown quota. If the startup poll yielded nothing (timeout,
+  // non-2xx, unrecognized body) and no header has reported Remaining, the floor
+  // check would compare against null forever and the sweep would run unbounded.
+  // Headers only start arriving with the first enrichment response, so this is
+  // the last safe moment to refuse.
+  if (quota.remaining === null && !args.includes("--allow-unknown-quota")) {
+    console.error(
+      "✗ Quota unknown: /subscription/intel-usage yielded no Remaining. " +
+        "Refusing to start an unbounded sweep — retry, or pass " +
+        "--allow-unknown-quota to proceed on header-based accounting alone.",
+    );
+    process.exit(1);
+  }
 
   let attested = 0;
   let written = 0;

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -901,6 +901,11 @@ async function main() {
     for (let i = 0; i < batch.length; i++) {
       if (Number(results[i]?.result) === 1) {
         written++;
+        appendFileSync(
+          progressFile,
+          JSON.stringify({ address: batch[i].address, write: "written" }) +
+            "\n",
+        );
         continue;
       }
       newSkippedExists++;
@@ -922,6 +927,10 @@ async function main() {
     for (const w of batch) {
       if (!skipped.has(w.address)) {
         written++;
+        appendFileSync(
+          progressFile,
+          JSON.stringify({ address: w.address, write: "written" }) + "\n",
+        );
         continue;
       }
       refreshSkippedChanged++;
@@ -938,10 +947,13 @@ async function main() {
       if (news.length > 0) await flushNewWrites(news);
       if (refreshes.length > 0) await flushRefreshWrites(refreshes);
     } catch (err) {
-      // Put the batch back so the next flush retries it instead of dropping
-      // already-fetched, quality-gate-passed results. Each address already
-      // has a `{address, status}` line in progressFile from the per-address
-      // loop, so a write lost here would never be retried on resume.
+      // Put the batch back (protects an in-process retry, e.g. a later
+      // threshold flush succeeding after a transient blip) and re-throw so
+      // the caller halts rather than silently grinding through the queue.
+      // recordResult() deliberately never wrote a progressFile line for
+      // these addresses, so if the process halts here instead of retrying,
+      // a resumed run re-fetches and re-attempts them rather than skipping
+      // addresses whose write never landed.
       pendingWrites.unshift(...batch);
       throw err;
     }
@@ -995,6 +1007,7 @@ async function main() {
     consecutiveErrors = 0;
     if (status !== 200 || !data) {
       nullCount++;
+      appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
       return;
     }
     const entry = toAddressEntry(data);
@@ -1002,10 +1015,16 @@ async function main() {
       // Quality gate failed. On a refresh this deliberately leaves the prior
       // entry in place rather than deleting it.
       nullCount++;
+      appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
       return;
     }
     // The start snapshot decides the write mode. Absent then → HSETNX now;
     // present then → compare-and-set against the `updatedAt` we read.
+    // Progress for this address is recorded once the write is durably
+    // confirmed (flushNewWrites/flushRefreshWrites/noteSkip), not here —
+    // recording it now would let a resumed run skip an address whose label
+    // write never actually landed (e.g. the process halts on a flush
+    // failure before this batch is retried).
     const current = existing[address];
     pendingWrites.push({
       address,
@@ -1029,7 +1048,8 @@ async function main() {
         rawFile,
         JSON.stringify({ address, status, data, ts: Date.now() }) + "\n",
       );
-      appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
+      // recordResult() records progress itself, once the outcome (no write
+      // needed, or the write's durable result) is actually known.
       recordResult(address, status, data);
       if (dropped) console.log(`  quota ↓ after ${address}: ${quotaLine()}`);
     } catch (err) {
@@ -1045,10 +1065,6 @@ async function main() {
           appendFileSync(
             rawFile,
             JSON.stringify({ address, status, data, ts: Date.now() }) + "\n",
-          );
-          appendFileSync(
-            progressFile,
-            JSON.stringify({ address, status }) + "\n",
           );
           recordResult(address, status, data);
         } catch (retryErr) {

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -1024,15 +1024,17 @@ async function main() {
       appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
       return;
     }
-    // Body-sourced quota (no response header has ever reported a number) only
-    // refreshes via the periodic /subscription/intel-usage poll below, so
-    // `quota.remaining` can otherwise sit stale for up to INTEL_USAGE_EVERY
-    // requests while the floor check keeps comparing against it. Decrement it
-    // locally on every 200-with-data lookup — each one consumed an Intel
-    // Label datapoint on Arkham's side regardless of our own quality gate —
-    // so the floor check stays live between polls. Once headers appear,
+    // Body-sourced `remaining` only refreshes via the periodic
+    // /subscription/intel-usage poll below, so it can otherwise sit stale for
+    // up to INTEL_USAGE_EVERY requests while the floor check keeps comparing
+    // against it. Decrement it locally on every 200-with-data lookup — each
+    // one consumed an Intel Label datapoint on Arkham's side regardless of
+    // our own quality gate — so the floor check stays live between polls.
+    // Gate on remainingFromHeaders, NOT fromHeaders: a response that carries
+    // Usage/Limit but omits Remaining still leaves `remaining` body-sourced,
+    // and must keep this decrement active. Once a header reports Remaining,
     // noteQuotaHeaders() takes over per-request and this is a no-op.
-    if (!quota.fromHeaders && quota.remaining !== null) {
+    if (!quota.remainingFromHeaders && quota.remaining !== null) {
       quota.remaining -= 1;
     }
     const entry = toAddressEntry(data);
@@ -1131,7 +1133,7 @@ async function main() {
     // enough to the floor that a 500-request gap between real polls risks
     // overshooting it.
     const intelUsageEvery =
-      !quota.fromHeaders &&
+      !quota.remainingFromHeaders &&
       quota.remaining !== null &&
       quota.remaining - quotaFloor < 500
         ? 100

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -1024,6 +1024,17 @@ async function main() {
       appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
       return;
     }
+    // Body-sourced quota (no response header has ever reported a number) only
+    // refreshes via the periodic /subscription/intel-usage poll below, so
+    // `quota.remaining` can otherwise sit stale for up to INTEL_USAGE_EVERY
+    // requests while the floor check keeps comparing against it. Decrement it
+    // locally on every 200-with-data lookup — each one consumed an Intel
+    // Label datapoint on Arkham's side regardless of our own quality gate —
+    // so the floor check stays live between polls. Once headers appear,
+    // noteQuotaHeaders() takes over per-request and this is a no-op.
+    if (!quota.fromHeaders && quota.remaining !== null) {
+      quota.remaining -= 1;
+    }
     const entry = toAddressEntry(data);
     if (!entry) {
       // Quality gate failed. On a refresh this deliberately leaves the prior
@@ -1113,7 +1124,19 @@ async function main() {
         `  [${done}/${candidates.length}] attested=${attested} written=${written} skipExists=${newSkippedExists} skipChanged=${refreshSkippedChanged} null=${nullCount} errors=${errorCount} elapsed=${elapsed}s ${quotaLine()}`,
       );
     }
-    if (done % INTEL_USAGE_EVERY === 0) await logIntelUsage(`after ${done}`);
+    // Tighten the poll cadence near the floor while quota is body-sourced —
+    // the local per-address decrement above is a best-effort estimate (an
+    // unlabeled 404 may not consume a datapoint the same way), so refresh
+    // against the authoritative body more often once the estimate is close
+    // enough to the floor that a 500-request gap between real polls risks
+    // overshooting it.
+    const intelUsageEvery =
+      !quota.fromHeaders &&
+      quota.remaining !== null &&
+      quota.remaining - quotaFloor < 500
+        ? 100
+        : INTEL_USAGE_EVERY;
+    if (done % intelUsageEvery === 0) await logIntelUsage(`after ${done}`);
     if (i < candidates.length - 1) await sleep(REQ_SPACING_MS);
   }
 

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -136,7 +136,9 @@ function numericFlag(name, fallback) {
     }
     return fallback;
   }
-  const parsed = Number(raw);
+  // Number("") and Number("   ") are 0, so a shell-expansion accident like
+  // `--limit "$UNSET_VAR"` would silently become 0 instead of erroring.
+  const parsed = raw.trim() === "" ? NaN : Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) {
     console.error(`Invalid ${name}: ${raw} (expected a non-negative number)`);
     process.exit(1);

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -2,17 +2,71 @@
 /**
  * Tier 1 — bulk Arkham sweep of every distinct address that has interacted
  * with Mento, via /intelligence/address_enriched/{addr}/all. Persists into
- * Upstash `labels` hash (source: "arkham"), skipping manually-labeled addrs.
+ * Upstash `labels` hash (source: "arkham").
  *
- * Discovery extends ui-dashboard/src/lib/mento-address-discovery.ts
- * DISCOVERY_TARGETS with five sources the cron is missing.
+ * Discovery reads the indexer's PER-ADDRESS ROLLUP entities rather than raw
+ * event tables: one row per address instead of one row per event, so a full
+ * sweep costs ~80 Hasura pages instead of thousands. Rollups carry no chain
+ * filter — Arkham keys on the address, and EVM addresses are chain-agnostic.
  *
- * Resumes from .intel-marathon/tier1-progress-{chainId}.jsonl on restart.
+ * Enrichment order (cap-aware; the trial's Intel Label quota is the binding
+ * constraint, not throughput):
+ *   1. existing arkham-sourced `labels` entries (refresh, on by default)
+ *   2. every non-Broker-trader discovery (LPs, bridgers, borrowers, SP
+ *      depositors, trove owners, OLS callers, FPMM traders, yield positions)
+ *   3. Broker traders, descending by lifetime USD volume
+ *
+ * Write rules:
+ *   - manual entries (not arkham-sourced) are never enriched and never touched
+ *   - arkham-sourced entries are MERGED with the fresh result on the canonical
+ *     `mergeRefreshEntry` rules from ui-dashboard/src/lib/arkham.ts: Arkham
+ *     owns `name` and contributes tags, while `createdAt`, `isPublic`, and
+ *     user-edited `notes` survive the refresh. Only an auto-generated
+ *     "Arkham prediction (…)" note is replaced by the fresh one. A pass-1
+ *     entry that a human later curated or published keeps that state.
+ *   - a fresh result that fails the quality gate leaves the existing entry
+ *     in place
+ *   - unlabeled addresses are written as new entries
+ *
+ * Writes are race-safe. The `labels` snapshot is read once, but the run spans
+ * 70+ minutes over ~68k addresses, so a human editing the address book
+ * mid-run would otherwise be clobbered by a blind HSET. Mirroring
+ * `importLabelsIfAbsent` / `importArkhamRefreshLabelsIfUnchanged` in
+ * ui-dashboard/src/lib/address-labels.ts:
+ *   - new addresses go in via HSETNX, so anything that appeared at that field
+ *     mid-run wins
+ *   - refreshes go through a compare-and-set EVAL that writes only while the
+ *     stored row is still arkham-sourced AND its `updatedAt` still matches the
+ *     snapshot; a user edit or a deletion beats a stale refresh
+ * Both checks also enforce the manual-entry rule at the write boundary, not
+ * just in the queue filter. Skips are counted and logged per category.
+ *
+ * Quota: every enrichment response's X-Intel-Datapoints-{Usage,Limit,Remaining}
+ * headers are recorded, GET /subscription/intel-usage (free) is polled at start
+ * and every 500 addresses, and the run stops cleanly once Remaining reaches
+ * --quota-floor. The headers are unverified, so the intel-usage body
+ * (totalLimit - totalCount) seeds the same stop logic when they never appear.
+ * Two more brakes back that up: HTTP 402/403 halts immediately, and 10
+ * consecutive enrichment errors trip a circuit breaker rather than grinding
+ * the whole queue into failures.
+ *
+ * Resumes from .intel-marathon/tier1-progress-{scope}.jsonl on restart.
  *
  * Usage:
+ *   node ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs --dry-run
  *   UPSTASH_REDIS_REST_URL=... UPSTASH_REDIS_REST_TOKEN=... ARKHAM_API_KEY=... \
- *   node ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs --chain 42220
- *   node ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs --chain 143
+ *   node ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+ *
+ * Flags:
+ *   --dry-run          discovery + prioritization + counts only; no Arkham
+ *                      calls, no Upstash writes, no files written, and no
+ *                      ARKHAM_API_KEY required
+ *   --limit N          cap the number of addresses enriched this run
+ *   --quota-floor N    stop when Intel Label Remaining <= N (default 50)
+ *   --no-refresh       skip step 1; only enrich addresses with no label
+ *   --chain <id>       output-file scope tag only (default "all"). Discovery
+ *                      is cross-chain; pass this only to resume a prior
+ *                      per-chain progress file.
  */
 
 import process from "node:process";
@@ -27,18 +81,39 @@ import {
 const ARKHAM_BASE = "https://api.arkm.com";
 const HASURA_URL = "https://indexer.hyperindex.xyz/2f3dd15/v1/graphql";
 const OUT_DIR = ".intel-marathon";
-const PAGE_SIZE = 1000;
-const HARD_PAGE_CAP = 100;
-const REQ_SPACING_MS = 60; // standard bucket, ~16 req/s
+const PAGE_SIZE = 1000; // Hasura row cap
+const HARD_PAGE_CAP = 250; // 250k rows/source — sentinel against runaway loops
+const REQ_SPACING_MS = 60; // standard bucket (100 req/s), ~16 req/s sustained
 const RATE_LIMIT_BACKOFF_MS = 1500;
 const HIGH_CONFIDENCE = 0.85;
 const HSET_BATCH = 100;
+const QUOTA_FLOOR_DEFAULT = 50;
+const QUOTA_LOG_EVERY = 100; // log header-derived quota every N requests
+const INTEL_USAGE_EVERY = 500; // poll /subscription/intel-usage every N addresses
+const MAX_CONSECUTIVE_ERRORS = 10; // circuit breaker on a wedged/exhausted API
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-const required = [
-  "UPSTASH_REDIS_REST_URL",
-  "UPSTASH_REDIS_REST_TOKEN",
-  "ARKHAM_API_KEY",
-];
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const refresh = !args.includes("--no-refresh");
+
+function flagValue(name) {
+  const i = args.indexOf(name);
+  if (i < 0) return undefined;
+  const raw = args[i + 1];
+  return raw === undefined || raw.startsWith("--") ? undefined : raw;
+}
+
+const scope = flagValue("--chain") ?? "all";
+const limitArg = flagValue("--limit") ? Number(flagValue("--limit")) : Infinity;
+const quotaFloor = flagValue("--quota-floor")
+  ? Number(flagValue("--quota-floor"))
+  : QUOTA_FLOOR_DEFAULT;
+
+// Discovery is unauthenticated Hasura, so --dry-run needs no credentials.
+const required = dryRun
+  ? []
+  : ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN", "ARKHAM_API_KEY"];
 const missing = required.filter((k) => !process.env[k]);
 if (missing.length > 0) {
   console.error(`Missing env: ${missing.join(", ")}`);
@@ -48,51 +123,49 @@ if (missing.length > 0) {
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const arkhamKey = process.env.ARKHAM_API_KEY;
-
-const args = process.argv.slice(2);
-const chainArgIdx = args.indexOf("--chain");
-if (chainArgIdx < 0 || !args[chainArgIdx + 1]) {
-  console.error("Usage: --chain <chainId> (e.g. 42220 or 143)");
-  process.exit(1);
-}
-const chainId = Number(args[chainArgIdx + 1]);
-const limitArgIdx = args.indexOf("--limit");
-const limitArg = limitArgIdx >= 0 ? Number(args[limitArgIdx + 1]) : Infinity;
+const hasUpstash = Boolean(redisUrl && redisToken);
 
 // ---------------------------------------------------------------------------
-// Discovery — superset of mento-address-discovery.ts DISCOVERY_TARGETS.
-// Per-(table, field) tuple; chainIdColumn defaults to `chainId`.
+// Discovery — per-address rollup entities (field names from
+// indexer-envio/schema.graphql). `brokerTrader` marks the one source that is
+// deprioritized to the tail of the queue; everything else shares tier 2.
 // ---------------------------------------------------------------------------
 
-const DISCOVERY_TARGETS = [
-  // Existing cron targets (mirror DISCOVERY_TARGETS from lib).
-  { table: "SwapEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "SwapEvent", field: "recipient", chainIdColumn: "chainId" },
-  { table: "SwapEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "SwapEvent", field: "txTo", chainIdColumn: "chainId" },
-  { table: "LiquidityEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "LiquidityEvent", field: "recipient", chainIdColumn: "chainId" },
-  { table: "RebalanceEvent", field: "sender", chainIdColumn: "chainId" },
-  { table: "RebalanceEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "LiquidityPosition", field: "address", chainIdColumn: "chainId" },
-  { table: "OlsLiquidityEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "BridgeTransfer", field: "sender", chainIdColumn: "sourceChainId" },
-  { table: "BridgeTransfer", field: "recipient", chainIdColumn: "destChainId" },
-  // NEW: marathon-specific extensions.
-  { table: "TraderDailySnapshot", field: "trader", chainIdColumn: "chainId" },
+const DISCOVERY_SOURCES = [
   {
-    table: "BrokerTraderDailySnapshot",
-    field: "caller",
-    chainIdColumn: "chainId",
+    table: "TraderAllTimeAggregate",
+    addressFields: ["trader"],
+    volumeField: "volumeUsdWei",
+    where: "{ isProtocolActor: { _eq: false } }",
   },
-  { table: "BrokerSwapEvent", field: "caller", chainIdColumn: "chainId" },
-  { table: "Trove", field: "owner", chainIdColumn: "chainId" },
-  { table: "Pool", field: "rebalancerAddress", chainIdColumn: "chainId" },
+  {
+    table: "BrokerTraderAllTimeAggregate",
+    addressFields: ["caller"],
+    volumeField: "volumeUsdWei",
+    where: "{ isProtocolActor: { _eq: false } }",
+    brokerTrader: true,
+  },
+  { table: "LiquidityPosition", addressFields: ["address"] },
+  { table: "BorrowerInfo", addressFields: ["address"] },
+  { table: "StabilityPoolDepositor", addressFields: ["address"] },
+  { table: "Trove", addressFields: ["owner", "previousOwner"] },
+  { table: "BridgeBridger", addressFields: ["sender"] },
+  { table: "StethPosition", addressFields: ["wallet"] },
+  { table: "SusdsPosition", addressFields: ["wallet"] },
+  // Event tables, not rollups: page with distinct_on so one row lands per
+  // address. `LiquidityEvent.sender` is deliberately absent — it holds the
+  // router/pool contract, not the LP.
+  {
+    table: "OlsLiquidityEvent",
+    addressFields: ["caller"],
+    distinctOn: "caller",
+  },
+  {
+    table: "LiquidityEvent",
+    addressFields: ["recipient"],
+    distinctOn: "recipient",
+  },
 ];
-
-// BridgeBridger has no chainId column (one row per cross-chain sender).
-// Query it separately, no chain filter.
-const CROSS_CHAIN_TARGETS = [{ table: "BridgeBridger", field: "sender" }];
 
 const isValidAddress = (v) =>
   typeof v === "string" && /^0x[a-f0-9]{40}$/.test(v);
@@ -111,75 +184,94 @@ async function hasura(query, variables) {
   return body.data;
 }
 
-async function fetchDistinct(target, chain) {
-  const { table, field, chainIdColumn } = target;
-  const filter = chainIdColumn
-    ? `where: { ${chainIdColumn}: { _eq: $chainId } }`
-    : "";
-  const vars = chainIdColumn
-    ? { chainId: chain, limit: PAGE_SIZE, offset: 0 }
-    : { limit: PAGE_SIZE, offset: 0 };
-  const all = new Set();
-  for (let page = 0; page < HARD_PAGE_CAP; page++) {
-    vars.offset = page * PAGE_SIZE;
-    const query = `query Q($chainId: Int, $limit: Int!, $offset: Int!) {
+async function pageSource(source) {
+  const { table, addressFields, volumeField, where, distinctOn } = source;
+  const selection = [...addressFields, ...(volumeField ? [volumeField] : [])];
+  // distinct_on requires order_by to lead with the same column; plain rollup
+  // pages order by the primary key so offset stepping is stable.
+  const orderField = distinctOn ?? "id";
+  const clauses = [
+    where ? `where: ${where}` : "",
+    distinctOn ? `distinct_on: [${distinctOn}]` : "",
+    `order_by: { ${orderField}: asc }`,
+    "limit: $limit",
+    "offset: $offset",
+  ].filter(Boolean);
+  const query = `query Q($limit: Int!, $offset: Int!) {
       rows: ${table}(
-        ${filter}
-        distinct_on: [${field}]
-        order_by: { ${field}: asc }
-        limit: $limit
-        offset: $offset
+        ${clauses.join("\n        ")}
       ) {
-        address: ${field}
+        ${selection.join("\n        ")}
       }
     }`;
-    const data = await hasura(query, vars);
+
+  const out = [];
+  for (let page = 0; page < HARD_PAGE_CAP; page++) {
+    const data = await hasura(query, {
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    });
     const rows = data.rows ?? [];
-    if (rows.length === 0) break;
-    for (const r of rows) {
-      const lower = r.address?.toLowerCase();
-      if (lower && isValidAddress(lower)) all.add(lower);
-    }
-    if (rows.length < PAGE_SIZE) break;
+    out.push(...rows);
+    if (rows.length < PAGE_SIZE) return { rows: out, capped: false };
   }
-  return Array.from(all);
+  return { rows: out, capped: true };
 }
 
-async function discoverAll(chain) {
-  console.log(`→ Discovery for chain ${chain}...`);
-  const counts = {};
-  const all = new Set();
-  for (const target of DISCOVERY_TARGETS) {
-    try {
-      const found = await fetchDistinct(target, chain);
-      counts[`${target.table}.${target.field}`] = found.length;
-      for (const a of found) all.add(a);
-      console.log(`  ${target.table}.${target.field}: ${found.length}`);
-    } catch (err) {
-      console.warn(`  ⚠ ${target.table}.${target.field}: ${err.message}`);
-      counts[`${target.table}.${target.field}`] = `ERROR: ${err.message}`;
+async function discoverAll() {
+  console.log("→ Discovery from per-address rollups (all chains)...");
+  const registry = new Map(); // address → { sources, volumeWei, nonBroker }
+  const perSource = {}; // "Table.field" → distinct address count
+  for (const source of DISCOVERY_SOURCES) {
+    for (const field of source.addressFields) {
+      perSource[`${source.table}.${field}`] = 0;
     }
-  }
-  // Cross-chain targets (no chain filter, run once per script invocation; we still
-  // include them for both chains since they're chain-agnostic).
-  for (const target of CROSS_CHAIN_TARGETS) {
     try {
-      const found = await fetchDistinct(target, null);
-      counts[`${target.table}.${target.field}`] = found.length;
-      for (const a of found) all.add(a);
+      const { rows, capped } = await pageSource(source);
+      for (const row of rows) {
+        const volume = source.volumeField
+          ? BigInt(row[source.volumeField] ?? "0")
+          : 0n;
+        for (const field of source.addressFields) {
+          const address = row[field]?.toLowerCase();
+          if (!isValidAddress(address) || address === ZERO_ADDRESS) continue;
+          const key = `${source.table}.${field}`;
+          let rec = registry.get(address);
+          if (!rec) {
+            rec = { sources: [], volumeWei: 0n, nonBroker: false };
+            registry.set(address, rec);
+          }
+          if (!rec.sources.includes(key)) {
+            rec.sources.push(key);
+            perSource[key]++;
+          }
+          // Sum: TraderAllTimeAggregate is per (chainId, trader), and the same
+          // address can trade on both the v3 and v2 Broker paths.
+          rec.volumeWei += volume;
+          if (!source.brokerTrader) rec.nonBroker = true;
+        }
+      }
+      const counted = source.addressFields
+        .map((f) => `${f}=${perSource[`${source.table}.${f}`]}`)
+        .join(" ");
       console.log(
-        `  ${target.table}.${target.field}: ${found.length} (cross-chain)`,
+        `  ${source.table}: ${rows.length} rows → ${counted}${
+          capped ? " ⚠ HARD_PAGE_CAP hit — truncated" : ""
+        }`,
       );
     } catch (err) {
-      console.warn(`  ⚠ ${target.table}.${target.field}: ${err.message}`);
+      console.warn(`  ⚠ ${source.table}: ${err.message}`);
+      for (const field of source.addressFields) {
+        perSource[`${source.table}.${field}`] = `ERROR: ${err.message}`;
+      }
     }
   }
-  console.log(`→ Discovery total (deduped): ${all.size} addresses`);
-  return { addresses: Array.from(all).sort(), counts };
+  console.log(`→ Discovery total (deduped): ${registry.size} addresses`);
+  return { registry, perSource };
 }
 
 // ---------------------------------------------------------------------------
-// Upstash + existing-label filter
+// Upstash + candidate prioritization
 // ---------------------------------------------------------------------------
 
 async function upstash(path, init = {}) {
@@ -218,9 +310,8 @@ async function pipeline(commands) {
 }
 
 async function getLabels() {
-  // HGETALL of the entire `labels` hash. Used to filter out manually-labeled
-  // addresses (don't clobber). Per arkham.ts filterCandidates: in "new" mode,
-  // only unlabeled addresses get enriched.
+  // HGETALL of the entire `labels` hash — the manual/arkham split below is
+  // decided from it.
   const { result } = await upstash(`/hgetall/labels`);
   const map = {};
   for (let i = 0; i < result.length; i += 2) {
@@ -234,18 +325,234 @@ async function getLabels() {
   return map;
 }
 
-function filterCandidates(candidates, existing) {
-  return candidates.flatMap((a) => {
-    const address = a.toLowerCase();
+/**
+ * Compare-and-set refresh, adapted from
+ * HSET_ARKHAM_REFRESH_IF_UNCHANGED_SCRIPT in
+ * ui-dashboard/src/lib/address-labels.ts. ARGV is (field, expectedUpdatedAt,
+ * value) triples. Writes only while the stored row is still arkham-sourced and
+ * its `updatedAt` still matches what this run read at start; a row edited,
+ * re-sourced, or deleted mid-run is left alone.
+ *
+ * Returns the list of SKIPPED fields rather than the lib's written count, so
+ * the caller can attribute each skip to its address in the progress file.
+ */
+const REFRESH_IF_UNCHANGED_SCRIPT = `
+local skipped = {}
+for i = 1, #ARGV, 3 do
+  local field = ARGV[i]
+  local expected_updated_at = ARGV[i + 1]
+  local value = ARGV[i + 2]
+  local write_ok = false
+  local current = redis.call("HGET", KEYS[1], field)
+  if current ~= false then
+    local ok, parsed = pcall(cjson.decode, current)
+    if ok and type(parsed) == "table" then
+      local is_arkham = parsed["source"] == "arkham"
+      local tags = parsed["tags"]
+      if not is_arkham and type(tags) == "table" then
+        for _, tag in ipairs(tags) do
+          if tag == "arkham" then
+            is_arkham = true
+            break
+          end
+        end
+      end
+      local raw_updated_at = parsed["updatedAt"]
+      local current_updated_at = type(raw_updated_at) == "string" and raw_updated_at or ""
+      if is_arkham and current_updated_at == expected_updated_at then
+        write_ok = true
+      end
+    end
+  end
+  if write_ok then
+    redis.call("HSET", KEYS[1], field, value)
+  else
+    skipped[#skipped + 1] = field
+  end
+end
+return skipped
+`;
+
+const ARKHAM_TAG = "arkham";
+
+// Mirrors isArkhamSourced() in ui-dashboard/src/lib/address-labels-shared.ts:
+// new entries carry `source: "arkham"`, pre-source-field entries carry the
+// exact `"arkham"` tag sentinel. Non-exact display tags stay manual.
+function isArkhamSourced(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  return entry.source === "arkham" || entry.tags?.includes(ARKHAM_TAG) === true;
+}
+
+/**
+ * Order the work: arkham-sourced refreshes first, then everything discovered
+ * outside the Broker trader rollup, then Broker traders by lifetime USD volume
+ * descending. Manually-labeled addresses drop out entirely.
+ */
+function buildQueue(registry, existing) {
+  const queue = [];
+  const seen = new Set();
+  let manualSkipped = 0;
+  let labeledSkipped = 0;
+
+  if (refresh) {
+    const refreshTier = Object.entries(existing)
+      .filter(
+        ([address, entry]) => isValidAddress(address) && isArkhamSourced(entry),
+      )
+      .map(([address]) => address)
+      .sort();
+    for (const address of refreshTier) {
+      const rec = registry.get(address);
+      queue.push({
+        address,
+        tier: "refresh",
+        sources: rec?.sources ?? ["labels:arkham"],
+        volumeWei: rec?.volumeWei ?? 0n,
+      });
+      seen.add(address);
+    }
+  }
+
+  const discovery = [];
+  const brokerTraders = [];
+  for (const [address, rec] of registry) {
+    if (seen.has(address)) continue;
     const current = existing[address];
-    if (!current) return [address];
-    return []; // labeled (manual or arkham) — skip
-  });
+    if (current) {
+      if (isArkhamSourced(current)) labeledSkipped++;
+      else manualSkipped++;
+      continue;
+    }
+    const item = {
+      address,
+      tier: rec.nonBroker ? "discovery" : "broker-trader",
+      sources: rec.sources,
+      volumeWei: rec.volumeWei,
+    };
+    (rec.nonBroker ? discovery : brokerTraders).push(item);
+  }
+
+  // Volume desc, address asc as the tie-break so the order is reproducible
+  // across runs (needed for resume to line up with the prior run's progress).
+  const byVolume = (a, b) => {
+    if (a.volumeWei !== b.volumeWei) return a.volumeWei > b.volumeWei ? -1 : 1;
+    return a.address < b.address ? -1 : 1;
+  };
+  discovery.sort(byVolume);
+  brokerTraders.sort(byVolume);
+
+  queue.push(...discovery, ...brokerTraders);
+  return {
+    queue,
+    tiers: {
+      refresh: queue.length - discovery.length - brokerTraders.length,
+      discovery: discovery.length,
+      brokerTrader: brokerTraders.length,
+    },
+    manualSkipped,
+    labeledSkipped,
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Arkham — fetch + map to AddressEntry, mirrors arkham.ts toAddressEntry().
+// Arkham — fetch + quota accounting + map to AddressEntry.
 // ---------------------------------------------------------------------------
+
+// Trial plan: 10,000 unique labeled-address lookups per billing period
+// ("Intel Label Limit"). Observed rather than assumed — unlabeled 404s appear
+// not to consume quota, but the numbers come from the API either way.
+//
+// Two sources, in precedence order. Response headers are authoritative and
+// per-request, so once any have been seen they own the values. The
+// /subscription/intel-usage body is the fallback: the headers are unverified,
+// and without a fallback a header-less API would leave `remaining` null and the
+// --quota-floor stop would never fire.
+const quota = {
+  usage: null,
+  limit: null,
+  remaining: null,
+  seen: false, // any source has reported numbers
+  fromHeaders: false, // response headers have reported numbers at least once
+};
+
+const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
+
+function headerNumber(res, name) {
+  const raw = res.headers.get(name);
+  if (raw === null || raw.trim() === "") return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Records the quota headers; returns true when Remaining dropped. */
+function noteQuotaHeaders(res) {
+  const usage = headerNumber(res, "X-Intel-Datapoints-Usage");
+  const limit = headerNumber(res, "X-Intel-Datapoints-Limit");
+  const remaining = headerNumber(res, "X-Intel-Datapoints-Remaining");
+  if (usage === null && limit === null && remaining === null) return false;
+  const dropped =
+    quota.remaining !== null &&
+    remaining !== null &&
+    remaining < quota.remaining;
+  if (usage !== null) quota.usage = usage;
+  if (limit !== null) quota.limit = limit;
+  if (remaining !== null) quota.remaining = remaining;
+  quota.seen = true;
+  quota.fromHeaders = true;
+  return dropped;
+}
+
+function quotaLine() {
+  if (!quota.seen) return "quota not yet observed";
+  return `usage=${quota.usage ?? "?"} limit=${quota.limit ?? "?"} remaining=${
+    quota.remaining ?? "?"
+  } via=${quota.fromHeaders ? "headers" : "intel-usage"}`;
+}
+
+// Live body shape (probed 2026-08-24):
+//   { totalCount, totalLimit, chainUsage: {...}, periodStart }
+// Derive remaining from that pair; the "*remaining*" key scan is the secondary
+// path in case the shape changes.
+function remainingFromUsageBody(body) {
+  if (!body || typeof body !== "object") return null;
+  if (isFiniteNumber(body.totalLimit) && isFiniteNumber(body.totalCount)) {
+    return body.totalLimit - body.totalCount;
+  }
+  for (const [key, value] of Object.entries(body)) {
+    if (/remaining/i.test(key) && isFiniteNumber(value)) return value;
+  }
+  return null;
+}
+
+/** Free endpoint — does not consume Intel Label quota. */
+async function logIntelUsage(context) {
+  try {
+    const res = await fetch(`${ARKHAM_BASE}/subscription/intel-usage`, {
+      headers: { "API-Key": arkhamKey },
+      signal: AbortSignal.timeout(15_000),
+    });
+    noteQuotaHeaders(res);
+    if (!res.ok) {
+      console.warn(`  ⚠ intel-usage (${context}): HTTP ${res.status}`);
+      return;
+    }
+    const body = await res.json();
+    // Headers win once seen. Otherwise every poll refreshes the body-derived
+    // numbers, so the --quota-floor stop stays live on a header-less API.
+    if (!quota.fromHeaders) {
+      const remaining = remainingFromUsageBody(body);
+      if (remaining !== null) {
+        quota.remaining = remaining;
+        quota.seen = true;
+      }
+      if (isFiniteNumber(body.totalCount)) quota.usage = body.totalCount;
+      if (isFiniteNumber(body.totalLimit)) quota.limit = body.totalLimit;
+    }
+    console.log(`  intel-usage (${context}): ${JSON.stringify(body)}`);
+  } catch (err) {
+    console.warn(`  ⚠ intel-usage (${context}) failed: ${err.message}`);
+  }
+}
 
 async function fetchEnriched(address) {
   const url = new URL(
@@ -259,13 +566,19 @@ async function fetchEnriched(address) {
     headers: { "API-Key": arkhamKey },
     signal: AbortSignal.timeout(15_000),
   });
-  if (res.status === 404) return { status: 404, data: null };
+  const dropped = noteQuotaHeaders(res);
+  if (res.status === 404) return { status: 404, data: null, dropped };
   if (res.status === 401) throw new Error("ARKHAM_AUTH_FAIL");
+  // 402 Payment Required / 403 Forbidden — the plan is refusing the call, so
+  // the rest of the queue would refuse too. Halt rather than burn it.
+  if (res.status === 402 || res.status === 403)
+    throw new Error("ARKHAM_ENTITLEMENT");
   if (res.status === 429) throw new Error("ARKHAM_RATE_LIMITED");
   if (!res.ok) throw new Error(`arkham_http_${res.status}`);
-  return { status: 200, data: await res.json() };
+  return { status: 200, data: await res.json(), dropped };
 }
 
+// Mirrors arkham.ts toAddressEntry().
 function toAddressEntry(data) {
   let label, entity, topPred;
   const tagSet = new Set();
@@ -275,6 +588,9 @@ function toAddressEntry(data) {
     if (!entity && perChain.arkhamEntity?.name?.trim())
       entity = perChain.arkhamEntity;
     if (entity?.type) tagSet.add(entity.type);
+    // `populatedTags[].id` is the current field; `tags[].slug` is the one it
+    // replaced in 2026-08. Union both so either shape yields tags.
+    for (const t of perChain.populatedTags ?? []) if (t.id) tagSet.add(t.id);
     for (const t of perChain.tags ?? []) if (t.slug) tagSet.add(t.slug);
     for (const p of perChain.entityPredictions ?? []) {
       if (p.confidence < HIGH_CONFIDENCE) continue;
@@ -302,17 +618,138 @@ function toAddressEntry(data) {
   };
 }
 
+// Entry-shape limits, mirroring ui-dashboard/src/lib/address-labels-shared.ts.
+const MAX_NAME_LENGTH = 200;
+const MAX_NOTES_LENGTH = 500;
+const MAX_TAGS_COUNT = 20;
+const MAX_TAG_LENGTH = 50;
+const AUTO_NOTE_PREFIX = "Arkham prediction (";
+
+// Mirrors sanitizeEntry(): truncate name/notes, cap tag count and length,
+// trim and case-insensitively dedup tags. Needed after a merge because the
+// union of fresh + existing tags can exceed the cap.
+function sanitizeEntry(entry) {
+  const seenTags = new Set();
+  const tags = entry.tags.slice(0, MAX_TAGS_COUNT).flatMap((raw) => {
+    const t = String(raw).trim().slice(0, MAX_TAG_LENGTH);
+    if (!t) return [];
+    const key = t.toLowerCase();
+    if (seenTags.has(key)) return [];
+    seenTags.add(key);
+    return [t];
+  });
+  const notes = entry.notes?.slice(0, MAX_NOTES_LENGTH);
+  return {
+    ...entry,
+    name: entry.name.trim().slice(0, MAX_NAME_LENGTH),
+    tags,
+    ...(notes !== undefined ? { notes } : {}),
+  };
+}
+
+// Mirrors withoutArkhamTags(): the legacy provenance sentinel never survives
+// into a merged tag set — provenance lives in `source`.
+function withoutArkhamTags(tags) {
+  return tags.filter((tag) => String(tag).trim().toLowerCase() !== ARKHAM_TAG);
+}
+
+/**
+ * Merge a fresh Arkham result into the existing entry, mirroring
+ * `mergeRefreshEntry` in ui-dashboard/src/lib/arkham.ts exactly.
+ *
+ * Arkham owns `name` and contributes tags; `createdAt`, `isPublic`, and
+ * user-edited `notes` survive the refresh. A pass-1 entry that a human later
+ * curated or published in the address-book UI keeps that state — an overwrite
+ * would silently un-publish it, since fresh entries always carry
+ * `isPublic: false`. Only our own auto-generated "Arkham prediction (…)" note
+ * is replaced by the fresh one.
+ *
+ * A null fresh entry (quality gate failed) never reaches here, so the existing
+ * entry survives untouched. Manual entries never reach here either — buildQueue
+ * drops them — which is why the non-arkham branch just returns `fresh`, as the
+ * lib does.
+ */
+function buildWriteEntry(fresh, current) {
+  if (!current || !isArkhamSourced(current)) {
+    return { ...fresh, createdAt: current?.createdAt ?? fresh.updatedAt };
+  }
+  const isAutoNote = current.notes?.startsWith(AUTO_NOTE_PREFIX) === true;
+  const tags = withoutArkhamTags(
+    Array.from(new Set([...fresh.tags, ...(current.tags ?? [])])),
+  );
+  return sanitizeEntry({
+    name: fresh.name,
+    tags,
+    notes: isAutoNote ? fresh.notes : (current.notes ?? fresh.notes),
+    isPublic: current.isPublic ?? fresh.isPublic,
+    source: "arkham",
+    createdAt: current.createdAt ?? fresh.updatedAt,
+    updatedAt: fresh.updatedAt,
+  });
+}
+
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
+function printPlan(perSource, registry, plan) {
+  console.log("");
+  console.log("→ Per-source distinct addresses:");
+  for (const [key, count] of Object.entries(perSource)) {
+    console.log(`  ${key}: ${count}`);
+  }
+  console.log(`  TOTAL deduped: ${registry.size}`);
+  console.log("");
+  console.log("→ Enrichment plan:");
+  console.log(`  1. refresh (arkham-sourced labels): ${plan.tiers.refresh}`);
+  console.log(`  2. discovery (non-Broker-trader):   ${plan.tiers.discovery}`);
+  console.log(
+    `  3. Broker traders by volume:        ${plan.tiers.brokerTrader}`,
+  );
+  console.log(`  skipped, manual label:              ${plan.manualSkipped}`);
+  console.log(`  skipped, already arkham-labeled:    ${plan.labeledSkipped}`);
+  console.log(`  QUEUE TOTAL:                        ${plan.queue.length}`);
+}
+
 async function main() {
   const startedAt = Date.now();
+  const { registry, perSource } = await discoverAll();
+
+  // Dry runs still read labels when Upstash creds happen to be present, so the
+  // tier sizes are real rather than "everything is new".
+  let existing = {};
+  if (hasUpstash) {
+    console.log("→ Loading existing labels from Upstash...");
+    existing = await getLabels();
+    console.log(
+      `  ${Object.keys(existing).length} entries currently in labels`,
+    );
+  } else if (dryRun) {
+    console.log("→ No Upstash credentials — tier 1 (refresh) reported as 0.");
+  }
+
+  const plan = buildQueue(registry, existing);
+
+  if (dryRun) {
+    printPlan(perSource, registry, plan);
+    const top = plan.queue
+      .filter((c) => c.tier === "broker-trader")
+      .slice(0, 10);
+    if (top.length > 0) {
+      console.log("");
+      console.log("→ Top Broker traders by lifetime USD volume (wei):");
+      for (const c of top) console.log(`  ${c.address} ${c.volumeWei}`);
+    }
+    console.log("");
+    console.log("✓ Dry run — no Arkham calls, no writes.");
+    return;
+  }
+
   mkdirSync(OUT_DIR, { recursive: true });
-  const rawFile = `${OUT_DIR}/tier1-raw-${chainId}.jsonl`;
-  const progressFile = `${OUT_DIR}/tier1-progress-${chainId}.jsonl`;
+  const rawFile = `${OUT_DIR}/tier1-raw-${scope}.jsonl`;
+  const progressFile = `${OUT_DIR}/tier1-progress-${scope}.jsonl`;
 
   // Resume: load already-processed addresses from prior runs.
   const processed = new Set();
@@ -331,75 +768,202 @@ async function main() {
     console.log(`→ Resuming: ${processed.size} addresses already processed`);
   }
 
-  // Discovery
-  const { addresses, counts } = await discoverAll(chainId);
   writeFileSync(
-    `${OUT_DIR}/tier1-inventory-${chainId}.json`,
+    `${OUT_DIR}/tier1-inventory-${scope}.json`,
     JSON.stringify(
-      { chainId, counts, totalDeduped: addresses.length },
+      {
+        scope,
+        refresh,
+        perSource,
+        totalDeduped: registry.size,
+        tiers: plan.tiers,
+        manualSkipped: plan.manualSkipped,
+        labeledSkipped: plan.labeledSkipped,
+        queueTotal: plan.queue.length,
+      },
       null,
       2,
     ),
   );
-
-  // Filter against existing labels + already-processed.
-  console.log(`→ Loading existing labels from Upstash...`);
-  const existing = await getLabels();
-  console.log(`  ${Object.keys(existing).length} entries currently in labels`);
-  let candidates = filterCandidates(addresses, existing);
-  candidates = candidates.filter((a) => !processed.has(a));
-  if (candidates.length > limitArg) candidates = candidates.slice(0, limitArg);
-  console.log(
-    `→ ${candidates.length} candidates to enrich (after filtering existing + resume)`,
+  // Per-address provenance, in queue order — what surfaced each address and
+  // the lifetime USD volume that ranked it.
+  writeFileSync(
+    `${OUT_DIR}/tier1-plan-${scope}.jsonl`,
+    plan.queue
+      .map((c) =>
+        JSON.stringify({
+          address: c.address,
+          tier: c.tier,
+          sources: c.sources,
+          volumeUsdWei: String(c.volumeWei),
+        }),
+      )
+      .join("\n") + "\n",
   );
+  printPlan(perSource, registry, plan);
+
+  let candidates = plan.queue.filter((c) => !processed.has(c.address));
+  if (candidates.length > limitArg) candidates = candidates.slice(0, limitArg);
+  console.log("");
+  console.log(`→ ${candidates.length} addresses to enrich this run`);
+
+  await logIntelUsage("start");
 
   let attested = 0;
+  let written = 0;
+  let newSkippedExists = 0;
+  let refreshSkippedChanged = 0;
   let nullCount = 0;
   let errorCount = 0;
+  let stoppedForQuota = false;
+  let consecutiveErrors = 0;
   const pendingWrites = [];
-  let processedSinceLastFlush = 0;
+
+  function noteSkip(address, reason) {
+    appendFileSync(
+      progressFile,
+      JSON.stringify({ address, write: reason }) + "\n",
+    );
+  }
+
+  /** HSETNX batch — anything that appeared at the field mid-run wins. */
+  async function flushNewWrites(batch) {
+    const results = await pipeline(
+      batch.map((w) => [
+        "HSETNX",
+        "labels",
+        w.address,
+        JSON.stringify(w.entry),
+      ]),
+    );
+    for (let i = 0; i < batch.length; i++) {
+      if (Number(results[i]?.result) === 1) {
+        written++;
+        continue;
+      }
+      newSkippedExists++;
+      noteSkip(batch[i].address, "skipped_exists");
+    }
+  }
+
+  /** Compare-and-set batch — a row edited or deleted mid-run wins. */
+  async function flushRefreshWrites(batch) {
+    const argv = batch.flatMap((w) => [
+      w.address,
+      w.expectedUpdatedAt,
+      JSON.stringify(w.entry),
+    ]);
+    const [response] = await pipeline([
+      ["EVAL", REFRESH_IF_UNCHANGED_SCRIPT, "1", "labels", ...argv],
+    ]);
+    const skipped = new Set(response?.result ?? []);
+    for (const w of batch) {
+      if (!skipped.has(w.address)) {
+        written++;
+        continue;
+      }
+      refreshSkippedChanged++;
+      noteSkip(w.address, "skipped_changed");
+    }
+  }
 
   async function flushWrites() {
     if (pendingWrites.length === 0) return;
-    const commands = pendingWrites.map((w) => [
-      "HSET",
-      "labels",
-      w.address,
-      JSON.stringify(w.entry),
-    ]);
-    await pipeline(commands);
-    pendingWrites.length = 0;
+    const batch = pendingWrites.splice(0, pendingWrites.length);
+    const news = batch.filter((w) => w.mode === "new");
+    const refreshes = batch.filter((w) => w.mode === "refresh");
+    if (news.length > 0) await flushNewWrites(news);
+    if (refreshes.length > 0) await flushRefreshWrites(refreshes);
+  }
+
+  /** Halt on errors that every remaining address would hit too. */
+  async function haltIfFatal(message) {
+    if (message === "ARKHAM_AUTH_FAIL") {
+      console.error("✗ Arkham key rejected. Halting.");
+      await flushWrites();
+      process.exit(2);
+    }
+    if (message === "ARKHAM_ENTITLEMENT") {
+      console.error(
+        "✗ Arkham returned 402/403 — plan entitlement or Intel Label quota exhausted. Halting.",
+      );
+      console.error(`  quota: ${quotaLine()}`);
+      console.error(
+        `  Re-run once the quota resets; ${progressFile} resumes the queue.`,
+      );
+      await flushWrites();
+      process.exit(2);
+    }
+  }
+
+  /**
+   * Count one failure and trip the circuit breaker at the limit. Without this
+   * an API that starts refusing every call (quota exhaustion behind a status
+   * code we don't special-case, or an outage) would grind the whole queue into
+   * errors before anyone noticed.
+   */
+  async function noteFailure(message) {
+    errorCount++;
+    consecutiveErrors++;
+    if (consecutiveErrors < MAX_CONSECUTIVE_ERRORS) return;
+    await flushWrites();
+    console.error("");
+    console.error(
+      `✗ ${MAX_CONSECUTIVE_ERRORS} consecutive Arkham errors — halting.`,
+    );
+    console.error(`  last error: ${message}`);
+    console.error(`  quota: ${quotaLine()}`);
+    console.error(
+      `  Check GET /subscription/intel-usage; ${progressFile} resumes the queue.`,
+    );
+    process.exit(3);
+  }
+
+  function recordResult(address, status, data) {
+    // The call itself succeeded (200 or a clean 404), so the API is answering.
+    consecutiveErrors = 0;
+    if (status !== 200 || !data) {
+      nullCount++;
+      return;
+    }
+    const entry = toAddressEntry(data);
+    if (!entry) {
+      // Quality gate failed. On a refresh this deliberately leaves the prior
+      // entry in place rather than deleting it.
+      nullCount++;
+      return;
+    }
+    // The start snapshot decides the write mode. Absent then → HSETNX now;
+    // present then → compare-and-set against the `updatedAt` we read.
+    const current = existing[address];
+    pendingWrites.push({
+      address,
+      entry: buildWriteEntry(entry, current),
+      mode: current ? "refresh" : "new",
+      expectedUpdatedAt:
+        typeof current?.updatedAt === "string" ? current.updatedAt : "",
+    });
+    attested++;
   }
 
   for (let i = 0; i < candidates.length; i++) {
-    const address = candidates[i];
+    const address = candidates[i].address;
+    if (quota.remaining !== null && quota.remaining <= quotaFloor) {
+      stoppedForQuota = true;
+      break;
+    }
     try {
-      const { status, data } = await fetchEnriched(address);
+      const { status, data, dropped } = await fetchEnriched(address);
       appendFileSync(
         rawFile,
         JSON.stringify({ address, status, data, ts: Date.now() }) + "\n",
       );
       appendFileSync(progressFile, JSON.stringify({ address, status }) + "\n");
-      if (status === 404 || !data) {
-        nullCount++;
-      } else {
-        const entry = toAddressEntry(data);
-        if (entry) {
-          // Merge with existing if it was an arkham-sourced refresh. For now, simple insert.
-          const merged = { ...entry, createdAt: new Date().toISOString() };
-          pendingWrites.push({ address, entry: merged });
-          attested++;
-          if (pendingWrites.length >= HSET_BATCH) await flushWrites();
-        } else {
-          nullCount++;
-        }
-      }
+      recordResult(address, status, data);
+      if (pendingWrites.length >= HSET_BATCH) await flushWrites();
+      if (dropped) console.log(`  quota ↓ after ${address}: ${quotaLine()}`);
     } catch (err) {
-      if (err.message === "ARKHAM_AUTH_FAIL") {
-        console.error("✗ Arkham key rejected. Halting.");
-        await flushWrites();
-        process.exit(2);
-      }
+      await haltIfFatal(err.message);
       if (err.message === "ARKHAM_RATE_LIMITED") {
         console.warn(
           `  ⚠ 429 on ${address}, backing off ${RATE_LIMIT_BACKOFF_MS}ms`,
@@ -416,55 +980,56 @@ async function main() {
             progressFile,
             JSON.stringify({ address, status }) + "\n",
           );
-          if (status === 200 && data) {
-            const entry = toAddressEntry(data);
-            if (entry) {
-              pendingWrites.push({
-                address,
-                entry: { ...entry, createdAt: new Date().toISOString() },
-              });
-              attested++;
-            } else {
-              nullCount++;
-            }
-          } else {
-            nullCount++;
-          }
+          recordResult(address, status, data);
         } catch (retryErr) {
-          errorCount++;
+          // A key rotated or a plan exhausted mid-batch is still fatal here.
+          await haltIfFatal(retryErr.message);
           appendFileSync(
             progressFile,
             JSON.stringify({ address, error: retryErr.message }) + "\n",
           );
+          await noteFailure(retryErr.message);
         }
       } else {
-        errorCount++;
         appendFileSync(
           progressFile,
           JSON.stringify({ address, error: err.message }) + "\n",
         );
+        await noteFailure(err.message);
       }
     }
-    processedSinceLastFlush++;
-    if (processedSinceLastFlush % 200 === 0) {
+    const done = i + 1;
+    if (done % QUOTA_LOG_EVERY === 0) {
       await flushWrites();
       const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
       console.log(
-        `  [${i + 1}/${candidates.length}] attested=${attested} null=${nullCount} errors=${errorCount} elapsed=${elapsed}s`,
+        `  [${done}/${candidates.length}] attested=${attested} written=${written} skipExists=${newSkippedExists} skipChanged=${refreshSkippedChanged} null=${nullCount} errors=${errorCount} elapsed=${elapsed}s ${quotaLine()}`,
       );
     }
+    if (done % INTEL_USAGE_EVERY === 0) await logIntelUsage(`after ${done}`);
     if (i < candidates.length - 1) await sleep(REQ_SPACING_MS);
   }
 
   await flushWrites();
+  await logIntelUsage("end");
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
   console.log("");
-  console.log(`✓ Tier 1 chain=${chainId} done in ${elapsed}s.`);
-  console.log(`  candidates: ${candidates.length}`);
-  console.log(`  attested:   ${attested}`);
-  console.log(`  null:       ${nullCount}`);
-  console.log(`  errors:     ${errorCount}`);
-  console.log(`  raw:        ${rawFile}`);
+  if (stoppedForQuota) {
+    console.log(
+      `⚠ Stopped early: Intel Label remaining hit the --quota-floor of ${quotaFloor}.`,
+    );
+    console.log(`  Re-run after the quota resets; ${progressFile} resumes it.`);
+  }
+  console.log(`✓ Tier 1 scope=${scope} done in ${elapsed}s.`);
+  console.log(`  queued:        ${candidates.length}`);
+  console.log(`  attested:      ${attested}   (passed the quality gate)`);
+  console.log(`  written:       ${written}`);
+  console.log(`  skipped, field appeared mid-run: ${newSkippedExists}`);
+  console.log(`  skipped, entry changed mid-run:  ${refreshSkippedChanged}`);
+  console.log(`  null:          ${nullCount}`);
+  console.log(`  errors:        ${errorCount}`);
+  console.log(`  quota:         ${quotaLine()}`);
+  console.log(`  raw:           ${rawFile}`);
 }
 
 main().catch((err) => {

--- a/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier1-bulk-enrich.mjs
@@ -123,7 +123,19 @@ function flagValue(name) {
  */
 function numericFlag(name, fallback) {
   const raw = flagValue(name);
-  if (raw === undefined) return fallback;
+  if (raw === undefined) {
+    // A flag typed with no value (or immediately followed by another flag,
+    // e.g. `--limit --no-refresh`) must fail loudly rather than silently
+    // falling back — for --limit that fallback is Infinity, which would
+    // start an unbounded, quota-consuming sweep the caller didn't intend.
+    if (args.includes(name)) {
+      console.error(
+        `Missing value for ${name} (expected a non-negative number)`,
+      );
+      process.exit(1);
+    }
+    return fallback;
+  }
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) {
     console.error(`Invalid ${name}: ${raw} (expected a non-negative number)`);

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -393,12 +393,17 @@ function deriveTags(enriched, counterparties) {
   }
 
   if (contractFlag) tags.add("type:contract");
-  for (const t of arkhamTags) tags.add(t);
 
+  // Raw Arkham ids stay a SEPARATE group so the merge site can rank them
+  // last: this pass's forensic tags, then whatever the entry already holds,
+  // then the bulk Arkham dump — the 20-tag cap always sacrifices raw ids
+  // first, never curated content.
+  const forensic = Array.from(tags).map((t) => String(t).slice(0, 50));
   return {
     name: name?.slice(0, 200) ?? null,
-    tags: Array.from(tags)
-      .slice(0, 20)
+    tags: forensic.slice(0, 20),
+    arkhamTags: Array.from(arkhamTags)
+      .filter((t) => !tags.has(t))
       .map((t) => String(t).slice(0, 50)),
     entitySlug,
     contractFlag,
@@ -659,7 +664,11 @@ async function main() {
     }
 
     // Update labels entry — merge derived tags + name into existing or create.
-    if (derived.name || derived.tags.length > 0) {
+    if (
+      derived.name ||
+      derived.tags.length > 0 ||
+      derived.arkhamTags.length > 0
+    ) {
       const existingEntry = existingLabels[address];
       // Preserve manual entries (source !== arkham).
       const isManual =
@@ -670,14 +679,15 @@ async function main() {
           existingEntry.tags.includes("arkham")
         );
       if (!isManual) {
-        // Derived tags first: `derived.tags` already puts this pass's own
-        // ctp:/type: forensic tags ahead of raw Arkham ids (see deriveTags
-        // above). If `existingEntry.tags` came first instead, a Tier 1 entry
-        // that already fills the 20-tag cap with Arkham ids would crowd out
-        // this pass's own forensic tags at merge time.
+        // Cap precedence: this pass's forensic ctp:/type: tags, then the
+        // entry's existing tags (which may carry prior curated or forensic
+        // content), then the raw Arkham id dump last — so the 20-tag cap
+        // always drops raw ids before anything curated (mirrors the tier1
+        // buildWriteEntry ordering decision).
         const mergedTags = new Set([
           ...derived.tags,
           ...(existingEntry?.tags ?? []),
+          ...(derived.arkhamTags ?? []),
         ]);
         const newEntry = {
           // Tags-only entries keep an empty name (rendered as "—"); never

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -356,6 +356,9 @@ function deriveTags(enriched, counterparties) {
         tags.add(`entity:${perChain.arkhamEntity.type}`);
       if (perChain.arkhamEntity?.id)
         tags.add(`slug:${perChain.arkhamEntity.id}`);
+      // Arkham replaced `tags[].slug` with `populatedTags[].id` in 2026-08.
+      // Read both so the tag set survives either shape.
+      for (const t of perChain.populatedTags ?? []) if (t.id) tags.add(t.id);
       for (const t of perChain.tags ?? []) if (t.slug) tags.add(t.slug);
       if (perChain.contract === true) contractFlag = true;
     }

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -669,9 +669,14 @@ async function main() {
           existingEntry.tags.includes("arkham")
         );
       if (!isManual) {
+        // Derived tags first: `derived.tags` already puts this pass's own
+        // ctp:/type: forensic tags ahead of raw Arkham ids (see deriveTags
+        // above). If `existingEntry.tags` came first instead, a Tier 1 entry
+        // that already fills the 20-tag cap with Arkham ids would crowd out
+        // this pass's own forensic tags at merge time.
         const mergedTags = new Set([
-          ...(existingEntry?.tags ?? []),
           ...derived.tags,
+          ...(existingEntry?.tags ?? []),
         ]);
         const newEntry = {
           // Tags-only entries keep an empty name (rendered as "—"); never

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -362,8 +362,9 @@ function deriveTags(enriched, counterparties) {
       // Arkham replaced `tags[].slug` with `populatedTags[].id` in 2026-08.
       // Read both so the tag set survives either shape. Collected separately
       // and appended AFTER the forensic ctp:/type: tags below — Arkham
-      // returns up to ~31 distinct ids per address (81/11k measured over 15),
-      // which would otherwise crowd this pass's own tags out of the 20-cap.
+      // returns up to ~31 distinct ids per address (measured live: 81 of
+      // ~11k responses exceed 15 ids), which would otherwise crowd this
+      // pass's own tags out of the 20-cap.
       for (const t of perChain.populatedTags ?? [])
         if (t.id) arkhamTags.add(t.id);
       for (const t of perChain.tags ?? []) if (t.slug) arkhamTags.add(t.slug);

--- a/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
+++ b/ui-dashboard/scripts/intel-marathon/tier2-light-forensic.mjs
@@ -76,7 +76,8 @@ const CLUSTER_7DC0_CONTRACTS = [
 ];
 const CLUSTER_7DC0_DEPLOYER = "0x7dc08ec28f299c062d2941de1f9cfb741df8f022";
 
-// Chains Arkham supports as of 2026-04 (per arkham SKILL.md).
+// Chains Arkham supports per live GET /chains on 2026-08-24 (ton was
+// deregistered; hypercore and robinhood were added).
 const ARKHAM_CHAINS = new Set([
   "ethereum",
   "polygon",
@@ -89,10 +90,11 @@ const ARKHAM_CHAINS = new Set([
   "tron",
   "flare",
   "solana",
-  "ton",
   "dogecoin",
   "zcash",
   "hyperevm",
+  "hypercore",
+  "robinhood",
 ]);
 
 const isValidAddress = (v) =>
@@ -343,6 +345,7 @@ function deriveTags(enriched, counterparties) {
   let name = null;
   let entitySlug = null;
   let contractFlag = false;
+  const arkhamTags = new Set();
 
   if (enriched) {
     for (const perChain of Object.values(enriched)) {
@@ -357,9 +360,13 @@ function deriveTags(enriched, counterparties) {
       if (perChain.arkhamEntity?.id)
         tags.add(`slug:${perChain.arkhamEntity.id}`);
       // Arkham replaced `tags[].slug` with `populatedTags[].id` in 2026-08.
-      // Read both so the tag set survives either shape.
-      for (const t of perChain.populatedTags ?? []) if (t.id) tags.add(t.id);
-      for (const t of perChain.tags ?? []) if (t.slug) tags.add(t.slug);
+      // Read both so the tag set survives either shape. Collected separately
+      // and appended AFTER the forensic ctp:/type: tags below — Arkham
+      // returns up to ~31 distinct ids per address (81/11k measured over 15),
+      // which would otherwise crowd this pass's own tags out of the 20-cap.
+      for (const t of perChain.populatedTags ?? [])
+        if (t.id) arkhamTags.add(t.id);
+      for (const t of perChain.tags ?? []) if (t.slug) arkhamTags.add(t.slug);
       if (perChain.contract === true) contractFlag = true;
     }
   }
@@ -385,6 +392,7 @@ function deriveTags(enriched, counterparties) {
   }
 
   if (contractFlag) tags.add("type:contract");
+  for (const t of arkhamTags) tags.add(t);
 
   return {
     name: name?.slice(0, 200) ?? null,

--- a/ui-dashboard/src/lib/__tests__/arkham.test.ts
+++ b/ui-dashboard/src/lib/__tests__/arkham.test.ts
@@ -52,6 +52,19 @@ function makeArkhamResponse(
   return out;
 }
 
+/**
+ * Strip `tags` from every chain entry. Production responses have carried
+ * `populatedTags` and no `tags` field since 2026-08 — omitting the key is the
+ * point of the fixture, so it can't be expressed as `tags: undefined` under
+ * `exactOptionalPropertyTypes`.
+ */
+function withoutLegacyTags(
+  response: Record<string, ArkhamEnrichedAddress>,
+): Record<string, ArkhamEnrichedAddress> {
+  for (const perChain of Object.values(response)) delete perChain.tags;
+  return response;
+}
+
 type MockFetchEntry =
   | { status: number; body?: unknown; ok?: boolean }
   | ((url: string, init: RequestInit) => Promise<Response> | Response);
@@ -217,6 +230,70 @@ describe("toAddressEntry", () => {
       (t) => t === "exchange",
     ).length;
     expect(occurrences).toBe(1);
+  });
+
+  // Arkham replaced `tags[].slug` with `populatedTags[].id` in 2026-08. Both
+  // shapes stay covered: the new one is what production returns, the legacy
+  // one keeps working if Arkham re-adds the field.
+  it("reads tags from populatedTags[].id (current Arkham shape)", () => {
+    const entry = toAddressEntry(
+      withoutLegacyTags(
+        makeArkhamResponse({
+          arkhamLabel: {
+            name: "Binance 14",
+            address: "0xabc",
+            chainType: "evm",
+          },
+          populatedTags: [
+            { id: "cex", label: "CEX", rank: 1 },
+            { id: "whale", label: "Whale", rank: 2 },
+          ],
+        }),
+      ),
+    );
+    expect(entry?.tags).toContain("cex");
+    expect(entry?.tags).toContain("whale");
+  });
+
+  it("reads tags from legacy tags[].slug when populatedTags is absent", () => {
+    const entry = toAddressEntry(
+      makeArkhamResponse({
+        arkhamLabel: { name: "Binance 14", address: "0xabc", chainType: "evm" },
+        tags: [{ id: "t1", name: "CEX", slug: "cex" }],
+      }),
+    );
+    expect(entry?.tags).toContain("cex");
+  });
+
+  it("unions both tag shapes and dedups the overlap", () => {
+    const entry = toAddressEntry(
+      makeArkhamResponse({
+        arkhamLabel: { name: "Binance 14", address: "0xabc", chainType: "evm" },
+        tags: [{ id: "t1", name: "CEX", slug: "cex" }],
+        populatedTags: [
+          { id: "cex", label: "CEX" },
+          { id: "bridge", label: "Bridge" },
+        ],
+      }),
+    );
+    expect(entry?.tags).toContain("bridge");
+    expect((entry?.tags ?? []).filter((t) => t === "cex")).toHaveLength(1);
+  });
+
+  it("ignores populatedTags entries with an empty id", () => {
+    const entry = toAddressEntry(
+      withoutLegacyTags(
+        makeArkhamResponse({
+          arkhamLabel: {
+            name: "Binance 14",
+            address: "0xabc",
+            chainType: "evm",
+          },
+          populatedTags: [{ id: "", label: "Nameless" }, { id: "cex" }],
+        }),
+      ),
+    );
+    expect(entry?.tags).toEqual(["cex"]);
   });
 
   it("flags ML-only labels with a confidence note", () => {

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -19,8 +19,10 @@ import {
 const ARKHAM_BASE = "https://api.arkm.com";
 const REQUEST_TIMEOUT_MS = 10_000;
 
-// Pacing for the standard rate-limit bucket (20 req/s). 60ms spacing leaves
-// ~16 req/s sustained — comfortably under the limit even with clock jitter.
+// Pacing for the standard rate-limit bucket (100 req/s as of 2026-08). 60ms
+// spacing leaves ~16 req/s sustained — well under the limit even with clock
+// jitter, and the trial's Intel Label quota, not throughput, is the binding
+// constraint on a bulk sweep.
 const REQ_SPACING_MS = 60;
 
 // Confidence floor for ML-attributed addresses. Below this, treat predictions
@@ -45,12 +47,27 @@ type ArkhamLabel = {
   chainType: string;
 };
 
+/**
+ * Legacy tag shape. Arkham stopped returning `tags` on enriched responses in
+ * 2026-08 — `populatedTags` replaced it. Kept as an optional read so a
+ * re-added field is picked up without another code change.
+ */
 type ArkhamTag = {
   id: string;
   name: string;
   slug: string;
   type?: string;
   description?: string;
+};
+
+/**
+ * Current tag shape (2026-08). `id` is the stable machine identifier and is
+ * the equivalent of the legacy `tags[].slug`; `label` is display text.
+ */
+type ArkhamPopulatedTag = {
+  id: string;
+  label?: string;
+  rank?: number;
 };
 
 type ArkhamEntityPrediction = {
@@ -68,6 +85,7 @@ export type ArkhamEnrichedAddress = {
   isUserAddress: boolean | null;
   contract: boolean | null;
   tags?: ArkhamTag[];
+  populatedTags?: ArkhamPopulatedTag[];
   entityPredictions?: ArkhamEntityPrediction[];
   clusterIds?: string[];
 };
@@ -176,6 +194,25 @@ export function hasUsableLabel(data: ArkhamMultiChainResponse): boolean {
 }
 
 /**
+ * Union the tag identifiers one per-chain entry carries into `into`.
+ *
+ * Arkham returns `populatedTags[].id` today; `tags[].slug` is the field it
+ * replaced in 2026-08. Both are read so the tag set is correct whichever
+ * shape the response carries.
+ */
+function addChainTags(
+  perChain: ArkhamEnrichedAddress,
+  into: Set<string>,
+): void {
+  for (const t of perChain.populatedTags ?? []) {
+    if (t.id) into.add(t.id);
+  }
+  for (const t of perChain.tags ?? []) {
+    if (t.slug) into.add(t.slug);
+  }
+}
+
+/**
  * Map an Arkham response onto our `AddressEntry` schema.
  *
  * Returns `null` when nothing is worth persisting (caller should skip the
@@ -202,9 +239,7 @@ export function toAddressEntry(
     if (!entity && perChain.arkhamEntity?.name?.trim())
       entity = perChain.arkhamEntity;
     if (entity?.type) tagSet.add(entity.type);
-    for (const t of perChain.tags ?? []) {
-      if (t.slug) tagSet.add(t.slug);
-    }
+    addChainTags(perChain, tagSet);
     for (const p of perChain.entityPredictions ?? []) {
       if (p.confidence < HIGH_CONFIDENCE) continue;
       if (!topPrediction || p.confidence > topPrediction.confidence) {
@@ -236,7 +271,7 @@ export function toAddressEntry(
 
 /**
  * Process a batch of addresses against Arkham, paced for the standard
- * 20 req/s rate limit.
+ * rate-limit bucket.
  *
  * Stops early on auth errors (misconfiguration — no point continuing).
  * Slows down on rate-limit errors (back off + retry once). Other errors are

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -371,8 +371,13 @@ export function mergeRefreshEntry(
   if (!existing || !isArkhamSourced(existing)) return fresh;
 
   const isAutoNote = existing.notes?.startsWith("Arkham prediction (");
+  // Existing tags first: `existing.tags` can carry curated forensic tags
+  // (e.g. tier2's ctp:/type: prefixes) ahead of a bulk Arkham tag dump. Now
+  // that populatedTags can fill the 20-tag cap on its own (see arkham.ts's
+  // addChainTags), putting `fresh` first would let a routine refresh
+  // silently evict that curated content once sanitizeEntry truncates.
   const tags = withoutArkhamTags(
-    Array.from(new Set([...fresh.tags, ...existing.tags])),
+    Array.from(new Set([...existing.tags, ...fresh.tags])),
   );
 
   return sanitizeEntry({

--- a/ui-dashboard/src/lib/arkham.ts
+++ b/ui-dashboard/src/lib/arkham.ts
@@ -225,28 +225,7 @@ export function toAddressEntry(
 ): AddressEntry | null {
   if (!hasUsableLabel(data)) return null;
 
-  // EVM addresses are chain-agnostic, so the same `arkhamEntity`/`arkhamLabel`
-  // typically appears on every covered chain. Pick the strongest signal once;
-  // union tags across all chains.
-  let label: string | undefined;
-  let entity: ArkhamEntity | null = null;
-  let topPrediction: ArkhamEntityPrediction | undefined;
-  const tagSet = new Set<string>();
-
-  for (const perChain of Object.values(data)) {
-    const trimmed = perChain.arkhamLabel?.name?.trim();
-    if (!label && trimmed) label = trimmed;
-    if (!entity && perChain.arkhamEntity?.name?.trim())
-      entity = perChain.arkhamEntity;
-    if (entity?.type) tagSet.add(entity.type);
-    addChainTags(perChain, tagSet);
-    for (const p of perChain.entityPredictions ?? []) {
-      if (p.confidence < HIGH_CONFIDENCE) continue;
-      if (!topPrediction || p.confidence > topPrediction.confidence) {
-        topPrediction = p;
-      }
-    }
-  }
+  const { label, entity, topPrediction, tagSet } = resolveArkhamSignal(data);
 
   // Prefer the curated label, then entity name, then the predicted entity ID.
   const name = label || entity?.name?.trim() || topPrediction?.entityId || "";
@@ -351,6 +330,57 @@ export async function enrichBatch(
   }
 
   return results;
+}
+
+/**
+ * Pick the highest-confidence entity prediction between `current` and a
+ * per-chain prediction list, ignoring anything below `HIGH_CONFIDENCE`.
+ */
+function pickBetterPrediction(
+  current: ArkhamEntityPrediction | undefined,
+  predictions: ArkhamEntityPrediction[] | undefined,
+): ArkhamEntityPrediction | undefined {
+  let best = current;
+  for (const p of predictions ?? []) {
+    if (p.confidence < HIGH_CONFIDENCE) continue;
+    if (!best || p.confidence > best.confidence) best = p;
+  }
+  return best;
+}
+
+/**
+ * Reduce a multi-chain Arkham response to one signal set: the strongest
+ * curated label/entity found on any chain, the highest-confidence ML
+ * prediction across all chains, and the union of tag identifiers.
+ *
+ * EVM addresses are chain-agnostic, so the same `arkhamEntity`/`arkhamLabel`
+ * typically appears on every covered chain — pick the strongest signal once.
+ */
+function resolveArkhamSignal(data: ArkhamMultiChainResponse): {
+  label: string | undefined;
+  entity: ArkhamEntity | null;
+  topPrediction: ArkhamEntityPrediction | undefined;
+  tagSet: Set<string>;
+} {
+  let label: string | undefined;
+  let entity: ArkhamEntity | null = null;
+  let topPrediction: ArkhamEntityPrediction | undefined;
+  const tagSet = new Set<string>();
+
+  for (const perChain of Object.values(data)) {
+    const trimmed = perChain.arkhamLabel?.name?.trim();
+    if (!label && trimmed) label = trimmed;
+    if (!entity && perChain.arkhamEntity?.name?.trim())
+      entity = perChain.arkhamEntity;
+    if (entity?.type) tagSet.add(entity.type);
+    addChainTags(perChain, tagSet);
+    topPrediction = pickBetterPrediction(
+      topPrediction,
+      perChain.entityPredictions,
+    );
+  }
+
+  return { label, entity, topPrediction, tagSet };
 }
 
 /**


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Arkham replaced `tags[].slug` with `populatedTags[].id` on enriched responses, so every tag read in the enrichment pipeline (tier1, tier2, smoke test, and the shared `arkham.ts` lib behind `/api/arkham/enrich`) silently returned zero tags.
- Tier1 discovery paged raw Celo-only event tables, missing Polygon and Monad actors, and enriched one address per request with no awareness of the API trial's 10,000-lookup Intel Label cap.
- Tier1 skipped every already-labeled address and wrote with blind `HSET`, so pass-1 Arkham entries could never be refreshed, and a manual address-book edit made during a multi-hour run would be clobbered.

## The Solution

- All tag reads accept both shapes (`populatedTags[].id` first, legacy `tags[].slug` fallback), covered by tests for each shape.
- Discovery now pages the indexer's per-address rollup entities across all chains (68,433 distinct addresses in the live dry run) and aborts if any source fails rather than sweeping a silently incomplete set (`--allow-partial-discovery` overrides).
- The sweep is quota-aware: arkham-sourced refreshes first, then non-Broker discoveries, then Broker traders by lifetime volume; it observes `X-Intel-Datapoints-*` headers with an `/subscription/intel-usage` body fallback, stops at `--quota-floor`, halts on 401/402/403, and trips a circuit breaker after 10 consecutive errors.
- Refreshes merge on the canonical `mergeRefreshEntry` rules (`isPublic` and user-edited notes survive); writes are race-safe (`HSETNX` for new entries, compare-and-set Lua for refreshes, skips counted).
- Limit: tier1 has no test file; its pure functions were validated by review harnesses not kept in-repo (see Deferrals).

## Details

- Discovery sources: `TraderAllTimeAggregate`, `BrokerTraderAllTimeAggregate` (both filtered `isProtocolActor: false`, ranked by `volumeUsdWei`), `LiquidityPosition`, `BorrowerInfo`, `StabilityPoolDepositor`, `Trove.owner/previousOwner`, `BridgeBridger`, `Steth/SusdsPosition`, plus `distinct_on` pages of `OlsLiquidityEvent.caller` and `LiquidityEvent.recipient` (`sender` holds router contracts). Narrower than the production cron's `DISCOVERY_TARGETS` by design; documented in the script header.
- The refresh CAS Lua adapts `HSET_ARKHAM_REFRESH_IF_UNCHANGED_SCRIPT` from `address-labels.ts`, returning skipped fields instead of a written count so each skip is attributed in the progress file.
- Quota accounting tracks header-derived and body-derived `remaining` separately; a partial header set can no longer disable the body fallback. `--quota-floor`/`--limit` reject non-finite values.
- tier2 appends Arkham tags after its own `ctp:`/`type:` forensic tags — Arkham returns up to 31 distinct ids per address (81 of ~11k live responses exceed 15), which would otherwise crowd them out of the 20-tag cap. tier2's hardcoded Arkham chain list updated to the live 2026-08 state (`ton` deregistered; `hypercore`, `robinhood` added).
- `run.sh` resolves credentials env-first so worktrees without `terraform/terraform.tfvars` run with exported vars; errors name the missing variable. Secret values are never echoed.
- `eslint-baseline.json`: four `src/lib/arkham.ts` tuples re-pinned (two line-shift, two genuine complexity reductions after extracting `addChainTags()`).

## Validation

- `vitest` arkham/address-label suites: 266 passed (73 in the two arkham suites re-run after review fixes at `297c65bf`); new tests cover populatedTags-only, legacy-tags-only, both-shape union, and empty-id rejection.
- `node --check` / `bash -n` on all changed scripts; `eslint-baseline-diff check` exit 0; full `pnpm agent:quality-gate --run --parallel 4` at `297c65bf`: all mapped commands passed (dashboard lint, typecheck, coverage, knip, dep-cruiser, browser tests, React Doctor diff+score, size-limit, targeted trunk, tf:test).
- Live: 68,433-address dry run against the production indexer; 25-address smoke run (18 attested/written, 0 errors, quota headers observed end-to-end); a full quota-budgeted production run is in flight on this exact code's first commit plus in-tree review fixes.
- Review: `review` skill (opus) with 4 applied fixes incl. a negative-control-proven dead quota brake; codex (second model family) two passes — its decisive finding (discovery catch-and-continue) is fixed here. Security: manual focused pass on `run.sh` credential handling (no secret echo, no injection); the claude-security scan was not run — it requires diff-egress approval unavailable mid-run.
- Known gap: the `X-Intel-Datapoints-*` header path is verified live, but the body-fallback path has only harness coverage (real API always sent full headers).

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2033 — resume silently drops errored addresses (pre-existing retry policy, made visible by the new circuit breaker)
- https://github.com/mento-protocol/monitoring-monorepo/issues/2034 — extract tier1 pure functions into a tested module

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production Upstash `labels` are discovered, refreshed, and merged during long bulk runs; safeguards (CAS, manual skip, quota brakes) reduce but do not eliminate mis-label or partial-sweep risk.
> 
> **Overview**
> Fixes **silent empty tags** after Arkham switched enriched responses from `tags[].slug` to **`populatedTags[].id`**. Shared **`arkham.ts`**, the smoke test, tier1, tier2, and **`/api/arkham/enrich`** now union both shapes (via **`addChainTags`**), with new unit tests for each path.
> 
> **Tier1 bulk enrich** is reworked for a cross-chain sweep: discovery pages **indexer rollup entities** (~68k external actors) instead of per-chain event tables, **aborts** on partial discovery unless **`--allow-partial-discovery`**, and supports **`--dry-run`** without credentials. Enrichment is **quota-aware** (Intel Label headers + **`/subscription/intel-usage`** fallback, **`--quota-floor`**, 402/403 halt, 10-error circuit breaker) and **prioritized** (Arkham refreshes → non–Broker-trader discovery → Broker traders by volume). Writes use **`mergeRefreshEntry`** semantics, **`HSETNX`** for new rows, and **compare-and-set Lua** for refreshes so manual edits mid-run are not clobbered.
> 
> **`run.sh`** resolves credentials **env-first** (tfvars/Upstash optional on dry-run). **Tier2** reads both tag shapes, appends Arkham tags after forensic tags to respect the 20-tag cap, and updates the supported-chain set. **eslint-baseline** re-pins **`arkham.ts`** complexity entries after **`addChainTags`** extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297c65bf413d247ae59cf9e5f1895b58b6e613b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for current and legacy Arkham tag formats with merged, deduplicated tags.
  * Expanded chain metadata and enrichment coverage.
  * Improved enrichment workflows with resumable progress, dry runs, quota tracking, and safer refreshes.

* **Bug Fixes**
  * Preserved curated metadata and restored pending work after storage failures.
  * Improved credential validation, incomplete-discovery handling, and invalid command-line option errors.

* **Documentation**
  * Updated usage, credential, dry-run, worktree, API pacing, and metadata guidance.

* **Tests**
  * Added coverage for supported Arkham tag response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->