### PR TITLE
chore(docs): cloud-env smoke test — DO NOT MERGE

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,10 @@ Authority: canonical
 - [`governance-watchdog/DEPLOY_FROM_SCRATCH.md`](../governance-watchdog/DEPLOY_FROM_SCRATCH.md)
 - [`governance-watchdog/README.md`](../governance-watchdog/README.md)
 
+Authority: non-canonical
+
+- [`docs/notes/cloud-env-smoke-test.md`](notes/cloud-env-smoke-test.md)
+
 ## pr-checklists-process
 
 Authority: canonical

--- a/docs/notes/cloud-env-smoke-test.md
+++ b/docs/notes/cloud-env-smoke-test.md
@@ -1,0 +1,16 @@
+---
+title: Cloud Env Smoke Test
+status: active
+owner: eng
+canonical: false
+last_verified: 2026-08-24
+doc_type: note
+scope: repo-wide
+review_interval_days: 90
+garden_lane: operator-runbooks
+---
+
+# Cloud Env Smoke Test
+
+Throwaway marker file for a Claude cloud-environment workflow smoke test; it
+carries no operating truth and should be deleted once the test PR closes.


### PR DESCRIPTION
## The Problem

- Nobody had measured whether a Claude cloud session can drive this repo's
  full PR loop — gate, autoreview, hooks, push, PR — end to end. Failures were
  discovered one at a time, mid-task, by whoever happened to hit them.
- The cloud sandbox blocks egress the local workflow assumes, so operators
  could not say in advance which documented steps work there and which cannot.

## The Solution

This PR is a disposable probe, not a product change. It adds one throwaway
note and the generated `docs/README.md` index entry that the docs gate demands,
purely to give the workflow something to carry. The concrete benefit is the
findings list below: the cloud session now has a measured record of which
workflow steps run, which degrade gracefully, and which cannot run at all.

Material limits: it must never merge. The note it adds carries no operating
truth, and the branch exists only to exercise machinery. Close the PR and
delete the branch once the findings are read.

**Draft reason:** the repo default is ready-for-review, but this PR exists only
to exercise the open path. It requests no review and must not merge, so draft
is the correct state and was explicitly requested.

## Details

Changed files:

- `docs/notes/cloud-env-smoke-test.md` — new note, marked `canonical: false`.
- `docs/README.md` — regenerated by `pnpm docs:index --write`, not hand-edited.

Environment: Node v22.22.2, pnpm 11.9.0, shallow clone (depth 50),
`CLAUDE_CODE_REMOTE=true`.

Blocked in this sandbox, so unverifiable here:

- `./tools/trunk` cannot provision — `trunk.io` returns
  `Proxy tunneling failed: Forbidden`. The required Code Quality CI check is
  therefore unverified locally; CI is the first place formatting gets checked.
- `gh` is not installed, so the documented capability gate in
  `docs/notes/github-tooling-surfaces.md` cannot even be evaluated. This PR was
  opened through the GitHub MCP server.
- `codex` is not installed, so a bare `pnpm agent:autoreview` fails. The
  closeout ran under `--engine claude`.

## Validation

- `pnpm agent:quality-gate --run` — 4 of 5 mapped commands pass
  (`docs:index --check`, `agent:context-check`, `docs:navigation-eval`,
  `tf:test`). `./tools/trunk check` fails because the CLI cannot download.
  The first run also failed `docs:index --check`; `pnpm docs:index --write`
  fixed it.
- `pnpm agent:autoreview --engine claude` — 2 findings. One is valid and
  accepted: a throwaway file is being wired into the canonical docs index,
  which is the point of the probe and the reason this must not merge. The
  other, claiming the `docs/README.md` entry breaks a one-heading-one-authority
  convention, is a false positive: sections in that file carry several
  `Authority:` groups (`## agent-entry-points` has canonical, non-canonical,
  and unmanaged), and the generator correctly placed this entry under
  `## operator-runbooks`.
- Pre-commit and pre-push hooks fired and skipped with their documented
  trunk-unavailable warning. That degradation path works.
- `git push -u origin claude/cloud-env-smoke-test-yuvdeq` — succeeded first
  try, no retries.

## Deferrals

- None

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fg7SYMNXehFU1VkHATG3f6)_