### PR TITLE
docs(ADR): reconcile ADR 0065 — keep agent-quality-gate measured and cite ADR 0069

### DIFF
--- a/docs/adr/0065-scripts-file-size-watchlist-scope.md
+++ b/docs/adr/0065-scripts-file-size-watchlist-scope.md
@@ -177,7 +177,9 @@ that nothing holds in place.
   because their safety argument rests on `mkdir`/`link` atomicity,
   `ps -o lstart=`, Bash 3.2 job-control PGIDs and `/proc`, with no oracle for a
   rewrite. It stays in the report, still over the 1,000-line hard cap, and
-  stated rather than exempted. ADR 0069 is the row's justification.
+  stated rather than exempted. ADR 0069 is the row's justification. The monthly
+  scheduler continues to surface the row as actionable; that recurring
+  visibility is deliberate and needs no permanent single-row issue owner.
 - Thirty further `scripts/` files sit between the watch threshold and the
   hard cap. They are recorded and delta-tracked, and any that grows by more than
   100 raw lines becomes actionable on its own. The 2026-08-23 refresh produced

--- a/docs/adr/0065-scripts-file-size-watchlist-scope.md
+++ b/docs/adr/0065-scripts-file-size-watchlist-scope.md
@@ -3,7 +3,7 @@ title: scripts/ is inside the file-size watchlist, with named-mechanism exemptio
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-23
+last_verified: 2026-08-24
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -99,12 +99,12 @@ to satisfy a line count.
 | `agent-autoreview.mjs`, `agent-autoreview-core.mjs` | The wrapper materializes exactly these two helper names under a 2 MB aggregate cap, from six literal lists — `helper_paths`, two `runtime_paths` arrays, an `lstat` loop, an ACL loop, and a Perl `@names` copy list that assigns each name its own file mode. Admitting a third rewrites that materializer. |
 
 **Nothing whose split is merely expensive is exempt.** `agent-quality-gate.sh`
