### PR TITLE
fix: make issue board sync race-safe

### DIFF
--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -77,7 +77,10 @@ Routing labels:
    labels. After each open-state projection, it re-reads the issue and
    reprojects bounded concurrent state changes. After a Done transition, it
    verifies that the issue remains closed and has no queue label. If the issue
-   reopened, it restores the previous queue label and projects the open state.
+   reopened, it restores a queue label confirmed immediately before cleanup and
+   projects the open state. If only an older enumerated queue label is known,
+   it uses `needs-grooming`. This keeps the issue visible without granting stale
+   review or release authority.
    It fails if a closed issue retains a queue label or if state does not settle
    within the bounded attempts. A per-issue failure does not stop later issues.
    The command exits nonzero after it lists the successful and failed issue

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -3,7 +3,7 @@ title: Agent Issue Workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-21
+last_verified: 2026-08-25
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -70,11 +70,21 @@ Routing labels:
    the Project has an `In Review` status option. With the default GitHub status
    options, it falls back to `In Progress`.
 6. On merge, GitHub closes issues referenced with closing keywords. Run
-   `pnpm issue:board sync` after merge, or on a schedule, to move those closed
-   `in-pr` issues on Project #12 to `Done` and clear the queue label. When Done
-   means still requires post-merge production proof, use `Refs`, keep the issue
-   open and `in-pr`, and retain its current owner through the live checks. Close
-   the issue and run board sync only after its live acceptance criteria pass.
+   `pnpm issue:board sync` after merge, or on a schedule, to move closed
+   queue-labeled Project #12 items to `Done` and clear all queue labels. The
+   helper also clears queue labels from closed issues that have no Project item.
+   It re-reads and reclassifies each issue before it changes the Project item or
+   labels. It verifies each open-state Project write and reprojects bounded
+   concurrent state changes. After a Done transition, it fails if the issue is
+   no longer closed or if a queue label remains. When Done means still requires
+   post-merge production proof, use `Refs`, keep the issue open and `in-pr`, and
+   retain its current owner through the live checks. Close the issue and run
+   board sync only after its live acceptance criteria pass.
+   When the closed issue is listed in an editable canonical parent or tracker,
+   update that body in the same closeout. Mark its checklist item complete and
+   remove nearby status text that still treats the child as open. Preserve a
+   generated or explicitly immutable body; record its terminal evidence in a
+   comment or linked follow-up instead.
 7. If the PR closes unmerged, run `pnpm issue:release --issue <issue>` and
    restore `agent-ready` only when the remaining work is still clear; otherwise
    run `pnpm issue:release --issue <issue> --needs-grooming`.

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -76,12 +76,15 @@ Routing labels:
    It re-reads and reclassifies each issue before it changes the Project item or
    labels. After each open-state projection, it re-reads the issue and
    reprojects bounded concurrent state changes. After a Done transition, it
-   fails if the issue is no longer closed or if a queue label remains. A
-   per-issue failure does not stop later issues. The command exits nonzero after
-   it lists the successful and failed issue numbers. When Done means still
-   requires post-merge production proof, use `Refs`, keep the issue open and
-   `in-pr`, and retain its current owner through the live checks. Close the issue
-   and run board sync only after its live acceptance criteria pass.
+   verifies that the issue remains closed and has no queue label. If the issue
+   reopened, it restores the previous queue label and projects the open state.
+   It fails if a closed issue retains a queue label or if state does not settle
+   within the bounded attempts. A per-issue failure does not stop later issues.
+   The command exits nonzero after it lists the successful and failed issue
+   numbers. When Done means still requires post-merge production proof, use
+   `Refs`, keep the issue open and `in-pr`, and retain its current owner through
+   the live checks. Close the issue and run board sync only after its live
+   acceptance criteria pass.
    When the closed issue is listed in an editable canonical parent or tracker,
    update that body in the same closeout. Mark its checklist item complete and
    remove nearby status text that still treats the child as open. Preserve a

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -78,9 +78,13 @@ Routing labels:
    reprojects bounded concurrent state changes. After a Done transition, it
    verifies that the issue remains closed and has no queue label. If the issue
    reopened, it restores a queue label confirmed immediately before cleanup and
-   projects the open state. If only an older enumerated queue label is known,
-   it uses `needs-grooming`. This keeps the issue visible without granting stale
-   review or release authority.
+   projects the open state. If the confirmed state is ambiguous, or if only an
+   older enumerated queue label is known, it uses `needs-grooming`. If a
+   post-cleanup check or Done projection fails, it makes bounded attempts to
+   restore this retry state before exit. This keeps the issue visible without
+   granting stale claim, review, or release authority. A concurrent conflict
+   with a fallback `needs-grooming` label stays visible and fails closed for
+   manual resolution.
    It fails if a closed issue retains a queue label or if state does not settle
    within the bounded attempts. A per-issue failure does not stop later issues.
    The command exits nonzero after it lists the successful and failed issue

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -74,12 +74,14 @@ Routing labels:
    queue-labeled Project #12 items to `Done` and clear all queue labels. The
    helper also clears queue labels from closed issues that have no Project item.
    It re-reads and reclassifies each issue before it changes the Project item or
