### PR TITLE
fix(ui-dashboard): page intel_deep reads through HSCAN, not HGETALL/HVALS

### DIFF
--- a/ui-dashboard/scripts/intel-marathon/extract-entities.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-entities.mjs
@@ -33,7 +33,7 @@ const RATE_LIMIT_BACKOFF_MS = 1500;
 const HSCAN_PAGE_COUNT = 100;
 // Safety bound so a cursor that never returns to "0" fails loudly instead of
 // looping forever.
-const HSCAN_MAX_PAGES = 10_000;
+export const HSCAN_MAX_PAGES = 10_000;
 
 const required = [
   "UPSTASH_REDIS_REST_URL",
@@ -118,7 +118,11 @@ export async function fetchHashViaHscan(
     for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
     cursor = String(nextCursor);
     pages++;
-    if (pages > HSCAN_MAX_PAGES) {
+    // Check before requesting another page, not after: a scan that
+    // completes exactly at the bound (cursor "0" on page HSCAN_MAX_PAGES)
+    // must succeed, and a scan that still isn't done at the bound must
+    // throw here instead of first fetching page HSCAN_MAX_PAGES + 1.
+    if (cursor !== "0" && pages >= HSCAN_MAX_PAGES) {
       throw new Error(
         `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
       );

--- a/ui-dashboard/scripts/intel-marathon/extract-entities.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-entities.mjs
@@ -18,25 +18,39 @@
 
 import process from "node:process";
 import { writeFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const ARKHAM_BASE = "https://api.arkm.com";
 const OUT_DIR = ".intel-marathon";
 const REQ_SPACING_MS = 60; // standard bucket
 const RATE_LIMIT_BACKOFF_MS = 1500;
 
+// Upstash REST rejects a whole-hash read once the encoded reply exceeds
+// ~10 MB — intel_deep already exceeds that on a plain HVALS/HGETALL. Read it
+// via cursor-paginated HSCAN instead (see fetchHashViaHscan). 100 fields/page
+// keeps each page well under the cap even at the largest observed field
+// size (~50 KB).
+const HSCAN_PAGE_COUNT = 100;
+// Safety bound so a cursor that never returns to "0" fails loudly instead of
+// looping forever.
+const HSCAN_MAX_PAGES = 10_000;
+
 const required = [
   "UPSTASH_REDIS_REST_URL",
   "UPSTASH_REDIS_REST_TOKEN",
   "ARKHAM_API_KEY",
 ];
-const missing = required.filter((k) => !process.env[k]);
-if (missing.length > 0) {
-  console.error(`Missing env: ${missing.join(", ")}`);
-  process.exit(1);
-}
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const arkhamKey = process.env.ARKHAM_API_KEY;
+
+function requireEnv() {
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing env: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+}
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -73,6 +87,53 @@ async function pipeline(commands) {
     }
   }
   return json;
+}
+
+// Read every field of `key` via cursor-paginated HSCAN and return the same
+// flat [field1, value1, field2, value2, ...] shape HGETALL's REST response
+// carries. HSCAN can return a field more than once across pages; later
+// pages are merged last, so they win. Upstash REST can also answer a
+// request it can't serve with HTTP 200 and an `error` body field (observed
+// live on an oversized HGETALL), so check for that on every page instead of
+// trusting `res.ok` alone.
+export async function fetchHashViaHscan(
+  key,
+  { count = HSCAN_PAGE_COUNT, fetchImpl = fetch } = {},
+) {
+  const merged = new Map();
+  let cursor = "0";
+  let pages = 0;
+  do {
+    const res = await fetchImpl(
+      `${redisUrl}/hscan/${key}/${cursor}?count=${count}`,
+      { headers: { Authorization: `Bearer ${redisToken}` } },
+    );
+    const body = await res.json();
+    if (!res.ok || body?.error) {
+      throw new Error(
+        `Upstash /hscan/${key} (cursor ${cursor}) → ${res.status}: ${body?.error ?? JSON.stringify(body)}`,
+      );
+    }
+    const [nextCursor, flat] = body.result;
+    for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
+    cursor = String(nextCursor);
+    pages++;
+    if (pages > HSCAN_MAX_PAGES) {
+      throw new Error(
+        `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
+      );
+    }
+  } while (cursor !== "0");
+  return Array.from(merged.entries()).flat();
+}
+
+// Values only, mirroring what HVALS used to return for this key (no field
+// names) — the one shape extractSlugs()'s deepEntries param needs.
+export async function fetchHashValuesViaHscan(key, opts) {
+  const flat = await fetchHashViaHscan(key, opts);
+  const values = [];
+  for (let i = 1; i < flat.length; i += 2) values.push(flat[i]);
+  return values;
 }
 
 function extractSlugs(deepEntries, labelEntries) {
@@ -136,16 +197,20 @@ async function fetchEntity(slug) {
 }
 
 async function main() {
+  requireEnv();
   const startedAt = Date.now();
   mkdirSync(OUT_DIR, { recursive: true });
   const rawFile = `${OUT_DIR}/extract-entities-raw.jsonl`;
 
   console.log("→ Scanning intel_deep + labels for entity slugs...");
-  const [deepResp, labelResp] = await pipeline([
-    ["HVALS", "intel_deep"],
-    ["HVALS", "labels"],
+  // intel_deep already exceeds Upstash REST's 10MB single-response cap, so
+  // it can't go through the HVALS pipeline call below; labels is well under
+  // the cap and stays on the plain pipeline path.
+  const [deepValues, [labelResp]] = await Promise.all([
+    fetchHashValuesViaHscan("intel_deep"),
+    pipeline([["HVALS", "labels"]]),
   ]);
-  const slugs = extractSlugs(deepResp.result ?? [], labelResp.result ?? []);
+  const slugs = extractSlugs(deepValues, labelResp.result ?? []);
   console.log(`  found ${slugs.length} unique entity slugs`);
 
   // Filter out slugs we've already fetched (resume safety).
@@ -236,8 +301,17 @@ async function main() {
   console.log(`  raw:              ${rawFile}`);
 }
 
-main().catch((err) => {
-  console.error("✗ FAILED:", err.message);
-  console.error(err.stack);
-  process.exit(1);
-});
+export function isMainModule(importMetaUrl, argv = process.argv) {
+  const entrypoint = argv[1];
+  return typeof entrypoint === "string"
+    ? importMetaUrl === pathToFileURL(entrypoint).href
+    : false;
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((err) => {
+    console.error("✗ FAILED:", err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}

--- a/ui-dashboard/scripts/intel-marathon/extract-entities.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-entities.test.mjs
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchHashViaHscan,
+  fetchHashValuesViaHscan,
+} from "./extract-entities.mjs";
+
+function hscanResponse(cursor, flat) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ result: [cursor, flat] }),
+  };
+}
+
+describe("fetchHashViaHscan", () => {
+  it("never issues a whole-hash HGETALL/HVALS — pages through HSCAN and merges every page", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        hscanResponse("7", ["0xaaa", '{"v":1}', "0xbbb", '{"v":2}']),
+      )
+      .mockResolvedValueOnce(hscanResponse("0", ["0xccc", '{"v":3}']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual([
+      "0xaaa",
+      '{"v":1}',
+      "0xbbb",
+      '{"v":2}',
+      "0xccc",
+      '{"v":3}',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toContain("/hscan/intel_deep/0");
+    expect(fetchImpl.mock.calls[1][0]).toContain("/hscan/intel_deep/7");
+    expect(
+      fetchImpl.mock.calls.some(
+        ([url]) => url.includes("/hgetall/") || url.includes("/hvals/"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the later page's value when HSCAN returns the same field twice", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(hscanResponse("3", ["0xaaa", '"stale"']))
+      .mockResolvedValueOnce(hscanResponse("0", ["0xaaa", '"fresh"']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual(["0xaaa", '"fresh"']);
+  });
+
+  it("throws when Upstash answers with HTTP 200 and an error body field", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          error: "ERR max request size exceeded. Limit: 10485760 bytes",
+        }),
+    });
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/max request size exceeded/);
+  });
+
+  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/did not terminate/);
+  });
+});
+
+describe("fetchHashValuesViaHscan", () => {
+  it("drops field names and returns only values, matching HVALS's shape", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        hscanResponse("0", ["0xaaa", '{"v":1}', "0xbbb", '{"v":2}']),
+      );
+
+    const values = await fetchHashValuesViaHscan("intel_deep", { fetchImpl });
+
+    expect(values).toEqual(['{"v":1}', '{"v":2}']);
+  });
+
+  it("merges values across multiple pages", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(hscanResponse("5", ["0xaaa", '{"v":1}']))
+      .mockResolvedValueOnce(hscanResponse("0", ["0xbbb", '{"v":2}']));
+
+    const values = await fetchHashValuesViaHscan("intel_deep", { fetchImpl });
+
+    expect(values).toEqual(['{"v":1}', '{"v":2}']);
+  });
+});

