### PR TITLE
fix(cloud): fail early on missing shipping capabilities

### DIFF
--- a/docs/notes/codex-cloud-setup.md
+++ b/docs/notes/codex-cloud-setup.md
@@ -3,7 +3,7 @@ title: Codex Cloud Setup and Maintenance
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-20
+last_verified: 2026-08-24
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -26,12 +26,14 @@ cached-container maintenance script as:
 Setup prepares a fresh container. It:
 
 - marks the checkout safe for Git, configures token-backed GitHub credentials,
-  and adds or rewrites `origin` to HTTPS when required;
+  adds or rewrites `origin` to HTTPS when required, checks repository and pull
+  request API reads, and proves branch write access with a temporary branch;
 - refreshes `origin/main` and enables `.trunk/hooks`;
 - activates the `packageManager` version from `package.json` through Corepack;
 - verifies the repo-local autoreview helper, prewarms Trunk, installs Foundry,
   and checks OSV API egress;
-- installs the frozen workspace dependencies; and
+- installs the frozen workspace dependencies and Playwright Chromium with its
+  Linux host libraries; and
 - regenerates and verifies Envio types, then runs `pnpm agent:context-check`.
 
 Setup fails closed when required GitHub auth/fetch, helper, tool installation,
@@ -41,10 +43,34 @@ dedicated Cloud container rather than a developer workstation.
 
 ## GitHub and package tooling
 
-Setup expects `GH_TOKEN` (preferred) or `GITHUB_TOKEN`. If `gh` is absent on an
+Setup expects `GH_TOKEN` (preferred) or `GITHUB_TOKEN` with repository Contents
+read/write and pull-request read/write access. If `gh` is absent on an
 apt-based image, it first tries the configured apt sources and then adds the
 official GitHub CLI repository as a fallback. It verifies `gh` auth before
-configuring fetch/push credentials and refreshing `origin/main`.
+configuring fetch/push credentials. Setup then reads the repository and pull
+request APIs and creates and deletes a unique temporary branch. This final
+probe fails early when a token can fetch but cannot publish commits.
+
+Playwright uses `install --with-deps chromium` after workspace installation so
+dashboard browser tests can launch in a fresh Linux image. Set
+`CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS=false` only when the base image already
+provides Chromium and all host libraries.
+
+## Required outbound access
+
+The setup path needs HTTPS access to the hosts below when the corresponding
+tool is not already present in the image or cache:
+
+- `github.com` and `api.github.com` for Git transport and API capability probes;
+- `cli.github.com` for the GitHub CLI apt fallback;
+- `registry.npmjs.org` for workspace and tool packages;
+- `trunk.io` plus GitHub release hosts for Trunk and its managed tools;
+- `foundry.paradigm.xyz` plus GitHub release hosts for Foundry;
+- `api.osv.dev` for the supply-chain egress probe; and
+- Playwright's download hosts, including `cdn.playwright.dev`, for Chromium.
+
+Configure these in the Cloud environment network policy. Do not add proxy
+bypasses in the repository except for the existing explicit Trunk override.
 
 The pinned Trunk CLI is prewarmed and `./tools/trunk install` supplies its
 managed linters and runtimes. If the Cloud proxy blocks Trunk, allowlist

--- a/docs/notes/codex-cloud-setup.md
+++ b/docs/notes/codex-cloud-setup.md
@@ -49,7 +49,10 @@ apt-based image, it first tries the configured apt sources and then adds the
 official GitHub CLI repository as a fallback. It verifies `gh` auth before
 configuring fetch/push credentials. Setup then reads the repository and pull
 request APIs and creates and deletes a unique temporary branch. This final
-probe fails early when a token can fetch but cannot publish commits.
+probe fails early when a token can fetch but cannot publish commits. GitHub
+does not expose a non-mutating pull-request write probe, so setup verifies only
+pull-request reads; the token must still have pull-request write permission for
+PR creation, edits, and review replies.
 
 Playwright uses `install --with-deps chromium` after workspace installation so
 dashboard browser tests can launch in a fresh Linux image. Set