-   labels. It verifies each open-state Project write and reprojects bounded
-   concurrent state changes. After a Done transition, it fails if the issue is
-   no longer closed or if a queue label remains. When Done means still requires
-   post-merge production proof, use `Refs`, keep the issue open and `in-pr`, and
-   retain its current owner through the live checks. Close the issue and run
-   board sync only after its live acceptance criteria pass.
+   labels. After each open-state projection, it re-reads the issue and
+   reprojects bounded concurrent state changes. After a Done transition, it
+   fails if the issue is no longer closed or if a queue label remains. A
+   per-issue failure does not stop later issues. The command exits nonzero after
+   it lists the successful and failed issue numbers. When Done means still
+   requires post-merge production proof, use `Refs`, keep the issue open and
+   `in-pr`, and retain its current owner through the live checks. Close the issue
+   and run board sync only after its live acceptance criteria pass.
    When the closed issue is listed in an editable canonical parent or tracker,
    update that body in the same closeout. Mark its checklist item complete and
    remove nearby status text that still treats the child as open. Preserve a

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -78,8 +78,8 @@ async function authenticatedApiCheck() {
   if (text !== "") {
     try {
       body = JSON.parse(text);
-    } catch (error) {
-      parseError = String(error);
+    } catch {
+      parseError = "invalid-json";
     }
   }
   return {
@@ -98,9 +98,11 @@ async function authenticatedApiCheck() {
 
 Keep the raw response text and the full parsed body local. Record only the
 status and the minimum non-sensitive fields that prove the acceptance criteria.
-Record `parseError` when parsing non-empty response text fails. Redact secrets,
-private labels, forensic reports, and personal data. Do not inspect cookies or
-browser storage. Do not use this path for a cross-origin request or a mutation.
+Set `parseError` to the fixed `invalid-json` category when non-empty response
+text cannot be parsed. Do not include response text or parser details in it.
+Redact secrets, private labels, forensic reports, and personal data. Do not
+inspect cookies or browser storage. Do not use this path for a cross-origin
+request or a mutation.
 
 For a simulated authenticated session:
 

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -81,13 +81,24 @@ if (text !== "") {
     parseError = String(error);
   }
 }
-({ status, text, body, parseError });
+({
+  status,
+  parseError,
+  fields:
+    body === null
+      ? null
+      : {
+          // Select only the non-sensitive fields needed for this check.
+          expectedField: body.expectedField,
+        },
+});
 ```
 
-Record the status, raw text, and parsed fields that prove the acceptance
-criteria. Record `parseError` when parsing non-empty response text fails. Do not
-inspect cookies or browser storage. Do not use this path for a cross-origin
-request or a mutation.
+Keep the raw response text and the full parsed body local. Record only the
+status and the minimum non-sensitive fields that prove the acceptance criteria.
+Record `parseError` when parsing non-empty response text fails. Redact secrets,
+private labels, forensic reports, and personal data. Do not inspect cookies or
+browser storage. Do not use this path for a cross-origin request or a mutation.
 
 For a simulated authenticated session:
 

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -70,12 +70,24 @@ const response = await fetch("/api/...", {
   cache: "no-store",
   credentials: "same-origin",
 });
-({ status: response.status, body: await response.json() });
+const status = response.status;
+const text = await response.text();
+let body = null;
+let parseError = null;
+if (text !== "") {
+  try {
+    body = JSON.parse(text);
+  } catch (error) {
+    parseError = String(error);
+  }
+}
+({ status, text, body, parseError });
 ```
 
-Record the status and the response fields that prove the acceptance criteria.
-Do not inspect cookies or browser storage. Do not use this path for a
-cross-origin request or a mutation.
+Record the status, raw text, and parsed fields that prove the acceptance
+criteria. Record `parseError` when the response is not valid JSON. Do not inspect
+cookies or browser storage. Do not use this path for a cross-origin request or
+a mutation.
 
 For a simulated authenticated session:
 

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -3,7 +3,7 @@ title: Dashboard Local and Browser Verification
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-14
+last_verified: 2026-08-25
 doc_type: runbook
 scope: ui-dashboard
 review_interval_days: 90
@@ -60,6 +60,22 @@ Logged-out checks must use an isolated browser context or clear both
 Public pages show `Sign in`; protected pages (`/address-book` and its nested
 `/address-book/entities` section, `/integrations`, and `/revenue`) redirect to
 `/sign-in?callbackUrl=...` when auth is configured.
+
+When API proof needs an existing authenticated browser session, keep the page
+on the target origin and run a read-only same-origin request through page
+evaluation:
+
+```js
+const response = await fetch("/api/...", {
+  cache: "no-store",
+  credentials: "same-origin",
+});
+({ status: response.status, body: await response.json() });
+```
+
+Record the status and the response fields that prove the acceptance criteria.
+Do not inspect cookies or browser storage. Do not use this path for a
+cross-origin request or a mutation.
 
 For a simulated authenticated session:
 

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -66,32 +66,34 @@ on the target origin and run a read-only same-origin request through page
 evaluation:
 
 ```js
-const response = await fetch("/api/...", {
-  cache: "no-store",
-  credentials: "same-origin",
-});
-const status = response.status;
-const text = await response.text();
-let body = null;
-let parseError = null;
-if (text !== "") {
-  try {
-    body = JSON.parse(text);
-  } catch (error) {
-    parseError = String(error);
+async function authenticatedApiCheck() {
+  const response = await fetch("/api/...", {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+  const status = response.status;
+  const text = await response.text();
+  let body = null;
+  let parseError = null;
+  if (text !== "") {
+    try {
+      body = JSON.parse(text);
+    } catch (error) {
+      parseError = String(error);
+    }
   }
+  return {
+    status,
+    parseError,
+    fields:
+      body === null
+        ? null
+        : {
+            // Select only the non-sensitive fields needed for this check.
+            expectedField: body.expectedField,
+          },
+  };
 }
-({
-  status,
-  parseError,
-  fields:
-    body === null
-      ? null
-      : {
-          // Select only the non-sensitive fields needed for this check.
-          expectedField: body.expectedField,
-        },
-});
 ```
 
 Keep the raw response text and the full parsed body local. Record only the

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -85,9 +85,9 @@ if (text !== "") {
 ```
 
 Record the status, raw text, and parsed fields that prove the acceptance
-criteria. Record `parseError` when the response is not valid JSON. Do not inspect
-cookies or browser storage. Do not use this path for a cross-origin request or
-a mutation.
+criteria. Record `parseError` when parsing non-empty response text fails. Do not
+inspect cookies or browser storage. Do not use this path for a cross-origin
+request or a mutation.
 
 For a simulated authenticated session:
 

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -3,7 +3,7 @@ title: GitHub Tooling Surfaces — gh CLI vs MCP
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-21
+last_verified: 2026-08-25
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -84,6 +84,24 @@ Do not build a gh-over-MCP shim; the skills document the two native paths.
 | failing-check log reads                        | `get_job_logs`, `get_check_run`                                                                         |
 | `gh issue edit` / labels / comments            | `issue_write`, `issue_read`, `add_issue_comment`                                                        |
 | `pnpm pr:ready-state --watch` foreground loop  | `subscribe_pr_activity` webhook events + scheduled self check-ins (e.g. `send_later`); never sleep-poll |
+
+## Exact workflow-run selection
+
+Resolve the full target commit SHA before querying GitHub Actions. Select runs
+with the commit, then bind every claim to the returned `databaseId`:
+
+```bash
+gh run list --commit <full-sha> \
+  --json databaseId,headSha,workflowName,status,conclusion,url
+gh run view <databaseId>
+gh run watch <databaseId> --exit-status
+```
+
+Require `headSha` to equal the target SHA and `workflowName` to equal the
+expected workflow. A workflow display name, branch filter, or list position is
+not sufficient evidence because each can select an older or unrelated run. For
+pull requests, keep `pnpm pr:ready-state` and `gh pr checks` as the canonical
+probes.
 
 ## Issue workboard transitions
 

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -91,7 +91,7 @@ Resolve the full target commit SHA before querying GitHub Actions. Select runs
 with the commit, then bind every claim to the returned `databaseId`:
 
 ```bash
-gh run list --workflow <expected-workflow> --commit <full-sha> --limit 1000 \
+gh run list --workflow <expected-workflow> --all --commit <full-sha> --limit 1000 \
   --json databaseId,headSha,workflowName,status,conclusion,url
 gh run view <databaseId>
 gh run watch <databaseId> --exit-status

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -91,7 +91,7 @@ Resolve the full target commit SHA before querying GitHub Actions. Select runs
 with the commit, then bind every claim to the returned `databaseId`:
 
 ```bash
-gh run list --commit <full-sha> \
+gh run list --workflow <expected-workflow> --commit <full-sha> --limit 1000 \
   --json databaseId,headSha,workflowName,status,conclusion,url
 gh run view <databaseId>
 gh run watch <databaseId> --exit-status

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -87,21 +87,26 @@ Do not build a gh-over-MCP shim; the skills document the two native paths.
 
 ## Exact workflow-run selection
 
-Resolve the full target commit SHA before querying GitHub Actions. Select runs
-with the commit, then bind every claim to the returned `databaseId`:
+Resolve the expected workflow path to exactly one workflow database ID. Stop if
+the path has zero or multiple matches. Then resolve the full target commit SHA,
+select runs with both IDs, and bind every claim to the returned run
+`databaseId`:
 
 ```bash
-gh run list --workflow <expected-workflow> --all --commit <full-sha> --limit 1000 \
-  --json databaseId,headSha,workflowName,status,conclusion,url
+gh workflow list --all --limit 1000 --json id,path,state \
+  --jq '.[] | select(.path == "<expected-workflow-path>")'
+gh run list --workflow <workflow-database-id> --all --commit <full-sha> \
+  --limit 1000 \
+  --json databaseId,headSha,workflowDatabaseId,status,conclusion,url
 gh run view <databaseId>
 gh run watch <databaseId> --exit-status
 ```
 
-Require `headSha` to equal the target SHA and `workflowName` to equal the
-expected workflow. A workflow display name, branch filter, or list position is
-not sufficient evidence because each can select an older or unrelated run. For
-pull requests, keep `pnpm pr:ready-state` and `gh pr checks` as the canonical
-probes.
+Use the unique workflow row's `id` as `<workflow-database-id>`. Require each
+run's `headSha` to equal the target SHA and `workflowDatabaseId` to equal that
+ID. A workflow display name, branch filter, or list position is not sufficient
+evidence because each can select an older or unrelated run. For pull requests,
+keep `pnpm pr:ready-state` and `gh pr checks` as the canonical probes.
 
 ## Issue workboard transitions
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -3,7 +3,7 @@ title: Quick Commands
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-24
+last_verified: 2026-08-25
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -110,7 +110,7 @@ pnpm integrations:probe:test   # Unit tests for probe adapters/parsers
 pnpm issue:claim --count 3 --agent codex       # Claim ready issues and move them to In Progress
 pnpm issue:review --pr 123 --issue 901         # Move claimed issue to in-pr / review
 pnpm issue:release --issue 901                 # Release a mistaken claim back to agent-ready
-pnpm issue:board sync                          # Re-project labels and close merged in-pr board items
+pnpm issue:board sync                          # Re-project open labels, mark closed board items Done, and verify closed queue labels clear
 pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -75,7 +75,10 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `pnpm sentry:project:test` in the projection arm.
   `deploy/deploy-indexer-verify{,-analysis}{,.test}.mjs` and
   `deploy/deploy-indexer-verify-status-identity.mjs` use one any-depth arm;
-  both verifier tests run.
+  both verifier tests run. The exact `pr/agent-issue-board.mjs`,
+  `pr/agent-issue-board.test.mjs`, and
+  `pr/issue-board-{backfill,cli,commands,projects,state,sync,transport}.mjs` set
+  routes to `pnpm issue:board:test`.
 - **Gate runtime module pins.** Before `cd`, `agent-quality-gate.sh` loads
   `$script_source_dir/gate/run-handles.sh`; move it with its signature, self-test
   route, and missing-helper fixture. It also pins

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -24,21 +24,19 @@ maintenance utilities.
 [ADR 0064](../docs/adr/0064-scripts-module-directories.md) governs these
 subdirectories.
 
-| Directory       | Holds                                  |
-| --------------- | -------------------------------------- |
-| `deploy/`       | deploy wrappers and their Node helpers |
-| `workflows/`    | scripts backing Actions workflow jobs  |
-| `bootstrap/`    | container and hosted-session setup     |
-| `context/`      | agent context, budget, doc catalog     |
-| `docs/`         | audit planner, garden, navigation eval |
-| `pr/`           | PR and issue state projections         |
-| `supply-chain/` | lockfile, audit, pin, skew gates       |
-| `mcp/`          | MCP broker, launcher, config rendering |
-| `alerts/`       | alert-rule lint, peg-policy checks     |
-| `repo-health/`  | code-health, file-size, lint wrappers  |
-| `terraform/`    | movable Terraform guards and helpers   |
-| `gate/`         | gate routing engine + helpers          |
-| `sentry/`       | triage/autofix/gate/broker/ci-wiring   |
+- `deploy/`: deploy wrappers and their Node helpers
+- `workflows/`: scripts backing Actions workflow jobs
+- `bootstrap/`: container and hosted-session setup
+- `context/`: agent context, budget, doc catalog
+- `docs/`: audit planner, garden, navigation eval
+- `pr/`: PR and issue state projections
+- `supply-chain/`: lockfile, audit, pin, skew gates
+- `mcp/`: MCP broker, launcher, config rendering
+- `alerts/`: alert-rule lint, peg-policy checks
+- `repo-health/`: code-health, file-size, lint wrappers
+- `terraform/`: movable Terraform guards and helpers
+- `gate/`: gate routing engine + helpers
+- `sentry/`: triage/autofix/gate/broker/ci-wiring
 
 `lib/` and `production-infra-identity-contract/` predate the reorganization.
 `.config/wt.toml` and eight docs pin flat `setup.sh`.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5709,6 +5709,7 @@ assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- pnpm docs:garden:test (shared GitHub issue lifecycle module changed)"
 assert_contains "- pnpm docs:navigation-eval:test (shared GitHub issue lifecycle module changed)"
 assert_contains "- pnpm sentry:project:test (shared GitHub issue lifecycle module changed)"
+assert_contains "- pnpm issue:board:test (shared GitHub issue lifecycle module changed)"
 
 run_gate "docs/evals/documentation-navigation-fixtures.json"
 assert_contains "- pnpm docs:navigation-eval:test (documentation navigation evaluation contract changed)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5487,6 +5487,9 @@ assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
 run_gate "scripts/pr/issue-board-commands.mjs"
 assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
 
+run_gate "scripts/pr/issue-board-sync.mjs"
+assert_contains "- pnpm issue:board:test (agent issue board helper changed)"
+
 run_gate "scripts/supply-chain/version-skew-check.mjs"
 assert_contains "- pnpm skew:check:test (version skew checker changed)"
 

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -276,6 +276,10 @@ export const AGENT_MODULE_ARMS = [
         command: "pnpm sentry:project:test",
         reason: "shared GitHub issue lifecycle module changed",
       },
+      {
+        command: "pnpm issue:board:test",
+        reason: "shared GitHub issue lifecycle module changed",
+      },
     ],
   },
   {

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -415,11 +415,12 @@ export const AGENT_MODULE_ARMS = [
       "scripts/pr/issue-board-commands.mjs",
       "scripts/pr/issue-board-projects.mjs",
       "scripts/pr/issue-board-state.mjs",
+      "scripts/pr/issue-board-sync.mjs",
       "scripts/pr/issue-board-transport.mjs",
     ],
     effects: [
       {
-        why: "agent-issue-board.mjs is the entry point over six layers (cli, transport, state, projects, backfill, commands). The one suite covers the pure state machine through the entry's re-exports, so every layer routes to it.",
+        why: "agent-issue-board.mjs is the entry point over seven layers (cli, transport, state, projects, backfill, commands, sync). The one suite covers the pure state machine through the entry's re-exports, so every layer routes to it.",
         command: "pnpm issue:board:test",
         reason: "agent issue board helper changed",
       },

--- a/scripts/pr/agent-issue-board.mjs
+++ b/scripts/pr/agent-issue-board.mjs
@@ -26,7 +26,7 @@ import {
 } from "./issue-board-commands.mjs";
 
 export { parseArgs, parseIssueNumbers } from "./issue-board-cli.mjs";
-export { backfill, buildClaimComment } from "./issue-board-commands.mjs";
+export { backfill, buildClaimComment, sync } from "./issue-board-commands.mjs";
 export {
   buildBackfillPlan,
   parseClaimComment,
@@ -43,6 +43,7 @@ export {
   isRecoverableClaimRaceError,
   isReleasable,
   isReviewable,
+  ISSUE_STATE_LABELS,
   labelsForState,
   projectDateFieldValue,
   projectPrFieldValue,

--- a/scripts/pr/agent-issue-board.mjs
+++ b/scripts/pr/agent-issue-board.mjs
@@ -4,13 +4,14 @@
  * the repo's GitHub Projects workboard.
  *
  * This file is the entry point and the public surface. The implementation
- * lives in six layers it composes:
+ * lives in seven layers it composes:
  *   - `issue-board-state.mjs`     pure transitions and predicates
  *   - `issue-board-cli.mjs`       argv parsing and usage text
  *   - `issue-board-transport.mjs` the bounded `gh` runner and issue readers
  *   - `issue-board-projects.mjs`  Projects V2 field IO
  *   - `issue-board-backfill.mjs`  trusted claim recovery and fill-only plans
- *   - `issue-board-commands.mjs`  claim, review, release, sync, backfill
+ *   - `issue-board-commands.mjs`  claim, review, release, and backfill
+ *   - `issue-board-sync.mjs`      reconciliation and closeout
  */
 
 import { fileURLToPath } from "node:url";
@@ -22,16 +23,12 @@ import {
   release,
   renderResults,
   review,
-  sync,
 } from "./issue-board-commands.mjs";
+import { sync } from "./issue-board-sync.mjs";
 
 export { parseArgs, parseIssueNumbers } from "./issue-board-cli.mjs";
-export {
-  backfill,
-  buildClaimComment,
-  IssueBoardSyncError,
-  sync,
-} from "./issue-board-commands.mjs";
+export { backfill, buildClaimComment } from "./issue-board-commands.mjs";
+export { IssueBoardSyncError, sync } from "./issue-board-sync.mjs";
 export {
   buildBackfillPlan,
   parseClaimComment,

--- a/scripts/pr/agent-issue-board.mjs
+++ b/scripts/pr/agent-issue-board.mjs
@@ -26,7 +26,12 @@ import {
 } from "./issue-board-commands.mjs";
 
 export { parseArgs, parseIssueNumbers } from "./issue-board-cli.mjs";
-export { backfill, buildClaimComment, sync } from "./issue-board-commands.mjs";
+export {
+  backfill,
+  buildClaimComment,
+  IssueBoardSyncError,
+  sync,
+} from "./issue-board-commands.mjs";
 export {
   buildBackfillPlan,
   parseClaimComment,

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -512,7 +512,7 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
       listIssuesByLabels: async (_options, labels, { state }) =>
         labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
       findIssueProjectItem: async (_options, issue) => {
-        events.push("find");
+        events.push(issue.projectItems[0] ? "find:visible" : "find:missing");
         return issue.projectItems[0]?.id ?? null;
       },
       updateProjectFields: async () => events.push("project"),
@@ -522,7 +522,8 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
         events.push(
           reads === 1 ? "refresh" : reads === 2 ? "pre-cleanup" : "verify",
         );
-        return reads <= 2 ? refreshedIssue : { ...refreshedIssue, labels: [] };
+        if (reads === 1) return listedIssue;
+        return reads === 2 ? refreshedIssue : { ...refreshedIssue, labels: [] };
       },
       sleep: async () => events.push("sleep"),
     },
@@ -530,11 +531,58 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
 
   assertDeepEqual(events, [
     "refresh",
-    "find",
-    "project",
+    "find:missing",
     "pre-cleanup",
+    "find:visible",
+    "project",
     "labels",
     "verify",
+  ]);
+});
+
+test("sync reapplies Done to the same Project item before label cleanup", async () => {
+  const issue = {
+    number: 921,
+    title: "closed item with a concurrent Project write",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [{ id: "item-921", project: { id: "project" } }],
+  };
+  const events = [];
+  let reads = 0;
+
+  await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [issue] : [],
+      findIssueProjectItem: async () => {
+        events.push("find");
+        return "item-921";
+      },
+      updateProjectFields: async () => events.push("project"),
+      editIssueLabels: async () => events.push("labels"),
+      getIssue: async () => {
+        reads += 1;
+        events.push(`read:${reads}`);
+        return reads < 3 ? issue : { ...issue, labels: [] };
+      },
+      sleep: async () => {
+        throw new Error("an immediately satisfied postcondition must not wait");
+      },
+    },
+  );
+
+  assertDeepEqual(events, [
+    "read:1",
+    "find",
+    "project",
+    "read:2",
+    "find",
+    "project",
+    "labels",
+    "read:3",
   ]);
 });
 
@@ -796,7 +844,7 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     },
   );
 
-  assertDeepEqual(updates, ["review", "done"]);
+  assertDeepEqual(updates, ["review", "done", "done"]);
   assertDeepEqual(results, [
     { number: 928, title: "concurrent close", state: "done" },
   ]);

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -10,6 +10,7 @@ import {
   isReleasable,
   isRecoverableClaimRaceError,
   isReviewable,
+  ISSUE_STATE_LABELS,
   labelsForState,
   parseArgs,
   parseIssueNumbers,
@@ -20,6 +21,7 @@ import {
   selectStatusOption,
   shouldRollbackFailedTransition,
   stateFromLabels,
+  sync,
   validateOpenPr,
 } from "./agent-issue-board.mjs";
 import {
@@ -368,19 +370,386 @@ test("active label transition claims the issue and removes stale state", () => {
   });
 });
 
-test("closed in-pr issues sync to done and clear state labels", () => {
-  assertEqual(
-    stateFromLabels({
-      state: "CLOSED",
-      labels: [{ name: "in-pr" }],
-    }),
-    "done",
-  );
+test("closed issues with any queue label sync to done", () => {
+  for (const label of ISSUE_STATE_LABELS) {
+    assertEqual(
+      stateFromLabels({
+        state: "CLOSED",
+        labels: [{ name: label }],
+      }),
+      "done",
+      label,
+    );
+  }
   assertDeepEqual(labelsForState("done"), {
     addLabels: [],
     removeLabels: ["agent-ready", "agent-active", "in-pr", "needs-grooming"],
     statusOptions: ["Done"],
   });
+});
+
+test("sync clears every closed queue label without requiring a Project item", async () => {
+  const queries = [];
+  const edits = [];
+  const reads = new Map();
+  const closedIssues = new Map(
+    ISSUE_STATE_LABELS.map((label, index) => [
+      label,
+      {
+        number: 900 + index,
+        title: `closed ${label}`,
+        state: "CLOSED",
+        labels: [{ name: label }],
+      },
+    ]),
+  );
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) => {
+        queries.push(`${state}:${label}`);
+        return state === "closed" ? [closedIssues.get(label)] : [];
+      },
+      findIssueProjectItem: async () => null,
+      updateProjectFields: async () => {
+        throw new Error("closed issues without Project items must still sync");
+      },
+      editIssueLabels: async (_options, issue, state) => {
+        edits.push({ number: issue.number, state });
+      },
+      getIssue: async (_options, number) => {
+        const issue = [...closedIssues.values()].find(
+          (candidate) => candidate.number === number,
+        );
+        const read = (reads.get(number) ?? 0) + 1;
+        reads.set(number, read);
+        return read === 1 ? issue : { ...issue, labels: [] };
+      },
+      sleep: async () => {
+        throw new Error("an immediately satisfied postcondition must not wait");
+      },
+    },
+  );
+
+  assertDeepEqual(
+    queries,
+    ISSUE_STATE_LABELS.flatMap((label) => [`open:${label}`, `closed:${label}`]),
+  );
+  assertDeepEqual(
+    results.map(({ number, state }) => ({ number, state })),
+    ISSUE_STATE_LABELS.map((_label, index) => ({
+      number: 900 + index,
+      state: "done",
+    })),
+  );
+  assertDeepEqual(
+    edits,
+    ISSUE_STATE_LABELS.map((_label, index) => ({
+      number: 900 + index,
+      state: "done",
+    })),
+  );
+  assertDeepEqual(
+    [...reads.values()],
+    ISSUE_STATE_LABELS.map(() => 2),
+  );
+});
+
+test("sync uses refreshed Project visibility before closed-item cleanup", async () => {
+  const listedIssue = {
+    number: 920,
+    title: "closed review item",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  const refreshedIssue = {
+    ...listedIssue,
+    projectItems: [{ id: "item-920", project: { id: "project" } }],
+  };
+  const events = [];
+  let reads = 0;
+
+  await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+      findIssueProjectItem: async (_options, issue) => {
+        events.push("find");
+        return issue.projectItems[0]?.id ?? null;
+      },
+      updateProjectFields: async () => events.push("project"),
+      editIssueLabels: async () => events.push("labels"),
+      getIssue: async () => {
+        reads += 1;
+        events.push(reads === 1 ? "refresh" : "verify");
+        return reads === 1 ? refreshedIssue : { ...refreshedIssue, labels: [] };
+      },
+      sleep: async () => events.push("sleep"),
+    },
+  );
+
+  assertDeepEqual(events, ["refresh", "find", "project", "labels", "verify"]);
+});
+
+test("sync reclassifies an issue that reopened after enumeration", async () => {
+  const listedIssue = {
+    number: 925,
+    title: "reopened review item",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  const reopenedIssue = {
+    ...listedIssue,
+    state: "OPEN",
+    labels: [{ name: "agent-active" }],
+  };
+  const updates = [];
+  let edits = 0;
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+      getIssue: async () => reopenedIssue,
+      findIssueProjectItem: async () => {
+        throw new Error("a reopened issue must not take the Done path");
+      },
+      ensureProjectItem: async () => "item-925",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async () => {
+        edits += 1;
+      },
+    },
+  );
+
+  assertDeepEqual(results, [
+    { number: 925, title: "reopened review item", state: "active" },
+  ]);
+  assertDeepEqual(updates, ["active"]);
+  assertEqual(edits, 0, "reopened issue label edits");
+});
+
+test("sync reprojects a concurrent claim after an open Project write", async () => {
+  const readyIssue = {
+    number: 926,
+    title: "concurrent claim",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const activeIssue = {
+    ...readyIssue,
+    labels: [{ name: "agent-active" }],
+  };
+  const reads = [readyIssue, activeIssue, activeIssue];
+  const updates = [];
+  let waits = 0;
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "agent-ready" && state === "open" ? [readyIssue] : [],
+      getIssue: async () => reads.shift(),
+      ensureProjectItem: async () => "item-926",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      sleep: async () => {
+        waits += 1;
+      },
+    },
+  );
+
+  assertDeepEqual(updates, ["ready", "active"]);
+  assertEqual(waits, 1, "claim drift wait");
+  assertDeepEqual(results, [
+    { number: 926, title: "concurrent claim", state: "active" },
+  ]);
+});
+
+test("sync bounds repeated open-state projection drift", async () => {
+  const readyIssue = {
+    number: 929,
+    title: "oscillating claim",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const activeIssue = {
+    ...readyIssue,
+    labels: [{ name: "agent-active" }],
+  };
+  const reads = [readyIssue, activeIssue, readyIssue, activeIssue];
+  const updates = [];
+  let waits = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabel: async (_options, label, { state }) =>
+            label === "agent-ready" && state === "open" ? [readyIssue] : [],
+          getIssue: async () => reads.shift(),
+          ensureProjectItem: async () => "item-929",
+          updateProjectFields: async (_options, _project, _item, state) => {
+            updates.push(state);
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #929 did not stabilize during sync after 3 attempts; last projection drift was ready -> active/,
+  );
+
+  assertDeepEqual(updates, ["ready", "active", "ready"]);
+  assertEqual(waits, 2, "bounded open-state drift waits");
+});
+
+test("sync reprojects Done when an issue closes after an open Project write", async () => {
+  const reviewIssue = {
+    number: 928,
+    title: "concurrent close",
+    state: "OPEN",
+    labels: [{ name: "in-pr" }],
+  };
+  const closedIssue = {
+    ...reviewIssue,
+    state: "CLOSED",
+    labels: [],
+  };
+  const reads = [reviewIssue, closedIssue, closedIssue];
+  const updates = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "in-pr" && state === "open" ? [reviewIssue] : [],
+      getIssue: async () => reads.shift(),
+      ensureProjectItem: async () => "item-928",
+      findIssueProjectItem: async () => "item-928",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async () => {},
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(updates, ["review", "done"]);
+  assertDeepEqual(results, [
+    { number: 928, title: "concurrent close", state: "done" },
+  ]);
+});
+
+test("sync fails if a closed issue reopens during Done cleanup", async () => {
+  const issue = {
+    number: 927,
+    title: "concurrent reopen",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  let reads = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabel: async (_options, label, { state }) =>
+            label === "in-pr" && state === "closed" ? [issue] : [],
+          getIssue: async () => {
+            reads += 1;
+            return reads === 1
+              ? issue
+              : { ...issue, state: "OPEN", labels: [] };
+          },
+          findIssueProjectItem: async () => null,
+          editIssueLabels: async () => {},
+          sleep: async () => {
+            throw new Error("a state change must fail without retrying");
+          },
+        },
+      ),
+    /Issue #927 changed state during sync: expected CLOSED, got OPEN/,
+  );
+  assertEqual(reads, 2, "refresh and postcondition reads");
+});
+
+test("sync fails when a closed issue retains a queue label", async () => {
+  const issue = {
+    number: 930,
+    title: "stale closed claim",
+    state: "CLOSED",
+    labels: [{ name: "agent-active" }],
+  };
+  let waits = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabel: async (_options, label, { state }) =>
+            label === "agent-active" && state === "closed" ? [issue] : [],
+          findIssueProjectItem: async () => null,
+          editIssueLabels: async () => {},
+          getIssue: async () => issue,
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #930 retained queue label\(s\) after sync: agent-active/,
+  );
+  assertEqual(waits, 2, "bounded verification waits");
+});
+
+test("sync dry-run refreshes once and skips the unapplied postcondition", async () => {
+  const issue = {
+    number: 940,
+    title: "dry-run closed item",
+    state: "CLOSED",
+    labels: [{ name: "needs-grooming" }],
+  };
+  let edits = 0;
+  let reads = 0;
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: true },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "needs-grooming" && state === "closed" ? [issue] : [],
+      findIssueProjectItem: async () => null,
+      editIssueLabels: async () => {
+        edits += 1;
+      },
+      getIssue: async () => {
+        reads += 1;
+        return issue;
+      },
+    },
+  );
+
+  assertEqual(edits, 1, "dry-run label plan");
+  assertEqual(reads, 1, "dry-run refresh reads");
+  assertEqual(results[0].state, "done", "dry-run result state");
 });
 
 test("claim guard only accepts open agent-ready issues", () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -722,6 +722,72 @@ test("sync restores retry labels when a late Done projection fails", async () =>
   ]);
 });
 
+test("sync quarantines ambiguous retry labels after late Done failure", async () => {
+  const listedIssue = {
+    number: 944,
+    title: "ambiguous late Done retry",
+    state: "CLOSED",
+    labels: [{ name: "agent-active" }, { name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  const restoredLabels = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            state === "all" &&
+            currentIssue.labels.some((label) => labels.includes(label.name))
+              ? [currentIssue]
+              : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            throw new Error("ambiguous late Done projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state !== "done") return;
+            currentIssue = {
+              ...currentIssue,
+              labels: [],
+              projectItems: [{ id: "item-944", project: { id: "project" } }],
+            };
+          },
+          addIssueLabels: async (_options, _issue, labels) => {
+            restoredLabels.push(...labels);
+            currentIssue = {
+              ...currentIssue,
+              labels: labels.map((name) => ({ name })),
+            };
+          },
+          sleep: async () => {
+            throw new Error("an immediately restored quarantine must not wait");
+          },
+        },
+      ),
+    /ambiguous late Done projection failed/,
+  );
+
+  assertDeepEqual(restoredLabels, ["needs-grooming"]);
+  assertDeepEqual(currentIssue.labels, [{ name: "needs-grooming" }]);
+  assertEqual(isClaimable(currentIssue), false, "ambiguous retry claimability");
+  assertEqual(
+    isReviewable(currentIssue),
+    false,
+    "ambiguous retry reviewability",
+  );
+  assertEqual(
+    isReleasable(currentIssue),
+    false,
+    "ambiguous retry releasability",
+  );
+});
+
 test("sync retries transient retry-label recovery failures", async () => {
   const listedIssue = {
     number: 941,
@@ -786,6 +852,184 @@ test("sync retries transient retry-label recovery failures", async () => {
   assertEqual(recoveryReads, 5, "bounded recovery reads");
   assertEqual(addCalls, 2, "bounded recovery label additions");
   assertEqual(waits, 2, "bounded recovery waits");
+  assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
+});
+
+test("sync restores retry state after post-cleanup verification fails", async () => {
+  const listedIssue = {
+    number: 945,
+    title: "post-cleanup verification retry",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let cleanupApplied = false;
+  let failVerification = true;
+  let addCalls = 0;
+  const updates = [];
+
+  const dependencies = {
+    getProject: async () => ({ id: "project" }),
+    listIssuesByLabels: async (_options, labels, { state }) =>
+      state === "all" &&
+      currentIssue.labels.some((label) => labels.includes(label.name))
+        ? [currentIssue]
+        : [],
+    getIssue: async () => {
+      if (cleanupApplied && failVerification) {
+        failVerification = false;
+        throw new Error("post-cleanup verification read failed");
+      }
+      return currentIssue;
+    },
+    findIssueProjectItem: async () => null,
+    ensureProjectItem: async () => "item-945",
+    updateProjectFields: async (_options, _project, _item, state) => {
+      updates.push(state);
+    },
+    editIssueLabels: async (_options, _issue, state) => {
+      if (state !== "done") return;
+      cleanupApplied = true;
+      currentIssue = { ...currentIssue, state: "OPEN", labels: [] };
+    },
+    addIssueLabels: async (_options, _issue, labels) => {
+      addCalls += 1;
+      currentIssue = {
+        ...currentIssue,
+        labels: labels.map((name) => ({ name })),
+      };
+    },
+    sleep: async () => {
+      throw new Error("an immediately restored retry state must not wait");
+    },
+  };
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        dependencies,
+      ),
+    /post-cleanup verification read failed/,
+  );
+
+  assertEqual(addCalls, 1, "post-cleanup retry-label additions");
+  assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
+
+  cleanupApplied = false;
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    dependencies,
+  );
+  assertDeepEqual(updates, ["review"]);
+  assertDeepEqual(results, [
+    {
+      number: 945,
+      title: "post-cleanup verification retry",
+      state: "review",
+    },
+  ]);
+});
+
+test("sync restores retry state when reopen refresh fails", async () => {
+  const listedIssue = {
+    number: 948,
+    title: "reopen refresh retry",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  let addCalls = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => {
+            reads += 1;
+            if (reads === 4) throw new Error("reopen refresh failed");
+            return currentIssue;
+          },
+          findIssueProjectItem: async () => null,
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state === "done") {
+              currentIssue = { ...currentIssue, state: "OPEN", labels: [] };
+            }
+          },
+          addIssueLabels: async (_options, _issue, labels) => {
+            addCalls += 1;
+            currentIssue = {
+              ...currentIssue,
+              labels: labels.map((name) => ({ name })),
+            };
+          },
+          sleep: async () => {
+            throw new Error("an immediately restored reopen must not wait");
+          },
+        },
+      ),
+    /reopen refresh failed/,
+  );
+
+  assertEqual(reads, 6, "reopen refresh and recovery reads");
+  assertEqual(addCalls, 1, "reopen refresh retry-label additions");
+  assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
+});
+
+test("sync restores retry state after an ambiguous cleanup failure", async () => {
+  const listedIssue = {
+    number: 946,
+    title: "ambiguous cleanup retry",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let addCalls = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            state === "all" &&
+            currentIssue.labels.some((label) => labels.includes(label.name))
+              ? [currentIssue]
+              : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async () => null,
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state !== "done") return;
+            currentIssue = { ...currentIssue, state: "OPEN", labels: [] };
+            throw new Error("cleanup failed after mutation");
+          },
+          addIssueLabels: async (_options, _issue, labels) => {
+            addCalls += 1;
+            currentIssue = {
+              ...currentIssue,
+              labels: labels.map((name) => ({ name })),
+            };
+          },
+          sleep: async () => {
+            throw new Error(
+              "an immediately restored cleanup retry must not wait",
+            );
+          },
+        },
+      ),
+    /cleanup failed after mutation/,
+  );
+
+  assertEqual(addCalls, 1, "ambiguous cleanup retry-label additions");
   assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
 });
 
@@ -870,6 +1114,138 @@ test("sync quarantines stale queue evidence after late Done failure", async () =
   assertDeepEqual(results, [
     { number: 942, title: "stale enumerated retry label", state: "done" },
   ]);
+});
+
+test("sync leaves a successful stale-quarantine race fail-closed", async () => {
+  const listedIssue = {
+    number: 947,
+    title: "stale quarantine transition",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = { ...listedIssue, labels: [] };
+  let addCalls = 0;
+  const edits = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            throw new Error("stale quarantine projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            edits.push(state);
+            if (state === "done") {
+              currentIssue = {
+                ...currentIssue,
+                labels: [],
+                projectItems: [{ id: "item-947", project: { id: "project" } }],
+              };
+            }
+          },
+          addIssueLabels: async (_options, _issue, labels) => {
+            addCalls += 1;
+            currentIssue = {
+              ...currentIssue,
+              state: "OPEN",
+              labels: [
+                ...labels.map((name) => ({ name })),
+                { name: "agent-ready" },
+              ],
+            };
+          },
+          sleep: async () => {},
+        },
+      ),
+    /stale quarantine projection failed/,
+  );
+
+  assertEqual(addCalls, 1, "stale quarantine additions");
+  assertDeepEqual(edits, ["done"]);
+  assertDeepEqual(currentIssue.labels, [
+    { name: "needs-grooming" },
+    { name: "agent-ready" },
+  ]);
+  assertEqual(isClaimable(currentIssue), false, "successful race claimability");
+  assertEqual(
+    isReviewable(currentIssue),
+    false,
+    "successful race reviewability",
+  );
+  assertEqual(
+    isReleasable(currentIssue),
+    false,
+    "successful race releasability",
+  );
+});
+
+test("sync leaves an ambiguous add failure conflict quarantined", async () => {
+  const listedIssue = {
+    number: 949,
+    title: "ambiguous quarantine add",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = { ...listedIssue, labels: [] };
+  let addCalls = 0;
+  const edits = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            throw new Error("ambiguous quarantine projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            edits.push(state);
+            if (state === "done") {
+              currentIssue = {
+                ...currentIssue,
+                labels: [],
+                projectItems: [{ id: "item-949", project: { id: "project" } }],
+              };
+            }
+          },
+          addIssueLabels: async () => {
+            addCalls += 1;
+            currentIssue = {
+              ...currentIssue,
+              state: "OPEN",
+              labels: [{ name: "needs-grooming" }, { name: "agent-ready" }],
+            };
+            throw new Error("quarantine add failed before mutation");
+          },
+          sleep: async () => {},
+        },
+      ),
+    /ambiguous quarantine projection failed/,
+  );
+
+  assertEqual(addCalls, 1, "ambiguous quarantine additions");
+  assertDeepEqual(edits, ["done"]);
+  assertDeepEqual(currentIssue.labels, [
+    { name: "needs-grooming" },
+    { name: "agent-ready" },
+  ]);
+  assertEqual(isClaimable(currentIssue), false, "ambiguous add claimability");
 });
 
 test("sync preserves a pre-existing quarantine conflict", async () => {
@@ -1703,6 +2079,70 @@ test("sync quarantines an ambiguous closed queue state", async () => {
   assertDeepEqual(updates, ["grooming"]);
   assertEqual(reads, 6, "ambiguous-source recovery reads");
   assertEqual(waits, 1, "ambiguous-source recovery waits");
+});
+
+test("sync leaves a normal fallback reopen race fail-closed", async () => {
+  const listedIssue = {
+    number: 950,
+    title: "normal fallback reopen race",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }, { name: "agent-active" }],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  let waits = 0;
+  const edits = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") &&
+            labels.includes("agent-active") &&
+            state === "all"
+              ? [listedIssue]
+              : [],
+          getIssue: async () => {
+            reads += 1;
+            return currentIssue;
+          },
+          findIssueProjectItem: async () => null,
+          ensureProjectItem: async () => {
+            throw new Error("sync must not project a fallback conflict");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            edits.push(state);
+            currentIssue =
+              state === "done"
+                ? { ...listedIssue, state: "OPEN", labels: [] }
+                : {
+                    ...listedIssue,
+                    state: "OPEN",
+                    labels: [
+                      { name: "needs-grooming" },
+                      { name: "agent-ready" },
+                    ],
+                  };
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #950 retained conflicting queue labels after 3 attempts: needs-grooming, agent-ready/,
+  );
+
+  assertDeepEqual(edits, ["done", "grooming"]);
+  assertEqual(reads, 6, "normal fallback conflict reads");
+  assertEqual(waits, 2, "normal fallback conflict waits");
+  assertDeepEqual(currentIssue.labels, [
+    { name: "needs-grooming" },
+    { name: "agent-ready" },
+  ]);
+  assertEqual(isClaimable(currentIssue), false, "normal race claimability");
 });
 
 test("sync preserves a concurrent queue transition before reopen restore", async () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -1647,7 +1647,7 @@ test("sync fails closed for ambiguous labels after reopen restore", async () => 
   assertEqual(waits, 2, "bounded ambiguous-state waits");
 });
 
-test("sync does not restore an ambiguous closed queue state", async () => {
+test("sync quarantines an ambiguous closed queue state", async () => {
   const listedIssue = {
     number: 937,
     title: "ambiguous closed state",
@@ -1658,44 +1658,51 @@ test("sync does not restore an ambiguous closed queue state", async () => {
   let reads = 0;
   let waits = 0;
   const edits = [];
+  const updates = [];
 
-  await assertRejects(
-    () =>
-      sync(
-        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
-        {
-          getProject: async () => ({ id: "project" }),
-          listIssuesByLabels: async (_options, labels, { state }) =>
-            labels.includes("in-pr") &&
-            labels.includes("agent-active") &&
-            state === "all"
-              ? [listedIssue]
-              : [],
-          getIssue: async () => {
-            reads += 1;
-            return currentIssue;
-          },
-          findIssueProjectItem: async () => null,
-          ensureProjectItem: async () => {
-            throw new Error("sync must not project an unknown restored state");
-          },
-          editIssueLabels: async (_options, _issue, state) => {
-            edits.push(state);
-            if (state === "done") {
-              currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
-            }
-          },
-          sleep: async () => {
-            waits += 1;
-          },
-        },
-      ),
-    /Issue #937 lost its queue state during sync after 3 attempt\(s\); last projection drift was done -> no queue state/,
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") &&
+        labels.includes("agent-active") &&
+        state === "all"
+          ? [listedIssue]
+          : [],
+      getIssue: async () => {
+        reads += 1;
+        return currentIssue;
+      },
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-937",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async (_options, _issue, state) => {
+        edits.push(state);
+        currentIssue =
+          state === "done"
+            ? { ...listedIssue, state: "OPEN", labels: [] }
+            : {
+                ...listedIssue,
+                state: "OPEN",
+                labels: [{ name: "needs-grooming" }],
+              };
+      },
+      sleep: async () => {
+        waits += 1;
+      },
+    },
   );
 
-  assertDeepEqual(edits, ["done"]);
-  assertEqual(reads, 4, "bounded ambiguous-source reads");
-  assertEqual(waits, 2, "bounded ambiguous-source waits");
+  assertDeepEqual(results, [
+    { number: 937, title: "ambiguous closed state", state: "grooming" },
+  ]);
+  assertDeepEqual(edits, ["done", "grooming"]);
+  assertDeepEqual(updates, ["grooming"]);
+  assertEqual(reads, 6, "ambiguous-source recovery reads");
+  assertEqual(waits, 1, "ambiguous-source recovery waits");
 });
 
 test("sync preserves a concurrent queue transition before reopen restore", async () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -537,6 +537,9 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
     "project",
     "labels",
     "verify",
+    "find:visible",
+    "project",
+    "verify",
   ]);
 });
 
@@ -583,6 +586,125 @@ test("sync reapplies Done to the same Project item before label cleanup", async 
     "project",
     "labels",
     "read:3",
+    "find",
+    "project",
+    "read:4",
+  ]);
+});
+
+test("sync projects a Project item that appears after label cleanup", async () => {
+  const listedIssue = {
+    number: 922,
+    title: "closed item with late Project visibility",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  const verifiedIssue = {
+    ...listedIssue,
+    labels: [],
+    projectItems: [{ id: "item-922", project: { id: "project" } }],
+  };
+  const reads = [listedIssue, listedIssue, verifiedIssue, verifiedIssue];
+  const events = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      findIssueProjectItem: async (_options, issue) => {
+        events.push(issue.projectItems[0] ? "find:visible" : "find:missing");
+        return issue.projectItems[0]?.id ?? null;
+      },
+      updateProjectFields: async () => events.push("project"),
+      editIssueLabels: async () => events.push("labels"),
+      getIssue: async () => {
+        events.push("read");
+        return reads.shift();
+      },
+      sleep: async () => {
+        throw new Error("an immediately satisfied postcondition must not wait");
+      },
+    },
+  );
+
+  assertDeepEqual(events, [
+    "read",
+    "find:missing",
+    "read",
+    "find:missing",
+    "labels",
+    "read",
+    "find:visible",
+    "project",
+    "read",
+  ]);
+  assertDeepEqual(results, [
+    {
+      number: 922,
+      title: "closed item with late Project visibility",
+      state: "done",
+    },
+  ]);
+});
+
+test("sync reprojects a reopen during the late Project write", async () => {
+  const listedIssue = {
+    number: 923,
+    title: "reopen during late Project projection",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  const clearedIssue = {
+    ...listedIssue,
+    labels: [],
+    projectItems: [{ id: "item-923", project: { id: "project" } }],
+  };
+  const activeIssue = {
+    ...listedIssue,
+    state: "OPEN",
+    labels: [{ name: "agent-active" }],
+    projectItems: clearedIssue.projectItems,
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  const updates = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      getIssue: async () => {
+        reads += 1;
+        return currentIssue;
+      },
+      findIssueProjectItem: async (_options, issue) =>
+        issue.projectItems[0]?.id ?? null,
+      ensureProjectItem: async () => "item-923",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+        if (state === "done") currentIssue = activeIssue;
+      },
+      editIssueLabels: async (_options, _issue, state) => {
+        if (state === "done") currentIssue = clearedIssue;
+      },
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(updates, ["done", "active"]);
+  assertEqual(reads, 5, "closed verification and reopened projection reads");
+  assertDeepEqual(results, [
+    {
+      number: 923,
+      title: "reopen during late Project projection",
+      state: "active",
+    },
   ]);
 });
 
@@ -824,7 +946,13 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     state: "CLOSED",
     labels: [],
   };
-  const reads = [reviewIssue, closedIssue, closedIssue, closedIssue];
+  const reads = [
+    reviewIssue,
+    closedIssue,
+    closedIssue,
+    closedIssue,
+    closedIssue,
+  ];
   const updates = [];
 
   const results = await sync(
@@ -844,7 +972,7 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     },
   );
 
-  assertDeepEqual(updates, ["review", "done", "done"]);
+  assertDeepEqual(updates, ["review", "done", "done", "done"]);
   assertDeepEqual(results, [
     { number: 928, title: "concurrent close", state: "done" },
   ]);

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -1040,6 +1040,75 @@ test("sync compensates for a concurrent queue transition after the restore read"
   ]);
 });
 
+test("sync restores provisional state when compensation loses a transition", async () => {
+  const listedIssue = {
+    number: 937,
+    title: "compensation transition race",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  const edits = [];
+  const updates = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      getIssue: async () => {
+        reads += 1;
+        return currentIssue;
+      },
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-937",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async (_options, issue, state) => {
+        edits.push(state);
+        if (edits.length === 1) {
+          assertEqual(state, "done");
+          currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+          return;
+        }
+        if (edits.length === 2) {
+          assertEqual(state, "review");
+          assertDeepEqual(issue.labels, [], "fresh restore snapshot");
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }, { name: "agent-active" }],
+          };
+          return;
+        }
+        if (edits.length === 3) {
+          assertEqual(state, "active");
+          currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+          return;
+        }
+        assertEqual(state, "review");
+        assertDeepEqual(issue.labels, [], "label-less compensation snapshot");
+        currentIssue = {
+          ...listedIssue,
+          state: "OPEN",
+          labels: [{ name: "in-pr" }],
+        };
+      },
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(edits, ["done", "review", "active", "review"]);
+  assertDeepEqual(updates, ["review"]);
+  assertEqual(reads, 8, "restore, compensation, repair, and projection reads");
+  assertDeepEqual(results, [
+    { number: 937, title: "compensation transition race", state: "review" },
+  ]);
+});
+
 test("sync carries restore compensation through Project verification", async () => {
   const listedIssue = {
     number: 935,

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -978,7 +978,7 @@ test("sync reprojects Done when an issue closes after an open Project write", as
   ]);
 });
 
-test("sync restores queue state when a closed issue reopens during Done cleanup", async () => {
+test("sync compensates for a concurrent queue transition after the restore read", async () => {
   const listedIssue = {
     number: 927,
     title: "concurrent reopen",
@@ -998,13 +998,6 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
         labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
       getIssue: async () => {
         reads += 1;
-        if (reads === 6) {
-          currentIssue = {
-            ...listedIssue,
-            state: "OPEN",
-            labels: [{ name: "in-pr" }],
-          };
-        }
         return currentIssue;
       },
       findIssueProjectItem: async () => null,
@@ -1012,15 +1005,26 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
       updateProjectFields: async (_options, _project, _item, state) => {
         updates.push(state);
       },
-      editIssueLabels: async (_options, _issue, state) => {
+      editIssueLabels: async (_options, issue, state) => {
         edits.push(state);
         if (state === "done") {
           currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
-        } else {
+        } else if (state === "review") {
+          assertDeepEqual(
+            issue.labels,
+            [],
+            "fresh label-less restore snapshot",
+          );
           currentIssue = {
             ...listedIssue,
             state: "OPEN",
             labels: [{ name: "in-pr" }, { name: "agent-active" }],
+          };
+        } else {
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "agent-active" }],
           };
         }
       },
@@ -1028,12 +1032,184 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
     },
   );
 
-  assertDeepEqual(edits, ["done", "review"]);
-  assertDeepEqual(updates, ["review"]);
-  assertEqual(reads, 7, "refresh, closeout, restore, and projection reads");
+  assertDeepEqual(edits, ["done", "review", "active"]);
+  assertDeepEqual(updates, ["active"]);
+  assertEqual(reads, 7, "restore, compensation, and projection reads");
   assertDeepEqual(results, [
-    { number: 927, title: "concurrent reopen", state: "review" },
+    { number: 927, title: "concurrent reopen", state: "active" },
   ]);
+});
+
+test("sync carries restore compensation through Project verification", async () => {
+  const listedIssue = {
+    number: 935,
+    title: "transition after restored projection",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  let waits = 0;
+  const edits = [];
+  const updates = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      getIssue: async () => {
+        reads += 1;
+        return currentIssue;
+      },
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-935",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+        if (state === "review") {
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }, { name: "agent-active" }],
+          };
+        }
+      },
+      editIssueLabels: async (_options, _issue, state) => {
+        edits.push(state);
+        currentIssue = {
+          ...listedIssue,
+          state: "OPEN",
+          labels:
+            state === "done"
+              ? []
+              : [{ name: state === "review" ? "in-pr" : "agent-active" }],
+        };
+      },
+      sleep: async () => {
+        waits += 1;
+      },
+    },
+  );
+
+  assertDeepEqual(edits, ["done", "review", "active"]);
+  assertDeepEqual(updates, ["review", "active"]);
+  assertEqual(reads, 8, "restore and later Project verification reads");
+  assertEqual(waits, 2, "bounded projection retries");
+  assertDeepEqual(results, [
+    {
+      number: 935,
+      title: "transition after restored projection",
+      state: "active",
+    },
+  ]);
+});
+
+test("sync fails closed for ambiguous labels after reopen restore", async () => {
+  const listedIssue = {
+    number: 936,
+    title: "ambiguous transition after restore",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  let waits = 0;
+  const edits = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => {
+            reads += 1;
+            return currentIssue;
+          },
+          findIssueProjectItem: async () => null,
+          ensureProjectItem: async () => {
+            throw new Error("sync must not project an ambiguous state");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            edits.push(state);
+            currentIssue = {
+              ...listedIssue,
+              state: "OPEN",
+              labels:
+                state === "done"
+                  ? []
+                  : [
+                      { name: "in-pr" },
+                      { name: "agent-active" },
+                      { name: "agent-ready" },
+                    ],
+            };
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #936 retained conflicting queue labels after 3 attempts: agent-ready, agent-active, in-pr/,
+  );
+
+  assertDeepEqual(edits, ["done", "review"]);
+  assertEqual(reads, 6, "bounded ambiguous-state reads");
+  assertEqual(waits, 2, "bounded ambiguous-state waits");
+});
+
+test("sync does not restore an ambiguous closed queue state", async () => {
+  const listedIssue = {
+    number: 937,
+    title: "ambiguous closed state",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }, { name: "agent-active" }],
+  };
+  let currentIssue = listedIssue;
+  let reads = 0;
+  let waits = 0;
+  const edits = [];
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") &&
+            labels.includes("agent-active") &&
+            state === "all"
+              ? [listedIssue]
+              : [],
+          getIssue: async () => {
+            reads += 1;
+            return currentIssue;
+          },
+          findIssueProjectItem: async () => null,
+          ensureProjectItem: async () => {
+            throw new Error("sync must not project an unknown restored state");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            edits.push(state);
+            if (state === "done") {
+              currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+            }
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #937 lost its queue state during sync after 3 attempt\(s\); last projection drift was done -> no queue state/,
+  );
+
+  assertDeepEqual(edits, ["done"]);
+  assertEqual(reads, 4, "bounded ambiguous-source reads");
+  assertEqual(waits, 2, "bounded ambiguous-source waits");
 });
 
 test("sync preserves a concurrent queue transition before reopen restore", async () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -650,6 +650,129 @@ test("sync projects a Project item that appears after label cleanup", async () =
   ]);
 });
 
+test("sync restores retry labels when a late Done projection fails", async () => {
+  const listedIssue = {
+    number: 938,
+    title: "late Done retry",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let failLateDone = true;
+  let projectState = "review";
+  const restoredLabels = [];
+
+  const dependencies = {
+    getProject: async () => ({ id: "project" }),
+    listIssuesByLabels: async (_options, labels, { state }) =>
+      state === "all" &&
+      currentIssue.labels.some((label) => labels.includes(label.name))
+        ? [currentIssue]
+        : [],
+    getIssue: async () => currentIssue,
+    findIssueProjectItem: async (_options, issue) =>
+      issue.projectItems[0]?.id ?? null,
+    updateProjectFields: async (_options, _project, _item, state) => {
+      if (failLateDone) throw new Error("late Done projection failed");
+      projectState = state;
+    },
+    editIssueLabels: async (_options, _issue, state) => {
+      if (state !== "done") return;
+      currentIssue = {
+        ...currentIssue,
+        labels: [],
+        projectItems: [{ id: "item-938", project: { id: "project" } }],
+      };
+    },
+    addIssueLabels: async (_options, issue, labels) => {
+      assertDeepEqual(issue.labels, [], "fresh retry-label snapshot");
+      restoredLabels.push(...labels);
+      currentIssue = {
+        ...currentIssue,
+        labels: labels.map((name) => ({ name })),
+      };
+    },
+    sleep: async () => {
+      throw new Error("an immediately restored retry label must not wait");
+    },
+  };
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        dependencies,
+      ),
+    /late Done projection failed/,
+  );
+  assertDeepEqual(restoredLabels, ["in-pr"]);
+  assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
+
+  failLateDone = false;
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    dependencies,
+  );
+
+  assertEqual(projectState, "done", "retried Project state");
+  assertDeepEqual(currentIssue.labels, []);
+  assertDeepEqual(results, [
+    { number: 938, title: "late Done retry", state: "done" },
+  ]);
+});
+
+test("sync preserves a concurrent retry label after late Done failure", async () => {
+  const listedIssue = {
+    number: 939,
+    title: "late Done concurrent reopen",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let addCalls = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            currentIssue = {
+              ...currentIssue,
+              state: "OPEN",
+              labels: [{ name: "agent-active" }],
+            };
+            throw new Error("late Done projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state !== "done") return;
+            currentIssue = {
+              ...currentIssue,
+              labels: [],
+              projectItems: [{ id: "item-939", project: { id: "project" } }],
+            };
+          },
+          addIssueLabels: async () => {
+            addCalls += 1;
+          },
+          sleep: async () => {},
+        },
+      ),
+    /late Done projection failed/,
+  );
+
+  assertEqual(addCalls, 0, "concurrent queue label restore calls");
+  assertDeepEqual(currentIssue.labels, [{ name: "agent-active" }]);
+});
+
 test("sync reprojects a reopen during the late Project write", async () => {
   const listedIssue = {
     number: 923,
@@ -1106,6 +1229,77 @@ test("sync restores provisional state when compensation loses a transition", asy
   assertEqual(reads, 8, "restore, compensation, repair, and projection reads");
   assertDeepEqual(results, [
     { number: 937, title: "compensation transition race", state: "review" },
+  ]);
+});
+
+test("sync compensates a conflict created by provisional repair", async () => {
+  const listedIssue = {
+    number: 940,
+    title: "provisional repair conflict",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  let currentIssue = listedIssue;
+  const edits = [];
+  const updates = [];
+  let waits = 0;
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      getIssue: async () => currentIssue,
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-940",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+        if (state === "review") {
+          currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+        }
+      },
+      editIssueLabels: async (_options, issue, state) => {
+        edits.push(state);
+        if (edits.length === 1) {
+          currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+          return;
+        }
+        if (edits.length === 2) {
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }],
+          };
+          return;
+        }
+        if (edits.length === 3) {
+          assertDeepEqual(issue.labels, [], "label-less repair snapshot");
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }, { name: "agent-active" }],
+          };
+          return;
+        }
+        assertEqual(state, "active");
+        currentIssue = {
+          ...listedIssue,
+          state: "OPEN",
+          labels: [{ name: "agent-active" }],
+        };
+      },
+      sleep: async () => {
+        waits += 1;
+      },
+    },
+  );
+
+  assertDeepEqual(edits, ["done", "review", "review", "active"]);
+  assertDeepEqual(updates, ["review", "active"]);
+  assertEqual(waits, 2, "bounded outer reconciliation waits");
+  assertDeepEqual(results, [
+    { number: 940, title: "provisional repair conflict", state: "active" },
   ]);
 });
 

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -31,7 +31,7 @@ import {
 } from "./issue-board-projects.mjs";
 import {
   listIssueComments,
-  listIssuesByLabel,
+  listIssuesByLabels,
 } from "./issue-board-transport.mjs";
 
 let passed = 0;
@@ -161,11 +161,11 @@ test("project scope failures name the read-write gh refresh command", () => {
   );
 });
 
-test("queue-label issue lists request all states without an is:all query", async () => {
+test("queue-label issue lists use one all-state OR query", async () => {
   const calls = [];
-  await listIssuesByLabel(
+  await listIssuesByLabels(
     { repo: "mento-protocol/monitoring-monorepo" },
-    "agent-active",
+    ISSUE_STATE_LABELS,
     {
       state: "all",
       json: async (args) => {
@@ -184,7 +184,7 @@ test("queue-label issue lists request all states without an is:all query", async
       "--state",
       "all",
       "--search",
-      "is:issue label:agent-active",
+      `is:issue label:${ISSUE_STATE_LABELS.join(",")}`,
       "--limit",
       "1000",
       "--json",
@@ -444,9 +444,9 @@ test("sync clears every closed queue label without requiring a Project item", as
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) => {
-        queries.push(`${state}:${label}`);
-        return state === "all" ? [closedIssues.get(label)] : [];
+      listIssuesByLabels: async (_options, labels, { state }) => {
+        queries.push(`${state}:${labels.join(",")}`);
+        return state === "all" ? [...closedIssues.values()] : [];
       },
       findIssueProjectItem: async () => null,
       updateProjectFields: async () => {
@@ -469,10 +469,7 @@ test("sync clears every closed queue label without requiring a Project item", as
     },
   );
 
-  assertDeepEqual(
-    queries,
-    ISSUE_STATE_LABELS.map((label) => `all:${label}`),
-  );
+  assertDeepEqual(queries, [`all:${ISSUE_STATE_LABELS.join(",")}`]);
   assertDeepEqual(
     results.map(({ number, state }) => ({ number, state })),
     ISSUE_STATE_LABELS.map((_label, index) => ({
@@ -512,8 +509,8 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "all" ? [listedIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
       findIssueProjectItem: async (_options, issue) => {
         events.push("find");
         return issue.projectItems[0]?.id ?? null;
@@ -560,8 +557,8 @@ test("sync reclassifies an issue that reopened after enumeration", async () => {
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "all" ? [listedIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
       getIssue: async () => reopenedIssue,
       findIssueProjectItem: async () => {
         throw new Error("a reopened issue must not take the Done path");
@@ -603,8 +600,8 @@ test("sync reclassifies a reopen before the Done label edit", async () => {
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "all" ? [closedIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [closedIssue] : [],
       getIssue: async () => reads.shift(),
       findIssueProjectItem: async () => null,
       ensureProjectItem: async () => "item-924",
@@ -644,8 +641,8 @@ test("sync reprojects a concurrent claim after an open Project write", async () 
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "agent-ready" && state === "all" ? [readyIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("agent-ready") && state === "all" ? [readyIssue] : [],
       getIssue: async () => reads.shift(),
       ensureProjectItem: async () => "item-926",
       updateProjectFields: async (_options, _project, _item, state) => {
@@ -685,8 +682,10 @@ test("sync bounds repeated open-state projection drift", async () => {
         { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
         {
           getProject: async () => ({ id: "project" }),
-          listIssuesByLabel: async (_options, label, { state }) =>
-            label === "agent-ready" && state === "all" ? [readyIssue] : [],
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("agent-ready") && state === "all"
+              ? [readyIssue]
+              : [],
           getIssue: async () => reads.shift(),
           ensureProjectItem: async () => "item-929",
           updateProjectFields: async (_options, _project, _item, state) => {
@@ -725,8 +724,8 @@ test("sync attempts later issues and reports partial results after a failure", a
       { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
       {
         getProject: async () => ({ id: "project" }),
-        listIssuesByLabel: async (_options, label, { state }) =>
-          label === "agent-ready" && state === "all"
+        listIssuesByLabels: async (_options, labels, { state }) =>
+          labels.includes("agent-ready") && state === "all"
             ? [failingIssue, successfulIssue]
             : [],
         getIssue: async (_options, number) =>
@@ -784,8 +783,8 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "all" ? [reviewIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [reviewIssue] : [],
       getIssue: async () => reads.shift(),
       ensureProjectItem: async () => "item-928",
       findIssueProjectItem: async () => "item-928",
@@ -819,10 +818,17 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
     { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "all" ? [listedIssue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
       getIssue: async () => {
         reads += 1;
+        if (reads === 6) {
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }],
+          };
+        }
         return currentIssue;
       },
       findIssueProjectItem: async () => null,
@@ -838,7 +844,7 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
           currentIssue = {
             ...listedIssue,
             state: "OPEN",
-            labels: [{ name: "in-pr" }],
+            labels: [{ name: "in-pr" }, { name: "agent-active" }],
           };
         }
       },
@@ -848,10 +854,103 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
 
   assertDeepEqual(edits, ["done", "review"]);
   assertDeepEqual(updates, ["review"]);
-  assertEqual(reads, 5, "refresh, closeout, restore, and projection reads");
+  assertEqual(reads, 7, "refresh, closeout, restore, and projection reads");
   assertDeepEqual(results, [
     { number: 927, title: "concurrent reopen", state: "review" },
   ]);
+});
+
+test("sync preserves a concurrent queue transition before reopen restore", async () => {
+  const listedIssue = {
+    number: 933,
+    title: "transition during restore",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  const labelLessIssue = { ...listedIssue, state: "OPEN", labels: [] };
+  const activeIssue = {
+    ...listedIssue,
+    state: "OPEN",
+    labels: [{ name: "agent-active" }],
+  };
+  const reads = [
+    listedIssue,
+    listedIssue,
+    labelLessIssue,
+    activeIssue,
+    activeIssue,
+  ];
+  const edits = [];
+  const updates = [];
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+      getIssue: async () => reads.shift(),
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-933",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async (_options, _issue, state) => {
+        edits.push(state);
+      },
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(edits, ["done"]);
+  assertDeepEqual(updates, ["active"]);
+  assertDeepEqual(results, [
+    { number: 933, title: "transition during restore", state: "active" },
+  ]);
+});
+
+test("sync fails closed while an open queue-label conflict persists", async () => {
+  const issue = {
+    number: 934,
+    title: "release in progress",
+    state: "OPEN",
+    labels: [{ name: "in-pr" }, { name: "agent-ready" }],
+  };
+  let reads = 0;
+  let waits = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") &&
+            labels.includes("agent-ready") &&
+            state === "all"
+              ? [issue]
+              : [],
+          getIssue: async () => {
+            reads += 1;
+            return issue;
+          },
+          editIssueLabels: async () => {
+            throw new Error("sync must not select one conflicting label");
+          },
+          ensureProjectItem: async () => {
+            throw new Error("sync must not project an ambiguous state");
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /Issue #934 retained conflicting queue labels after 3 attempts: agent-ready, in-pr/,
+  );
+
+  assertEqual(reads, 3, "bounded conflict reads");
+  assertEqual(waits, 2, "bounded conflict waits");
 });
 
 test("sync fails when a closed issue retains a queue label", async () => {
@@ -869,8 +968,8 @@ test("sync fails when a closed issue retains a queue label", async () => {
         { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
         {
           getProject: async () => ({ id: "project" }),
-          listIssuesByLabel: async (_options, label, { state }) =>
-            label === "agent-active" && state === "all" ? [issue] : [],
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("agent-active") && state === "all" ? [issue] : [],
           findIssueProjectItem: async () => null,
           editIssueLabels: async () => {},
           getIssue: async () => issue,
@@ -898,8 +997,8 @@ test("sync dry-run refreshes once and skips the unapplied postcondition", async 
     { repo: "mento-protocol/monitoring-monorepo", dryRun: true },
     {
       getProject: async () => ({ id: "project" }),
-      listIssuesByLabel: async (_options, label, { state }) =>
-        label === "needs-grooming" && state === "all" ? [issue] : [],
+      listIssuesByLabels: async (_options, labels, { state }) =>
+        labels.includes("needs-grooming") && state === "all" ? [issue] : [],
       findIssueProjectItem: async () => null,
       editIssueLabels: async () => {
         edits += 1;

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -722,6 +722,217 @@ test("sync restores retry labels when a late Done projection fails", async () =>
   ]);
 });
 
+test("sync retries transient retry-label recovery failures", async () => {
+  const listedIssue = {
+    number: 941,
+    title: "transient retry-label recovery",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = listedIssue;
+  let recovering = false;
+  let recoveryReads = 0;
+  let addCalls = 0;
+  let waits = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => {
+            if (recovering && recoveryReads++ === 0) {
+              throw new Error("transient recovery read failure");
+            }
+            return currentIssue;
+          },
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            recovering = true;
+            throw new Error("late Done projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state !== "done") return;
+            currentIssue = {
+              ...currentIssue,
+              labels: [],
+              projectItems: [{ id: "item-941", project: { id: "project" } }],
+            };
+          },
+          addIssueLabels: async (_options, _issue, labels) => {
+            addCalls += 1;
+            if (addCalls === 1) {
+              throw new Error("retry-label add failed before mutation");
+            }
+            currentIssue = {
+              ...currentIssue,
+              labels: labels.map((name) => ({ name })),
+            };
+            throw new Error("ambiguous retry-label add failure");
+          },
+          sleep: async () => {
+            waits += 1;
+          },
+        },
+      ),
+    /late Done projection failed/,
+  );
+
+  assertEqual(recoveryReads, 5, "bounded recovery reads");
+  assertEqual(addCalls, 2, "bounded recovery label additions");
+  assertEqual(waits, 2, "bounded recovery waits");
+  assertDeepEqual(currentIssue.labels, [{ name: "in-pr" }]);
+});
+
+test("sync quarantines stale queue evidence after late Done failure", async () => {
+  const listedIssue = {
+    number: 942,
+    title: "stale enumerated retry label",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = { ...listedIssue, labels: [] };
+  let firstEnumeration = true;
+  let failLateDone = true;
+  let projectState = "review";
+  const restoredLabels = [];
+
+  const dependencies = {
+    getProject: async () => ({ id: "project" }),
+    listIssuesByLabels: async (_options, labels, { state }) => {
+      if (state !== "all") return [];
+      if (firstEnumeration) {
+        firstEnumeration = false;
+        return [listedIssue];
+      }
+      return currentIssue.labels.some((label) => labels.includes(label.name))
+        ? [currentIssue]
+        : [];
+    },
+    getIssue: async () => currentIssue,
+    findIssueProjectItem: async (_options, issue) =>
+      issue.projectItems[0]?.id ?? null,
+    updateProjectFields: async (_options, _project, _item, state) => {
+      if (failLateDone) throw new Error("late Done projection failed");
+      projectState = state;
+    },
+    editIssueLabels: async (_options, _issue, state) => {
+      if (state !== "done") return;
+      currentIssue = {
+        ...currentIssue,
+        labels: [],
+        projectItems: [{ id: "item-942", project: { id: "project" } }],
+      };
+    },
+    addIssueLabels: async (_options, issue, labels) => {
+      assertDeepEqual(issue.labels, [], "stale recovery snapshot");
+      restoredLabels.push(...labels);
+      currentIssue = {
+        ...currentIssue,
+        state: "OPEN",
+        labels: labels.map((name) => ({ name })),
+      };
+    },
+    sleep: async () => {
+      throw new Error("an immediately restored stale label must not wait");
+    },
+  };
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        dependencies,
+      ),
+    /late Done projection failed/,
+  );
+  assertDeepEqual(restoredLabels, ["needs-grooming"]);
+  assertDeepEqual(currentIssue.labels, [{ name: "needs-grooming" }]);
+  assertEqual(isClaimable(currentIssue), false, "stale retry claimability");
+  assertEqual(isReviewable(currentIssue), false, "stale retry reviewability");
+  assertEqual(isReleasable(currentIssue), false, "stale retry releasability");
+
+  failLateDone = false;
+  currentIssue = { ...currentIssue, state: "CLOSED" };
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    dependencies,
+  );
+
+  assertEqual(projectState, "done", "retried stale Project state");
+  assertDeepEqual(currentIssue.labels, []);
+  assertDeepEqual(results, [
+    { number: 942, title: "stale enumerated retry label", state: "done" },
+  ]);
+});
+
+test("sync preserves a pre-existing quarantine conflict", async () => {
+  const listedIssue = {
+    number: 943,
+    title: "label-less reopen during historical recovery",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+    projectItems: [],
+  };
+  let currentIssue = { ...listedIssue, labels: [] };
+  let addCalls = 0;
+
+  await assertRejects(
+    () =>
+      sync(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ({ id: "project" }),
+          listIssuesByLabels: async (_options, labels, { state }) =>
+            labels.includes("in-pr") && state === "all" ? [listedIssue] : [],
+          getIssue: async () => currentIssue,
+          findIssueProjectItem: async (_options, issue) =>
+            issue.projectItems[0]?.id ?? null,
+          updateProjectFields: async () => {
+            currentIssue = {
+              ...currentIssue,
+              state: "OPEN",
+              labels: [{ name: "needs-grooming" }, { name: "agent-ready" }],
+            };
+            throw new Error("late Done projection failed");
+          },
+          editIssueLabels: async (_options, _issue, state) => {
+            if (state === "done") {
+              currentIssue = {
+                ...currentIssue,
+                labels: [],
+                projectItems: [{ id: "item-943", project: { id: "project" } }],
+              };
+            }
+          },
+          addIssueLabels: async () => {
+            addCalls += 1;
+          },
+          sleep: async () => {
+            throw new Error("same-label compensation must not wait");
+          },
+        },
+      ),
+    /late Done projection failed/,
+  );
+
+  assertEqual(addCalls, 0, "historical restore attempts");
+  assertDeepEqual(currentIssue.state, "OPEN");
+  assertDeepEqual(currentIssue.labels, [
+    { name: "needs-grooming" },
+    { name: "agent-ready" },
+  ]);
+  assertEqual(isClaimable(currentIssue), false, "conflict claimability");
+  assertEqual(isReviewable(currentIssue), false, "conflict reviewability");
+  assertEqual(isReleasable(currentIssue), false, "conflict releasability");
+});
+
 test("sync preserves a concurrent retry label after late Done failure", async () => {
   const listedIssue = {
     number: 939,
@@ -745,23 +956,35 @@ test("sync preserves a concurrent retry label after late Done failure", async ()
           findIssueProjectItem: async (_options, issue) =>
             issue.projectItems[0]?.id ?? null,
           updateProjectFields: async () => {
-            currentIssue = {
-              ...currentIssue,
-              state: "OPEN",
-              labels: [{ name: "agent-active" }],
-            };
             throw new Error("late Done projection failed");
           },
           editIssueLabels: async (_options, _issue, state) => {
-            if (state !== "done") return;
+            if (state === "done") {
+              currentIssue = {
+                ...currentIssue,
+                labels: [],
+                projectItems: [{ id: "item-939", project: { id: "project" } }],
+              };
+            }
+            if (state === "active") {
+              currentIssue = {
+                ...currentIssue,
+                state: "OPEN",
+                labels: [{ name: "agent-active" }],
+              };
+            }
+          },
+          addIssueLabels: async (_options, issue, labels) => {
+            assertDeepEqual(issue.labels, [], "pre-add retry snapshot");
+            addCalls += 1;
             currentIssue = {
               ...currentIssue,
-              labels: [],
-              projectItems: [{ id: "item-939", project: { id: "project" } }],
+              state: "OPEN",
+              labels: [
+                ...labels.map((name) => ({ name })),
+                { name: "agent-active" },
+              ],
             };
-          },
-          addIssueLabels: async () => {
-            addCalls += 1;
           },
           sleep: async () => {},
         },
@@ -769,7 +992,7 @@ test("sync preserves a concurrent retry label after late Done failure", async ()
     /late Done projection failed/,
   );
 
-  assertEqual(addCalls, 0, "concurrent queue label restore calls");
+  assertEqual(addCalls, 1, "add-only retry-label restoration call");
   assertDeepEqual(currentIssue.labels, [{ name: "agent-active" }]);
 });
 
@@ -1647,6 +1870,13 @@ test("claim guard only accepts open agent-ready issues", () => {
   );
   assertEqual(
     isClaimable({
+      state: "OPEN",
+      labels: [{ name: "agent-ready" }, { name: "needs-grooming" }],
+    }),
+    false,
+  );
+  assertEqual(
+    isClaimable({
       state: "CLOSED",
       labels: [{ name: "agent-ready" }],
     }),
@@ -1666,6 +1896,13 @@ test("review guard only accepts open agent-active issues", () => {
     isReviewable({
       state: "OPEN",
       labels: [{ name: "agent-ready" }],
+    }),
+    false,
+  );
+  assertEqual(
+    isReviewable({
+      state: "OPEN",
+      labels: [{ name: "agent-active" }, { name: "needs-grooming" }],
     }),
     false,
   );

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -10,6 +10,7 @@ import {
   isReleasable,
   isRecoverableClaimRaceError,
   isReviewable,
+  IssueBoardSyncError,
   ISSUE_STATE_LABELS,
   labelsForState,
   parseArgs,
@@ -425,7 +426,7 @@ test("sync clears every closed queue label without requiring a Project item", as
         );
         const read = (reads.get(number) ?? 0) + 1;
         reads.set(number, read);
-        return read === 1 ? issue : { ...issue, labels: [] };
+        return read <= 2 ? issue : { ...issue, labels: [] };
       },
       sleep: async () => {
         throw new Error("an immediately satisfied postcondition must not wait");
@@ -453,7 +454,7 @@ test("sync clears every closed queue label without requiring a Project item", as
   );
   assertDeepEqual(
     [...reads.values()],
-    ISSUE_STATE_LABELS.map(() => 2),
+    ISSUE_STATE_LABELS.map(() => 3),
   );
 });
 
@@ -486,14 +487,23 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
       editIssueLabels: async () => events.push("labels"),
       getIssue: async () => {
         reads += 1;
-        events.push(reads === 1 ? "refresh" : "verify");
-        return reads === 1 ? refreshedIssue : { ...refreshedIssue, labels: [] };
+        events.push(
+          reads === 1 ? "refresh" : reads === 2 ? "pre-cleanup" : "verify",
+        );
+        return reads <= 2 ? refreshedIssue : { ...refreshedIssue, labels: [] };
       },
       sleep: async () => events.push("sleep"),
     },
   );
 
-  assertDeepEqual(events, ["refresh", "find", "project", "labels", "verify"]);
+  assertDeepEqual(events, [
+    "refresh",
+    "find",
+    "project",
+    "pre-cleanup",
+    "labels",
+    "verify",
+  ]);
 });
 
 test("sync reclassifies an issue that reopened after enumeration", async () => {
@@ -536,6 +546,48 @@ test("sync reclassifies an issue that reopened after enumeration", async () => {
   ]);
   assertDeepEqual(updates, ["active"]);
   assertEqual(edits, 0, "reopened issue label edits");
+});
+
+test("sync reclassifies a reopen before the Done label edit", async () => {
+  const closedIssue = {
+    number: 924,
+    title: "reopen before cleanup",
+    state: "CLOSED",
+    labels: [{ name: "in-pr" }],
+  };
+  const activeIssue = {
+    ...closedIssue,
+    state: "OPEN",
+    labels: [{ name: "agent-active" }],
+  };
+  const reads = [closedIssue, activeIssue, activeIssue];
+  const updates = [];
+  let edits = 0;
+
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "in-pr" && state === "closed" ? [closedIssue] : [],
+      getIssue: async () => reads.shift(),
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-924",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async () => {
+        edits += 1;
+      },
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(updates, ["active"]);
+  assertEqual(edits, 0, "stale Done label edits");
+  assertDeepEqual(results, [
+    { number: 924, title: "reopen before cleanup", state: "active" },
+  ]);
 });
 
 test("sync reprojects a concurrent claim after an open Project write", async () => {
@@ -617,6 +669,67 @@ test("sync bounds repeated open-state projection drift", async () => {
   assertEqual(waits, 2, "bounded open-state drift waits");
 });
 
+test("sync attempts later issues and reports partial results after a failure", async () => {
+  const failingIssue = {
+    number: 931,
+    title: "failed projection",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const successfulIssue = {
+    number: 932,
+    title: "successful projection",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const updates = [];
+  let observed;
+
+  try {
+    await sync(
+      { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+      {
+        getProject: async () => ({ id: "project" }),
+        listIssuesByLabel: async (_options, label, { state }) =>
+          label === "agent-ready" && state === "open"
+            ? [failingIssue, successfulIssue]
+            : [],
+        getIssue: async (_options, number) =>
+          number === failingIssue.number ? failingIssue : successfulIssue,
+        ensureProjectItem: async (_options, _project, issue) =>
+          `item-${issue.number}`,
+        updateProjectFields: async (_options, _project, item) => {
+          updates.push(item);
+          if (item === "item-931") throw new Error("Project write failed");
+        },
+      },
+    );
+  } catch (error) {
+    observed = error;
+  }
+
+  assert(observed instanceof IssueBoardSyncError, "aggregate sync error type");
+  assertDeepEqual(updates, ["item-931", "item-932"]);
+  assertDeepEqual(observed.results, [
+    { number: 932, title: "successful projection", state: "ready" },
+  ]);
+  assertDeepEqual(observed.failures, [
+    {
+      number: 931,
+      title: "failed projection",
+      message: "Project write failed",
+    },
+  ]);
+  assert(
+    observed.message.includes("Succeeded: #932."),
+    "success summary in aggregate error",
+  );
+  assert(
+    observed.message.includes("Failed: #931: Project write failed."),
+    "failure summary in aggregate error",
+  );
+});
+
 test("sync reprojects Done when an issue closes after an open Project write", async () => {
   const reviewIssue = {
     number: 928,
@@ -629,7 +742,7 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     state: "CLOSED",
     labels: [],
   };
-  const reads = [reviewIssue, closedIssue, closedIssue];
+  const reads = [reviewIssue, closedIssue, closedIssue, closedIssue];
   const updates = [];
 
   const results = await sync(
@@ -655,39 +768,55 @@ test("sync reprojects Done when an issue closes after an open Project write", as
   ]);
 });
 
-test("sync fails if a closed issue reopens during Done cleanup", async () => {
-  const issue = {
+test("sync restores queue state when a closed issue reopens during Done cleanup", async () => {
+  const listedIssue = {
     number: 927,
     title: "concurrent reopen",
     state: "CLOSED",
     labels: [{ name: "in-pr" }],
   };
+  let currentIssue = listedIssue;
   let reads = 0;
+  const edits = [];
+  const updates = [];
 
-  await assertRejects(
-    () =>
-      sync(
-        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
-        {
-          getProject: async () => ({ id: "project" }),
-          listIssuesByLabel: async (_options, label, { state }) =>
-            label === "in-pr" && state === "closed" ? [issue] : [],
-          getIssue: async () => {
-            reads += 1;
-            return reads === 1
-              ? issue
-              : { ...issue, state: "OPEN", labels: [] };
-          },
-          findIssueProjectItem: async () => null,
-          editIssueLabels: async () => {},
-          sleep: async () => {
-            throw new Error("a state change must fail without retrying");
-          },
-        },
-      ),
-    /Issue #927 changed state during sync: expected CLOSED, got OPEN/,
+  const results = await sync(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ({ id: "project" }),
+      listIssuesByLabel: async (_options, label, { state }) =>
+        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+      getIssue: async () => {
+        reads += 1;
+        return currentIssue;
+      },
+      findIssueProjectItem: async () => null,
+      ensureProjectItem: async () => "item-927",
+      updateProjectFields: async (_options, _project, _item, state) => {
+        updates.push(state);
+      },
+      editIssueLabels: async (_options, _issue, state) => {
+        edits.push(state);
+        if (state === "done") {
+          currentIssue = { ...listedIssue, state: "OPEN", labels: [] };
+        } else {
+          currentIssue = {
+            ...listedIssue,
+            state: "OPEN",
+            labels: [{ name: "in-pr" }],
+          };
+        }
+      },
+      sleep: async () => {},
+    },
   );
-  assertEqual(reads, 2, "refresh and postcondition reads");
+
+  assertDeepEqual(edits, ["done", "review"]);
+  assertDeepEqual(updates, ["review"]);
+  assertEqual(reads, 5, "refresh, closeout, restore, and projection reads");
+  assertDeepEqual(results, [
+    { number: 927, title: "concurrent reopen", state: "review" },
+  ]);
 });
 
 test("sync fails when a closed issue retains a queue label", async () => {

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -161,13 +161,13 @@ test("project scope failures name the read-write gh refresh command", () => {
   );
 });
 
-test("queue-label issue lists pass the requested state to gh", async () => {
+test("queue-label issue lists request all states without an is:all query", async () => {
   const calls = [];
   await listIssuesByLabel(
     { repo: "mento-protocol/monitoring-monorepo" },
     "agent-active",
     {
-      state: "closed",
+      state: "all",
       json: async (args) => {
         calls.push(args);
         return [];
@@ -182,9 +182,9 @@ test("queue-label issue lists pass the requested state to gh", async () => {
       "-R",
       "mento-protocol/monitoring-monorepo",
       "--state",
-      "closed",
+      "all",
       "--search",
-      "is:issue is:closed label:agent-active",
+      "is:issue label:agent-active",
       "--limit",
       "1000",
       "--json",
@@ -419,7 +419,7 @@ test("closed issues with any queue label sync to done", () => {
   }
   assertDeepEqual(labelsForState("done"), {
     addLabels: [],
-    removeLabels: ["agent-ready", "agent-active", "in-pr", "needs-grooming"],
+    removeLabels: ISSUE_STATE_LABELS,
     statusOptions: ["Done"],
   });
 });
@@ -446,7 +446,7 @@ test("sync clears every closed queue label without requiring a Project item", as
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) => {
         queries.push(`${state}:${label}`);
-        return state === "closed" ? [closedIssues.get(label)] : [];
+        return state === "all" ? [closedIssues.get(label)] : [];
       },
       findIssueProjectItem: async () => null,
       updateProjectFields: async () => {
@@ -471,7 +471,7 @@ test("sync clears every closed queue label without requiring a Project item", as
 
   assertDeepEqual(
     queries,
-    ISSUE_STATE_LABELS.flatMap((label) => [`open:${label}`, `closed:${label}`]),
+    ISSUE_STATE_LABELS.map((label) => `all:${label}`),
   );
   assertDeepEqual(
     results.map(({ number, state }) => ({ number, state })),
@@ -513,7 +513,7 @@ test("sync uses refreshed Project visibility before closed-item cleanup", async 
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+        label === "in-pr" && state === "all" ? [listedIssue] : [],
       findIssueProjectItem: async (_options, issue) => {
         events.push("find");
         return issue.projectItems[0]?.id ?? null;
@@ -561,7 +561,7 @@ test("sync reclassifies an issue that reopened after enumeration", async () => {
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+        label === "in-pr" && state === "all" ? [listedIssue] : [],
       getIssue: async () => reopenedIssue,
       findIssueProjectItem: async () => {
         throw new Error("a reopened issue must not take the Done path");
@@ -604,7 +604,7 @@ test("sync reclassifies a reopen before the Done label edit", async () => {
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "closed" ? [closedIssue] : [],
+        label === "in-pr" && state === "all" ? [closedIssue] : [],
       getIssue: async () => reads.shift(),
       findIssueProjectItem: async () => null,
       ensureProjectItem: async () => "item-924",
@@ -645,7 +645,7 @@ test("sync reprojects a concurrent claim after an open Project write", async () 
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "agent-ready" && state === "open" ? [readyIssue] : [],
+        label === "agent-ready" && state === "all" ? [readyIssue] : [],
       getIssue: async () => reads.shift(),
       ensureProjectItem: async () => "item-926",
       updateProjectFields: async (_options, _project, _item, state) => {
@@ -686,7 +686,7 @@ test("sync bounds repeated open-state projection drift", async () => {
         {
           getProject: async () => ({ id: "project" }),
           listIssuesByLabel: async (_options, label, { state }) =>
-            label === "agent-ready" && state === "open" ? [readyIssue] : [],
+            label === "agent-ready" && state === "all" ? [readyIssue] : [],
           getIssue: async () => reads.shift(),
           ensureProjectItem: async () => "item-929",
           updateProjectFields: async (_options, _project, _item, state) => {
@@ -726,7 +726,7 @@ test("sync attempts later issues and reports partial results after a failure", a
       {
         getProject: async () => ({ id: "project" }),
         listIssuesByLabel: async (_options, label, { state }) =>
-          label === "agent-ready" && state === "open"
+          label === "agent-ready" && state === "all"
             ? [failingIssue, successfulIssue]
             : [],
         getIssue: async (_options, number) =>
@@ -785,7 +785,7 @@ test("sync reprojects Done when an issue closes after an open Project write", as
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "open" ? [reviewIssue] : [],
+        label === "in-pr" && state === "all" ? [reviewIssue] : [],
       getIssue: async () => reads.shift(),
       ensureProjectItem: async () => "item-928",
       findIssueProjectItem: async () => "item-928",
@@ -820,7 +820,7 @@ test("sync restores queue state when a closed issue reopens during Done cleanup"
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "in-pr" && state === "closed" ? [listedIssue] : [],
+        label === "in-pr" && state === "all" ? [listedIssue] : [],
       getIssue: async () => {
         reads += 1;
         return currentIssue;
@@ -870,7 +870,7 @@ test("sync fails when a closed issue retains a queue label", async () => {
         {
           getProject: async () => ({ id: "project" }),
           listIssuesByLabel: async (_options, label, { state }) =>
-            label === "agent-active" && state === "closed" ? [issue] : [],
+            label === "agent-active" && state === "all" ? [issue] : [],
           findIssueProjectItem: async () => null,
           editIssueLabels: async () => {},
           getIssue: async () => issue,
@@ -899,7 +899,7 @@ test("sync dry-run refreshes once and skips the unapplied postcondition", async 
     {
       getProject: async () => ({ id: "project" }),
       listIssuesByLabel: async (_options, label, { state }) =>
-        label === "needs-grooming" && state === "closed" ? [issue] : [],
+        label === "needs-grooming" && state === "all" ? [issue] : [],
       findIssueProjectItem: async () => null,
       editIssueLabels: async () => {
         edits += 1;

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -29,7 +29,10 @@ import {
   readBackfillProjectFields,
   writeBackfillProjectFields,
 } from "./issue-board-projects.mjs";
-import { listIssueComments } from "./issue-board-transport.mjs";
+import {
+  listIssueComments,
+  listIssuesByLabel,
+} from "./issue-board-transport.mjs";
 
 let passed = 0;
 let failed = 0;
@@ -156,6 +159,38 @@ test("project scope failures name the read-write gh refresh command", () => {
     hint.includes("`read:project` alone"),
     "missing read-only scope warning",
   );
+});
+
+test("queue-label issue lists pass the requested state to gh", async () => {
+  const calls = [];
+  await listIssuesByLabel(
+    { repo: "mento-protocol/monitoring-monorepo" },
+    "agent-active",
+    {
+      state: "closed",
+      json: async (args) => {
+        calls.push(args);
+        return [];
+      },
+    },
+  );
+
+  assertDeepEqual(calls, [
+    [
+      "issue",
+      "list",
+      "-R",
+      "mento-protocol/monitoring-monorepo",
+      "--state",
+      "closed",
+      "--search",
+      "is:issue is:closed label:agent-active",
+      "--limit",
+      "1000",
+      "--json",
+      "id,number,title,url,labels,state,projectItems",
+    ],
+  ]);
 });
 
 test("project mutation scope failures receive the same guidance", () => {

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -12,6 +12,7 @@ import {
   isRecoverableClaimRaceError,
   isReleasable,
   isReviewable,
+  ISSUE_STATE_LABELS,
   labelNames,
   labelsForState,
   shouldRollbackFailedTransition,
@@ -43,6 +44,9 @@ import {
 import { backfillIssue } from "./issue-board-backfill.mjs";
 
 const CLAIM_SETTLE_MS = 1500;
+const SYNC_RECONCILE_ATTEMPTS = 3;
+const SYNC_VERIFY_ATTEMPTS = 3;
+const SYNC_VERIFY_SETTLE_MS = 250;
 
 async function editIssueLabels(options, issue, state) {
   const transition = labelsForState(state);
@@ -320,39 +324,129 @@ export async function release(options) {
   return results;
 }
 
-export async function sync(options) {
-  const project = await getProject(options);
-  const byNumber = new Map();
-  for (const label of [
-    "agent-ready",
-    "agent-active",
-    "in-pr",
-    "needs-grooming",
-  ]) {
-    for (const issue of await listIssuesByLabel(options, label)) {
-      byNumber.set(issue.number, issue);
+async function verifySyncCloseout(options, issue, operations) {
+  let staleLabels = [];
+  for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
+    const verified = await operations.getIssue(options, issue.number);
+    const verifiedState = String(verified.state ?? "").toUpperCase();
+    if (verifiedState !== "CLOSED") {
+      throw new Error(
+        `Issue #${issue.number} changed state during sync: expected CLOSED, got ${verifiedState || "UNKNOWN"}`,
+      );
+    }
+    const verifiedLabels = labelNames(verified);
+    staleLabels = ISSUE_STATE_LABELS.filter((label) =>
+      verifiedLabels.has(label),
+    );
+    if (staleLabels.length === 0) return;
+    if (attempt < SYNC_VERIFY_ATTEMPTS) {
+      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
     }
   }
