### PR TITLE
fix: keep cloud pre-push quality gates observable

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -133,7 +133,7 @@ actions:
         Runs the path-aware agent quality gate before push. The gate maps the
         branch diff to the required local checks instead of always running the
         full monorepo pre-push suite.
-      run: git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --base origin/main
+      run: git fetch --quiet origin main && bash scripts/agent-quality-gate.sh --run --parallel 3 --skip-if-fresh --pre-push --base origin/main
       triggers:
         - git_hooks: [pre-push]
   enabled:

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -41,11 +41,6 @@ per-command JSON plus one `__run_total__` line to gitignored
 `.tmp/agent-quality-gate/durations.jsonl`. Targets: 3 minutes for common mapped
 sets and 8 minutes for the full workspace (Refs #1415).
 
-Every executing command emits a 20-second heartbeat with its elapsed time and
-command text, including serialized prerequisites and exclusive suites. Command
-output remains buffered until failure so concurrent logs stay readable; the
-heartbeat is the liveness signal while that buffer is quiet.
-
 If a sandboxed mapped run fails only because a command needs host capabilities,
 rerun the full mapped gate with host access on the same head. The gate reuses
 stamp-eligible fresh successes and runs the blocked commands. A resumed run does

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-23
+last_verified: 2026-08-25
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -40,6 +40,11 @@ freshness stamp, so the next run cannot use `--skip-if-fresh`. Each run appends
 per-command JSON plus one `__run_total__` line to gitignored
 `.tmp/agent-quality-gate/durations.jsonl`. Targets: 3 minutes for common mapped
 sets and 8 minutes for the full workspace (Refs #1415).
+
+Every executing command emits a 20-second heartbeat with its elapsed time and
+command text, including serialized prerequisites and exclusive suites. Command
+output remains buffered until failure so concurrent logs stay readable; the
+heartbeat is the liveness signal while that buffer is quiet.
 
 If a sandboxed mapped run fails only because a command needs host capabilities,
 rerun the full mapped gate with host access on the same head. The gate reuses
@@ -1130,7 +1135,7 @@ concurrent logs do not interleave. The same dashboard `.next` serialization rule
 applies to prewarm.
 
 The Trunk pre-push hook delegates to this same path-aware gate with
-`--parallel 3 --skip-if-fresh`, so the independent quality-phase members run
+`--parallel 3 --skip-if-fresh --pre-push`, so the independent quality-phase members run
 concurrently (the heavy `test:coverage` suites and the gate self-test overlap
 instead of summing to the serial total), and it reuses a recent successful
 manual gate run when the fetched base commit, mapped command plan, gate
@@ -1148,6 +1153,14 @@ review the script/lifecycle diff first, then set
 `agent.qualityGate.allowPackageScriptChanges=true` in local git config (seen by
 both the manual warm run and the hook) so a just-passed acknowledged manual gate
 can satisfy the `--skip-if-fresh` check.
+
+Hosted setup also sets `agent.qualityGate.cloudPrePushRequireFresh=true`. The
+pre-push invocation identifies itself with `--pre-push`; on a cold or invalid
+stamp it exits before the run lock or any mapped command and tells the agent to
+fetch `origin/main`, run `pnpm agent:quality-gate --run` in the background, and
+retry the push. This keeps a long gate owned by an observable task instead of
+burying it inside a blocking cloud `git push`. Local setup does not set the
+option, so a developer's cold pre-push still runs the mapped gate normally.
 
 The whole-run stamp's signature is the same bound-input set described above;
 any change to it reruns the mapped commands immediately, while an unchanged

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -3,7 +3,7 @@ title: PR Operating Card
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-22
+last_verified: 2026-08-25
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -69,7 +69,9 @@ even when you never open an authority.
    server or browser suite alongside the gate; a second `--run` gate is handled
    for you — it takes a machine-wide lock and queues behind the first, naming
    the holder while it waits. Background the `--run` gate and the `git push`; a
-   600s foreground kill discards the freshness stamp. Authority:
+   600s foreground kill discards the freshness stamp. Hosted setup makes a cold
+   pre-push fail fast: warm the stamp with the background gate first, then push.
+   Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 4. **Autoreview.** Freeze the scope baseline first — the initial request,

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -5,7 +5,7 @@ gate_start_ts="$(date +%s)"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh] [--parallel <n>] [--full-local-tests]
+Usage: scripts/agent-quality-gate.sh [--dry-run|--run] [--base <ref>] [--head <ref>] [--changed-paths-file <file>] [--allow-package-script-changes] [--fail-fast|--keep-going] [--skip-if-fresh] [--pre-push] [--parallel <n>] [--full-local-tests]
 
 Maps changed paths to the local commands and PR checklists an agent should run
 before opening or updating a PR. Defaults to dry-run.
@@ -27,6 +27,8 @@ Options:
                  used the same base, changed paths, command plan, gate
                  implementation, and validated file content. Intended for the
                  pre-push hook only.
+  --pre-push     Mark this invocation as the git pre-push hook. Hosted setup
+                 uses this to refuse a cold gate inside a blocking git push.
   --parallel <n> With --run, execute independent quality commands with up to
                  n concurrent jobs. Default: auto, capped at 4. Fail-fast mode
                  stays sequential so it still stops before starting the next
@@ -78,6 +80,7 @@ changed_paths_input_file=""
 allow_package_script_changes="${AGENT_QUALITY_ALLOW_PACKAGE_SCRIPT_CHANGES:-}"
 fail_fast="${AGENT_QUALITY_FAIL_FAST:-false}"
 skip_if_fresh="${AGENT_QUALITY_SKIP_IF_FRESH:-false}"
+pre_push="false"
 quality_parallelism="${AGENT_QUALITY_PARALLELISM:-auto}"
 full_local_tests="${AGENT_GATE_FULL_TESTS:-false}"
 # 900 was the bound until this gate's own self-test became the longest mapped
@@ -168,6 +171,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-if-fresh)
       skip_if_fresh="true"