-is the largest example and stays in the report: it is the entire subject of
-[issue 1498](https://github.com/mento-protocol/monitoring-monorepo/issues/1498),
-which decomposes it into sourced helper modules, so exempting it would suppress
-exactly the row that already has an owner. `pr-ready-state{,-core}.mjs` sit
-behind `materialize_feedback_runtime`'s two basename lists, required and
-optional, which already prove themselves extensible.
+is the largest example and stays measured at the hard cap without an exemption.
+Its residual process-control and execution layers are deliberate: [ADR
+0069](0069-gate-routing-table-as-data.md) rejected splitting them without a
+schema, test oracle, or checkable invariant. `pr-ready-state{,-core}.mjs` sit
+behind `materialize_feedback_runtime`'s two basename lists, required and optional,
+which already prove themselves extensible.
 `pr-feedback-state-claude.mjs` and `pr-ready-state-review-signals.mjs` are
 version-split optional entries, so coherent snapshots from before either split
 still work. The D3 move (issue 1877) added a location resolver under both lists
@@ -177,9 +177,7 @@ that nothing holds in place.
   because their safety argument rests on `mkdir`/`link` atomicity,
   `ps -o lstart=`, Bash 3.2 job-control PGIDs and `/proc`, with no oracle for a
   rewrite. It stays in the report, still over the 1,000-line hard cap, and
-  stated rather than exempted;
-  [issue 1498](https://github.com/mento-protocol/monitoring-monorepo/issues/1498)
-  stays open as its owner.
+  stated rather than exempted. ADR 0069 is the row's justification.
 - Thirty further `scripts/` files sit between the watch threshold and the
   hard cap. They are recorded and delta-tracked, and any that grows by more than
   100 raw lines becomes actionable on its own. The 2026-08-23 refresh produced

--- a/docs/adr/0065-scripts-file-size-watchlist-scope.md
+++ b/docs/adr/0065-scripts-file-size-watchlist-scope.md
@@ -163,7 +163,7 @@ that nothing holds in place.
   three, all at hard or near-hard.
 - Two `scripts/` files join that queue: `agent-quality-gate.sh` and
   `sentry-triage-archive.mjs`. Both are over the hard cap with nothing holding
-  them, and the first already has an issue.
+  them.
 - **The gate's row shrank by 45% at D5c, and the residual is the process-control
   layer by design.** Projected here at `2e3df696` as ~3,519 raw / ~2,266 rough
   from a 6,163-raw file; measured after D5c landed, the gate is **3,327 raw /

--- a/docs/adr/0069-gate-routing-table-as-data.md
+++ b/docs/adr/0069-gate-routing-table-as-data.md
@@ -27,12 +27,13 @@ record; what is live is the table, the engine, and the checks in section 5.
 
 ## Context
 
-`scripts/agent-quality-gate.sh` is 6,100 lines and the largest file in the
-repository. It is the subject of
+`scripts/agent-quality-gate.sh` was 6,100 lines and the largest file in the
+repository when this decision began. It was the subject of
 [issue 1498](https://github.com/mento-protocol/monitoring-monorepo/issues/1498)
 and the one hard-cap row [ADR 0065](0065-scripts-file-size-watchlist-scope.md)
 deliberately refuses to exempt, on the ground that its split is expensive rather
-than architecturally forbidden.
+than architecturally forbidden. D5c later removed the routing arms and exposed
+the residual process-control and execution layers governed by this decision.
 
 It is not one thing. The largest single region is routing: one `while IFS= read
 -r path` loop over the changed set, holding **13 top-level `case` statements**,
@@ -518,11 +519,12 @@ gate is not a trust root.
   its owned paths. Other changed-path classes keep their prior plan, except that
   the autoreview-core source class now receives the checklist and both gate
   suites by design.
-- **Issue 1498 is not satisfied as written.** Its acceptance criteria name sourced
+- **Issue 1498's original split is rejected.** Its acceptance criteria named sourced
   `scripts/lib/gate-*.sh` helpers for the watchdog, stamps and executor —
-  exactly the layers this decision keeps in bash. The criteria are rewritten
-  rather than quietly satisfied: ADR 0065 cites 1498 by number as the reason the
-  gate is not exempt, so the two records must stay consistent.
+  exactly the residual layers this decision keeps together in bash. Moving
+  those crash boundaries across files would provide no schema, test oracle, or
+  checkable invariant. The issue now reconciles ADR 0065 with this rejection
+  and needs no permanent ownership role for the measured row.
 - **`check-sentry-suites-in-ci-gate-extract.mjs` outlived the check it was
   written for.** Its `runProbeShell`, `probeDirs` and `bashFunctionSource` backed
   the classifier probe; D5c made that probe an import, and what keeps the module
@@ -570,4 +572,4 @@ gate is not a trust root.
   `scripts/gate/routing-table/pattern-oracle.test.mjs`, which is the standing
   proof rather than a one-off measurement.
 - Deferred-track queue: <https://github.com/mento-protocol/monitoring-monorepo/issues/1877>
-- Gate-split owner: <https://github.com/mento-protocol/monitoring-monorepo/issues/1498>
+- Reconciled gate-split record: <https://github.com/mento-protocol/monitoring-monorepo/issues/1498>


### PR DESCRIPTION
## The Problem

- ADR 0065 described issue #1498 both as an ongoing owner for the quality gate's file-size row and as work that would split the gate into sourced helpers.
- ADR 0069 rejected that split, so readers received conflicting guidance about whether the residual gate layers should move.

## The Solution

- ADRs 0065 and 0069 now agree: ADR 0065 keeps `agent-quality-gate.sh` measured at the hard cap without an exemption and cites ADR 0069 as the reason its residual process-control and execution layers remain together.
- This gives maintainers one consistent disposition while preserving visibility in the watchlist. This PR changes documentation only; it does not change gate behavior, watchlist selection, or exemption rules.

## Details

- Refreshes ADR 0065's `last_verified` date to 2026-08-24.
- Removes stale claims in ADRs 0065 and 0069 that issue #1498 must stay open as the row's owner.
- Records ADR 0069's rejection of sourced Bash helpers for the residual crash boundaries.
- Preserves the rejected split and the hard-cap row without touching `scripts/`.

Closes #1498

## Validation

- `git grep -n "sourced helper\\|gate-\\*\\.sh" -- docs/`
- `node scripts/repo-health/file-size-watchlist.mjs`
- `git diff --stat origin/main -- scripts/`
- `pnpm docs:index --check`
- `pnpm agent:context-check`
- `pnpm agent:quality-gate --run`
