### PR TITLE
test(shared-config): pin toHumanUnits truncation past the 6-digit cap

### DIFF
--- a/shared-config/__tests__/units.test.ts
+++ b/shared-config/__tests__/units.test.ts
@@ -39,4 +39,15 @@ describe("toHumanUnits", () => {
     expect(toHumanUnits(0n, 18)).toBe(0);
     expect(toHumanUnits(0n, 6)).toBe(0);
   });
+
+  it("truncates fractional digits past the 6-digit cap", () => {
+    // The cap is deliberate (keeps the Number cast lossless), so pin the
+    // discard rather than leave it to a future reader to rediscover.
+    // 0.1234567 with 18 decimals renders as 0.123456 — the 7th digit is cut,
+    // not rounded.
+    expect(toHumanUnits(1_234_567n * 10n ** 11n, 18)).toBe(0.123456);
+    // A dust balance below the cap collapses to exactly 0, so callers must
+    // not treat a 0 result as proof the raw balance was 0.
+    expect(toHumanUnits(1n, 18)).toBe(0);
+  });
 });


### PR DESCRIPTION
## The Problem

- `toHumanUnits` caps fractional precision at 6 digits. The cap is deliberate and explained in a source comment, but no test asserted it, so widening or narrowing it would break no build.
- Two consequences of the cap were undocumented in test form: the 7th fractional digit is discarded rather than rounded, and any balance below the cap converts to exactly `0`. A caller reading a `0` result as "the raw balance was 0" is wrong for dust balances, and nothing caught that assumption.

## The Solution

`toHumanUnits` now has both behaviours pinned by assertion, so a change to the 6-digit cap or to the truncation-vs-rounding choice fails CI instead of silently reaching the metrics-bridge alert probe and the dashboard rebalance tooltip that share this function.

Material limit: this is a test-only change. `toHumanUnits` itself is untouched, so no runtime behaviour changes and no consumer needs updating. The test pins current behaviour rather than proposing that truncation is the right choice.

This PR is also a deliberate end-to-end exercise of the Claude cloud session workflow — gate, commit, push, PR — to find friction in that environment. Findings are in Details.

## Details

Added one `it(...)` block to `shared-config/__tests__/units.test.ts`:

- `toHumanUnits(1_234_567n * 10n ** 11n, 18)` → `0.123456`, pinning that the 7th digit is cut, not rounded.
- `toHumanUnits(1n, 18)` → `0`, pinning the dust-collapse case.

Both follow from the existing implementation: the fraction is computed as `((raw % divisor) * 1_000_000n) / divisor`, and BigInt division truncates.

### Cloud-environment findings from this run

Recorded here because this PR doubles as the environment test:

- `trunk.io` is not in the environment's egress allowlist, so the Trunk launcher cannot self-download. The quality gate maps `./tools/trunk check` on the changed paths as its first command, and that arm fails in 0s with no diagnostic, so the gate cannot return green in a cloud session. Prettier and markdownlint are Trunk-managed only, so no local formatting check exists here at all.
- The `.trunk/hooks` pre-commit and pre-push shims detect this and skip with a warning, exactly as their comments describe. Commit and push both succeeded.
- Every workspace package declares a Node engine floor of 24 and `.node-version` pins 24, but the container runs Node v22.22.2. Every `pnpm` invocation prints Unsupported-engine warnings.
- `docs/notes/github-tooling-surfaces.md` states that every `api.github.com/repos/*` path returns 403 in these sessions. That is no longer true — REST `/repos/*` now returns 200. GraphQL is still restricted to a pinned operation set, and the `gh` binary cannot be downloaded, so the MCP-first routing conclusion still holds; only the stated reason is stale.

## Validation

- `pnpm agent:quality-gate` — mapped the `shared-config` surface and 12 commands.
- `pnpm agent:quality-gate --run --keep-going` — 11 of 12 green, including `pnpm --filter @mento-protocol/config test:coverage` (which runs the added test), all three consumer typechecks, `knip`, `code-health:deps`, the dashboard `size-limit`, and `tf:test`. The single failure is `./tools/trunk check`, blocked by the allowlist gap above and not by this diff.
- `./tools/trunk fmt` could not run for the same reason. The added lines were kept within the repo's existing style and under an 80-character print width by hand. Code Quality CI subsequently passed on this head, confirming the formatting.
- Full CI on `dab2f22`: all checks green, `mergeable_state: clean`. CodeRabbit reported no actionable comments; the Claude reviewer returned LGTM.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — test-only change.