-  for (const issue of await listIssuesByLabel(options, "in-pr", {
-    state: "closed",
-  })) {
-    byNumber.set(issue.number, issue);
+  throw new Error(
+    `Issue #${issue.number} retained queue label(s) after sync: ${staleLabels.join(", ")}`,
+  );
+}
+
+function syncStateFromIssue(issue) {
+  const state = stateFromLabels(issue);
+  if (state) return state;
+  return String(issue.state ?? "").toUpperCase() === "CLOSED" ? "done" : null;
+}
+
+async function syncIssue(options, project, listedIssue, operations) {
+  let issue = await operations.getIssue(options, listedIssue.number);
+  let drift = null;
+
+  for (let attempt = 1; attempt <= SYNC_RECONCILE_ATTEMPTS; attempt += 1) {
+    const state = syncStateFromIssue(issue);
+    if (!state) {
+      if (!drift) return null;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        issue = await operations.getIssue(options, issue.number);
+        continue;
+      }
+      throw new Error(
+        `Issue #${issue.number} lost its queue state during sync after ${attempt} attempt(s); last projection drift was ${drift}`,
+      );
+    }
+
+    if (state === "done") {
+      const itemId = await operations.findIssueProjectItem(
+        options,
+        issue,
+        project,
+      );
+      if (itemId) {
+        await operations.updateProjectFields(
+          options,
+          project,
+          itemId,
+          state,
+          {},
+        );
+      }
+      await operations.editIssueLabels(options, issue, state);
+      if (!options.dryRun) {
+        await verifySyncCloseout(options, issue, operations);
+      }
+      return { number: issue.number, title: issue.title, state };
+    }
+
+    const itemId = await operations.ensureProjectItem(options, project, issue);
+    if (!itemId) return null;
+    await operations.updateProjectFields(options, project, itemId, state, {});
+    if (options.dryRun) {
+      return { number: issue.number, title: issue.title, state };
+    }
+
+    const verified = await operations.getIssue(options, issue.number);
+    const verifiedState = syncStateFromIssue(verified);
+    if (verifiedState === state) {
+      return { number: issue.number, title: issue.title, state };
+    }
+
+    drift = `${state} -> ${verifiedState ?? "no queue state"}`;
+    if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+      issue = verified;
+      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+    }
+  }
+
+  throw new Error(
+    `Issue #${issue.number} did not stabilize during sync after ${SYNC_RECONCILE_ATTEMPTS} attempts; last projection drift was ${drift}`,
+  );
+}
+
+export async function sync(options, dependencies = {}) {
+  const operations = {
+    editIssueLabels,
+    ensureProjectItem,
+    findIssueProjectItem,
+    getIssue,
+    getProject,
+    listIssuesByLabel,
+    sleep,
+    updateProjectFields,
+    ...dependencies,
+  };
+  const project = await operations.getProject(options);
+  const byNumber = new Map();
+  for (const label of ISSUE_STATE_LABELS) {
+    for (const state of ["open", "closed"]) {
+      for (const issue of await operations.listIssuesByLabel(options, label, {
+        state,
+      })) {
+        byNumber.set(issue.number, issue);
+      }
+    }
   }
 
   const results = [];
-  for (const issue of byNumber.values()) {
-    const state = stateFromLabels(issue);
-    if (!state) continue;
-    const itemId =
-      state === "done"
-        ? await findIssueProjectItem(options, issue, project)
-        : await ensureProjectItem(options, project, issue);
-    if (!itemId) continue;
-    await updateProjectFields(options, project, itemId, state, {});
-    if (state === "done") {
-      await editIssueLabels(options, issue, state);
-    }
-    results.push({ number: issue.number, title: issue.title, state });
+  for (const listedIssue of byNumber.values()) {
+    const result = await syncIssue(options, project, listedIssue, operations);
+    if (result) results.push(result);
   }
   return results;
 }

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -1,5 +1,5 @@
 /**
- * Issue-board commands: claim, review, release, sync, and backfill.
+ * Issue-board commands: claim, review, release, and backfill.
  *
  * Each command drives one label transition, projects it onto the workboard,
  * and posts the matching issue comment. Label edits happen first and roll back
@@ -12,9 +12,7 @@ import {
   isRecoverableClaimRaceError,
   isReleasable,
   isReviewable,
-  ISSUE_STATE_LABELS,
   labelNames,
-  labelsForState,
   shouldRollbackFailedTransition,
   stateFromLabels,
 } from "./issue-board-state.mjs";
@@ -32,11 +30,11 @@ import {
 } from "./issue-board-projects.mjs";
 import {
   ensurePrExists,
+  editIssueLabels,
   getGitBranch,
   getIssue,
   getPrIssues,
   listIssueComments,
-  listIssuesByLabels,
   listReadyIssues,
   runGh,
   sleep,
@@ -44,30 +42,6 @@ import {
 import { backfillIssue } from "./issue-board-backfill.mjs";
 
 const CLAIM_SETTLE_MS = 1500;
-const SYNC_RECONCILE_ATTEMPTS = 3;
-const SYNC_VERIFY_ATTEMPTS = 3;
-const SYNC_VERIFY_SETTLE_MS = 250;
-
-async function editIssueLabels(options, issue, state) {
-  const transition = labelsForState(state);
-  const existingLabels = labelNames(issue);
-  const addLabels = transition.addLabels.filter(
-    (label) => !existingLabels.has(label),
-  );
-  const removeLabels = transition.removeLabels.filter((label) =>
-    existingLabels.has(label),
-  );
-  if (addLabels.length === 0 && removeLabels.length === 0) return;
-
-  const args = ["issue", "edit", String(issue.number), "-R", options.repo];
-  if (addLabels.length > 0) {
-    args.push("--add-label", addLabels.join(","));
-  }
-  if (removeLabels.length > 0) {
-    args.push("--remove-label", removeLabels.join(","));
-  }
-  await runGh(args, { dryRun: options.dryRun, mutates: true });
-}
 
 export function buildClaimComment(metadata, issue) {
   const lines = [
@@ -321,286 +295,6 @@ export async function release(options) {
       state: options.releaseState,
     });
   }
-  return results;
-}
-
-async function verifySyncCloseout(options, issue, operations) {
-  let staleLabels = [];
-  for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
-    const verified = await operations.getIssue(options, issue.number);
-    const verifiedState = String(verified.state ?? "").toUpperCase();
-    if (verifiedState !== "CLOSED") {
-      return verified;
-    }
-    const verifiedLabels = labelNames(verified);
-    staleLabels = ISSUE_STATE_LABELS.filter((label) =>
-      verifiedLabels.has(label),
-    );
-    if (staleLabels.length === 0) return verified;
-    if (attempt < SYNC_VERIFY_ATTEMPTS) {
-      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-    }
-  }
-  throw new Error(
-    `Issue #${issue.number} retained queue label(s) after sync: ${staleLabels.join(", ")}`,
-  );
-}
-
-function syncStateFromIssue(issue) {
-  const state = stateFromLabels(issue);
-  if (state) return state;
-  return String(issue.state ?? "").toUpperCase() === "CLOSED" ? "done" : null;
-}
-
-function queueLabelsFromIssue(issue) {
-  const labels = labelNames(issue);
-  return ISSUE_STATE_LABELS.filter((label) => labels.has(label));
-}
-
-function hasExactQueueLabels(issue, state) {
-  const expected = labelsForState(state).addLabels;
-  const actual = queueLabelsFromIssue(issue);
-  return (
-    actual.length === expected.length &&
-    expected.every((label) => actual.includes(label))
-  );
-}
-
-function conflictingOpenQueueLabels(issue) {
-  if (String(issue.state ?? "").toUpperCase() !== "OPEN") return [];
-  const labels = queueLabelsFromIssue(issue);
-  return labels.length > 1 ? labels : [];
-}
-
-export class IssueBoardSyncError extends AggregateError {
-  constructor(results, failures) {
-    const normalizedFailures = failures.map(({ number, title, error }) => ({
-      number,
-      title,
-      message: error instanceof Error ? error.message : String(error),
-    }));
-    const succeeded = results.map((result) => `#${result.number}`).join(", ");
-    const failed = normalizedFailures
-      .map((failure) => `#${failure.number}: ${failure.message}`)
-      .join("; ");
-    super(
-      failures.map((failure) => failure.error),
-      [
-        `Issue-board sync completed with ${normalizedFailures.length} failure(s) after ${results.length} success(es).`,
-        `Succeeded: ${succeeded || "none"}.`,
-        `Failed: ${failed}.`,
-      ].join("\n"),
-    );
-    this.name = "IssueBoardSyncError";
-    this.results = results;
-    this.failures = normalizedFailures;
-  }
-}
-
-async function syncIssue(options, project, listedIssue, operations) {
-  let issue = await operations.getIssue(options, listedIssue.number);
-  let drift = null;
-
-  for (let attempt = 1; attempt <= SYNC_RECONCILE_ATTEMPTS; attempt += 1) {
-    const conflictingLabels = conflictingOpenQueueLabels(issue);
-    if (conflictingLabels.length > 0) {
-      drift = `conflicting queue labels (${conflictingLabels.join(", ")})`;
-      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-        issue = await operations.getIssue(options, issue.number);
-        continue;
-      }
-      throw new Error(
-        `Issue #${issue.number} retained conflicting queue labels after ${SYNC_RECONCILE_ATTEMPTS} attempts: ${conflictingLabels.join(", ")}`,
-      );
-    }
-
-    const state = syncStateFromIssue(issue);
-    if (!state) {
-      if (!drift) return null;
-      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-        issue = await operations.getIssue(options, issue.number);
-        continue;
-      }
-      throw new Error(
-        `Issue #${issue.number} lost its queue state during sync after ${attempt} attempt(s); last projection drift was ${drift}`,
-      );
-    }
-
-    if (state === "done") {
-      const itemId = await operations.findIssueProjectItem(
-        options,
-        issue,
-        project,
-      );
-      if (itemId) {
-        await operations.updateProjectFields(
-          options,
-          project,
-          itemId,
-          state,
-          {},
-        );
-      }
-      if (options.dryRun) {
-        await operations.editIssueLabels(options, issue, state);
-        return { number: issue.number, title: issue.title, state };
-      }
-
-      const closeoutIssue = await operations.getIssue(options, issue.number);
-      const closeoutState = syncStateFromIssue(closeoutIssue);
-      if (closeoutState !== "done") {
-        drift = `done -> ${closeoutState ?? "no queue state"}`;
-        if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-          issue = closeoutIssue;
-          await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-          continue;
-        }
-        break;
-      }
-
-      const closeoutItemId = await operations.findIssueProjectItem(
-        options,
-        closeoutIssue,
-        project,
-      );
-      if (closeoutItemId) {
-        await operations.updateProjectFields(
-          options,
-          project,
-          closeoutItemId,
-          state,
-          {},
-        );
-      }
-
-      const reopenState = stateFromLabels({
-        ...closeoutIssue,
-        state: "OPEN",
-      });
-      await operations.editIssueLabels(options, closeoutIssue, state);
-      let verifiedIssue = await verifySyncCloseout(
-        options,
-        closeoutIssue,
-        operations,
-      );
-      if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
-        const verifiedItemId = await operations.findIssueProjectItem(
-          options,
-          verifiedIssue,
-          project,
-        );
-        if (!verifiedItemId) {
-          return { number: issue.number, title: issue.title, state };
-        }
-        await operations.updateProjectFields(
-          options,
-          project,
-          verifiedItemId,
-          state,
-          {},
-        );
-        verifiedIssue = await verifySyncCloseout(
-          options,
-          verifiedIssue,
-          operations,
-        );
-        if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
-          return { number: issue.number, title: issue.title, state };
-        }
-      }
-
-      let reopenedIssue = verifiedIssue;
-      let reopenedState = syncStateFromIssue(reopenedIssue);
-      if (!reopenedState && reopenState) {
-        reopenedIssue = await operations.getIssue(options, issue.number);
-        reopenedState = syncStateFromIssue(reopenedIssue);
-        if (!reopenedState) {
-          await operations.editIssueLabels(options, reopenedIssue, reopenState);
-          reopenedIssue = await operations.getIssue(options, issue.number);
-          reopenedState = syncStateFromIssue(reopenedIssue);
-        }
-      }
-      drift =
-        reopenedState &&
-        reopenedState !== "done" &&
-        !hasExactQueueLabels(reopenedIssue, reopenedState)
-          ? `done -> conflicting queue labels (${queueLabelsFromIssue(reopenedIssue).join(", ")})`
-          : `done -> ${reopenedState ?? "no queue state"}`;
-      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-        issue = reopenedIssue;
-        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-        continue;
-      }
-      break;
-    }
-
-    const itemId = await operations.ensureProjectItem(options, project, issue);
-    if (!itemId) return null;
-    await operations.updateProjectFields(options, project, itemId, state, {});
-    if (options.dryRun) {
-      return { number: issue.number, title: issue.title, state };
-    }
-
-    const verified = await operations.getIssue(options, issue.number);
-    const verifiedState = syncStateFromIssue(verified);
-    if (verifiedState === state && hasExactQueueLabels(verified, state)) {
-      return { number: issue.number, title: issue.title, state };
-    }
-
-    drift =
-      verifiedState === state
-        ? `${state} -> conflicting queue labels (${queueLabelsFromIssue(verified).join(", ")})`
-        : `${state} -> ${verifiedState ?? "no queue state"}`;
-    if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-      issue = verified;
-      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-    }
-  }
-
-  throw new Error(
-    `Issue #${issue.number} did not stabilize during sync after ${SYNC_RECONCILE_ATTEMPTS} attempts; last projection drift was ${drift}`,
-  );
-}
-
-export async function sync(options, dependencies = {}) {
-  const operations = {
-    editIssueLabels,
-    ensureProjectItem,
-    findIssueProjectItem,
-    getIssue,
-    getProject,
-    listIssuesByLabels,
-    sleep,
-    updateProjectFields,
-    ...dependencies,
-  };
-  const project = await operations.getProject(options);
-  const byNumber = new Map();
-  for (const issue of await operations.listIssuesByLabels(
-    options,
-    ISSUE_STATE_LABELS,
-    { state: "all" },
-  )) {
-    byNumber.set(issue.number, issue);
-  }
-
-  const results = [];
-  const failures = [];
-  for (const listedIssue of byNumber.values()) {
-    try {
-      const result = await syncIssue(options, project, listedIssue, operations);
-      if (result) results.push(result);
-    } catch (error) {
-      failures.push({
-        number: listedIssue.number,
-        title: listedIssue.title,
-        error,
-      });
-    }
-  }
-  if (failures.length > 0) throw new IssueBoardSyncError(results, failures);
   return results;
 }
 

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -460,6 +460,21 @@ async function syncIssue(options, project, listedIssue, operations) {
         break;
       }
 
+      const closeoutItemId = await operations.findIssueProjectItem(
+        options,
+        closeoutIssue,
+        project,
+      );
+      if (closeoutItemId) {
+        await operations.updateProjectFields(
+          options,
+          project,
+          closeoutItemId,
+          state,
+          {},
+        );
+      }
+
       const reopenState = stateFromLabels({
         ...closeoutIssue,
         state: "OPEN",

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -496,12 +496,10 @@ export async function sync(options, dependencies = {}) {
   const project = await operations.getProject(options);
   const byNumber = new Map();
   for (const label of ISSUE_STATE_LABELS) {
-    for (const state of ["open", "closed"]) {
-      for (const issue of await operations.listIssuesByLabel(options, label, {
-        state,
-      })) {
-        byNumber.set(issue.number, issue);
-      }
+    for (const issue of await operations.listIssuesByLabel(options, label, {
+      state: "all",
+    })) {
+      byNumber.set(issue.number, issue);
     }
   }
 

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -330,15 +330,13 @@ async function verifySyncCloseout(options, issue, operations) {
     const verified = await operations.getIssue(options, issue.number);
     const verifiedState = String(verified.state ?? "").toUpperCase();
     if (verifiedState !== "CLOSED") {
-      throw new Error(
-        `Issue #${issue.number} changed state during sync: expected CLOSED, got ${verifiedState || "UNKNOWN"}`,
-      );
+      return verified;
     }
     const verifiedLabels = labelNames(verified);
     staleLabels = ISSUE_STATE_LABELS.filter((label) =>
       verifiedLabels.has(label),
     );
-    if (staleLabels.length === 0) return;
+    if (staleLabels.length === 0) return null;
     if (attempt < SYNC_VERIFY_ATTEMPTS) {
       await operations.sleep(SYNC_VERIFY_SETTLE_MS);
     }
@@ -352,6 +350,31 @@ function syncStateFromIssue(issue) {
   const state = stateFromLabels(issue);
   if (state) return state;
   return String(issue.state ?? "").toUpperCase() === "CLOSED" ? "done" : null;
+}
+
+export class IssueBoardSyncError extends AggregateError {
+  constructor(results, failures) {
+    const normalizedFailures = failures.map(({ number, title, error }) => ({
+      number,
+      title,
+      message: error instanceof Error ? error.message : String(error),
+    }));
+    const succeeded = results.map((result) => `#${result.number}`).join(", ");
+    const failed = normalizedFailures
+      .map((failure) => `#${failure.number}: ${failure.message}`)
+      .join("; ");
+    super(
+      failures.map((failure) => failure.error),
+      [
+        `Issue-board sync completed with ${normalizedFailures.length} failure(s) after ${results.length} success(es).`,
+        `Succeeded: ${succeeded || "none"}.`,
+        `Failed: ${failed}.`,
+      ].join("\n"),
+    );
+    this.name = "IssueBoardSyncError";
+    this.results = results;
+    this.failures = normalizedFailures;
+  }
 }
 
 async function syncIssue(options, project, listedIssue, operations) {
@@ -387,11 +410,50 @@ async function syncIssue(options, project, listedIssue, operations) {
           {},
         );
       }
-      await operations.editIssueLabels(options, issue, state);
-      if (!options.dryRun) {
-        await verifySyncCloseout(options, issue, operations);
+      if (options.dryRun) {
+        await operations.editIssueLabels(options, issue, state);
+        return { number: issue.number, title: issue.title, state };
       }
-      return { number: issue.number, title: issue.title, state };
+
+      const closeoutIssue = await operations.getIssue(options, issue.number);
+      const closeoutState = syncStateFromIssue(closeoutIssue);
+      if (closeoutState !== "done") {
+        drift = `done -> ${closeoutState ?? "no queue state"}`;
+        if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+          issue = closeoutIssue;
+          await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+          continue;
+        }
+        break;
+      }
+
+      const reopenState = stateFromLabels({
+        ...closeoutIssue,
+        state: "OPEN",
+      });
+      await operations.editIssueLabels(options, closeoutIssue, state);
+      let reopenedIssue = await verifySyncCloseout(
+        options,
+        closeoutIssue,
+        operations,
+      );
+      if (!reopenedIssue) {
+        return { number: issue.number, title: issue.title, state };
+      }
+
+      let reopenedState = syncStateFromIssue(reopenedIssue);
+      if (!reopenedState && reopenState) {
+        await operations.editIssueLabels(options, reopenedIssue, reopenState);
+        reopenedIssue = await operations.getIssue(options, issue.number);
+        reopenedState = syncStateFromIssue(reopenedIssue);
+      }
+      drift = `done -> ${reopenedState ?? "no queue state"}`;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        issue = reopenedIssue;
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        continue;
+      }
+      break;
     }
 
     const itemId = await operations.ensureProjectItem(options, project, issue);
@@ -444,10 +506,20 @@ export async function sync(options, dependencies = {}) {
   }
 
   const results = [];
+  const failures = [];
   for (const listedIssue of byNumber.values()) {
-    const result = await syncIssue(options, project, listedIssue, operations);
-    if (result) results.push(result);
+    try {
+      const result = await syncIssue(options, project, listedIssue, operations);
+      if (result) results.push(result);
+    } catch (error) {
+      failures.push({
+        number: listedIssue.number,
+        title: listedIssue.title,
+        error,
+      });
+    }
   }
+  if (failures.length > 0) throw new IssueBoardSyncError(results, failures);
   return results;
 }
 

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -130,7 +130,7 @@ async function claimIssue(options, project, issue, metadata) {
   requireClaimIdField(project);
   if (!isClaimable(issue)) {
     throw new Error(
-      `Issue #${issue.number} is not claimable; expected open agent-ready without agent-active/in-pr`,
+      `Issue #${issue.number} is not claimable; expected open agent-ready without agent-active/in-pr/needs-grooming`,
     );
   }
   const itemId = await transitionIssue(
@@ -147,13 +147,15 @@ async function claimIssue(options, project, issue, metadata) {
   await sleep(CLAIM_SETTLE_MS);
   await verifyClaimOwnership(options, project, itemId, issue, metadata);
   const verified = await getIssue(options, issue.number);
-  if (!labelNames(verified).has("agent-active")) {
-    throw new Error(`Issue #${issue.number} did not retain agent-active`);
-  }
   if (
-    labelNames(verified).has("agent-ready") ||
-    labelNames(verified).has("in-pr")
+    String(verified.state ?? "").toUpperCase() !== "OPEN" ||
+    !labelNames(verified).has("agent-active")
   ) {
+    throw new Error(
+      `Issue #${issue.number} did not retain agent-active on an open issue`,
+    );
+  }
+  if (!isReviewable(verified)) {
     throw new Error(`Issue #${issue.number} has conflicting state labels`);
   }
   await commentOnIssue(

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -336,7 +336,7 @@ async function verifySyncCloseout(options, issue, operations) {
     staleLabels = ISSUE_STATE_LABELS.filter((label) =>
       verifiedLabels.has(label),
     );
-    if (staleLabels.length === 0) return null;
+    if (staleLabels.length === 0) return verified;
     if (attempt < SYNC_VERIFY_ATTEMPTS) {
       await operations.sleep(SYNC_VERIFY_SETTLE_MS);
     }
@@ -480,15 +480,38 @@ async function syncIssue(options, project, listedIssue, operations) {
         state: "OPEN",
       });
       await operations.editIssueLabels(options, closeoutIssue, state);
-      let reopenedIssue = await verifySyncCloseout(
+      let verifiedIssue = await verifySyncCloseout(
         options,
         closeoutIssue,
         operations,
       );
-      if (!reopenedIssue) {
-        return { number: issue.number, title: issue.title, state };
+      if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+        const verifiedItemId = await operations.findIssueProjectItem(
+          options,
+          verifiedIssue,
+          project,
+        );
+        if (!verifiedItemId) {
+          return { number: issue.number, title: issue.title, state };
+        }
+        await operations.updateProjectFields(
+          options,
+          project,
+          verifiedItemId,
+          state,
+          {},
+        );
+        verifiedIssue = await verifySyncCloseout(
+          options,
+          verifiedIssue,
+          operations,
+        );
+        if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+          return { number: issue.number, title: issue.title, state };
+        }
       }
 
+      let reopenedIssue = verifiedIssue;
       let reopenedState = syncStateFromIssue(reopenedIssue);
       if (!reopenedState && reopenState) {
         reopenedIssue = await operations.getIssue(options, issue.number);

--- a/scripts/pr/issue-board-commands.mjs
+++ b/scripts/pr/issue-board-commands.mjs
@@ -36,7 +36,7 @@ import {
   getIssue,
   getPrIssues,
   listIssueComments,
-  listIssuesByLabel,
+  listIssuesByLabels,
   listReadyIssues,
   runGh,
   sleep,
@@ -352,6 +352,26 @@ function syncStateFromIssue(issue) {
   return String(issue.state ?? "").toUpperCase() === "CLOSED" ? "done" : null;
 }
 
+function queueLabelsFromIssue(issue) {
+  const labels = labelNames(issue);
+  return ISSUE_STATE_LABELS.filter((label) => labels.has(label));
+}
+
+function hasExactQueueLabels(issue, state) {
+  const expected = labelsForState(state).addLabels;
+  const actual = queueLabelsFromIssue(issue);
+  return (
+    actual.length === expected.length &&
+    expected.every((label) => actual.includes(label))
+  );
+}
+
+function conflictingOpenQueueLabels(issue) {
+  if (String(issue.state ?? "").toUpperCase() !== "OPEN") return [];
+  const labels = queueLabelsFromIssue(issue);
+  return labels.length > 1 ? labels : [];
+}
+
 export class IssueBoardSyncError extends AggregateError {
   constructor(results, failures) {
     const normalizedFailures = failures.map(({ number, title, error }) => ({
@@ -382,6 +402,19 @@ async function syncIssue(options, project, listedIssue, operations) {
   let drift = null;
 
   for (let attempt = 1; attempt <= SYNC_RECONCILE_ATTEMPTS; attempt += 1) {
+    const conflictingLabels = conflictingOpenQueueLabels(issue);
+    if (conflictingLabels.length > 0) {
+      drift = `conflicting queue labels (${conflictingLabels.join(", ")})`;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        issue = await operations.getIssue(options, issue.number);
+        continue;
+      }
+      throw new Error(
+        `Issue #${issue.number} retained conflicting queue labels after ${SYNC_RECONCILE_ATTEMPTS} attempts: ${conflictingLabels.join(", ")}`,
+      );
+    }
+
     const state = syncStateFromIssue(issue);
     if (!state) {
       if (!drift) return null;
@@ -443,11 +476,20 @@ async function syncIssue(options, project, listedIssue, operations) {
 
       let reopenedState = syncStateFromIssue(reopenedIssue);
       if (!reopenedState && reopenState) {
-        await operations.editIssueLabels(options, reopenedIssue, reopenState);
         reopenedIssue = await operations.getIssue(options, issue.number);
         reopenedState = syncStateFromIssue(reopenedIssue);
+        if (!reopenedState) {
+          await operations.editIssueLabels(options, reopenedIssue, reopenState);
+          reopenedIssue = await operations.getIssue(options, issue.number);
+          reopenedState = syncStateFromIssue(reopenedIssue);
+        }
       }
-      drift = `done -> ${reopenedState ?? "no queue state"}`;
+      drift =
+        reopenedState &&
+        reopenedState !== "done" &&
+        !hasExactQueueLabels(reopenedIssue, reopenedState)
+          ? `done -> conflicting queue labels (${queueLabelsFromIssue(reopenedIssue).join(", ")})`
+          : `done -> ${reopenedState ?? "no queue state"}`;
       if (attempt < SYNC_RECONCILE_ATTEMPTS) {
         issue = reopenedIssue;
         await operations.sleep(SYNC_VERIFY_SETTLE_MS);
@@ -465,11 +507,14 @@ async function syncIssue(options, project, listedIssue, operations) {
 
     const verified = await operations.getIssue(options, issue.number);
     const verifiedState = syncStateFromIssue(verified);
-    if (verifiedState === state) {
+    if (verifiedState === state && hasExactQueueLabels(verified, state)) {
       return { number: issue.number, title: issue.title, state };
     }
 
-    drift = `${state} -> ${verifiedState ?? "no queue state"}`;
+    drift =
+      verifiedState === state
+        ? `${state} -> conflicting queue labels (${queueLabelsFromIssue(verified).join(", ")})`
+        : `${state} -> ${verifiedState ?? "no queue state"}`;
     if (attempt < SYNC_RECONCILE_ATTEMPTS) {
       issue = verified;
       await operations.sleep(SYNC_VERIFY_SETTLE_MS);
@@ -488,19 +533,19 @@ export async function sync(options, dependencies = {}) {
     findIssueProjectItem,
     getIssue,
     getProject,
-    listIssuesByLabel,
+    listIssuesByLabels,
     sleep,
     updateProjectFields,
     ...dependencies,
   };
   const project = await operations.getProject(options);
   const byNumber = new Map();
-  for (const label of ISSUE_STATE_LABELS) {
-    for (const issue of await operations.listIssuesByLabel(options, label, {
-      state: "all",
-    })) {
-      byNumber.set(issue.number, issue);
-    }
+  for (const issue of await operations.listIssuesByLabels(
+    options,
+    ISSUE_STATE_LABELS,
+    { state: "all" },
+  )) {
+    byNumber.set(issue.number, issue);
   }
 
   const results = [];

--- a/scripts/pr/issue-board-state.mjs
+++ b/scripts/pr/issue-board-state.mjs
@@ -101,7 +101,8 @@ export function isClaimable(issue) {
     issue.state === "OPEN" &&
     labels.has("agent-ready") &&
     !labels.has("agent-active") &&
-    !labels.has("in-pr")
+    !labels.has("in-pr") &&
+    !labels.has("needs-grooming")
   );
 }
 

--- a/scripts/pr/issue-board-state.mjs
+++ b/scripts/pr/issue-board-state.mjs
@@ -6,15 +6,13 @@
  * offline suite (`pnpm issue:board:test`) exercises end to end.
  */
 
+import { ISSUE_STATE_LABELS } from "../lib/gh-issue-lifecycle.mjs";
+
+export { ISSUE_STATE_LABELS };
+
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const DEFAULT_PROJECT_OWNER = "mento-protocol";
 export const DEFAULT_PROJECT_NUMBER = 12;
-export const ISSUE_STATE_LABELS = Object.freeze([
-  "agent-ready",
-  "agent-active",
-  "in-pr",
-  "needs-grooming",
-]);
 
 const STATE_TRANSITIONS = {
   ready: {

--- a/scripts/pr/issue-board-state.mjs
+++ b/scripts/pr/issue-board-state.mjs
@@ -9,6 +9,12 @@
 export const DEFAULT_REPO = "mento-protocol/monitoring-monorepo";
 export const DEFAULT_PROJECT_OWNER = "mento-protocol";
 export const DEFAULT_PROJECT_NUMBER = 12;
+export const ISSUE_STATE_LABELS = Object.freeze([
+  "agent-ready",
+  "agent-active",
+  "in-pr",
+  "needs-grooming",
+]);
 
 const STATE_TRANSITIONS = {
   ready: {
@@ -33,7 +39,7 @@ const STATE_TRANSITIONS = {
   },
   done: {
     addLabels: [],
-    removeLabels: ["agent-ready", "agent-active", "in-pr", "needs-grooming"],
+    removeLabels: ISSUE_STATE_LABELS,
     statusOptions: ["Done"],
   },
 };
@@ -78,7 +84,12 @@ export function labelNames(issue) {
 
 export function stateFromLabels(issue) {
   const labels = labelNames(issue);
-  if (issue.state === "CLOSED" && labels.has("in-pr")) return "done";
+  if (
+    String(issue.state ?? "").toUpperCase() === "CLOSED" &&
+    ISSUE_STATE_LABELS.some((label) => labels.has(label))
+  ) {
+    return "done";
+  }
   if (labels.has("in-pr")) return "review";
   if (labels.has("agent-active")) return "active";
   if (labels.has("agent-ready")) return "ready";

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -63,6 +63,35 @@ function queueLabelsFromIssue(issue) {
   return ISSUE_STATE_LABELS.filter((label) => labels.has(label));
 }
 
+function nearestQueueLabels(...issues) {
+  for (const issue of issues) {
+    const queueLabels = queueLabelsFromIssue(issue);
+    if (queueLabels.length > 0) return queueLabels;
+  }
+  return [];
+}
+
+function retryQueueSnapshotForCloseout(
+  closeoutIssue,
+  initialIssue,
+  listedIssue,
+) {
+  const closeoutQueueLabels = queueLabelsFromIssue(closeoutIssue);
+  if (closeoutQueueLabels.length > 0) {
+    return { labels: closeoutQueueLabels, compensateAfterAdd: true };
+  }
+
+  // Stale queue evidence needs a visible state that cannot grant review or
+  // release authority if the issue reopens during recovery.
+  return {
+    labels:
+      nearestQueueLabels(initialIssue, listedIssue).length > 0
+        ? labelsForState("grooming").addLabels
+        : [],
+    compensateAfterAdd: false,
+  };
+}
+
 function hasExactQueueLabels(issue, state) {
   const expected = labelsForState(state).addLabels;
   const actual = queueLabelsFromIssue(issue);
@@ -152,36 +181,95 @@ async function compensateProvisionalQueueLabel(
   return { issue: currentIssue, provisionalQueueLabel };
 }
 
-async function preserveRetryQueueLabels(
+async function reconcileRetryQueueObservation(
   options,
   issue,
   retryQueueLabels,
   operations,
 ) {
-  let verified = await operations.getIssue(options, issue.number);
-  if (queueLabelsFromIssue(verified).length > 0) return verified;
+  let verified = issue;
+  if (
+    retryQueueLabels.length === 1 &&
+    queueLabelsFromIssue(verified).length > 0
+  ) {
+    ({ issue: verified } = await compensateProvisionalQueueLabel(
+      options,
+      verified,
+      retryQueueLabels[0],
+      operations,
+    ));
+  }
+  return verified;
+}
+
+async function preserveRetryQueueLabels(
+  options,
+  issue,
+  retryQueueLabels,
+  compensateAfterAdd,
+  operations,
+) {
   if (retryQueueLabels.length === 0) {
     throw new Error(`Issue #${issue.number} has no queue label to restore`);
   }
 
-  await operations.addIssueLabels(options, verified, retryQueueLabels);
+  let lastError = null;
+  let addAttempted = false;
   for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
-    verified = await operations.getIssue(options, issue.number);
-    if (retryQueueLabels.length === 1) {
-      ({ issue: verified } = await compensateProvisionalQueueLabel(
-        options,
-        verified,
-        retryQueueLabels[0],
-        operations,
-      ));
+    let verified;
+    try {
+      verified = await operations.getIssue(options, issue.number);
+      if (addAttempted && compensateAfterAdd) {
+        verified = await reconcileRetryQueueObservation(
+          options,
+          verified,
+          retryQueueLabels,
+          operations,
+        );
+      }
+      if (queueLabelsFromIssue(verified).length > 0) return verified;
+    } catch (error) {
+      lastError = error;
+      if (attempt < SYNC_VERIFY_ATTEMPTS) {
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+      }
+      continue;
     }
-    if (queueLabelsFromIssue(verified).length > 0) return verified;
+
+    let addError = null;
+    addAttempted = true;
+    try {
+      await operations.addIssueLabels(options, verified, retryQueueLabels);
+    } catch (error) {
+      addError = error;
+    }
+
+    try {
+      verified = await operations.getIssue(options, issue.number);
+      if (compensateAfterAdd) {
+        verified = await reconcileRetryQueueObservation(
+          options,
+          verified,
+          retryQueueLabels,
+          operations,
+        );
+      }
+      if (queueLabelsFromIssue(verified).length > 0) return verified;
+      lastError =
+        addError ??
+        new Error(
+          `Issue #${issue.number} still has no queue label after restoration attempt ${attempt}`,
+        );
+    } catch (error) {
+      lastError = error;
+    }
     if (attempt < SYNC_VERIFY_ATTEMPTS) {
       await operations.sleep(SYNC_VERIFY_SETTLE_MS);
     }
   }
   throw new Error(
-    `Issue #${issue.number} has no queue label after retry-label restoration`,
+    `Issue #${issue.number} has no queue label after ${SYNC_VERIFY_ATTEMPTS} retry-label restoration attempts`,
+    { cause: lastError },
   );
 }
 
@@ -212,6 +300,7 @@ export class IssueBoardSyncError extends AggregateError {
 
 async function syncIssue(options, project, listedIssue, operations) {
   let issue = await operations.getIssue(options, listedIssue.number);
+  const initialIssue = issue;
   let drift = null;
   let provisionalQueueLabel = null;
 
@@ -296,7 +385,11 @@ async function syncIssue(options, project, listedIssue, operations) {
       }
 
       const reopenState = restoreStateFromCloseoutIssue(closeoutIssue);
-      const retryQueueLabels = queueLabelsFromIssue(closeoutIssue);
+      const retryQueueSnapshot = retryQueueSnapshotForCloseout(
+        closeoutIssue,
+        initialIssue,
+        listedIssue,
+      );
       await operations.editIssueLabels(options, closeoutIssue, state);
       let verifiedIssue = await verifySyncCloseout(
         options,
@@ -325,7 +418,8 @@ async function syncIssue(options, project, listedIssue, operations) {
             await preserveRetryQueueLabels(
               options,
               verifiedIssue,
-              retryQueueLabels,
+              retryQueueSnapshot.labels,
+              retryQueueSnapshot.compensateAfterAdd,
               operations,
             );
           } catch (retryError) {

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -18,6 +18,7 @@ import {
   updateProjectFields,
 } from "./issue-board-projects.mjs";
 import {
+  addIssueLabels,
   editIssueLabels,
   getIssue,
   listIssuesByLabels,
@@ -25,6 +26,7 @@ import {
 } from "./issue-board-transport.mjs";
 
 const SYNC_RECONCILE_ATTEMPTS = 3;
+const SYNC_COMPENSATE_ATTEMPTS = 3;
 const SYNC_VERIFY_ATTEMPTS = 3;
 const SYNC_VERIFY_SETTLE_MS = 250;
 
@@ -97,13 +99,10 @@ async function restoreProvisionalQueueLabel(
   operations,
 ) {
   const provisionalState = stateForQueueLabel(issue, provisionalQueueLabel);
-  if (!provisionalState) return { issue, provisionalQueueLabel: null };
+  if (!provisionalState) return issue;
 
   await operations.editIssueLabels(options, issue, provisionalState);
-  return {
-    issue: await operations.getIssue(options, issue.number),
-    provisionalQueueLabel,
-  };
+  return operations.getIssue(options, issue.number);
 }
 
 async function compensateProvisionalQueueLabel(
@@ -112,54 +111,78 @@ async function compensateProvisionalQueueLabel(
   provisionalQueueLabel,
   operations,
 ) {
-  if (!provisionalQueueLabel) return { issue, provisionalQueueLabel };
-  if (String(issue.state ?? "").toUpperCase() !== "OPEN") {
-    return { issue, provisionalQueueLabel: null };
-  }
-
-  const queueLabels = queueLabelsFromIssue(issue);
-  if (!queueLabels.includes(provisionalQueueLabel)) {
-    if (queueLabels.length === 0) {
-      return restoreProvisionalQueueLabel(
-        options,
-        issue,
-        provisionalQueueLabel,
-        operations,
-      );
+  let currentIssue = issue;
+  for (let attempt = 1; attempt <= SYNC_COMPENSATE_ATTEMPTS; attempt += 1) {
+    if (!provisionalQueueLabel) {
+      return { issue: currentIssue, provisionalQueueLabel };
     }
-    return { issue, provisionalQueueLabel: null };
-  }
-  if (queueLabels.length !== 2) {
-    return { issue, provisionalQueueLabel };
-  }
+    if (String(currentIssue.state ?? "").toUpperCase() !== "OPEN") {
+      return { issue: currentIssue, provisionalQueueLabel: null };
+    }
 
-  const concurrentLabel = queueLabels.find(
-    (label) => label !== provisionalQueueLabel,
-  );
-  const concurrentState = stateForQueueLabel(issue, concurrentLabel);
-  if (!concurrentState) return { issue, provisionalQueueLabel };
+    const queueLabels = queueLabelsFromIssue(currentIssue);
+    if (!queueLabels.includes(provisionalQueueLabel)) {
+      if (queueLabels.length === 0) {
+        currentIssue = await restoreProvisionalQueueLabel(
+          options,
+          currentIssue,
+          provisionalQueueLabel,
+          operations,
+        );
+        continue;
+      }
+      return { issue: currentIssue, provisionalQueueLabel: null };
+    }
+    if (queueLabels.length !== 2) {
+      return { issue: currentIssue, provisionalQueueLabel };
+    }
 
-  await operations.editIssueLabels(options, issue, concurrentState);
-  const verified = await operations.getIssue(options, issue.number);
-  if (
-    String(verified.state ?? "").toUpperCase() === "OPEN" &&
-    queueLabelsFromIssue(verified).length === 0
-  ) {
-    return restoreProvisionalQueueLabel(
-      options,
-      verified,
-      provisionalQueueLabel,
-      operations,
+    const concurrentLabel = queueLabels.find(
+      (label) => label !== provisionalQueueLabel,
     );
+    const concurrentState = stateForQueueLabel(currentIssue, concurrentLabel);
+    if (!concurrentState) {
+      return { issue: currentIssue, provisionalQueueLabel };
+    }
+
+    await operations.editIssueLabels(options, currentIssue, concurrentState);
+    currentIssue = await operations.getIssue(options, currentIssue.number);
   }
-  return {
-    issue: verified,
-    provisionalQueueLabel: queueLabelsFromIssue(verified).includes(
-      provisionalQueueLabel,
-    )
-      ? provisionalQueueLabel
-      : null,
-  };
+
+  return { issue: currentIssue, provisionalQueueLabel };
+}
+
+async function preserveRetryQueueLabels(
+  options,
+  issue,
+  retryQueueLabels,
+  operations,
+) {
+  let verified = await operations.getIssue(options, issue.number);
+  if (queueLabelsFromIssue(verified).length > 0) return verified;
+  if (retryQueueLabels.length === 0) {
+    throw new Error(`Issue #${issue.number} has no queue label to restore`);
+  }
+
+  await operations.addIssueLabels(options, verified, retryQueueLabels);
+  for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
+    verified = await operations.getIssue(options, issue.number);
+    if (retryQueueLabels.length === 1) {
+      ({ issue: verified } = await compensateProvisionalQueueLabel(
+        options,
+        verified,
+        retryQueueLabels[0],
+        operations,
+      ));
+    }
+    if (queueLabelsFromIssue(verified).length > 0) return verified;
+    if (attempt < SYNC_VERIFY_ATTEMPTS) {
+      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+    }
+  }
+  throw new Error(
+    `Issue #${issue.number} has no queue label after retry-label restoration`,
+  );
 }
 
 export class IssueBoardSyncError extends AggregateError {
@@ -273,6 +296,7 @@ async function syncIssue(options, project, listedIssue, operations) {
       }
 
       const reopenState = restoreStateFromCloseoutIssue(closeoutIssue);
+      const retryQueueLabels = queueLabelsFromIssue(closeoutIssue);
       await operations.editIssueLabels(options, closeoutIssue, state);
       let verifiedIssue = await verifySyncCloseout(
         options,
@@ -288,13 +312,31 @@ async function syncIssue(options, project, listedIssue, operations) {
         if (!verifiedItemId) {
           return { number: issue.number, title: issue.title, state };
         }
-        await operations.updateProjectFields(
-          options,
-          project,
-          verifiedItemId,
-          state,
-          {},
-        );
+        try {
+          await operations.updateProjectFields(
+            options,
+            project,
+            verifiedItemId,
+            state,
+            {},
+          );
+        } catch (projectionError) {
+          try {
+            await preserveRetryQueueLabels(
+              options,
+              verifiedIssue,
+              retryQueueLabels,
+              operations,
+            );
+          } catch (retryError) {
+            throw new AggregateError(
+              [projectionError, retryError],
+              `Issue #${issue.number} late Done projection and retry-label restoration failed`,
+              { cause: retryError },
+            );
+          }
+          throw projectionError;
+        }
         verifiedIssue = await verifySyncCloseout(
           options,
           verifiedIssue,
@@ -375,6 +417,7 @@ async function syncIssue(options, project, listedIssue, operations) {
 
 export async function sync(options, dependencies = {}) {
   const operations = {
+    addIssueLabels,
     editIssueLabels,
     ensureProjectItem,
     findIssueProjectItem,

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -1,0 +1,379 @@
+/**
+ * Issue-board reconciliation and closeout.
+ *
+ * Queue labels remain authoritative. This layer projects each observed state
+ * onto the workboard and verifies concurrent close, reopen, and label changes.
+ */
+
+import {
+  ISSUE_STATE_LABELS,
+  labelNames,
+  labelsForState,
+  stateFromLabels,
+} from "./issue-board-state.mjs";
+import {
+  ensureProjectItem,
+  findIssueProjectItem,
+  getProject,
+  updateProjectFields,
+} from "./issue-board-projects.mjs";
+import {
+  editIssueLabels,
+  getIssue,
+  listIssuesByLabels,
+  sleep,
+} from "./issue-board-transport.mjs";
+
+const SYNC_RECONCILE_ATTEMPTS = 3;
+const SYNC_VERIFY_ATTEMPTS = 3;
+const SYNC_VERIFY_SETTLE_MS = 250;
+
+async function verifySyncCloseout(options, issue, operations) {
+  let staleLabels = [];
+  for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
+    const verified = await operations.getIssue(options, issue.number);
+    const verifiedState = String(verified.state ?? "").toUpperCase();
+    if (verifiedState !== "CLOSED") {
+      return verified;
+    }
+    const verifiedLabels = labelNames(verified);
+    staleLabels = ISSUE_STATE_LABELS.filter((label) =>
+      verifiedLabels.has(label),
+    );
+    if (staleLabels.length === 0) return verified;
+    if (attempt < SYNC_VERIFY_ATTEMPTS) {
+      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+    }
+  }
+  throw new Error(
+    `Issue #${issue.number} retained queue label(s) after sync: ${staleLabels.join(", ")}`,
+  );
+}
+
+function syncStateFromIssue(issue) {
+  const state = stateFromLabels(issue);
+  if (state) return state;
+  return String(issue.state ?? "").toUpperCase() === "CLOSED" ? "done" : null;
+}
+
+function queueLabelsFromIssue(issue) {
+  const labels = labelNames(issue);
+  return ISSUE_STATE_LABELS.filter((label) => labels.has(label));
+}
+
+function hasExactQueueLabels(issue, state) {
+  const expected = labelsForState(state).addLabels;
+  const actual = queueLabelsFromIssue(issue);
+  return (
+    actual.length === expected.length &&
+    expected.every((label) => actual.includes(label))
+  );
+}
+
+function conflictingOpenQueueLabels(issue) {
+  if (String(issue.state ?? "").toUpperCase() !== "OPEN") return [];
+  const labels = queueLabelsFromIssue(issue);
+  return labels.length > 1 ? labels : [];
+}
+
+function stateForQueueLabel(issue, label) {
+  return stateFromLabels({
+    ...issue,
+    state: "OPEN",
+    labels: [{ name: label }],
+  });
+}
+
+function restoreStateFromCloseoutIssue(issue) {
+  const queueLabels = queueLabelsFromIssue(issue);
+  if (queueLabels.length !== 1) return null;
+  return stateForQueueLabel(issue, queueLabels[0]);
+}
+
+async function compensateProvisionalQueueLabel(
+  options,
+  issue,
+  provisionalQueueLabel,
+  operations,
+) {
+  if (!provisionalQueueLabel) return { issue, provisionalQueueLabel };
+  if (String(issue.state ?? "").toUpperCase() !== "OPEN") {
+    return { issue, provisionalQueueLabel: null };
+  }
+
+  const queueLabels = queueLabelsFromIssue(issue);
+  if (!queueLabels.includes(provisionalQueueLabel)) {
+    return { issue, provisionalQueueLabel: null };
+  }
+  if (queueLabels.length !== 2) {
+    return { issue, provisionalQueueLabel };
+  }
+
+  const concurrentLabel = queueLabels.find(
+    (label) => label !== provisionalQueueLabel,
+  );
+  const concurrentState = stateForQueueLabel(issue, concurrentLabel);
+  if (!concurrentState) return { issue, provisionalQueueLabel };
+
+  await operations.editIssueLabels(options, issue, concurrentState);
+  const verified = await operations.getIssue(options, issue.number);
+  return {
+    issue: verified,
+    provisionalQueueLabel: queueLabelsFromIssue(verified).includes(
+      provisionalQueueLabel,
+    )
+      ? provisionalQueueLabel
+      : null,
+  };
+}
+
+export class IssueBoardSyncError extends AggregateError {
+  constructor(results, failures) {
+    const normalizedFailures = failures.map(({ number, title, error }) => ({
+      number,
+      title,
+      message: error instanceof Error ? error.message : String(error),
+    }));
+    const succeeded = results.map((result) => `#${result.number}`).join(", ");
+    const failed = normalizedFailures
+      .map((failure) => `#${failure.number}: ${failure.message}`)
+      .join("; ");
+    super(
+      failures.map((failure) => failure.error),
+      [
+        `Issue-board sync completed with ${normalizedFailures.length} failure(s) after ${results.length} success(es).`,
+        `Succeeded: ${succeeded || "none"}.`,
+        `Failed: ${failed}.`,
+      ].join("\n"),
+    );
+    this.name = "IssueBoardSyncError";
+    this.results = results;
+    this.failures = normalizedFailures;
+  }
+}
+
+async function syncIssue(options, project, listedIssue, operations) {
+  let issue = await operations.getIssue(options, listedIssue.number);
+  let drift = null;
+  let provisionalQueueLabel = null;
+
+  for (let attempt = 1; attempt <= SYNC_RECONCILE_ATTEMPTS; attempt += 1) {
+    ({ issue, provisionalQueueLabel } = await compensateProvisionalQueueLabel(
+      options,
+      issue,
+      provisionalQueueLabel,
+      operations,
+    ));
+    const conflictingLabels = conflictingOpenQueueLabels(issue);
+    if (conflictingLabels.length > 0) {
+      drift = `conflicting queue labels (${conflictingLabels.join(", ")})`;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        issue = await operations.getIssue(options, issue.number);
+        continue;
+      }
+      throw new Error(
+        `Issue #${issue.number} retained conflicting queue labels after ${SYNC_RECONCILE_ATTEMPTS} attempts: ${conflictingLabels.join(", ")}`,
+      );
+    }
+
+    const state = syncStateFromIssue(issue);
+    if (!state) {
+      if (!drift) return null;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        issue = await operations.getIssue(options, issue.number);
+        continue;
+      }
+      throw new Error(
+        `Issue #${issue.number} lost its queue state during sync after ${attempt} attempt(s); last projection drift was ${drift}`,
+      );
+    }
+
+    if (state === "done") {
+      const itemId = await operations.findIssueProjectItem(
+        options,
+        issue,
+        project,
+      );
+      if (itemId) {
+        await operations.updateProjectFields(
+          options,
+          project,
+          itemId,
+          state,
+          {},
+        );
+      }
+      if (options.dryRun) {
+        await operations.editIssueLabels(options, issue, state);
+        return { number: issue.number, title: issue.title, state };
+      }
+
+      const closeoutIssue = await operations.getIssue(options, issue.number);
+      const closeoutState = syncStateFromIssue(closeoutIssue);
+      if (closeoutState !== "done") {
+        drift = `done -> ${closeoutState ?? "no queue state"}`;
+        if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+          issue = closeoutIssue;
+          await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+          continue;
+        }
+        break;
+      }
+
+      const closeoutItemId = await operations.findIssueProjectItem(
+        options,
+        closeoutIssue,
+        project,
+      );
+      if (closeoutItemId) {
+        await operations.updateProjectFields(
+          options,
+          project,
+          closeoutItemId,
+          state,
+          {},
+        );
+      }
+
+      const reopenState = restoreStateFromCloseoutIssue(closeoutIssue);
+      await operations.editIssueLabels(options, closeoutIssue, state);
+      let verifiedIssue = await verifySyncCloseout(
+        options,
+        closeoutIssue,
+        operations,
+      );
+      if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+        const verifiedItemId = await operations.findIssueProjectItem(
+          options,
+          verifiedIssue,
+          project,
+        );
+        if (!verifiedItemId) {
+          return { number: issue.number, title: issue.title, state };
+        }
+        await operations.updateProjectFields(
+          options,
+          project,
+          verifiedItemId,
+          state,
+          {},
+        );
+        verifiedIssue = await verifySyncCloseout(
+          options,
+          verifiedIssue,
+          operations,
+        );
+        if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+          return { number: issue.number, title: issue.title, state };
+        }
+      }
+
+      let reopenedIssue = verifiedIssue;
+      let reopenedState = syncStateFromIssue(reopenedIssue);
+      if (!reopenedState && reopenState) {
+        reopenedIssue = await operations.getIssue(options, issue.number);
+        reopenedState = syncStateFromIssue(reopenedIssue);
+        if (!reopenedState) {
+          await operations.editIssueLabels(options, reopenedIssue, reopenState);
+          [provisionalQueueLabel] = labelsForState(reopenState).addLabels;
+          reopenedIssue = await operations.getIssue(options, issue.number);
+          ({ issue: reopenedIssue, provisionalQueueLabel } =
+            await compensateProvisionalQueueLabel(
+              options,
+              reopenedIssue,
+              provisionalQueueLabel,
+              operations,
+            ));
+          reopenedState = syncStateFromIssue(reopenedIssue);
+        }
+      }
+      drift =
+        reopenedState &&
+        reopenedState !== "done" &&
+        !hasExactQueueLabels(reopenedIssue, reopenedState)
+          ? `done -> conflicting queue labels (${queueLabelsFromIssue(reopenedIssue).join(", ")})`
+          : `done -> ${reopenedState ?? "no queue state"}`;
+      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+        issue = reopenedIssue;
+        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+        continue;
+      }
+      break;
+    }
+
+    const itemId = await operations.ensureProjectItem(options, project, issue);
+    if (!itemId) return null;
+    await operations.updateProjectFields(options, project, itemId, state, {});
+    if (options.dryRun) {
+      return { number: issue.number, title: issue.title, state };
+    }
+
+    let verified = await operations.getIssue(options, issue.number);
+    ({ issue: verified, provisionalQueueLabel } =
+      await compensateProvisionalQueueLabel(
+        options,
+        verified,
+        provisionalQueueLabel,
+        operations,
+      ));
+    const verifiedState = syncStateFromIssue(verified);
+    if (verifiedState === state && hasExactQueueLabels(verified, state)) {
+      return { number: issue.number, title: issue.title, state };
+    }
+
+    drift =
+      verifiedState === state
+        ? `${state} -> conflicting queue labels (${queueLabelsFromIssue(verified).join(", ")})`
+        : `${state} -> ${verifiedState ?? "no queue state"}`;
+    if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+      issue = verified;
+      await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+    }
+  }
+
+  throw new Error(
+    `Issue #${issue.number} did not stabilize during sync after ${SYNC_RECONCILE_ATTEMPTS} attempts; last projection drift was ${drift}`,
+  );
+}
+
+export async function sync(options, dependencies = {}) {
+  const operations = {
+    editIssueLabels,
+    ensureProjectItem,
+    findIssueProjectItem,
+    getIssue,
+    getProject,
+    listIssuesByLabels,
+    sleep,
+    updateProjectFields,
+    ...dependencies,
+  };
+  const project = await operations.getProject(options);
+  const byNumber = new Map();
+  for (const issue of await operations.listIssuesByLabels(
+    options,
+    ISSUE_STATE_LABELS,
+    { state: "all" },
+  )) {
+    byNumber.set(issue.number, issue);
+  }
+
+  const results = [];
+  const failures = [];
+  for (const listedIssue of byNumber.values()) {
+    try {
+      const result = await syncIssue(options, project, listedIssue, operations);
+      if (result) results.push(result);
+    } catch (error) {
+      failures.push({
+        number: listedIssue.number,
+        title: listedIssue.title,
+        error,
+      });
+    }
+  }
+  if (failures.length > 0) throw new IssueBoardSyncError(results, failures);
+  return results;
+}

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -77,17 +77,20 @@ function retryQueueSnapshotForCloseout(
   listedIssue,
 ) {
   const closeoutQueueLabels = queueLabelsFromIssue(closeoutIssue);
-  if (closeoutQueueLabels.length > 0) {
+  if (closeoutQueueLabels.length === 1) {
     return { labels: closeoutQueueLabels, compensateAfterAdd: true };
   }
 
-  // Stale queue evidence needs a visible state that cannot grant review or
-  // release authority if the issue reopens during recovery.
+  // Ambiguous or stale queue evidence needs a visible state that cannot grant
+  // claim, review, or release authority if the issue reopens during recovery.
+  const hasRetryEvidence =
+    closeoutQueueLabels.length > 1 ||
+    nearestQueueLabels(initialIssue, listedIssue).length > 0;
   return {
-    labels:
-      nearestQueueLabels(initialIssue, listedIssue).length > 0
-        ? labelsForState("grooming").addLabels
-        : [],
+    labels: hasRetryEvidence ? labelsForState("grooming").addLabels : [],
+    // GitHub label additions are idempotent. A successful quarantine add does
+    // not prove that this recovery created the label. Preserve any conflict so
+    // a stale fallback cannot grant claim, review, or release authority.
     compensateAfterAdd: false,
   };
 }
@@ -214,12 +217,12 @@ async function preserveRetryQueueLabels(
   }
 
   let lastError = null;
-  let addAttempted = false;
+  let provisionalAddConfirmed = false;
   for (let attempt = 1; attempt <= SYNC_VERIFY_ATTEMPTS; attempt += 1) {
     let verified;
     try {
       verified = await operations.getIssue(options, issue.number);
-      if (addAttempted && compensateAfterAdd) {
+      if (provisionalAddConfirmed && compensateAfterAdd) {
         verified = await reconcileRetryQueueObservation(
           options,
           verified,
@@ -237,16 +240,16 @@ async function preserveRetryQueueLabels(
     }
 
     let addError = null;
-    addAttempted = true;
     try {
       await operations.addIssueLabels(options, verified, retryQueueLabels);
+      provisionalAddConfirmed = true;
     } catch (error) {
       addError = error;
     }
 
     try {
       verified = await operations.getIssue(options, issue.number);
-      if (compensateAfterAdd) {
+      if (provisionalAddConfirmed && compensateAfterAdd) {
         verified = await reconcileRetryQueueObservation(
           options,
           verified,
@@ -392,22 +395,23 @@ async function syncIssue(options, project, listedIssue, operations) {
       const reopenState =
         restoreStateFromCloseoutIssue(closeoutIssue) ??
         (retryQueueSnapshot.labels.length > 0 ? "grooming" : null);
-      await operations.editIssueLabels(options, closeoutIssue, state);
-      let verifiedIssue = await verifySyncCloseout(
-        options,
-        closeoutIssue,
-        operations,
-      );
-      if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
-        const verifiedItemId = await operations.findIssueProjectItem(
+      let verifiedIssue;
+      try {
+        await operations.editIssueLabels(options, closeoutIssue, state);
+        verifiedIssue = await verifySyncCloseout(
           options,
-          verifiedIssue,
-          project,
+          closeoutIssue,
+          operations,
         );
-        if (!verifiedItemId) {
-          return { number: issue.number, title: issue.title, state };
-        }
-        try {
+        if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+          const verifiedItemId = await operations.findIssueProjectItem(
+            options,
+            verifiedIssue,
+            project,
+          );
+          if (!verifiedItemId) {
+            return { number: issue.number, title: issue.title, state };
+          }
           await operations.updateProjectFields(
             options,
             project,
@@ -415,65 +419,71 @@ async function syncIssue(options, project, listedIssue, operations) {
             state,
             {},
           );
-        } catch (projectionError) {
-          try {
-            await preserveRetryQueueLabels(
-              options,
-              verifiedIssue,
-              retryQueueSnapshot.labels,
-              retryQueueSnapshot.compensateAfterAdd,
-              operations,
-            );
-          } catch (retryError) {
-            throw new AggregateError(
-              [projectionError, retryError],
-              `Issue #${issue.number} late Done projection and retry-label restoration failed`,
-              { cause: retryError },
-            );
+          verifiedIssue = await verifySyncCloseout(
+            options,
+            verifiedIssue,
+            operations,
+          );
+          if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
+            return { number: issue.number, title: issue.title, state };
           }
-          throw projectionError;
         }
-        verifiedIssue = await verifySyncCloseout(
-          options,
-          verifiedIssue,
-          operations,
-        );
-        if (String(verifiedIssue.state ?? "").toUpperCase() === "CLOSED") {
-          return { number: issue.number, title: issue.title, state };
-        }
-      }
 
-      let reopenedIssue = verifiedIssue;
-      let reopenedState = syncStateFromIssue(reopenedIssue);
-      if (!reopenedState && reopenState) {
-        reopenedIssue = await operations.getIssue(options, issue.number);
-        reopenedState = syncStateFromIssue(reopenedIssue);
-        if (!reopenedState) {
-          await operations.editIssueLabels(options, reopenedIssue, reopenState);
-          [provisionalQueueLabel] = labelsForState(reopenState).addLabels;
+        let reopenedIssue = verifiedIssue;
+        let reopenedState = syncStateFromIssue(reopenedIssue);
+        if (!reopenedState && reopenState) {
           reopenedIssue = await operations.getIssue(options, issue.number);
-          ({ issue: reopenedIssue, provisionalQueueLabel } =
-            await compensateProvisionalQueueLabel(
+          reopenedState = syncStateFromIssue(reopenedIssue);
+          if (!reopenedState) {
+            await operations.editIssueLabels(
               options,
               reopenedIssue,
-              provisionalQueueLabel,
-              operations,
-            ));
-          reopenedState = syncStateFromIssue(reopenedIssue);
+              reopenState,
+            );
+            provisionalQueueLabel = retryQueueSnapshot.compensateAfterAdd
+              ? labelsForState(reopenState).addLabels[0]
+              : null;
+            reopenedIssue = await operations.getIssue(options, issue.number);
+            ({ issue: reopenedIssue, provisionalQueueLabel } =
+              await compensateProvisionalQueueLabel(
+                options,
+                reopenedIssue,
+                provisionalQueueLabel,
+                operations,
+              ));
+            reopenedState = syncStateFromIssue(reopenedIssue);
+          }
         }
+        drift =
+          reopenedState &&
+          reopenedState !== "done" &&
+          !hasExactQueueLabels(reopenedIssue, reopenedState)
+            ? `done -> conflicting queue labels (${queueLabelsFromIssue(reopenedIssue).join(", ")})`
+            : `done -> ${reopenedState ?? "no queue state"}`;
+        if (attempt < SYNC_RECONCILE_ATTEMPTS) {
+          issue = reopenedIssue;
+          await operations.sleep(SYNC_VERIFY_SETTLE_MS);
+          continue;
+        }
+        break;
+      } catch (postCleanupError) {
+        try {
+          await preserveRetryQueueLabels(
+            options,
+            verifiedIssue ?? closeoutIssue,
+            retryQueueSnapshot.labels,
+            retryQueueSnapshot.compensateAfterAdd,
+            operations,
+          );
+        } catch (retryError) {
+          throw new AggregateError(
+            [postCleanupError, retryError],
+            `Issue #${issue.number} post-cleanup sync and retry-label restoration failed`,
+            { cause: retryError },
+          );
+        }
+        throw postCleanupError;
       }
-      drift =
-        reopenedState &&
-        reopenedState !== "done" &&
-        !hasExactQueueLabels(reopenedIssue, reopenedState)
-          ? `done -> conflicting queue labels (${queueLabelsFromIssue(reopenedIssue).join(", ")})`
-          : `done -> ${reopenedState ?? "no queue state"}`;
-      if (attempt < SYNC_RECONCILE_ATTEMPTS) {
-        issue = reopenedIssue;
-        await operations.sleep(SYNC_VERIFY_SETTLE_MS);
-        continue;
-      }
-      break;
     }
 
     const itemId = await operations.ensureProjectItem(options, project, issue);

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -90,6 +90,22 @@ function restoreStateFromCloseoutIssue(issue) {
   return stateForQueueLabel(issue, queueLabels[0]);
 }
 
+async function restoreProvisionalQueueLabel(
+  options,
+  issue,
+  provisionalQueueLabel,
+  operations,
+) {
+  const provisionalState = stateForQueueLabel(issue, provisionalQueueLabel);
+  if (!provisionalState) return { issue, provisionalQueueLabel: null };
+
+  await operations.editIssueLabels(options, issue, provisionalState);
+  return {
+    issue: await operations.getIssue(options, issue.number),
+    provisionalQueueLabel,
+  };
+}
+
 async function compensateProvisionalQueueLabel(
   options,
   issue,
@@ -103,6 +119,14 @@ async function compensateProvisionalQueueLabel(
 
   const queueLabels = queueLabelsFromIssue(issue);
   if (!queueLabels.includes(provisionalQueueLabel)) {
+    if (queueLabels.length === 0) {
+      return restoreProvisionalQueueLabel(
+        options,
+        issue,
+        provisionalQueueLabel,
+        operations,
+      );
+    }
     return { issue, provisionalQueueLabel: null };
   }
   if (queueLabels.length !== 2) {
@@ -117,6 +141,17 @@ async function compensateProvisionalQueueLabel(
 
   await operations.editIssueLabels(options, issue, concurrentState);
   const verified = await operations.getIssue(options, issue.number);
+  if (
+    String(verified.state ?? "").toUpperCase() === "OPEN" &&
+    queueLabelsFromIssue(verified).length === 0
+  ) {
+    return restoreProvisionalQueueLabel(
+      options,
+      verified,
+      provisionalQueueLabel,
+      operations,
+    );
+  }
   return {
     issue: verified,
     provisionalQueueLabel: queueLabelsFromIssue(verified).includes(

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -384,12 +384,14 @@ async function syncIssue(options, project, listedIssue, operations) {
         );
       }
 
-      const reopenState = restoreStateFromCloseoutIssue(closeoutIssue);
       const retryQueueSnapshot = retryQueueSnapshotForCloseout(
         closeoutIssue,
         initialIssue,
         listedIssue,
       );
+      const reopenState =
+        restoreStateFromCloseoutIssue(closeoutIssue) ??
+        (retryQueueSnapshot.labels.length > 0 ? "grooming" : null);
       await operations.editIssueLabels(options, closeoutIssue, state);
       let verifiedIssue = await verifySyncCloseout(
         options,

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -135,6 +135,25 @@ export async function editIssueLabels(options, issue, state) {
   await runGh(args, { dryRun: options.dryRun, mutates: true });
 }
 
+export async function addIssueLabels(options, issue, labels) {
+  const existingLabels = labelNames(issue);
+  const addLabels = labels.filter((label) => !existingLabels.has(label));
+  if (addLabels.length === 0) return;
+
+  await runGh(
+    [
+      "issue",
+      "edit",
+      String(issue.number),
+      "-R",
+      options.repo,
+      "--add-label",
+      addLabels.join(","),
+    ],
+    { dryRun: options.dryRun, mutates: true },
+  );
+}
+
 export async function ghJson(args, opts = {}) {
   const stdout = await runGh(args, opts);
   return stdout.trim() ? JSON.parse(stdout) : null;

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -179,13 +179,15 @@ export async function listReadyIssues(options) {
 export async function listIssuesByLabel(
   options,
   label,
-  { state = "open" } = {},
+  { state = "open", json = ghJson } = {},
 ) {
-  const issues = await ghJson([
+  const issues = await json([
     "issue",
     "list",
     "-R",
     options.repo,
+    "--state",
+    state,
     "--search",
     `is:issue is:${state} label:${label}`,
     "--limit",

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -8,7 +8,12 @@
 
 import { spawn } from "node:child_process";
 
-import { splitRepo, validateOpenPr } from "./issue-board-state.mjs";
+import {
+  labelNames,
+  labelsForState,
+  splitRepo,
+  validateOpenPr,
+} from "./issue-board-state.mjs";
 
 const GH_OUTPUT_MAX_BYTES = 20 * 1024 * 1024;
 // A bounded traversal must fail rather than use an incomplete comment history.
@@ -107,6 +112,27 @@ export function runGh(args, { dryRun = false, mutates = false } = {}) {
       resolve(stdout);
     });
   });
+}
+
+export async function editIssueLabels(options, issue, state) {
+  const transition = labelsForState(state);
+  const existingLabels = labelNames(issue);
+  const addLabels = transition.addLabels.filter(
+    (label) => !existingLabels.has(label),
+  );
+  const removeLabels = transition.removeLabels.filter((label) =>
+    existingLabels.has(label),
+  );
+  if (addLabels.length === 0 && removeLabels.length === 0) return;
+
+  const args = ["issue", "edit", String(issue.number), "-R", options.repo];
+  if (addLabels.length > 0) {
+    args.push("--add-label", addLabels.join(","));
+  }
+  if (removeLabels.length > 0) {
+    args.push("--remove-label", removeLabels.join(","));
+  }
+  await runGh(args, { dryRun: options.dryRun, mutates: true });
 }
 
 export async function ghJson(args, opts = {}) {

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -176,9 +176,9 @@ export async function listReadyIssues(options) {
   return issues ?? [];
 }
 
-export async function listIssuesByLabel(
+export async function listIssuesByLabels(
   options,
-  label,
+  labels,
   { state = "open", json = ghJson } = {},
 ) {
   const stateQualifier = state === "all" ? "" : ` is:${state}`;
@@ -190,7 +190,7 @@ export async function listIssuesByLabel(
     "--state",
     state,
     "--search",
-    `is:issue${stateQualifier} label:${label}`,
+    `is:issue${stateQualifier} label:${labels.join(",")}`,
     "--limit",
     "1000",
     "--json",

--- a/scripts/pr/issue-board-transport.mjs
+++ b/scripts/pr/issue-board-transport.mjs
@@ -181,6 +181,7 @@ export async function listIssuesByLabel(
   label,
   { state = "open", json = ghJson } = {},
 ) {
+  const stateQualifier = state === "all" ? "" : ` is:${state}`;
   const issues = await json([
     "issue",
     "list",
@@ -189,7 +190,7 @@ export async function listIssuesByLabel(
     "--state",
     state,
     "--search",
-    `is:issue is:${state} label:${label}`,
+    `is:issue${stateQualifier} label:${label}`,
     "--limit",
     "1000",
     "--json",


### PR DESCRIPTION
## The Problem

- Board sync queried closed `in-pr` issues only. Closed issues with another queue label could keep stale queue state, especially when they had no Project item.
- Sync projected search-result snapshots without checking for a concurrent claim, release, reopen, or close. A successful run could leave the Project status inconsistent with the issue labels.
- Done cleanup could remove the last discoverable queue label when a later read or Project write failed.

## The Solution

Sync now enumerates every queue label across open and closed issues. It re-reads each issue before mutation, rechecks open-state Project writes, and reprojects bounded concurrent drift. A Done transition verifies that the issue remains closed and has no queue label.

Post-cleanup recovery restores an exact queue state only when one fresh label was confirmed before cleanup. Ambiguous or older evidence restores `needs-grooming`. Fallback conflicts remain visible and fail closed because GitHub label additions are idempotent and do not prove which actor added a label.

GitHub does not provide an atomic issue-and-Project transaction. Sync uses bounded reconciliation and preserves a discoverable retry or quarantine state when a later operation fails.

## Details

- Defines one shared queue-label list for state classification, transitions, and sync queries.
- Clears queue labels from closed issues even when no Project item exists.
- Covers cleanup mutation errors, verification errors, late Done projection errors, reopen refresh errors, and ambiguous label-add outcomes.
- Prevents `needs-grooming` conflicts from granting claim, review, or release authority.
- Updates the issue workflow, quick commands, GitHub tooling, and dashboard verification notes with the reflected closeout rules.

## Validation

- `node scripts/pr/agent-issue-board.test.mjs` — 80 passed.
- Targeted ESLint on the two changed root scripts — passed.
- `./tools/trunk check` on the latest three changed files — passed.
- `node scripts/context/docs-index.test.mjs` — 28 passed.
- `node scripts/context/docs-index.mjs --check` — passed.
- `git diff --check` — passed.
- Three independent final diff reviews — no blocking findings.
- The documented authenticated browser helper returned redacted success and malformed-JSON evidence without a payload leak. No UI implementation changed.
- Full local `agent:quality-gate` and autoreview were not run to completion, per the user's mini-PR waiver. CI provides the full repository verification.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the material GitHub transaction limit.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every known deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision is not applicable; this change hardens the existing workboard workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved issue-board synchronization with state reconciliation, closed-issue cleanup, retries, dry-run support, and clearer success and failure reporting.
  * Added safeguards for concurrent updates, reopened issues, conflicting labels, incomplete workboard projections, and ambiguous closeout states.
* **Documentation**
  * Expanded guidance for dashboard verification, workflow-run selection, issue-board synchronization, and post-merge tracking.
  * Added response-data redaction guidance and clarified closed-label cleanup procedures.
* **Tests**
  * Added comprehensive coverage for retries, cleanup failures, partial failures, concurrent changes, state transitions, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
