### PR TITLE
docs: clarify issue and gate workflows

### DIFF
--- a/.agents/roles/verifier.md
+++ b/.agents/roles/verifier.md
@@ -20,9 +20,10 @@ Run diff-scoped verification and report only actionable results.
 2. Run `pnpm agent:quality-gate --dry-run` and confirm mapped commands/checklists match changed surfaces.
 3. Unless the requester asked for dry verification only, run
    `pnpm agent:quality-gate --run` as a background task. Before invoking it,
-   ensure that no direct `pnpm` validation, dashboard server, or browser suite
-   is active in the same worktree. From invocation until it exits, do not start
-   any of them there.
+   ensure that no direct validation, dashboard server, or browser suite is
+   active on the same machine. From invocation until it exits, do not start any
+   of them there. Use same-machine spare workers only for read-only work. Run
+   concurrent validation from a fully hydrated checkout on another machine.
 4. Report every failed or skipped command, the relevant output, and the
    smallest next fix.
 

--- a/.agents/roles/verifier.md
+++ b/.agents/roles/verifier.md
@@ -19,9 +19,10 @@ Run diff-scoped verification and report only actionable results.
 1. Inspect the branch diff against `origin/main`.
 2. Run `pnpm agent:quality-gate --dry-run` and confirm mapped commands/checklists match changed surfaces.
 3. Unless the requester asked for dry verification only, run
-   `pnpm agent:quality-gate --run` as a background task. While that gate is
-   queued or running, do not start direct `pnpm` validation, another gate, a
-   dashboard server, or a browser suite in the same worktree.
+   `pnpm agent:quality-gate --run` as a background task. Before invoking it,
+   ensure that no direct `pnpm` validation, dashboard server, or browser suite
+   is active in the same worktree. From invocation until it exits, do not start
+   any of them there.
 4. Report every failed or skipped command, the relevant output, and the
    smallest next fix.
 

--- a/.agents/roles/verifier.md
+++ b/.agents/roles/verifier.md
@@ -19,8 +19,9 @@ Run diff-scoped verification and report only actionable results.
 1. Inspect the branch diff against `origin/main`.
 2. Run `pnpm agent:quality-gate --dry-run` and confirm mapped commands/checklists match changed surfaces.
 3. Unless the requester asked for dry verification only, run
-   `pnpm agent:quality-gate --run` as a background task. Do not run another
-   gate, dashboard server, or browser suite concurrently in the same worktree.
+   `pnpm agent:quality-gate --run` as a background task. While that gate is
+   queued or running, do not start direct `pnpm` validation, another gate, a
+   dashboard server, or a browser suite in the same worktree.
 4. Report every failed or skipped command, the relevant output, and the
    smallest next fix.
 

--- a/.agents/skills/doc-garden/SKILL.md
+++ b/.agents/skills/doc-garden/SKILL.md
@@ -91,3 +91,9 @@ Summarize the disposition and evidence for every packet file in the PR body.
 Open a normal ready-for-review PR, use `Closes #<issue>` only when the entire
 packet is complete, and follow the repository ship/readiness workflow through
 review and merge.
+
+If a PR merges only part of a generated packet, keep the generated issue body
+and packet markers unchanged. Record merged work in issue comments and PR
+links. Follow the partial-merge route in
+[`agent-issue-workflow.md`](../../../docs/notes/agent-issue-workflow.md); never
+return the generated packet to `agent-ready`.

--- a/.claude/skills/doc-garden/SKILL.md
+++ b/.claude/skills/doc-garden/SKILL.md
@@ -91,3 +91,9 @@ Summarize the disposition and evidence for every packet file in the PR body.
 Open a normal ready-for-review PR, use `Closes #<issue>` only when the entire
 packet is complete, and follow the repository ship/readiness workflow through
 review and merge.