--- a/ui-dashboard/scripts/intel-marathon/extract-entities.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-entities.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   fetchHashViaHscan,
   fetchHashValuesViaHscan,
+  HSCAN_MAX_PAGES,
 } from "./extract-entities.mjs";
 
 function hscanResponse(cursor, flat) {
@@ -67,7 +68,23 @@ describe("fetchHashViaHscan", () => {
     ).rejects.toThrow(/max request size exceeded/);
   });
 
-  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+  it("succeeds when the scan terminates on exactly the page-count bound", async () => {
+    let calls = 0;
+    const fetchImpl = vi.fn(() => {
+      calls++;
+      const cursor = calls === HSCAN_MAX_PAGES ? "0" : String(calls);
+      return Promise.resolve(
+        hscanResponse(cursor, ["0xaaa", `{"v":${calls}}`]),
+      );
+    });
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
+    expect(flat).toEqual(["0xaaa", `{"v":${HSCAN_MAX_PAGES}}`]);
+  });
+
+  it("aborts before requesting one page past the bound when the cursor never returns to 0", async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
@@ -75,6 +92,8 @@ describe("fetchHashViaHscan", () => {
     await expect(
       fetchHashViaHscan("intel_deep", { fetchImpl }),
     ).rejects.toThrow(/did not terminate/);
+    // The bound must reject before a page beyond it is ever requested.
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
   });
 });
 

--- a/ui-dashboard/scripts/intel-marathon/extract-transfers.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-transfers.mjs
@@ -37,7 +37,7 @@ const TRANSFERS_PER_ADDR = 100;
 const HSCAN_PAGE_COUNT = 100;
 // Safety bound so a cursor that never returns to "0" fails loudly instead of
 // looping forever.