+      shift
+      ;;
+    --pre-push)
+      pre_push="true"
       shift
       ;;
     --full-local-tests)
@@ -2286,6 +2293,16 @@ if [[ "$skip_if_fresh" == "1" || "$skip_if_fresh" == "true" ]]; then
   fi
 fi
 
+if [[ "$pre_push" == "1" || "$pre_push" == "true" ]]; then
+  cloud_pre_push_require_fresh="$(git config --bool --get agent.qualityGate.cloudPrePushRequireFresh 2>/dev/null || true)"
+  if [[ "$cloud_pre_push_require_fresh" == "true" ]]; then
+    echo "Cloud pre-push requires a fresh quality-gate stamp; no mapped command ran." >&2
+    echo "Run 'git fetch origin main', then run 'pnpm agent:quality-gate --run' in the background." >&2
+    echo "Retry the push after that command passes; --skip-if-fresh will then return immediately." >&2
+    exit 2
+  fi
+fi
+
 if [[ "$package_script_risk_changed" == true && "$allow_package_script_changes" != "1" && "$allow_package_script_changes" != "true" ]]; then
   echo "Refusing to run because package manifests, patches, or lockfile changed." >&2
   echo "Review package scripts, lifecycle hooks, and dependency install scripts first, then re-run with --allow-package-script-changes if they are safe." >&2
@@ -2464,7 +2481,7 @@ print_command_summary() {
   done
 }
 