+
+If a PR merges only part of a generated packet, keep the generated issue body
+and packet markers unchanged. Record merged work in issue comments and PR
+links. Follow the partial-merge route in
+[`agent-issue-workflow.md`](../../../docs/notes/agent-issue-workflow.md); never
+return the generated packet to `agent-ready`.

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -85,6 +85,11 @@ Before restoring `agent-ready` after a partial merge, update the issue body:
 mark the merged work complete, isolate the remaining acceptance criteria, and
 restate the current Done means. Do not return an issue to the ready queue while
 its body still presents merged work as pending.
+Generated documentation-garden issues are the exception. Their marked packet
+bodies are immutable until closure. After a partial merge, do not edit the body
+or restore `agent-ready`; set `needs-grooming`. A human can resume the frozen
+packet or create a linked ordinary follow-up before closing it. Record merged
+work in issue comments and PR links, not in the generated body.
 Do not release a production-closeout issue merely because its PR merged; retain
 `in-pr` until live proof passes or the owner explicitly releases work they
 cannot continue.

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -81,6 +81,10 @@ Routing labels:
 
 For other partial work, keep the issue open. Remove `in-pr` after merge and set
 `agent-ready` or `needs-grooming` based on the remaining acceptance criteria.
+Before restoring `agent-ready` after a partial merge, update the issue body:
+mark the merged work complete, isolate the remaining acceptance criteria, and
+restate the current Done means. Do not return an issue to the ready queue while
+its body still presents merged work as pending.
 Do not release a production-closeout issue merely because its PR merged; retain
 `in-pr` until live proof passes or the owner explicitly releases work they
 cannot continue.

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -831,12 +831,13 @@ also executes that shell fixture in CI.
 The [PR operating card](pr-operating-card.md#the-loop) owns ordinary gate and
 closeout sequencing. A second `--run` gate no longer needs a convention: the
 run lock above queues it behind the first one, on any worktree. What is still
-yours to avoid is a dashboard server or browser suite you started yourself
-alongside a gate — the lock does not know about those. Browser tests and
-size-limit both run `next build` and can rewrite `next-env.d.ts`; run focused
-checks first, then let one gate own the mapped batch. For a non-trivial batch, freeze the card's scope baseline
-and run autoreview after the gate; after accepted fixes, rerun focused checks
-and autoreview.
+yours to avoid in the same worktree while a full gate is queued or running is
+direct `pnpm` validation, a dashboard server, or a browser suite you started
+yourself — the lock does not know about those. Browser tests and size-limit
+both run `next build` and can rewrite `next-env.d.ts`; run focused checks first,
+then let one gate own the mapped batch. For a non-trivial batch, freeze the
+card's scope baseline and run autoreview after the gate; after accepted fixes,
+rerun focused checks and autoreview.
 
 **Stage timing and capture deadlines.** The wrapper and helper append
 best-effort stage JSONL to `.tmp/agent-autoreview/durations.jsonl`; override

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -314,12 +314,14 @@ The gate owns the machine while it runs. Two rules make that true, and both
 exist because contention — not flakiness — produced the failures in issue
 #1802.
 
-Before invoking a full gate, wait for all direct `pnpm` validation in the same
-worktree to finish. While the gate is queued or running, do not start direct
-`pnpm` validation there. The gate owns dependency setup and local validation
-parallelism. Concurrent package-manager processes can recreate or invalidate
-`node_modules`. Use spare workers for read-only work, or use a separate, fully
-hydrated worktree.
+Before invoking a full gate, wait for all direct validation, dashboard servers,
+and browser suites on the same machine to finish. From invocation until the
+gate exits, do not start any of them there. The gate owns dependency setup and
+local validation parallelism. Concurrent package-manager processes in the same
+worktree can recreate or invalidate `node_modules`. Validation from another
+worktree on the same machine can still starve the gate of CPU and memory. Use
+spare workers for read-only work. Run concurrent validation only from a fully
+hydrated checkout on another machine.
 
 **One `--run` gate at a time, machine-wide.** `--run` takes a mkdir lock
 (`$HOME/.cache/agent-quality-gate/run.lock`, falling back to
@@ -832,14 +834,15 @@ also executes that shell fixture in CI.
 The [PR operating card](pr-operating-card.md#the-loop) owns ordinary gate and
 closeout sequencing. A second `--run` gate no longer needs a convention: the
 run lock above queues it behind the first one, on any worktree. Before invoking
-a full gate, ensure that no direct `pnpm` validation, dashboard server, or
-browser suite you started is active in the same worktree. From invocation until
-the gate exits, do not start any of them there — the lock does not know about
-those processes. Browser tests and size-limit both run `next build` and can
-rewrite `next-env.d.ts`; run focused checks first, then let one gate own the
-mapped batch. For a non-trivial batch, freeze the card's scope baseline and run
-autoreview after the gate; after accepted fixes, rerun focused checks and
-autoreview.
+a full gate, ensure that no direct validation, dashboard server, or browser
+suite is active on the same machine. From invocation until the gate exits, do
+not start any of them there — the lock does not know about those processes.
+Browser tests and size-limit both run `next build` and can rewrite
+`next-env.d.ts` in the same worktree; validation in another worktree can still
+starve the gate. Run focused checks first, then let one gate own the mapped
+batch. Run concurrent validation only on another machine. For a non-trivial
+batch, freeze the card's scope baseline and run autoreview after the gate; after
+accepted fixes, rerun focused checks and autoreview.
 
 **Stage timing and capture deadlines.** The wrapper and helper append
 best-effort stage JSONL to `.tmp/agent-autoreview/durations.jsonl`; override

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -314,8 +314,9 @@ The gate owns the machine while it runs. Two rules make that true, and both
 exist because contention — not flakiness — produced the failures in issue
 #1802.
 
-Do not start direct `pnpm` validation in the same worktree while a full gate is
-queued or running. The gate owns dependency setup and local validation
+Before invoking a full gate, wait for all direct `pnpm` validation in the same
+worktree to finish. While the gate is queued or running, do not start direct
+`pnpm` validation there. The gate owns dependency setup and local validation
 parallelism. Concurrent package-manager processes can recreate or invalidate
 `node_modules`. Use spare workers for read-only work, or use a separate, fully
 hydrated worktree.
@@ -830,14 +831,15 @@ also executes that shell fixture in CI.
 
 The [PR operating card](pr-operating-card.md#the-loop) owns ordinary gate and
 closeout sequencing. A second `--run` gate no longer needs a convention: the
-run lock above queues it behind the first one, on any worktree. What is still
-yours to avoid in the same worktree while a full gate is queued or running is
-direct `pnpm` validation, a dashboard server, or a browser suite you started
-yourself — the lock does not know about those. Browser tests and size-limit
-both run `next build` and can rewrite `next-env.d.ts`; run focused checks first,
-then let one gate own the mapped batch. For a non-trivial batch, freeze the
-card's scope baseline and run autoreview after the gate; after accepted fixes,
-rerun focused checks and autoreview.
+run lock above queues it behind the first one, on any worktree. Before invoking
+a full gate, ensure that no direct `pnpm` validation, dashboard server, or
+browser suite you started is active in the same worktree. From invocation until
+the gate exits, do not start any of them there — the lock does not know about
+those processes. Browser tests and size-limit both run `next build` and can
+rewrite `next-env.d.ts`; run focused checks first, then let one gate own the
+mapped batch. For a non-trivial batch, freeze the card's scope baseline and run
+autoreview after the gate; after accepted fixes, rerun focused checks and
+autoreview.
 
 **Stage timing and capture deadlines.** The wrapper and helper append
 best-effort stage JSONL to `.tmp/agent-autoreview/durations.jsonl`; override

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -314,6 +314,12 @@ The gate owns the machine while it runs. Two rules make that true, and both
 exist because contention — not flakiness — produced the failures in issue
 #1802.
 
+Do not start direct `pnpm` validation in the same worktree while a full gate is
+queued or running. The gate owns dependency setup and local validation
+parallelism. Concurrent package-manager processes can recreate or invalidate
+`node_modules`. Use spare workers for read-only work, or use a separate, fully
+hydrated worktree.
+
 **One `--run` gate at a time, machine-wide.** `--run` takes a mkdir lock
 (`$HOME/.cache/agent-quality-gate/run.lock`, falling back to
 `$TMPDIR/agent-quality-gate-<uid>`; override with

--- a/docs/notes/documentation-gardening.md
+++ b/docs/notes/documentation-gardening.md
@@ -130,6 +130,14 @@ Every document receives one evidence-backed disposition: **Keep**,
   envelope; once published, that envelope is immutable until closure. Semantic
   edits use a claimed issue and a normal reviewed PR.
 
+Generated packet bodies are the exception to the generic partial-merge body
+reconciliation rule. If a PR merges before the packet is complete, keep the
+generated title, body, and markers unchanged. Do not restore `agent-ready`; set
+`needs-grooming`. A human can resume the frozen packet or create a linked
+ordinary follow-up before closing it. Record merged work in issue comments and
+PR links, not in the generated body. Use `Closes` only after every file in the
+original packet is accounted for.
+
 Run `pnpm docs:index --check` after a gardening batch. If classification changed,
 regenerate the catalog with `pnpm docs:index --write` and review the generated
 diff before committing it.

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -87,11 +87,12 @@ even when you never open an authority.
    deploys and never applies Terraform. It **refuses package-script,
    package-manager, or lockfile changes until their lifecycle risk is reviewed
    and explicitly acknowledged** — do not bypass the refusal; review the surface
-   and pass `--allow-package-script-changes`. Do not run a competing dashboard
-   server or browser suite alongside the gate; a second `--run` gate is handled
-   for you — it takes a machine-wide lock and queues behind the first, naming
-   the holder while it waits. Background the `--run` gate and the `git push`; a
-   600s foreground kill discards the freshness stamp. Authority:
+   and pass `--allow-package-script-changes`. While a full gate is queued or
+   running, do not start direct `pnpm` validation, a dashboard server, or a
+   browser suite in the same worktree. A second `--run` gate takes a
+   machine-wide lock and queues behind the first, naming the holder while it
+   waits. Background the `--run` gate and the `git push`; a 600s foreground
+   kill discards the freshness stamp. Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 4. **Autoreview.** Freeze the scope baseline first — the initial request,
@@ -340,7 +341,11 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    present the evidence, then stop and ask. If the merge itself satisfies Done
    means, sync the issue state and workboard afterward per
    [`agent-issue-workflow.md`](agent-issue-workflow.md). If live proof remains,
-   continue to production closeout first.
+   continue to production closeout first. After a partial merge, keep the issue
+   open. Before `issue:release` restores `agent-ready`, update the issue body:
+   mark merged work complete, isolate the remaining acceptance criteria, and
+   restate the current Done means. Use `needs-grooming` instead when the
+   remaining scope is unclear.
 
 9. **Production closeout when required.** When Done means includes deployed or
    live behavior, merge is an intermediate state. Monitor the owning deployment
@@ -364,9 +369,10 @@ These bind regardless of which step you are on:
 - **Package-script, package-manager, and lockfile changes require explicit
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s
-  foreground that a kill would truncate, and do not start a dashboard server or
-  browser suite alongside a gate. A second `--run` gate queues on the gate's own
-  machine-wide lock instead of racing.
+  foreground that a kill would truncate. While a full gate is queued or
+  running, do not start direct `pnpm` validation, a dashboard server, or a
+  browser suite in the same worktree. A second `--run` gate queues on the gate's
+  own machine-wide lock instead of racing.
 - **Secrets are IaC-owned and Terraform apply needs human approval** — plan
   first, never one-off `gh secret set` / `vercel env add` /
   `gcloud secrets versions add`.

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -88,12 +88,14 @@ even when you never open an authority.
    package-manager, or lockfile changes until their lifecycle risk is reviewed
    and explicitly acknowledged** — do not bypass the refusal; review the surface
    and pass `--allow-package-script-changes`. Before invoking a full gate,
-   ensure that no direct `pnpm` validation, dashboard server, or browser suite
-   is active in the same worktree. From invocation until the gate exits, do not
-   start any of them there. A second `--run` gate takes a machine-wide lock and
-   queues behind the first, naming the holder while it waits. Background the
-   `--run` gate and the `git push`; a 600s foreground kill discards the
-   freshness stamp. Authority:
+   ensure that no direct validation, dashboard server, or browser suite is
+   active on the same machine. From invocation until the gate exits, do not
+   start any of them there. Use same-machine spare workers only for read-only
+   work; run concurrent validation from a fully hydrated checkout on another
+   machine. A second `--run` gate takes a machine-wide lock and queues behind
+   the first, naming the holder while it waits. Background the `--run` gate and
+   the `git push`; a 600s foreground kill discards the freshness stamp.
+   Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 4. **Autoreview.** Freeze the scope baseline first — the initial request,
@@ -346,7 +348,12 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    open. Before `issue:release` restores `agent-ready`, update the issue body:
    mark merged work complete, isolate the remaining acceptance criteria, and
    restate the current Done means. Use `needs-grooming` instead when the
-   remaining scope is unclear.
+   remaining scope is unclear. Generated documentation-garden packets are the
+   exception: do not edit their immutable issue bodies or restore
+   `agent-ready`. Set `needs-grooming`. A human can resume the frozen packet or
+   create a linked ordinary follow-up before closing it. Record merged work in
+   issue comments and PR links, not in the generated body. Authority:
+   [`documentation-gardening.md`](documentation-gardening.md).
 
 9. **Production closeout when required.** When Done means includes deployed or
    live behavior, merge is an intermediate state. Monitor the owning deployment
@@ -371,10 +378,11 @@ These bind regardless of which step you are on:
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s
   foreground that a kill would truncate. Before invoking a full gate, ensure
-  that no direct `pnpm` validation, dashboard server, or browser suite is active
-  in the same worktree. From invocation until the gate exits, do not start any
-  of them there. A second `--run` gate queues on the gate's own machine-wide lock
-  instead of racing.
+  that no direct validation, dashboard server, or browser suite is active on
+  the same machine. From invocation until the gate exits, do not start any of
+  them there. Use same-machine spare workers only for read-only work. Run
+  concurrent validation from another machine. A second `--run` gate queues on
+  the gate's own machine-wide lock instead of racing.
 - **Secrets are IaC-owned and Terraform apply needs human approval** — plan
   first, never one-off `gh secret set` / `vercel env add` /
   `gcloud secrets versions add`.

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -87,12 +87,13 @@ even when you never open an authority.
    deploys and never applies Terraform. It **refuses package-script,
    package-manager, or lockfile changes until their lifecycle risk is reviewed
    and explicitly acknowledged** — do not bypass the refusal; review the surface
-   and pass `--allow-package-script-changes`. While a full gate is queued or
-   running, do not start direct `pnpm` validation, a dashboard server, or a
-   browser suite in the same worktree. A second `--run` gate takes a
-   machine-wide lock and queues behind the first, naming the holder while it
-   waits. Background the `--run` gate and the `git push`; a 600s foreground
-   kill discards the freshness stamp. Authority:
+   and pass `--allow-package-script-changes`. Before invoking a full gate,
+   ensure that no direct `pnpm` validation, dashboard server, or browser suite
+   is active in the same worktree. From invocation until the gate exits, do not
+   start any of them there. A second `--run` gate takes a machine-wide lock and
+   queues behind the first, naming the holder while it waits. Background the
+   `--run` gate and the `git push`; a 600s foreground kill discards the
+   freshness stamp. Authority:
    [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md).
 
 4. **Autoreview.** Freeze the scope baseline first — the initial request,
@@ -369,10 +370,11 @@ These bind regardless of which step you are on:
 - **Package-script, package-manager, and lockfile changes require explicit
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s
-  foreground that a kill would truncate. While a full gate is queued or
-  running, do not start direct `pnpm` validation, a dashboard server, or a
-  browser suite in the same worktree. A second `--run` gate queues on the gate's
-  own machine-wide lock instead of racing.
+  foreground that a kill would truncate. Before invoking a full gate, ensure
+  that no direct `pnpm` validation, dashboard server, or browser suite is active
+  in the same worktree. From invocation until the gate exits, do not start any
+  of them there. A second `--run` gate queues on the gate's own machine-wide lock
+  instead of racing.
 - **Secrets are IaC-owned and Terraform apply needs human approval** — plan
   first, never one-off `gh secret set` / `vercel env add` /
   `gcloud secrets versions add`.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -397,8 +397,11 @@ Field expectations:
    near twice the baseline, and do not pause solely for cycle count before five
    review-triggered patch cycles are complete. Pause for reclassification before
    starting a sixth.
-3. Run `pnpm agent:quality-gate --run` once for the batch; it owns test
-   execution.
+3. Before invoking the gate, ensure that no direct validation, dashboard server,
+   or browser suite is active on the same machine. From invocation until it
+   exits, do not start any of them there. Run
+   `pnpm agent:quality-gate --run` once for the batch; it owns test execution.
+   Run concurrent validation from a fully hydrated checkout on another machine.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
    run `pnpm agent:autoreview` as a structured source-review closeout at the
    batch boundary rather than as an inner loop. Verify accepted findings before

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -399,7 +399,8 @@ Field expectations:
    starting a sixth.
 3. Before invoking the gate, ensure that no direct validation, dashboard server,
    or browser suite is active on the same machine. From invocation until it
-   exits, do not start any of them there. Run
+   exits, do not start any of them there. Use same-machine spare workers only
+   for read-only work. Run
    `pnpm agent:quality-gate --run` once for the batch; it owns test execution.
    Run concurrent validation from a fully hydrated checkout on another machine.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,


### PR DESCRIPTION
## The Problem

- A partial merge can return an issue to `agent-ready` while its body still presents merged work as pending. This makes the remaining scope unclear.
- Direct validation can compete with a queued or running full gate and invalidate dependency state.

## The Solution

- Require issue-body reconciliation before restoring `agent-ready` after a partial merge.
- Give the full gate exclusive ownership of dependency setup and local validation in its worktree.

## Details

- Mark merged work complete, isolate the remaining acceptance criteria, and restate the current Done means before returning an issue to the ready queue.
- Use spare workers for read-only work or a separate, fully hydrated worktree while a full gate is queued or running.
- This PR changes documentation only. It does not change runtime behavior.

## Validation

- `./tools/trunk fmt docs/notes/agent-issue-workflow.md docs/notes/agent-quality-gate-mechanics.md`
- `./tools/trunk check docs/notes/agent-issue-workflow.md docs/notes/agent-quality-gate-mechanics.md`
- `pnpm docs:index --check`
- `pnpm agent:context-check`
- `pnpm docs:navigation-eval -- --check-fixtures`
- Full local ship gate and source autoreview waived by the user for this docs-only PR. CI remains enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified partial-merge workflows, including preserving generated issue details, recording merged work, and routing incomplete items for grooming rather than restoring readiness.
  * Expanded quality-gate guidance to prevent direct validation, dashboard servers, and browser suites from running on the same machine during gate execution.
  * Documented requirements for concurrent validation, including use of a fully prepared checkout on a separate machine and limiting same-machine activity to read-only tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->