### PR TITLE
fix(docs): restore navigation evaluation headroom

### DIFF
--- a/docs/evals/documentation-navigation-fixtures.json
+++ b/docs/evals/documentation-navigation-fixtures.json
@@ -7,7 +7,7 @@
     "answer_evidence_percent": 100,
     "questions_over_context_budget": 0,
     "max_question_source_bytes": 45000,
-    "max_total_unique_source_bytes": 266000,
+    "max_total_unique_source_bytes": 262000,
     "min_total_unique_source_headroom_bytes": 32768
   },
   "bootstrap_sources": ["AGENTS.md", "docs/README.md"],
@@ -163,6 +163,7 @@
       "category": "pr-hazards",
       "question": "Why does the agent quality gate refuse to run after package scripts or lockfiles change, and what explicit flag is required after reviewing that lifecycle surface?",
       "accepted_routes": [
+        ["docs/notes/quick-commands.md"],
         ["docs/notes/agent-quality-gate-mechanics.md"],
         ["docs/notes/pr-operating-card.md"]
       ],
@@ -192,6 +193,7 @@
       "category": "commands",
       "question": "What exact shared probe must run before declaring a PR all clear, and which current-head Codex approval or break-glass signal is required?",
       "accepted_routes": [
+        ["docs/notes/quick-commands.md"],
         ["docs/notes/pr-ready-state.md"],
         ["docs/notes/pr-operating-card.md"]
       ],

--- a/docs/evals/documentation-navigation.md
+++ b/docs/evals/documentation-navigation.md
@@ -166,9 +166,9 @@ The 32 KiB reserve is an authoring margin, not extra model context. Do not raise
 the 262,000-byte cap to absorb normal documentation growth. Restore the reserve
 by routing questions through narrower canonical sources that still contain the
 required answer, and keep deeper authority as an accepted alternative when it
-remains valid. The first enforcement pass applied that rule to the two largest
-single-question selections: package-script refusal and PR readiness now share
-the PR operating card as their narrow route. Run
+remains valid. Package-script refusal and PR readiness use the quick-command
+reference as their narrow route. The quality-gate mechanics, readiness guide,
+and PR operating card remain accepted deeper authorities. Run
 `pnpm docs:navigation-eval -- --check-fixtures --json` to inspect the selected
 floor, required reserve, and remaining surplus.
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -49,6 +49,9 @@ pnpm code-health:schema-diff       # GraphQL schema breaking-change diff vs orig
 pnpm code-health                   # Run knip + deps together (everything except history + duplication)
 pnpm agent:quality-gate            # Map changed paths to required local checks and PR checklists
 pnpm agent:quality-gate --run      # Execute the mapped local-only checks
+# Package scripts, package-manager settings, and lockfiles can change code that
+# runs during install. Review those changes before acknowledging them:
+pnpm agent:quality-gate --run --allow-package-script-changes
 pnpm agent:context-check           # Validate repo-visible agent instructions, links, and routing
 pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
 pnpm agent:autoreview              # Isolated closeout review; multi-pass uses --prepare-bundle-dir DIR + one fresh-context reviewer; quality gate owns tests
@@ -65,6 +68,9 @@ pnpm docs:navigation-eval -- --prompt          # Print the bounded read-only eva
 pnpm docs:navigation-eval -- --prompt --base-commit <full-sha>  # Pin a committed result to a reachable default-branch ancestor
 pnpm docs:navigation-eval -- --validate <result.json>  # Recompute authority, evidence, route, and context scores
 pnpm agent:context-budget --strict # Enforce root, scoped-file, and aggregate-route AGENTS byte caps
+# Run feedback-state first. Final all-clear needs the current-head Codex
+# PR-description +1 or this exact-head human override:
+# /pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>
 pnpm --silent pr:feedback-state --pr 123 --json  # Normalize unresolved/reply-required feedback before all-clear
 pnpm pr:ready-state --pr 123 --json              # Final current-head required-readiness probe
 node scripts/pr/review-process-metrics.mjs --prs <pr1,pr2,...> --output <result.json>  # Collect a new cohort; define its boundary and tracking issue first

--- a/scripts/docs/docs-navigation-eval.test.mjs
+++ b/scripts/docs/docs-navigation-eval.test.mjs
@@ -433,15 +433,16 @@ test("fixture byte budgets can contain every cheapest accepted route", () => {
       floor.total_unique_route_bytes >=
       reserve,
   );
+  assert.equal(context.suite.targets.max_total_unique_source_bytes, 262_000);
   assert.equal(reserve, 32_768);
   const selectedRoutes = new Map(
     floor.questions.map((question) => [question.question_id, question.route]),
   );
   assert.deepEqual(selectedRoutes.get("pr-hazard-package-script-refusal"), [
-    "docs/notes/pr-operating-card.md",
+    "docs/notes/quick-commands.md",
   ]);
   assert.deepEqual(selectedRoutes.get("commands-pr-readiness"), [
-    "docs/notes/pr-operating-card.md",
+    "docs/notes/quick-commands.md",
   ]);
 
   const questionTooTight = structuredClone(context.suite);


### PR DESCRIPTION
## The Problem

- PR #1988 expanded the PR operating card and raised the accepted-route union cap.
- The integrated `main` route union left 26,134 bytes of headroom, below the required 32,768-byte reserve.
- Main CI run [32827764003](https://github.com/mento-protocol/monitoring-monorepo/actions/runs/32827764003) failed in the documentation navigation evaluation.

## The Solution

- Route the package-script refusal and PR readiness questions through the concise quick-command reference.
- Restore the documented 262,000-byte cap while keeping the 32,768-byte reserve unchanged.
- Keep the deeper mechanics, readiness, and operating-card documents as accepted alternatives. This PR does not complete the personal skill-store work in #1985.

## Details

- Add the package-lifecycle acknowledgment flag and current-head readiness override syntax to `docs/notes/quick-commands.md`.
- Pin the cap and selected narrow routes in the navigation regression test.
- Refs #1985

## Validation

- `pnpm agent:quality-gate --run` — passed all eight mapped commands.
- `pnpm docs:navigation-eval:test` — passed, 34/34.
- `pnpm docs:navigation-eval -- --check-fixtures --json` — passed with 216,922 unique route bytes, 45,078 bytes of headroom, and a 12,310-byte reserve surplus.
- Deterministic local autoreview — passed with no findings.
- Independent prepared-bundle review — passed with no findings at manifest `94f3186d301c7fbb938f7ae3ba2559d7412e4f92ca6d07140831cba9f07e9f82`.
- Claude Security scan — skipped (Codex surface).

## Deferrals

- [#1985](https://github.com/mento-protocol/monitoring-monorepo/issues/1985) tracks the remaining personal skill-store work.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this restores the documented navigation budget and routing contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quick-reference guidance for reviewing package-script changes, package-manager settings, and lockfiles.
  * Clarified final readiness requirements, including feedback-state and approval checks.
  * Updated documentation navigation to direct relevant questions to the quick-commands reference.
* **Tests**
  * Updated navigation checks and documentation size expectations to reflect the revised guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->