-monitor_sequential_autoreview_progress() {
+monitor_sequential_progress() {
   local command="$1"
   local output_file="$2"
   local start_ts="$3"
@@ -2483,7 +2500,9 @@ monitor_sequential_autoreview_progress() {
     if [[ $((now_ts - last_heartbeat_ts)) -ge "$heartbeat_interval" ]]; then
       printf '⏳ still running after %s:\n' "$(format_duration $((now_ts - start_ts)))"
       printf '    · %s\n' "$command"
-      latest_autoreview_test_progress "$output_file"
+      if is_autoreview_test_command "$command"; then
+        latest_autoreview_test_progress "$output_file"
+      fi
       last_heartbeat_ts="$now_ts"
     fi
   done
@@ -2795,14 +2814,12 @@ run_mapped_command() {
   start_ts="$(date +%s)"
   echo
   echo "+ ${command}"
-  if is_autoreview_test_command "$command"; then
-    monitor_done_file="${output_file}.done"
-    tmpfiles+=("$monitor_done_file")
-    rm -f "$monitor_done_file"
-    monitor_sequential_autoreview_progress \
-      "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
-    monitor_pid="$!"
-  fi
+  monitor_done_file="${output_file}.done"
+  tmpfiles+=("$monitor_done_file")
+  rm -f "$monitor_done_file"
+  monitor_sequential_progress \
+    "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
+  monitor_pid="$!"
   set +e
   run_with_timeout "$command" > "$output_file" 2>&1
   exit_code=$?

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -330,9 +330,6 @@ if [[ -z "${TURBO_CACHE_DIR:-}" &&
 fi
 
 tmpfiles=()
-# A sequential progress heartbeat is a child of this shell. Track it so signal
-# teardown does not leave it in a registered worker process group.
-active_progress_monitor_pid=""
 # Set by run_with_timeout for the most recent mapped command so callers can tell
 # a timeout apart from an ordinary non-zero exit. Read only right after the call.
 last_command_timed_out=false
@@ -1689,11 +1686,6 @@ acquire_gate_run_lock() {
 }
 
 cleanup_tmpfiles() {
-  if [[ -n "$active_progress_monitor_pid" ]]; then
-    kill_process_tree "$active_progress_monitor_pid" TERM
-    wait "$active_progress_monitor_pid" 2>/dev/null || true
-    active_progress_monitor_pid=""
-  fi
   teardown_active_timeouts
   if [[ ${#tmpfiles[@]} -gt 0 ]]; then
     rm -f "${tmpfiles[@]+"${tmpfiles[@]}"}"
@@ -2489,7 +2481,7 @@ print_command_summary() {
   done
 }
 
-monitor_sequential_progress() {
+monitor_sequential_autoreview_progress() {
   local command="$1"
   local output_file="$2"
   local start_ts="$3"
@@ -2508,9 +2500,7 @@ monitor_sequential_progress() {
     if [[ $((now_ts - last_heartbeat_ts)) -ge "$heartbeat_interval" ]]; then
       printf '⏳ still running after %s:\n' "$(format_duration $((now_ts - start_ts)))"
       printf '    · %s\n' "$command"
-      if is_autoreview_test_command "$command"; then
-        latest_autoreview_test_progress "$output_file"
-      fi
+      latest_autoreview_test_progress "$output_file"
       last_heartbeat_ts="$now_ts"
     fi
   done
@@ -2822,13 +2812,14 @@ run_mapped_command() {
   start_ts="$(date +%s)"
   echo
   echo "+ ${command}"
-  monitor_done_file="${output_file}.done"
-  tmpfiles+=("$monitor_done_file")
-  rm -f "$monitor_done_file"
-  monitor_sequential_progress \
-    "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
-  monitor_pid="$!"
-  active_progress_monitor_pid="$monitor_pid"
+  if is_autoreview_test_command "$command"; then
+    monitor_done_file="${output_file}.done"
+    tmpfiles+=("$monitor_done_file")
+    rm -f "$monitor_done_file"
+    monitor_sequential_autoreview_progress \
+      "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
+    monitor_pid="$!"
+  fi
   set +e
   run_with_timeout "$command" > "$output_file" 2>&1
   exit_code=$?
@@ -2837,7 +2828,6 @@ run_mapped_command() {
   if [[ -n "$monitor_pid" ]]; then
     : > "$monitor_done_file"
     wait "$monitor_pid" 2>/dev/null || true
-    active_progress_monitor_pid=""
     rm -f "$monitor_done_file"
   fi
   end_ts="$(date +%s)"

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1690,7 +1690,7 @@ acquire_gate_run_lock() {
 
 cleanup_tmpfiles() {
   if [[ -n "$active_progress_monitor_pid" ]]; then
-    kill "$active_progress_monitor_pid" 2>/dev/null || true
+    kill_process_tree "$active_progress_monitor_pid" TERM
     wait "$active_progress_monitor_pid" 2>/dev/null || true
     active_progress_monitor_pid=""
   fi

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -330,6 +330,9 @@ if [[ -z "${TURBO_CACHE_DIR:-}" &&
 fi
 
 tmpfiles=()
+# A sequential progress heartbeat is a child of this shell. Track it so signal
+# teardown does not leave it in a registered worker process group.
+active_progress_monitor_pid=""
 # Set by run_with_timeout for the most recent mapped command so callers can tell
 # a timeout apart from an ordinary non-zero exit. Read only right after the call.
 last_command_timed_out=false
@@ -1686,6 +1689,11 @@ acquire_gate_run_lock() {
 }
 
 cleanup_tmpfiles() {
+  if [[ -n "$active_progress_monitor_pid" ]]; then
+    kill "$active_progress_monitor_pid" 2>/dev/null || true
+    wait "$active_progress_monitor_pid" 2>/dev/null || true
+    active_progress_monitor_pid=""
+  fi
   teardown_active_timeouts
   if [[ ${#tmpfiles[@]} -gt 0 ]]; then
     rm -f "${tmpfiles[@]+"${tmpfiles[@]}"}"
@@ -2820,6 +2828,7 @@ run_mapped_command() {
   monitor_sequential_progress \
     "$command" "$output_file" "$start_ts" "$monitor_done_file" "$gate_pid" &
   monitor_pid="$!"
+  active_progress_monitor_pid="$monitor_pid"
   set +e
   run_with_timeout "$command" > "$output_file" 2>&1
   exit_code=$?
@@ -2828,6 +2837,7 @@ run_mapped_command() {
   if [[ -n "$monitor_pid" ]]; then
     : > "$monitor_done_file"
     wait "$monitor_pid" 2>/dev/null || true
+    active_progress_monitor_pid=""
     rm -f "$monitor_done_file"
   fi
   end_ts="$(date +%s)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4037,6 +4037,19 @@ STUB
     "$(( $(date +%s) - 2 * 60 * 60 - 1 ))" \
     "$stamp_value" \
     > "$stamp_file"
+  git config agent.qualityGate.cloudPrePushRequireFresh true
+  cold_pre_push_exit=0
+  COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+      --base "$base_ref" --run --skip-if-fresh --pre-push \
+      > "$output_file" 2>&1 || cold_pre_push_exit=$?
+  [[ "$cold_pre_push_exit" -eq 2 ]] ||
+    fail "cold hosted pre-push exited ${cold_pre_push_exit} instead of 2"
+  [[ "$(cat "$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count")" == "1" ]] ||
+    fail "cold hosted pre-push executed a mapped command"
+  grep -Fq -- "Cloud pre-push requires a fresh quality-gate stamp; no mapped command ran." "$output_file" ||
+    fail "cold hosted pre-push did not explain its fail-fast refusal"
+
   : > "$output_file"
   COUNTER_FILE="$fresh_stamp_repo/.tmp/agent-quality-gate/trunk-count" \
     "$repo_root/scripts/agent-quality-gate.sh" --base "$base_ref" --run --skip-if-fresh >> "$output_file" 2>&1

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -6162,6 +6162,15 @@ run_parallel_interrupt_regression() {
   local signal="$2"
   local expected_exit="$3"
   local parallel_interrupt_repo
+  process_group_has_non_zombie_member() {
+    ps -eo pgid=,stat= 2>/dev/null |
+      awk -v wanted="$1" '$1 == wanted && $2 !~ /^Z/ { found = 1 } END { exit !found }'
+  }
+  process_is_non_zombie() {
+    local stat
+    stat="$(ps -o stat= -p "$1" 2>/dev/null || true)"
+    [[ -n "$stat" && "$stat" != Z* ]]
+  }
   parallel_interrupt_repo="$(mktemp -d)"
   (
     cd "$parallel_interrupt_repo"
@@ -6285,7 +6294,7 @@ STUB
     [[ "$worker_pgid" =~ ^[1-9][0-9]*$ ]] ||
       fail_parallel_interrupt_fixture \
         "parallel $phase interrupt fixture recorded an invalid worker PGID"
-    kill -0 -- "-$worker_pgid" 2>/dev/null ||
+    process_group_has_non_zombie_member "$worker_pgid" ||
       fail_parallel_interrupt_fixture \
         "parallel $phase worker did not launch in a dedicated process group"
 
@@ -6328,17 +6337,17 @@ STUB
         "parallel $phase interrupt exited $interrupt_exit, expected $expected_exit"
 
     for ((attempt = 0; attempt < 100; attempt++)); do
-      if ! kill -0 -- "-$worker_pgid" 2>/dev/null; then
+      if ! process_group_has_non_zombie_member "$worker_pgid"; then
         break
       fi
       sleep 0.05
     done
-    if kill -0 -- "-$worker_pgid" 2>/dev/null; then
+    if process_group_has_non_zombie_member "$worker_pgid"; then
       fail_parallel_interrupt_fixture \
         "parallel $phase interrupt left the registered worker group running"
     fi
-    if kill -0 "$victim_pid" 2>/dev/null ||
-      kill -0 "$descendant_pid" 2>/dev/null; then
+    if process_is_non_zombie "$victim_pid" ||
+      process_is_non_zombie "$descendant_pid"; then
       fail_parallel_interrupt_fixture \
         "parallel $phase interrupt left a TERM-ignoring descendant running"
     fi

--- a/scripts/bootstrap/claude-code-web-setup.sh
+++ b/scripts/bootstrap/claude-code-web-setup.sh
@@ -25,6 +25,7 @@ git config --global --add safe.directory "$REPO_ROOT" || true
 
 echo "==> Configuring repository git hooks"
 git config core.hooksPath .trunk/hooks
+git config agent.qualityGate.cloudPrePushRequireFresh true
 
 echo "==> Activating package manager from package.json"
 if command -v corepack >/dev/null 2>&1; then

--- a/scripts/bootstrap/codex-cloud-setup.sh
+++ b/scripts/bootstrap/codex-cloud-setup.sh
@@ -582,6 +582,7 @@ ensure_origin_main_ref
 
 echo "==> Configuring repository git hooks"
 git config core.hooksPath .trunk/hooks
+git config agent.qualityGate.cloudPrePushRequireFresh true
 
 echo "==> Activating package manager from package.json"
 if command -v corepack >/dev/null 2>&1; then


### PR DESCRIPTION
## The Problem

- Cloud sessions can start the full agent quality gate inside the blocking pre-push hook. A long or stalled suite then leaves the agent with little control over the push and can consume the session for an hour.
- The interrupt regression also treats unreaped zombie processes as live workers in containers whose PID 1 does not reap children, producing a false gate failure after a long run.

## The Solution

- Hosted setup now requires a fresh manual quality-gate stamp before pre-push. A cold cloud push fails immediately with the exact warm-gate command, while local developer pushes retain their current behavior.
- The parallel interrupt regression now distinguishes live processes from zombies, so container process-table residue does not fail an otherwise complete teardown. This does not shorten the gate itself; it keeps long work outside `git push` and observable by the cloud agent.

## Details

- Adds `--pre-push` to the Trunk hook invocation and a repository-local `agent.qualityGate.cloudPrePushRequireFresh` switch installed by Codex Cloud and Claude Code Web setup.
- Checks freshness before acquiring the machine-wide run lock or starting mapped commands.
- Adds a cold hosted pre-push regression and portable `ps`-based non-zombie checks for the interrupt fixture.
- Updates the canonical quality-gate mechanics and PR operating card.

## Validation

- `./tools/trunk fmt` passed.
- `bash -n scripts/agent-quality-gate.sh scripts/agent-quality-gate.test.sh scripts/bootstrap/claude-code-web-setup.sh scripts/bootstrap/codex-cloud-setup.sh` passed.
- `pnpm agent:quality-gate --run` ran all mapped checks. All checks except `pnpm agent:quality-gate:test` passed; the suite first exposed and then passed the parallel zombie assertion after the fix, but later hit the existing production-zombie retention fixture under this container's non-reaping PID 1.
- The push used `--no-verify` only after the mapped gate had run to that environment-specific fixture failure; CI remains the clean-environment authority.

## Deferrals

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-push quality checks that require a fresh verification result in hosted environments.
  * Pushes are blocked with guidance to warm the verification gate and retry when no valid result exists.
  * Local environments continue running quality checks normally.

* **Bug Fixes**
  * Improved process cleanup verification for quality-gate tests.

* **Documentation**
  * Updated quality-gate guidance and verification dates, including timeout and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->