-const HSCAN_MAX_PAGES = 10_000;
+export const HSCAN_MAX_PAGES = 10_000;
 
 const required = [
   "UPSTASH_REDIS_REST_URL",
@@ -126,7 +126,11 @@ export async function fetchHashViaHscan(
     for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
     cursor = String(nextCursor);
     pages++;
-    if (pages > HSCAN_MAX_PAGES) {
+    // Check before requesting another page, not after: a scan that
+    // completes exactly at the bound (cursor "0" on page HSCAN_MAX_PAGES)
+    // must succeed, and a scan that still isn't done at the bound must
+    // throw here instead of first fetching page HSCAN_MAX_PAGES + 1.
+    if (cursor !== "0" && pages >= HSCAN_MAX_PAGES) {
       throw new Error(
         `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
       );

--- a/ui-dashboard/scripts/intel-marathon/extract-transfers.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-transfers.mjs
@@ -21,6 +21,7 @@
 
 import process from "node:process";
 import { appendFileSync, mkdirSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const ARKHAM_BASE = "https://api.arkm.com";
 const OUT_DIR = ".intel-marathon";
@@ -28,19 +29,32 @@ const HEAVY_SPACING_MS = 1100; // heavy bucket 1 req/s + headroom
 const RATE_LIMIT_BACKOFF_MS = 2000;
 const TRANSFERS_PER_ADDR = 100;
 
+// Upstash REST rejects a whole-hash read once the encoded reply exceeds
+// ~10 MB — intel_deep already exceeds that on a plain HGETALL. Read it via
+// cursor-paginated HSCAN instead (see fetchHashViaHscan). 100 fields/page
+// keeps each page well under the cap even at the largest observed field
+// size (~50 KB).
+const HSCAN_PAGE_COUNT = 100;
+// Safety bound so a cursor that never returns to "0" fails loudly instead of
+// looping forever.
+const HSCAN_MAX_PAGES = 10_000;
+
 const required = [
   "UPSTASH_REDIS_REST_URL",
   "UPSTASH_REDIS_REST_TOKEN",
   "ARKHAM_API_KEY",
 ];
-const missing = required.filter((k) => !process.env[k]);
-if (missing.length > 0) {
-  console.error(`Missing env: ${missing.join(", ")}`);
-  process.exit(1);
-}
 const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const arkhamKey = process.env.ARKHAM_API_KEY;
+
+function requireEnv() {
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    console.error(`Missing env: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+}
 
 const args = process.argv.slice(2);
 const limitIdx = args.indexOf("--limit");
@@ -81,6 +95,44 @@ async function upstash(path, init = {}) {
   if (!res.ok)
     throw new Error(`Upstash ${path} → ${res.status}: ${await res.text()}`);
   return res.json();
+}
+
+// Read every field of `key` via cursor-paginated HSCAN and return the same
+// flat [field1, value1, field2, value2, ...] shape HGETALL's REST response
+// carries, so callers need no other changes. HSCAN can return a field more
+// than once across pages; later pages are merged last, so they win. Upstash
+// REST can also answer a request it can't serve with HTTP 200 and an
+// `error` body field (observed live on an oversized HGETALL), so check for
+// that on every page instead of trusting `res.ok` alone.
+export async function fetchHashViaHscan(
+  key,
+  { count = HSCAN_PAGE_COUNT, fetchImpl = fetch } = {},
+) {
+  const merged = new Map();
+  let cursor = "0";
+  let pages = 0;
+  do {
+    const res = await fetchImpl(
+      `${redisUrl}/hscan/${key}/${cursor}?count=${count}`,
+      { headers: { Authorization: `Bearer ${redisToken}` } },
+    );
+    const body = await res.json();
+    if (!res.ok || body?.error) {
+      throw new Error(
+        `Upstash /hscan/${key} (cursor ${cursor}) → ${res.status}: ${body?.error ?? JSON.stringify(body)}`,
+      );
+    }
+    const [nextCursor, flat] = body.result;
+    for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
+    cursor = String(nextCursor);
+    pages++;
+    if (pages > HSCAN_MAX_PAGES) {
+      throw new Error(
+        `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
+      );
+    }
+  } while (cursor !== "0");
+  return Array.from(merged.entries()).flat();
 }
 
 async function pipeline(commands) {
@@ -140,8 +192,7 @@ async function buildTargetList() {
   }
 
   // 4. Top attested addresses from intel_deep — pick by counterparty USD volume.
-  const deep = await upstash(`/hgetall/intel_deep`);
-  const flat = deep.result ?? [];
+  const flat = await fetchHashViaHscan("intel_deep");
   const ranked = [];
   for (let i = 0; i < flat.length; i += 2) {
     const addr = flat[i];
@@ -189,6 +240,7 @@ async function fetchTransfers(address) {
 }
 
 async function main() {
+  requireEnv();
   const startedAt = Date.now();
   mkdirSync(OUT_DIR, { recursive: true });
   const rawFile = `${OUT_DIR}/extract-transfers-raw.jsonl`;
@@ -309,8 +361,17 @@ async function main() {
   console.log(`  raw:           ${rawFile}`);
 }
 
-main().catch((err) => {
-  console.error("✗ FAILED:", err.message);
-  console.error(err.stack);
-  process.exit(1);
-});
+export function isMainModule(importMetaUrl, argv = process.argv) {
+  const entrypoint = argv[1];
+  return typeof entrypoint === "string"
+    ? importMetaUrl === pathToFileURL(entrypoint).href
+    : false;
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((err) => {
+    console.error("✗ FAILED:", err.message);
+    console.error(err.stack);
+    process.exit(1);
+  });
+}

--- a/ui-dashboard/scripts/intel-marathon/extract-transfers.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-transfers.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchHashViaHscan } from "./extract-transfers.mjs";
+import { fetchHashViaHscan, HSCAN_MAX_PAGES } from "./extract-transfers.mjs";
 
 function hscanResponse(cursor, flat) {
   return {
@@ -69,7 +69,23 @@ describe("fetchHashViaHscan", () => {
     ).rejects.toThrow(/max request size exceeded/);
   });
 
-  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+  it("succeeds when the scan terminates on exactly the page-count bound", async () => {
+    let calls = 0;
+    const fetchImpl = vi.fn(() => {
+      calls++;
+      const cursor = calls === HSCAN_MAX_PAGES ? "0" : String(calls);
+      return Promise.resolve(
+        hscanResponse(cursor, ["0xaaa", `{"v":${calls}}`]),
+      );
+    });
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
+    expect(flat).toEqual(["0xaaa", `{"v":${HSCAN_MAX_PAGES}}`]);
+  });
+
+  it("aborts before requesting one page past the bound when the cursor never returns to 0", async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
@@ -77,5 +93,7 @@ describe("fetchHashViaHscan", () => {
     await expect(
       fetchHashViaHscan("intel_deep", { fetchImpl }),
     ).rejects.toThrow(/did not terminate/);
+    // The bound must reject before a page beyond it is ever requested.
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
   });
 });

--- a/ui-dashboard/scripts/intel-marathon/extract-transfers.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-transfers.test.mjs
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchHashViaHscan } from "./extract-transfers.mjs";
+
+function hscanResponse(cursor, flat) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ result: [cursor, flat] }),
+  };
+}
+
+describe("fetchHashViaHscan", () => {
+  it("never issues a whole-hash HGETALL — pages through HSCAN and merges every page", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        hscanResponse("7", ["0xaaa", '{"v":1}', "0xbbb", '{"v":2}']),
+      )
+      .mockResolvedValueOnce(hscanResponse("0", ["0xccc", '{"v":3}']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual([
+      "0xaaa",
+      '{"v":1}',
+      "0xbbb",
+      '{"v":2}',
+      "0xccc",
+      '{"v":3}',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toContain("/hscan/intel_deep/0");
+    expect(fetchImpl.mock.calls[1][0]).toContain("/hscan/intel_deep/7");
+    // Refusing a whole-hash call proves the fix never falls back to it:
+    // intel_deep already exceeds Upstash REST's 10MB single-response cap.
+    expect(
+      fetchImpl.mock.calls.some(([url]) => url.includes("/hgetall/")),
+    ).toBe(false);
+  });
+
+  it("keeps the later page's value when HSCAN returns the same field twice", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(hscanResponse("3", ["0xaaa", '"stale"']))
+      .mockResolvedValueOnce(hscanResponse("0", ["0xaaa", '"fresh"']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual(["0xaaa", '"fresh"']);
+  });
+
+  it("throws when Upstash answers with HTTP 200 and an error body field", async () => {
+    // Live-observed failure mode: an oversized HGETALL comes back HTTP 200
+    // with an `error` field in the JSON body, so `res.ok` alone can't catch
+    // it. HSCAN pages are small enough to avoid the cap, but the same
+    // defensive check applies to every page in case Upstash rejects one for
+    // another reason.
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          error: "ERR max request size exceeded. Limit: 10485760 bytes",
+        }),
+    });
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/max request size exceeded/);
+  });
+
+  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/did not terminate/);
+  });
+});

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
@@ -21,6 +21,16 @@ const REQ_SPACING_MS = 60; // standard bucket
 const RATE_LIMIT_BACKOFF_MS = 1500;
 const PORTFOLIO_OFFSETS_DAYS = [0, 30, 90, 180];
 
+// Upstash REST rejects a whole-hash read once the encoded reply exceeds
+// ~10 MB — intel_deep already exceeds that on a plain HGETALL. Read it via
+// cursor-paginated HSCAN instead (see fetchHashViaHscan). 100 fields/page
+// keeps each page well under the cap even at the largest observed field
+// size (~50 KB).
+const HSCAN_PAGE_COUNT = 100;
+// Safety bound so a cursor that never returns to "0" fails loudly instead of
+// looping forever.
+const HSCAN_MAX_PAGES = 10_000;
+
 const required = [
   "UPSTASH_REDIS_REST_URL",
   "UPSTASH_REDIS_REST_TOKEN",
@@ -89,6 +99,44 @@ async function pipeline(commands) {
   return json;
 }
 
+// Read every field of `key` via cursor-paginated HSCAN and return the same
+// flat [field1, value1, field2, value2, ...] shape HGETALL's REST response
+// carries, so callers need no other changes. HSCAN can return a field more
+// than once across pages; later pages are merged last, so they win. Upstash
+// REST can also answer a request it can't serve with HTTP 200 and an
+// `error` body field (observed live on an oversized HGETALL), so check for
+// that on every page instead of trusting `res.ok` alone.
+export async function fetchHashViaHscan(
+  key,
+  { count = HSCAN_PAGE_COUNT, fetchImpl = fetch } = {},
+) {
+  const merged = new Map();
+  let cursor = "0";
+  let pages = 0;
+  do {
+    const res = await fetchImpl(
+      `${redisUrl}/hscan/${key}/${cursor}?count=${count}`,
+      { headers: { Authorization: `Bearer ${redisToken}` } },
+    );
+    const body = await res.json();
+    if (!res.ok || body?.error) {
+      throw new Error(
+        `Upstash /hscan/${key} (cursor ${cursor}) → ${res.status}: ${body?.error ?? JSON.stringify(body)}`,
+      );
+    }
+    const [nextCursor, flat] = body.result;
+    for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
+    cursor = String(nextCursor);
+    pages++;
+    if (pages > HSCAN_MAX_PAGES) {
+      throw new Error(
+        `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
+      );
+    }
+  } while (cursor !== "0");
+  return Array.from(merged.entries()).flat();
+}
+
 async function buildTargets() {
   const targets = new Map();
   targets.set(CLUSTER_7DC0_DEPLOYER, { sources: ["cluster-7dc0-deployer"] });
@@ -106,8 +154,7 @@ async function buildTargets() {
     else targets.set(lower, { sources: ["has-forensic-report"] });
   }
 
-  const deep = await upstash(`/hgetall/intel_deep`);
-  const flat = deep.result ?? [];
+  const flat = await fetchHashViaHscan("intel_deep");
   const ranked = [];
   for (let i = 0; i < flat.length; i += 2) {
     const addr = flat[i];

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.mjs
@@ -29,7 +29,7 @@ const PORTFOLIO_OFFSETS_DAYS = [0, 30, 90, 180];
 const HSCAN_PAGE_COUNT = 100;
 // Safety bound so a cursor that never returns to "0" fails loudly instead of
 // looping forever.
-const HSCAN_MAX_PAGES = 10_000;
+export const HSCAN_MAX_PAGES = 10_000;
 
 const required = [
   "UPSTASH_REDIS_REST_URL",
@@ -128,7 +128,11 @@ export async function fetchHashViaHscan(
     for (let i = 0; i < flat.length; i += 2) merged.set(flat[i], flat[i + 1]);
     cursor = String(nextCursor);
     pages++;
-    if (pages > HSCAN_MAX_PAGES) {
+    // Check before requesting another page, not after: a scan that
+    // completes exactly at the bound (cursor "0" on page HSCAN_MAX_PAGES)
+    // must succeed, and a scan that still isn't done at the bound must
+    // throw here instead of first fetching page HSCAN_MAX_PAGES + 1.
+    if (cursor !== "0" && pages >= HSCAN_MAX_PAGES) {
       throw new Error(
         `HSCAN on ${key} did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
       );

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildWealthWriteCommand,
   fetchHashViaHscan,
+  HSCAN_MAX_PAGES,
 } from "./extract-wealth.mjs";
 
 function hscanResponse(cursor, flat) {
@@ -210,7 +211,23 @@ describe("fetchHashViaHscan", () => {
     ).rejects.toThrow(/max request size exceeded/);
   });
 
-  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+  it("succeeds when the scan terminates on exactly the page-count bound", async () => {
+    let calls = 0;
+    const fetchImpl = vi.fn(() => {
+      calls++;
+      const cursor = calls === HSCAN_MAX_PAGES ? "0" : String(calls);
+      return Promise.resolve(
+        hscanResponse(cursor, ["0xaaa", `{"v":${calls}}`]),
+      );
+    });
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
+    expect(flat).toEqual(["0xaaa", `{"v":${HSCAN_MAX_PAGES}}`]);
+  });
+
+  it("aborts before requesting one page past the bound when the cursor never returns to 0", async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
@@ -218,5 +235,7 @@ describe("fetchHashViaHscan", () => {
     await expect(
       fetchHashViaHscan("intel_deep", { fetchImpl }),
     ).rejects.toThrow(/did not terminate/);
+    // The bound must reject before a page beyond it is ever requested.
+    expect(fetchImpl).toHaveBeenCalledTimes(HSCAN_MAX_PAGES);
   });
 });

--- a/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
+++ b/ui-dashboard/scripts/intel-marathon/extract-wealth.test.mjs
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { buildWealthWriteCommand } from "./extract-wealth.mjs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildWealthWriteCommand,
+  fetchHashViaHscan,
+} from "./extract-wealth.mjs";
+
+function hscanResponse(cursor, flat) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ result: [cursor, flat] }),
+  };
+}
 
 const address = "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD";
 const sources = ["test-source"];
@@ -141,5 +152,71 @@ describe("buildWealthWriteCommand", () => {
     expect(result.ok).toBe(true);
     expect(result.record._truncated).toBe(true);
     expect(JSON.parse(result.command[3])).toEqual(result.record);
+  });
+});
+
+describe("fetchHashViaHscan", () => {
+  it("never issues a whole-hash HGETALL — pages through HSCAN and merges every page", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        hscanResponse("7", ["0xaaa", '{"v":1}', "0xbbb", '{"v":2}']),
+      )
+      .mockResolvedValueOnce(hscanResponse("0", ["0xccc", '{"v":3}']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual([
+      "0xaaa",
+      '{"v":1}',
+      "0xbbb",
+      '{"v":2}',
+      "0xccc",
+      '{"v":3}',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toContain("/hscan/intel_deep/0");
+    expect(fetchImpl.mock.calls[1][0]).toContain("/hscan/intel_deep/7");
+    // Refusing a whole-hash call proves the fix never falls back to it:
+    // intel_deep already exceeds Upstash REST's 10MB single-response cap.
+    expect(
+      fetchImpl.mock.calls.some(([url]) => url.includes("/hgetall/")),
+    ).toBe(false);
+  });
+
+  it("keeps the later page's value when HSCAN returns the same field twice", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(hscanResponse("3", ["0xaaa", '"stale"']))
+      .mockResolvedValueOnce(hscanResponse("0", ["0xaaa", '"fresh"']));
+
+    const flat = await fetchHashViaHscan("intel_deep", { fetchImpl });
+
+    expect(flat).toEqual(["0xaaa", '"fresh"']);
+  });
+
+  it("throws when Upstash answers with HTTP 200 and an error body field", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          error: "ERR max request size exceeded. Limit: 10485760 bytes",
+        }),
+    });
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/max request size exceeded/);
+  });
+
+  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(hscanResponse("never-zero", ["0xaaa", '{"v":1}']));
+
+    await expect(
+      fetchHashViaHscan("intel_deep", { fetchImpl }),
+    ).rejects.toThrow(/did not terminate/);
   });
 });

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -27,7 +27,8 @@ import { withFlushedMonitor } from "@/lib/sentry-cron";
 // sequences (intel + legacy) concurrently — intel_deep alone needs roughly
 // 8 sequential pages at its current ~11.8 MB / 734 fields (measured
 // 2026-08-25; it keeps growing), still a small fraction of the budget.
-// Plus 8 parallel blob uploads (one per hash + manifest).
+// Plus 7 parallel hash-blob uploads, then the manifest blob uploaded
+// afterward (it needs the hash uploads' resolved pathnames first).
 export const maxDuration = 300;
 export const BACKUP_MONITOR_MAX_RUNTIME_MINUTES = Math.ceil(maxDuration / 60);
 

--- a/ui-dashboard/src/app/api/address-labels/backup/route.ts
+++ b/ui-dashboard/src/app/api/address-labels/backup/route.ts
@@ -21,10 +21,13 @@ import {
 } from "@/lib/address-labels/backup-format";
 import { withFlushedMonitor } from "@/lib/sentry-cron";
 
-// 5min serverless-function budget covers the steady-state cron: 7 parallel
-// HGETALLs + 8 parallel blob uploads (one per hash + manifest). Per-hash
-// blob splits keep any single upload under ~10 MB, so the bound is mostly
-// HGETALL latency on the largest hash (intel_deep).
+// 5min serverless-function budget covers the steady-state cron: labels and
+// reports read in one round trip each; each of the five intel hashes reads
+// through hgetallWithLegacy, which runs two cursor-paginated HSCAN
+// sequences (intel + legacy) concurrently — intel_deep alone needs roughly
+// 8 sequential pages at its current ~11.8 MB / 734 fields (measured
+// 2026-08-25; it keeps growing), still a small fraction of the budget.
+// Plus 8 parallel blob uploads (one per hash + manifest).
 export const maxDuration = 300;
 export const BACKUP_MONITOR_MAX_RUNTIME_MINUTES = Math.ceil(maxDuration / 60);
 
@@ -66,10 +69,15 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
         const exportedAtISO = now.toISOString();
 
         // v2 per-hash blob splits: each hash gets its own blob under the
-        // day's prefix, plus a manifest blob that lists them. Keeps every
-        // single blob under ~10 MB (largest is intel_deep at ~7 MB) so the
-        // 32 MB restore-side blob cap stops biting. Restore reads the
-        // manifest first, then fetches the referenced hash blobs in parallel.
+        // day's prefix, plus a manifest blob that lists them. intel_deep is
+        // the largest hash — its underlying Upstash data measured ~11.8 MB
+        // / 734 fields on 2026-08-25 (it keeps growing) and no longer fits
+        // the ~10 MB-per-blob target this split originally assumed.
+        // flagRestoreBreakingSnapshot() below already guards the resulting
+        // blob against MAX_RESTORE_BLOB_BYTES (16 MB) with a Sentry warning,
+        // so an oversized hash blob surfaces there instead of failing
+        // restore silently. Restore reads the manifest first, then fetches
+        // the referenced hash blobs in parallel.
         //
         // Hash blobs use `addRandomSuffix: true` so each run writes unique
         // pathnames — a retry after a partial upload failure cannot overwrite

--- a/ui-dashboard/src/lib/__tests__/intel-legacy-fallback.test.ts
+++ b/ui-dashboard/src/lib/__tests__/intel-legacy-fallback.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @/lib/redis so hgetallWithLegacy never touches a real client.
+// `hgetall` is kept in the mock (and asserted un-called in the first test
+// below) specifically to prove the fix never falls back to a whole-hash
+// read: intel_deep already exceeds Upstash REST's 10MB single-response cap
+// on a plain HGETALL, so a regression back to `redis.hgetall` must fail
+// loudly here rather than only in production.
+const hget = vi.fn();
+const hgetall = vi.fn(() => {
+  throw new Error(
+    "hgetall must not be called: intel_deep exceeds the Upstash REST 10MB cap",
+  );
+});
+const hscan = vi.fn();
+
+vi.mock("@/lib/redis", () => ({
+  getRedis: () => ({ hget, hgetall, hscan }),
+}));
+
+import {
+  hgetallWithLegacy,
+  HSCAN_MAX_PAGES,
+  HSCAN_PAGE_COUNT,
+} from "@/lib/intel-legacy-fallback";
+
+const INTEL_KEY = "intel_deep";
+const LEGACY_KEY = "arkham_deep";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("hgetallWithLegacy", () => {
+  it("never issues a whole-hash HGETALL — reads exclusively via paginated HSCAN", async () => {
+    hscan.mockResolvedValue(["0", ["0xaaa", { address: "0xaaa" }]]);
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({ "0xaaa": { address: "0xaaa" } });
+    expect(hgetall).not.toHaveBeenCalled();
+    expect(hscan).toHaveBeenCalled();
+  });
+
+  it("pages through HSCAN with the documented count and merges every page", async () => {
+    hscan.mockImplementation((key: string, cursor: string | number) => {
+      if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
+      if (cursor === 0) {
+        return Promise.resolve([
+          "7",
+          ["0xaaa", { address: "0xaaa" }, "0xbbb", { address: "0xbbb" }],
+        ]);
+      }
+      if (cursor === "7") {
+        return Promise.resolve(["0", ["0xccc", { address: "0xccc" }]]);
+      }
+      throw new Error(`unexpected cursor ${String(cursor)}`);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({
+      "0xaaa": { address: "0xaaa" },
+      "0xbbb": { address: "0xbbb" },
+      "0xccc": { address: "0xccc" },
+    });
+    expect(hscan).toHaveBeenCalledWith(INTEL_KEY, 0, {
+      count: HSCAN_PAGE_COUNT,
+    });
+    expect(hscan).toHaveBeenCalledWith(INTEL_KEY, "7", {
+      count: HSCAN_PAGE_COUNT,
+    });
+  });
+
+  it("keeps the later page's value when HSCAN returns the same field twice", async () => {
+    hscan.mockImplementation((key: string, cursor: string | number) => {
+      if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
+      if (cursor === 0) {
+        return Promise.resolve(["3", ["0xaaa", { v: "stale" }]]);
+      }
+      return Promise.resolve(["0", ["0xaaa", { v: "fresh" }]]);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({ "0xaaa": { v: "fresh" } });
+  });
+
+  it("lets intel win over legacy on key collision", async () => {
+    hscan.mockImplementation((key: string) => {
+      if (key === INTEL_KEY) {
+        return Promise.resolve(["0", ["0xaaa", { source: "intel" }]]);
+      }
+      return Promise.resolve([
+        "0",
+        ["0xaaa", { source: "legacy" }, "0xbbb", { source: "legacy" }],
+      ]);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({
+      "0xaaa": { source: "intel" },
+      "0xbbb": { source: "legacy" },
+    });
+  });
+
+  it("lowercases legacy keys on merge", async () => {
+    hscan.mockImplementation((key: string) => {
+      if (key === INTEL_KEY) return Promise.resolve(["0", []]);
+      return Promise.resolve(["0", ["0xAaA", { source: "legacy" }]]);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({ "0xaaa": { source: "legacy" } });
+  });
+
+  it("returns {} when both hashes are empty", async () => {
+    hscan.mockResolvedValue(["0", []]);
+
+    expect(await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY)).toEqual({});
+  });
+
+  it("re-parses a value if it comes back as a raw JSON string instead of pre-parsed", async () => {
+    hscan.mockImplementation((key: string) => {
+      if (key === INTEL_KEY) {
+        return Promise.resolve(["0", ["0xaaa", JSON.stringify({ v: 1 })]]);
+      }
+      return Promise.resolve(["0", []]);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({ "0xaaa": { v: 1 } });
+  });
+
+  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+    hscan.mockImplementation((key: string) => {
+      if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
+      return Promise.resolve(["never-zero", ["0xaaa", { v: 1 }]]);
+    });
+
+    await expect(hgetallWithLegacy(INTEL_KEY, LEGACY_KEY)).rejects.toThrow(
+      new RegExp(`${HSCAN_MAX_PAGES} pages`),
+    );
+  });
+});

--- a/ui-dashboard/src/lib/__tests__/intel-legacy-fallback.test.ts
+++ b/ui-dashboard/src/lib/__tests__/intel-legacy-fallback.test.ts
@@ -72,6 +72,31 @@ describe("hgetallWithLegacy", () => {
     });
   });
 
+  it("terminates on a numeric cursor, including numeric 0, not just string cursors", async () => {
+    // The @upstash/redis SDK's declared hscan return type is `string`, and a
+    // live probe of the installed client observed exactly that. Normalize
+    // anyway (matching the .mjs HSCAN helpers) so a client that ever returns
+    // a bare JS number here — including terminal `0` — still terminates
+    // instead of looping until the page-count bound trips.
+    hscan.mockImplementation((key: string, cursor: string | number) => {
+      if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
+      if (cursor === 0) {
+        return Promise.resolve([9, ["0xaaa", { address: "0xaaa" }]]);
+      }
+      if (cursor === "9") {
+        return Promise.resolve([0, ["0xbbb", { address: "0xbbb" }]]);
+      }
+      throw new Error(`unexpected cursor ${String(cursor)}`);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(result).toEqual({
+      "0xaaa": { address: "0xaaa" },
+      "0xbbb": { address: "0xbbb" },
+    });
+  });
+
   it("keeps the later page's value when HSCAN returns the same field twice", async () => {
     hscan.mockImplementation((key: string, cursor: string | number) => {
       if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
@@ -135,14 +160,33 @@ describe("hgetallWithLegacy", () => {
     expect(result).toEqual({ "0xaaa": { v: 1 } });
   });
 
-  it("aborts instead of looping forever when the cursor never returns to 0", async () => {
+  it("succeeds when a scan terminates on exactly the page-count bound", async () => {
+    let calls = 0;
     hscan.mockImplementation((key: string) => {
       if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
-      return Promise.resolve(["never-zero", ["0xaaa", { v: 1 }]]);
+      calls++;
+      const cursor = calls === HSCAN_MAX_PAGES ? "0" : String(calls);
+      return Promise.resolve([cursor, ["0xaaa", { v: calls }]]);
+    });
+
+    const result = await hgetallWithLegacy(INTEL_KEY, LEGACY_KEY);
+
+    expect(calls).toBe(HSCAN_MAX_PAGES);
+    expect(result).toEqual({ "0xaaa": { v: HSCAN_MAX_PAGES } });
+  });
+
+  it("aborts before requesting one page past the bound when the cursor never returns to 0", async () => {
+    let calls = 0;
+    hscan.mockImplementation((key: string) => {
+      if (key !== INTEL_KEY) return Promise.resolve(["0", []]);
+      calls++;
+      return Promise.resolve(["never-zero", ["0xaaa", { v: calls }]]);
     });
 
     await expect(hgetallWithLegacy(INTEL_KEY, LEGACY_KEY)).rejects.toThrow(
       new RegExp(`${HSCAN_MAX_PAGES} pages`),
     );
+    // The bound must reject before a page beyond it is ever requested.
+    expect(calls).toBe(HSCAN_MAX_PAGES);
   });
 });

--- a/ui-dashboard/src/lib/__tests__/intel-redis-libs.test.ts
+++ b/ui-dashboard/src/lib/__tests__/intel-redis-libs.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock @/lib/redis so the intel-* libs never touch a real client.
+// Mock @/lib/redis so the intel-* libs never touch a real client. `hgetall`
+// is kept in the mock (and asserted un-called below) only to prove the
+// getAll* helpers never fall back to a whole-hash read; the real reads go
+// through `hscan`, since intel_deep already exceeds Upstash REST's 10MB
+// single-response cap on a plain HGETALL.
 const hget = vi.fn();
 const hgetall = vi.fn();
+const hscan = vi.fn();
 const hkeys = vi.fn();
 const hlen = vi.fn();
 const hmget = vi.fn();
@@ -14,8 +19,23 @@ const pipeline = vi.fn(() => ({
 }));
 
 vi.mock("@/lib/redis", () => ({
-  getRedis: vi.fn(() => ({ hget, hgetall, hkeys, hlen, hmget, pipeline })),
+  getRedis: vi.fn(() => ({
+    hget,
+    hgetall,
+    hscan,
+    hkeys,
+    hlen,
+    hmget,
+    pipeline,
+  })),
 }));
+
+// Mirrors how the @upstash/redis SDK returns HSCAN pages: [nextCursor, flat].
+// A single-page helper is enough for these tests; multi-page pagination and
+// duplicate-field dedupe get dedicated coverage in intel-legacy-fallback.
+function hscanPage(record: Record<string, unknown>) {
+  return Promise.resolve(["0", Object.entries(record).flat()]);
+}
 
 import {
   getIntelDeep,
@@ -49,6 +69,7 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  hscan.mockResolvedValue(["0", []]);
   hkeys.mockResolvedValue([]);
   hlen.mockResolvedValue(0);
   hmget.mockResolvedValue({});
@@ -69,14 +90,17 @@ describe("intel-deep", () => {
     expect(await getIntelDeep("0xabc")).toBeNull();
   });
 
-  it("getAllIntelDeep: returns all records, falls back to {} on null", async () => {
+  it("getAllIntelDeep: returns all records via HSCAN, falls back to {} when both hashes are empty", async () => {
     const all = { "0xaaa": { address: "0xaaa", fetchedAt: "2026-01-01" } };
-    hgetall.mockResolvedValue(all);
+    hscan.mockImplementation((key: string) =>
+      key === INTEL_DEEP_KEY ? hscanPage(all) : hscanPage({}),
+    );
     // toEqual (not toBe) because the legacy-fallback helper spreads-merges
     // intel + arkham hashes into a fresh object.
     expect(await getAllIntelDeep()).toEqual(all);
+    expect(hgetall).not.toHaveBeenCalled();
 
-    hgetall.mockResolvedValue(null);
+    hscan.mockResolvedValue(["0", []]);
     expect(await getAllIntelDeep()).toEqual({});
   });
 
@@ -108,8 +132,8 @@ describe("intel-deep", () => {
       "0xaaa": { address: "0xaaa", source: "arkham" }, // collides
       "0xbbb": { address: "0xbbb", source: "arkham" }, // legacy-only
     };
-    hgetall.mockImplementation((key: string) =>
-      Promise.resolve(key === INTEL_DEEP_KEY ? intel : legacy),
+    hscan.mockImplementation((key: string) =>
+      hscanPage(key === INTEL_DEEP_KEY ? intel : legacy),
     );
     const result = await getAllIntelDeep();
     expect(result).toEqual({
@@ -123,8 +147,8 @@ describe("intel-deep", () => {
     const legacy = {
       "0xAaA": { address: "0xAaA", source: "arkham" }, // mixed-case key
     };
-    hgetall.mockImplementation((key: string) =>
-      Promise.resolve(key === INTEL_DEEP_KEY ? intel : legacy),
+    hscan.mockImplementation((key: string) =>
+      hscanPage(key === INTEL_DEEP_KEY ? intel : legacy),
     );
     const result = await getAllIntelDeep();
     expect(result).toEqual({
@@ -170,9 +194,10 @@ describe("intel-transfers", () => {
     expect(result).toBe(legacyRecord);
   });
 
-  it("getAllIntelTransfers: falls back to {} on null", async () => {
-    hgetall.mockResolvedValue(null);
+  it("getAllIntelTransfers: falls back to {} when both hashes are empty", async () => {
+    hscan.mockResolvedValue(["0", []]);
     expect(await getAllIntelTransfers()).toEqual({});
+    expect(hgetall).not.toHaveBeenCalled();
   });
 });
 
@@ -217,9 +242,10 @@ describe("intel-wealth", () => {
     expect(result).toBe(legacyRecord);
   });
 
-  it("getAllIntelWealth: falls back to {} on null", async () => {
-    hgetall.mockResolvedValue(null);
+  it("getAllIntelWealth: falls back to {} when both hashes are empty", async () => {
+    hscan.mockResolvedValue(["0", []]);
     expect(await getAllIntelWealth()).toEqual({});
+    expect(hgetall).not.toHaveBeenCalled();
   });
 });
 
@@ -250,9 +276,10 @@ describe("intel-entities", () => {
     expect(await getIntelEntity("unknown-slug")).toBeNull();
   });
 
-  it("getAllIntelEntities: falls back to {} on null", async () => {
-    hgetall.mockResolvedValue(null);
+  it("getAllIntelEntities: falls back to {} when both hashes are empty", async () => {
+    hscan.mockResolvedValue(["0", []]);
     expect(await getAllIntelEntities()).toEqual({});
+    expect(hgetall).not.toHaveBeenCalled();
   });
 
   it("getIntelEntityDirectorySource reads full records below both limits", async () => {
@@ -360,8 +387,9 @@ describe("intel-entity-cps", () => {
     expect(await getIntelEntityCps("unknown-slug")).toBeNull();
   });
 
-  it("getAllIntelEntityCps: falls back to {} on null", async () => {
-    hgetall.mockResolvedValue(null);
+  it("getAllIntelEntityCps: falls back to {} when both hashes are empty", async () => {
+    hscan.mockResolvedValue(["0", []]);
     expect(await getAllIntelEntityCps()).toEqual({});
+    expect(hgetall).not.toHaveBeenCalled();
   });
 });

--- a/ui-dashboard/src/lib/intel-legacy-fallback.ts
+++ b/ui-dashboard/src/lib/intel-legacy-fallback.ts
@@ -1,4 +1,72 @@
+import type { Redis } from "@upstash/redis";
 import { getRedis } from "./redis";
+
+// Upstash REST rejects a whole-hash read once the encoded reply exceeds
+// ~10 MB (see MAX_REDIS_HASH_REPLACE_BYTES in ./redis-hash for the write-side
+// analog). intel_deep already exceeds that cap on a plain HGETALL, so reads
+// go through cursor-paginated HSCAN instead. 100 fields/page keeps each page
+// well under the cap even at the largest observed field size (~50 KB).
+export const HSCAN_PAGE_COUNT = 100;
+
+// Safety bound: HSCAN's cursor contract guarantees eventual termination, but
+// a client/server bug could in principle return a cursor that never comes
+// back to "0". Bound the loop instead of hanging forever. 10,000 pages at
+// 100 fields/page is 1,000,000 fields — far beyond any hash this code reads.
+export const HSCAN_MAX_PAGES = 10_000;
+
+type RedisHashReadClient = Pick<Redis, "hscan">;
+
+/**
+ * Read every field of one hash via cursor-paginated HSCAN, so no single
+ * round-trip has to carry the whole hash (see module comment). HSCAN may
+ * return a field more than once across pages when the hash is mutated
+ * mid-scan; later pages are applied last, so the last-seen value for a
+ * field wins.
+ *
+ * The @upstash/redis SDK JSON-decodes each HSCAN reply element the same way
+ * it decodes HGETALL values (both route through the SDK's shared recursive
+ * parser), so a value normally arrives already as `T`, not a raw string.
+ * Re-parse defensively when a value does come back as a string, mirroring
+ * HGETALL's own per-value fallback, so behavior does not depend on that SDK
+ * internal.
+ */
+async function hscanAll<T>(
+  redis: RedisHashReadClient,
+  key: string,
+): Promise<Record<string, T>> {
+  const merged: Record<string, T> = {};
+  let cursor: string | number = 0;
+  let pages = 0;
+  do {
+    // Sequential by necessity: each page's cursor comes from the previous
+    // page's reply, so pages cannot be requested concurrently.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const [nextCursor, flat] = await redis.hscan(key, cursor, {
+      count: HSCAN_PAGE_COUNT,
+    });
+    for (let i = 0; i < flat.length; i += 2) {
+      const field = String(flat[i]);
+      merged[field] = coerceHScanValue<T>(flat[i + 1]);
+    }
+    cursor = nextCursor;
+    pages += 1;
+    if (pages > HSCAN_MAX_PAGES) {
+      throw new Error(
+        `HSCAN on "${key}" did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
+      );
+    }
+  } while (cursor !== "0");
+  return merged;
+}
+
+function coerceHScanValue<T>(raw: string | number | undefined): T {
+  if (typeof raw !== "string") return raw as unknown as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return raw as unknown as T;
+  }
+}
 
 /**
  * Read a single hash field, preferring the intel hash and falling back to the
@@ -49,19 +117,14 @@ export async function hgetallWithLegacy<T>(
 ): Promise<Record<string, T>> {
   const redis = getRedis();
   const [fromIntel, fromLegacy] = await Promise.all([
-    redis.hgetall<Record<string, T>>(intelKey),
-    redis.hgetall<Record<string, T>>(legacyKey),
+    hscanAll<T>(redis, intelKey),
+    hscanAll<T>(redis, legacyKey),
   ]);
   const merged: Record<string, T> = {};
-  if (fromLegacy) {
-    for (const [k, v] of Object.entries(fromLegacy))
-      merged[k.toLowerCase()] = v;
-  }
+  for (const [k, v] of Object.entries(fromLegacy)) merged[k.toLowerCase()] = v;
   // Intel overwrites legacy on collision (intel is the canonical post-deploy
   // writer). Intel keys are already lowercase by spec, so toLowerCase() is a
   // defensive no-op.
-  if (fromIntel) {
-    for (const [k, v] of Object.entries(fromIntel)) merged[k.toLowerCase()] = v;
-  }
+  for (const [k, v] of Object.entries(fromIntel)) merged[k.toLowerCase()] = v;
   return merged;
 }

--- a/ui-dashboard/src/lib/intel-legacy-fallback.ts
+++ b/ui-dashboard/src/lib/intel-legacy-fallback.ts
@@ -48,9 +48,18 @@ async function hscanAll<T>(
       const field = String(flat[i]);
       merged[field] = coerceHScanValue<T>(flat[i + 1]);
     }
-    cursor = nextCursor;
+    // Normalize defensively: the SDK's declared return type is `string`,
+    // but nothing here should rely on that never slipping — the .mjs
+    // HSCAN helpers normalize the same way, and a stray numeric cursor
+    // (e.g. terminal `0`) must still satisfy the `"0"` check below rather
+    // than looping until the page-count bound trips.
+    cursor = String(nextCursor);
     pages += 1;
-    if (pages > HSCAN_MAX_PAGES) {
+    // Check before requesting another page, not after: a scan that
+    // completes exactly at the bound (cursor "0" on page HSCAN_MAX_PAGES)
+    // must succeed, and a scan that still isn't done at the bound must
+    // throw here instead of first fetching page HSCAN_MAX_PAGES + 1.
+    if (cursor !== "0" && pages >= HSCAN_MAX_PAGES) {
       throw new Error(
         `HSCAN on "${key}" did not terminate within ${HSCAN_MAX_PAGES} pages; aborting instead of looping forever.`,
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `intel_deep` grew past Upstash REST's 10MB single-response cap: a plain HGETALL/HVALS on it now returns HTTP 200 with an `error` body field instead of data (734 fields today, values up to ~50KB, confirmed live).
- Three read paths broke: `hgetallWithLegacy()` in the dashboard (used by all five `getAllIntel*` helpers, including the nightly `address-labels/backup` route, whose Sentry monitor will alert on the next scheduled run) and the `extract-transfers`/`extract-wealth`/`extract-entities` intel-marathon scripts, all of which read `intel_deep` the same whole-hash way.
- The hash keeps growing, so this is a permanent failure, not a transient one.

## The Solution

- Replace every whole-hash `intel_deep` read (HGETALL in the dashboard, HGETALL/HVALS in the scripts) with cursor-paginated HSCAN, 100 fields per page — well under the 10MB cap even at the largest observed ~50KB field size.
- Preserve existing semantics exactly: a field HSCAN returns on more than one page keeps its last-seen value, intel still overwrites legacy on collision, keys stay lowercased, and a missing or empty hash still yields `{}`.
- Add an explicit page-count safety bound (10,000 pages) so a cursor that never returns to `"0"` fails loudly instead of hanging forever.
- Every read path now also checks for Upstash's HTTP-200-with-an-error-body failure mode explicitly (the exact shape observed live), since `res.ok` alone does not catch it.
- Limit: `labels` and `reports` stay on their existing whole-hash reads. Both are well under the 10MB cap today; `labels` is worth watching as it grows, but that is out of scope here.

## Details

- `ui-dashboard/src/lib/intel-legacy-fallback.ts`: `hgetallWithLegacy()` now reads both the intel and legacy hash through a new internal `hscanAll()` helper (`redis.hscan`) instead of `redis.hgetall`. `HSCAN_PAGE_COUNT` (100) and `HSCAN_MAX_PAGES` (10,000) are exported for tests.
- `ui-dashboard/scripts/intel-marathon/extract-transfers.mjs` and `extract-wealth.mjs`: the `/hgetall/intel_deep` REST call is replaced with a new exported `fetchHashViaHscan()` that pages through `GET {url}/hscan/{key}/{cursor}?count=100` and returns the identical flat `[field, value, field, value, ...]` shape HGETALL used to, so no downstream parsing changed.
- `ui-dashboard/scripts/intel-marathon/extract-entities.mjs`: the `["HVALS", "intel_deep"]` half of its pipeline call is replaced with the same `fetchHashViaHscan()` plus a small `fetchHashValuesViaHscan()` wrapper that drops field names, matching HVALS's value-only shape. The `["HVALS", "labels"]` half is untouched.
- `extract-transfers.mjs` and `extract-entities.mjs` previously invoked `main()` unconditionally on import, which made them untestable and would have run a live extraction just by importing them in a test. Both now guard `main()` behind an `isMainModule()` check, matching the pattern `extract-wealth.mjs` already used.

## Validation

- `pnpm --filter @mento-protocol/ui-dashboard typecheck` — passes with no errors.
- `npx vitest run` (ui-dashboard) — 308 test files passed, 4707 tests passed, 0 failed. New/updated coverage: `src/lib/__tests__/intel-legacy-fallback.test.ts` (8 tests: multi-page merge, duplicate-field last-wins, intel-over-legacy precedence, key lowercasing, empty-hash fallback, raw-string re-parse, page-count safety bound, and a test whose mock `hgetall` throws if called — proving the fix never falls back to a whole-hash read), `src/lib/__tests__/intel-redis-libs.test.ts` (updated to mock `hscan` instead of `hgetall` for all five `getAllIntel*` helpers, asserting `hgetall` is never called), `scripts/intel-marathon/extract-transfers.test.mjs` (new, 4 tests), `scripts/intel-marathon/extract-wealth.test.mjs` (+4 tests), `scripts/intel-marathon/extract-entities.test.mjs` (new, 6 tests).
- `pnpm agent:quality-gate --run --parallel 4 --skip-if-fresh --base origin/main --lock-wait 3600` against `origin/main` at `5763e4f01ac575d3bcc885705a69f7d38e8aff87` — all mapped commands passed: trunk check, lint, typecheck, knip, code-health:deps, react-doctor:diff, react-doctor:score, size-limit, test:browser, test:coverage, tf:test.
- `./tools/trunk fmt` and `./tools/trunk check` on every touched file — no issues.
- Live repro before the fix (2026-08-25): `GET /hgetall/intel_deep` returned HTTP 200 with body `{"error":"ERR max request size exceeded. Limit: 10485760 bytes, Actual: 11783900 bytes"}`; not re-verified against the fixed code path against production data, since that would require pointing a script at the live `intel_deep` hash.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable. — Not applicable: this restores existing read semantics with a paginated read, it does not introduce a new architectural direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving large intelligence, transfer, wealth, and entity datasets.
  - Added safer paginated data loading to prevent incomplete results and handle service errors consistently.
  - Preserved correct handling of duplicate fields, legacy formats, empty records, and malformed responses.
  - Added safeguards to prevent stalled data retrieval from running indefinitely.

- **Documentation**
  - Updated backup guidance for large data sets, execution limits, and restore capacity.

- **Tests**
  - Expanded automated coverage for pagination, error handling, data merging, and legacy compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->