### PR TITLE
fix(ui-dashboard): disable non-production Sentry tracing

### DIFF
--- a/ui-dashboard/sentry.shared.ts
+++ b/ui-dashboard/sentry.shared.ts
@@ -181,15 +181,14 @@ export function filterAndStripSentryEvent<
   return stripAuthHeaders(event);
 }
 
-// Sample 20% of traces in production to stay within Sentry quota at scale;
-// keep 100% on preview + local where traffic is low and full fidelity is
-// useful for debugging. Tune once we have real volume data.
+// Sample 20% of traces in production and disable performance tracing on
+// preview and development deployments to preserve the Sentry quota.
 //
 // Exported as a pure function so the client config (which reads
 // NEXT_PUBLIC_VERCEL_ENV because plain VERCEL_ENV isn't exposed to the
 // browser bundle) can share the same table of rates.
 export function resolveTracesSampleRate(vercelEnv: string | undefined): number {
-  return vercelEnv === "production" ? 0.2 : 1.0;
+  return vercelEnv === "production" ? 0.2 : 0;
 }
 
 // Sentry recommends skipping `Sentry.init` entirely outside production-like

--- a/ui-dashboard/tests/sentry.shared.test.ts
+++ b/ui-dashboard/tests/sentry.shared.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from "vitest";
 import {
   filterAndStripSentryEvent,
+  resolveTracesSampleRate,
   shouldEnableSentry,
   stripAuthHeaders,
 } from "../sentry.shared";
+
+describe("resolveTracesSampleRate", () => {
+  it("samples 20% of production traces", () => {
+    expect(resolveTracesSampleRate("production")).toBe(0.2);
+  });
+
+  it.each(["preview", "development", undefined])(
+    "disables tracing when VERCEL_ENV is %s",
+    (vercelEnv) => {
+      expect(resolveTracesSampleRate(vercelEnv)).toBe(0);
+    },
+  );
+});
 
 // Minimal test harness: stripAuthHeaders takes an ErrorEvent | TransactionEvent
 // and mutates/returns it. For unit-test purposes we can cast a loose object to


### PR DESCRIPTION
## The Problem

- Preview and development deployments sampled every Sentry performance trace, while production sampled 20%.
- Non-production traffic could therefore consume performance units five times as aggressively as production traffic and exhaust the monthly allocation early.

## The Solution

- Preview, development, and non-Vercel environments now sample 0% of performance traces, while production remains at 20%.
- Error reporting and Session Replay remain unchanged; this PR only reduces non-production tracing.

## Details

- `resolveTracesSampleRate` returns `0.2` only when `VERCEL_ENV` is `production` and `0` otherwise.
- Unit coverage pins production, preview, development, and undefined-environment behavior.

## Validation

- `pnpm agent:quality-gate --run`
- `pnpm exec turbo run test:browser --filter=@mento-protocol/ui-dashboard --cache=local:rw` (29 passed after installing Playwright host dependencies)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to performance trace sampling; production behavior is unchanged and error reporting is unaffected.
> 
> **Overview**
> **Non-production Sentry performance traces are now fully disabled** instead of sampled at 100%, while production stays at **20%** tracing via `resolveTracesSampleRate`.
> 
> Preview, development, localhost (`undefined` `VERCEL_ENV`), and any other non-`production` value now get **`tracesSampleRate: 0`**, which cuts quota burn from preview/dev traffic that previously sent every trace. **Error events and Session Replay are unchanged**—only the shared traces sample rate table and its comment were updated.
> 
> Unit tests lock in **0.2** for production and **0** for preview, development, and undefined environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee60740a604cab01ac740790a5177436c817e48e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Adjusted production monitoring to sample a portion of traces.
  * Disabled tracing in preview and development environments to reduce unnecessary overhead.

* **Tests**
  * Added coverage verifying trace behavior across production, preview, development, and unspecified environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->