@@ -67,7 +70,9 @@ tool is not already present in the image or cache:
 - `trunk.io` plus GitHub release hosts for Trunk and its managed tools;
 - `foundry.paradigm.xyz` plus GitHub release hosts for Foundry;
 - `api.osv.dev` for the supply-chain egress probe; and
-- Playwright's download hosts, including `cdn.playwright.dev`, for Chromium.
+- Playwright's download hosts, including `cdn.playwright.dev`, for Chromium;
+  plus the Debian/Ubuntu package sources or approved package proxy configured
+  in the image for Linux host libraries.
 
 Configure these in the Cloud environment network policy. Do not add proxy
 bypasses in the repository except for the existing explicit Trunk override.

--- a/scripts/bootstrap/codex-cloud-setup.sh
+++ b/scripts/bootstrap/codex-cloud-setup.sh
@@ -175,21 +175,37 @@ MSG
 }
 
 verify_github_api_capabilities() {
+  local remote_url
   local repository
+  remote_url="$(git remote get-url origin)"
+  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
+    echo "==> Skipping GitHub API probes for non-GitHub origin: ${remote_url}"
+    return 0
+  fi
+
   repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
 
   echo "==> Verifying GitHub repository API access"
   gh api "repos/${repository}" >/dev/null
 
-  echo "==> Verifying GitHub pull-request API access"
+  echo "==> Verifying GitHub pull-request API read access"
   gh api "repos/${repository}/pulls?state=open&per_page=1" >/dev/null
 }
 
 verify_origin_write_access() (
+  local remote_url
   local probe_branch
   local probe_ref
+  local probe_suffix
   local created=false
-  probe_branch="codex-cloud-write-probe-$(date +%s)-$$"
+  remote_url="$(git remote get-url origin)"
+  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
+    echo "==> Skipping GitHub write probe for non-GitHub origin: ${remote_url}"
+    return 0
+  fi
+
+  probe_suffix="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+  probe_branch="codex-cloud-write-probe-${probe_suffix}"
   probe_ref="refs/heads/${probe_branch}"
 
   # Invoked indirectly by the EXIT trap below.
@@ -202,6 +218,8 @@ verify_origin_write_access() (
   }
   trap cleanup_probe_ref EXIT
 
+  # A dry run suppresses the ref update, so it cannot prove that the remote
+  # accepts branch creation. Use a collision-resistant ref and remove it here.
   echo "==> Verifying git can create and delete a temporary branch on origin"
   if ! git push origin "HEAD:${probe_ref}" >/dev/null; then
     cat >&2 <<'MSG'
@@ -215,7 +233,6 @@ MSG
   created=true
 
   if ! git push origin --delete "$probe_branch" >/dev/null; then
-    created=false
     echo "error: GitHub authentication created the temporary write probe but could not delete it: ${probe_branch}" >&2
     return 1
   fi

--- a/scripts/bootstrap/codex-cloud-setup.sh
+++ b/scripts/bootstrap/codex-cloud-setup.sh
@@ -155,7 +155,7 @@ MSG
 verify_origin_git_auth() {
   local remote_url
   remote_url="$(git remote get-url origin)"
-  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
+  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* && "$remote_url" != ssh://git@github.com/* ]]; then
     echo "==> Skipping GitHub auth probe for non-GitHub origin: ${remote_url}"
     return 0
   fi
@@ -178,13 +178,14 @@ verify_github_api_capabilities() {
   local remote_url
   local repository
   remote_url="$(git remote get-url origin)"
-  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
+  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* && "$remote_url" != ssh://git@github.com/* ]]; then
     echo "==> Skipping GitHub API probes for non-GitHub origin: ${remote_url}"
     return 0
   fi
 
   repository="${remote_url#https://github.com/}"
   repository="${repository#git@github.com:}"
+  repository="${repository#ssh://git@github.com/}"
   repository="${repository%.git}"
 
   echo "==> Verifying GitHub repository API access"
@@ -201,7 +202,7 @@ verify_origin_write_access() (
   local probe_suffix
   local cleanup_eligible=false
   remote_url="$(git remote get-url origin)"
-  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
+  if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* && "$remote_url" != ssh://git@github.com/* ]]; then
     echo "==> Skipping GitHub write probe for non-GitHub origin: ${remote_url}"
     return 0
   fi

--- a/scripts/bootstrap/codex-cloud-setup.sh
+++ b/scripts/bootstrap/codex-cloud-setup.sh
@@ -174,6 +174,54 @@ MSG
   return 1
 }
 
+verify_github_api_capabilities() {
+  local repository
+  repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+
+  echo "==> Verifying GitHub repository API access"
+  gh api "repos/${repository}" >/dev/null
+
+  echo "==> Verifying GitHub pull-request API access"
+  gh api "repos/${repository}/pulls?state=open&per_page=1" >/dev/null
+}
+
+verify_origin_write_access() (
+  local probe_branch
+  local probe_ref
+  local created=false
+  probe_branch="codex-cloud-write-probe-$(date +%s)-$$"
+  probe_ref="refs/heads/${probe_branch}"
+
+  # Invoked indirectly by the EXIT trap below.
+  # shellcheck disable=SC2329
+  cleanup_probe_ref() {
+    if [[ "$created" == "true" ]]; then
+      git push origin --delete "$probe_branch" >/dev/null 2>&1 ||
+        echo "warning: could not remove temporary GitHub write probe ${probe_branch}." >&2
+    fi
+  }
+  trap cleanup_probe_ref EXIT
+
+  echo "==> Verifying git can create and delete a temporary branch on origin"
+  if ! git push origin "HEAD:${probe_ref}" >/dev/null; then
+    cat >&2 <<'MSG'
+error: GitHub authentication can read this repository but cannot create a
+temporary branch. Give the Codex Cloud GH_TOKEN/GITHUB_TOKEN repository
+Contents read/write permission, then start a fresh session. Pull request and
+ship flows cannot publish commits with a read-only token.
+MSG
+    return 1
+  fi
+  created=true
+
+  if ! git push origin --delete "$probe_branch" >/dev/null; then
+    created=false
+    echo "error: GitHub authentication created the temporary write probe but could not delete it: ${probe_branch}" >&2
+    return 1
+  fi
+  created=false
+)
+
 append_no_proxy_host() {
   local host="$1"
   local existing=",${NO_PROXY:-},"
@@ -479,6 +527,16 @@ MSG
   return 1
 }
 
+install_playwright_host_dependencies() {
+  if is_disabled "${CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS:-true}"; then
+    echo "==> Skipping Playwright host dependencies because CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS=${CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS}"
+    return 0
+  fi
+
+  echo "==> Installing Playwright Chromium and Linux host dependencies"
+  pnpm --filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium
+}
+
 # The offline installer suite sources these functions without running setup.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
   return 0
@@ -495,6 +553,8 @@ configure_github_git_auth
 
 codex_cloud_ensure_origin_remote
 verify_origin_git_auth
+verify_github_api_capabilities
+verify_origin_write_access
 ensure_origin_main_ref
 
 echo "==> Configuring repository git hooks"
@@ -519,6 +579,8 @@ CI=true pnpm install --frozen-lockfile
 
 echo "==> Verifying dashboard dependency resolution"
 pnpm --filter @mento-protocol/ui-dashboard exec node -e "require.resolve('@sentry/nextjs/package.json')"
+
+install_playwright_host_dependencies
 
 echo "==> Running Envio codegen"
 # Drop any stale type facade first: a reused/cached checkout may already carry

--- a/scripts/bootstrap/codex-cloud-setup.sh
+++ b/scripts/bootstrap/codex-cloud-setup.sh
@@ -183,7 +183,9 @@ verify_github_api_capabilities() {
     return 0
   fi
 
-  repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  repository="${remote_url#https://github.com/}"
+  repository="${repository#git@github.com:}"
+  repository="${repository%.git}"
 
   echo "==> Verifying GitHub repository API access"
   gh api "repos/${repository}" >/dev/null
@@ -197,7 +199,7 @@ verify_origin_write_access() (
   local probe_branch
   local probe_ref
   local probe_suffix
-  local created=false
+  local cleanup_eligible=false
   remote_url="$(git remote get-url origin)"
   if [[ "$remote_url" != https://github.com/* && "$remote_url" != git@github.com:* ]]; then
     echo "==> Skipping GitHub write probe for non-GitHub origin: ${remote_url}"
@@ -211,7 +213,7 @@ verify_origin_write_access() (
   # Invoked indirectly by the EXIT trap below.
   # shellcheck disable=SC2329
   cleanup_probe_ref() {
-    if [[ "$created" == "true" ]]; then
+    if [[ "$cleanup_eligible" == "true" ]]; then
       git push origin --delete "$probe_branch" >/dev/null 2>&1 ||
         echo "warning: could not remove temporary GitHub write probe ${probe_branch}." >&2
     fi
@@ -221,6 +223,10 @@ verify_origin_write_access() (
   # A dry run suppresses the ref update, so it cannot prove that the remote
   # accepts branch creation. Use a collision-resistant ref and remove it here.
   echo "==> Verifying git can create and delete a temporary branch on origin"
+  # The server may create the ref even when the client loses the success
+  # response. Make cleanup eligible before the push so the EXIT trap also
+  # covers that ambiguous failure.
+  cleanup_eligible=true
   if ! git push origin "HEAD:${probe_ref}" >/dev/null; then
     cat >&2 <<'MSG'
 error: GitHub authentication can read this repository but cannot create a
@@ -230,13 +236,12 @@ ship flows cannot publish commits with a read-only token.
 MSG
     return 1
   fi
-  created=true
 
   if ! git push origin --delete "$probe_branch" >/dev/null; then
     echo "error: GitHub authentication created the temporary write probe but could not delete it: ${probe_branch}" >&2
     return 1
   fi
-  created=false
+  cleanup_eligible=false
 )
 
 append_no_proxy_host() {

--- a/scripts/bootstrap/codex-cloud-setup.test.sh
+++ b/scripts/bootstrap/codex-cloud-setup.test.sh
@@ -307,6 +307,22 @@ if grep -Fq "wrong-owner/wrong-repo" "$case_tool_log"; then
   fail "${case_name}: GH_REPO redirected an API probe"
 fi
 
+prepare_case "github-api-ssh-uri-origin"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  git() {
+    [[ "$*" == "remote get-url origin" ]] || return 1
+    echo "ssh://git@github.com/mento-protocol/monitoring-monorepo.git"
+  }
+  gh() { printf '%s\n' "$*" >>"$case_tool_log"; }
+  verify_github_api_capabilities
+) >"$case_stdout" 2>"$case_stderr"
+grep -Fxq "api repos/mento-protocol/monitoring-monorepo" "$case_tool_log" ||
+  fail "${case_name}: repository probe did not normalize the SSH URI origin"
+grep -Fxq "api repos/mento-protocol/monitoring-monorepo/pulls?state=open&per_page=1" "$case_tool_log" ||
+  fail "${case_name}: pull-request probe did not normalize the SSH URI origin"
+
 prepare_case "origin-write-access-refused"
 (
   # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh

--- a/scripts/bootstrap/codex-cloud-setup.test.sh
+++ b/scripts/bootstrap/codex-cloud-setup.test.sh
@@ -272,23 +272,75 @@ prepare_case "origin-write-access"
 (
   # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
   source "$setup_script"
-  git() { printf '%s\n' "$*" >>"$case_tool_log"; }
+  git() {
+    if [[ "$*" == "remote get-url origin" ]]; then
+      echo "https://github.com/mento-protocol/monitoring-monorepo.git"
+      return 0
+    fi
+    printf '%s\n' "$*" >>"$case_tool_log"
+  }
   verify_origin_write_access
 ) >"$case_stdout" 2>"$case_stderr"
 [[ "$(wc -l <"$case_tool_log")" -eq 2 ]] || fail "${case_name}: did not create and delete exactly one probe branch"
-sed -n '1p' "$case_tool_log" | grep -Eq '^push origin HEAD:refs/heads/codex-cloud-write-probe-[0-9]+-[0-9]+$' ||
+sed -n '1p' "$case_tool_log" | grep -Eq '^push origin HEAD:refs/heads/codex-cloud-write-probe-[0-9a-f]{32}$' ||
   fail "${case_name}: did not create a namespaced temporary branch"
-sed -n '2p' "$case_tool_log" | grep -Eq '^push origin --delete codex-cloud-write-probe-[0-9]+-[0-9]+$' ||
+sed -n '2p' "$case_tool_log" | grep -Eq '^push origin --delete codex-cloud-write-probe-[0-9a-f]{32}$' ||
   fail "${case_name}: did not delete the temporary branch"
 
 prepare_case "origin-write-access-refused"
 (
   # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
   source "$setup_script"
-  git() { printf '%s\n' "$*" >>"$case_tool_log"; return 1; }
+  git() {
+    if [[ "$*" == "remote get-url origin" ]]; then
+      echo "https://github.com/mento-protocol/monitoring-monorepo.git"
+      return 0
+    fi
+    printf '%s\n' "$*" >>"$case_tool_log"
+    return 1
+  }
   verify_origin_write_access
 ) >"$case_stdout" 2>"$case_stderr" && fail "${case_name}: accepted a read-only GitHub credential"
 grep -Fq "Contents read/write permission" "$case_stderr" ||
   fail "${case_name}: did not explain the required GitHub permission"
+
+prepare_case "origin-write-access-delete-retry"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  delete_attempts=0
+  git() {
+    if [[ "$*" == "remote get-url origin" ]]; then
+      echo "https://github.com/mento-protocol/monitoring-monorepo.git"
+      return 0
+    fi
+    printf '%s\n' "$*" >>"$case_tool_log"
+    if [[ "$*" == push\ origin\ --delete* ]]; then
+      delete_attempts=$((delete_attempts + 1))
+      [[ "$delete_attempts" -gt 1 ]]
+      return
+    fi
+  }
+  verify_origin_write_access
+) >"$case_stdout" 2>"$case_stderr" && fail "${case_name}: accepted an initial cleanup failure"
+[[ "$(grep -c '^push origin --delete ' "$case_tool_log")" -eq 2 ]] ||
+  fail "${case_name}: EXIT cleanup did not retry the failed deletion"
+
+prepare_case "non-github-origin-probes"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  git() {
+    [[ "$*" == "remote get-url origin" ]] || fail "${case_name}: attempted git mutation for non-GitHub origin"
+    echo "https://git.example.test/mento/monitoring-monorepo.git"
+  }
+  gh() { fail "${case_name}: attempted GitHub API access for non-GitHub origin"; }
+  verify_github_api_capabilities
+  verify_origin_write_access
+) >"$case_stdout" 2>"$case_stderr"
+grep -Fq "Skipping GitHub API probes for non-GitHub origin" "$case_stdout" ||
+  fail "${case_name}: did not skip GitHub API probes"
+grep -Fq "Skipping GitHub write probe for non-GitHub origin" "$case_stdout" ||
+  fail "${case_name}: did not skip GitHub write probe"
 
 echo "codex-cloud-setup.test.sh: all checks passed"

--- a/scripts/bootstrap/codex-cloud-setup.test.sh
+++ b/scripts/bootstrap/codex-cloud-setup.test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Case subshells intentionally isolate environment mutations.
+# shellcheck disable=SC2030,SC2031
 set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
@@ -246,5 +248,47 @@ fi
 [[ "$(wc -l <"$case_exec_log")" -eq 1 ]] || fail "${case_name}: did not execute the default installer exactly once"
 grep -Fxq "foundryup" "$case_tool_log" || fail "${case_name}: did not run foundryup"
 grep -Fxq "forge" "$case_tool_log" || fail "${case_name}: did not verify forge"
+
+prepare_case "playwright-host-dependencies"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  pnpm() { printf '%s\n' "$*" >"$case_tool_log"; }
+  install_playwright_host_dependencies
+) >"$case_stdout" 2>"$case_stderr"
+grep -Fxq -- "--filter @mento-protocol/ui-dashboard exec playwright install --with-deps chromium" "$case_tool_log" ||
+  fail "${case_name}: did not install Chromium with Linux host dependencies"
+
+prepare_case "playwright-host-dependencies-disabled"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  pnpm() { printf '%s\n' "$*" >"$case_tool_log"; }
+  CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS=false install_playwright_host_dependencies
+) >"$case_stdout" 2>"$case_stderr"
+[[ ! -s "$case_tool_log" ]] || fail "${case_name}: ran Playwright despite the explicit opt-out"
+
+prepare_case "origin-write-access"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  git() { printf '%s\n' "$*" >>"$case_tool_log"; }
+  verify_origin_write_access
+) >"$case_stdout" 2>"$case_stderr"
+[[ "$(wc -l <"$case_tool_log")" -eq 2 ]] || fail "${case_name}: did not create and delete exactly one probe branch"
+sed -n '1p' "$case_tool_log" | grep -Eq '^push origin HEAD:refs/heads/codex-cloud-write-probe-[0-9]+-[0-9]+$' ||
+  fail "${case_name}: did not create a namespaced temporary branch"
+sed -n '2p' "$case_tool_log" | grep -Eq '^push origin --delete codex-cloud-write-probe-[0-9]+-[0-9]+$' ||
+  fail "${case_name}: did not delete the temporary branch"
+
+prepare_case "origin-write-access-refused"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  git() { printf '%s\n' "$*" >>"$case_tool_log"; return 1; }
+  verify_origin_write_access
+) >"$case_stdout" 2>"$case_stderr" && fail "${case_name}: accepted a read-only GitHub credential"
+grep -Fq "Contents read/write permission" "$case_stderr" ||
+  fail "${case_name}: did not explain the required GitHub permission"
 
 echo "codex-cloud-setup.test.sh: all checks passed"

--- a/scripts/bootstrap/codex-cloud-setup.test.sh
+++ b/scripts/bootstrap/codex-cloud-setup.test.sh
@@ -287,6 +287,26 @@ sed -n '1p' "$case_tool_log" | grep -Eq '^push origin HEAD:refs/heads/codex-clou
 sed -n '2p' "$case_tool_log" | grep -Eq '^push origin --delete codex-cloud-write-probe-[0-9a-f]{32}$' ||
   fail "${case_name}: did not delete the temporary branch"
 
+prepare_case "github-api-origin-binding"
+(
+  # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
+  source "$setup_script"
+  git() {
+    [[ "$*" == "remote get-url origin" ]] || return 1
+    echo "https://github.com/mento-protocol/monitoring-monorepo.git"
+  }
+  gh() { printf '%s\n' "$*" >>"$case_tool_log"; }
+  GH_REPO="wrong-owner/wrong-repo" verify_github_api_capabilities
+) >"$case_stdout" 2>"$case_stderr"
+[[ "$(wc -l <"$case_tool_log")" -eq 2 ]] || fail "${case_name}: did not run both API probes"
+grep -Fxq "api repos/mento-protocol/monitoring-monorepo" "$case_tool_log" ||
+  fail "${case_name}: repository probe did not target origin"
+grep -Fxq "api repos/mento-protocol/monitoring-monorepo/pulls?state=open&per_page=1" "$case_tool_log" ||
+  fail "${case_name}: pull-request probe did not target origin"
+if grep -Fq "wrong-owner/wrong-repo" "$case_tool_log"; then
+  fail "${case_name}: GH_REPO redirected an API probe"
+fi
+
 prepare_case "origin-write-access-refused"
 (
   # shellcheck source=scripts/bootstrap/codex-cloud-setup.sh
@@ -303,6 +323,8 @@ prepare_case "origin-write-access-refused"
 ) >"$case_stdout" 2>"$case_stderr" && fail "${case_name}: accepted a read-only GitHub credential"
 grep -Fq "Contents read/write permission" "$case_stderr" ||
   fail "${case_name}: did not explain the required GitHub permission"
+[[ "$(grep -c '^push origin --delete ' "$case_tool_log")" -eq 1 ]] ||
+  fail "${case_name}: did not attempt cleanup after an ambiguous create failure"
 
 prepare_case "origin-write-access-delete-retry"
 (


### PR DESCRIPTION
## The Problem

- Codex Cloud setup accepted a GitHub token that could authenticate and fetch even when it could not push a task branch, so the failure appeared only at ship time.
- Fresh Cloud images downloaded Playwright Chromium without its Linux host libraries, which left every dashboard browser test unable to launch.
- Operators had no single list of the outbound hosts required by the setup path.

## The Solution

- Setup now fails early unless GitHub repository reads, pull-request API reads, and a real create/delete branch probe succeed.
- Setup installs Playwright Chromium with its Linux dependencies after workspace installation, so browser checks work in fresh containers. An explicit opt-out remains for prebuilt images.
- The canonical runbook now states the token permissions and outbound network access the environment needs.

## Details

- The write probe publishes the current commit to a unique `codex-cloud-write-probe-*` branch and deletes it immediately, with an EXIT cleanup fallback.
- `CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS=false` skips the Playwright provisioning step only when the base image already owns those dependencies.
- Focused shell fixtures cover dependency installation, opt-out behavior, successful branch cleanup, and read-only-token refusal.

## Validation

- `pnpm agent:quality-gate --run`
- `bash scripts/bootstrap/codex-cloud-setup.test.sh`
- `source scripts/bootstrap/codex-cloud-setup.sh && verify_github_api_capabilities && verify_origin_write_access` (the live temporary branch was created and deleted)
- `./tools/trunk check docs/notes/codex-cloud-setup.md scripts/bootstrap/codex-cloud-setup.sh scripts/bootstrap/codex-cloud-setup.test.sh`

## Security review

- Claude Security scan: skipped (Codex surface; the plugin is unavailable). The mapped gate and focused tests cover the credential and push-probe paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Setup now performs real git pushes to origin during every fresh container bootstrap, which requires write-capable tokens and briefly creates remote branches if cleanup fails; otherwise changes are confined to bootstrap scripts and operator docs.
> 
> **Overview**
> Codex Cloud setup now **validates GitHub shipping readiness during bootstrap** instead of failing later at ship time. After git auth, it probes the repository and open-PR APIs via `gh`, then pushes and deletes a unique `codex-cloud-write-probe-*` branch (with EXIT cleanup) so read-only tokens fail with a clear Contents read/write message.
> 
> **Playwright** is provisioned after `pnpm install` via `playwright install --with-deps chromium` on the dashboard package, with `CODEX_CLOUD_INSTALL_PLAYWRIGHT_DEPS=false` to skip when the image already has Chromium and host libs.
> 
> The **codex-cloud-setup runbook** documents required token scopes (Contents and PR read/write), the write probe, Playwright behavior, and a consolidated list of outbound HTTPS hosts (GitHub, npm, Trunk, Foundry, OSV, Playwright CDN). Shell tests cover Playwright install/opt-out and write-probe success vs read-only refusal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3409e991f81053e7f42a07bb6fc8ddbd0a3598dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now verifies GitHub repository and pull-request access, including temporary branch creation and removal.
  * Optional Playwright Chromium and required Linux dependencies can be installed automatically.
  * Non-GitHub repositories skip GitHub-specific checks.
  * SSH-based GitHub repository URLs are supported for access checks.

* **Bug Fixes**
  * Improved handling of read-only credentials, unavailable network access, and temporary branch cleanup failures.

* **Documentation**
  * Expanded guidance on permissions, outbound hosts, network policies, and browser requirements.

* **Tests**
  * Added coverage for access checks, cleanup retries, browser dependency installation, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->