### PR TITLE
fix(context): grade every Claude allow entry, not just Bash

### DIFF
--- a/scripts/context/check-settings-contract.mjs
+++ b/scripts/context/check-settings-contract.mjs
@@ -8,9 +8,12 @@
  * - the SessionEnd hook wiring for both runtimes, which must invoke
  *   `scripts/bootstrap/agent-session-end-hook.sh` through a derived repository
  *   root instead of a machine-local path;
- * - the verbatim copy of the `.claude/settings.json` Bash permission
- *   allowlist, which is an exact reviewed set so shell escaping or dynamic
- *   command construction cannot bypass a command-specific policy check.
+ * - the verbatim copies of the `.claude/settings.json` permission allowlists,
+ *   one per tool kind, each an exact reviewed set so shell escaping, dynamic
+ *   command construction, or a widened fetch specifier cannot bypass a
+ *   grant-specific policy check. Every string in `permissions.allow` grants
+ *   something, so a kind with no allowlist here fails closed instead of being
+ *   skipped.
  *
  * `check-agent-context.mjs` runs this module and folds the returned failures
  * into its own, so `pnpm agent:context-check` and the direct
@@ -111,6 +114,14 @@ const allowedClaudeBashPermissions = new Set([
   ...allowedClaudeOtherBashPermissions,
 ]);
 
+// Keep this in sync with `.claude/settings.json`. A `WebFetch` grant is scoped
+// entirely by its specifier, so the reviewed set holds whole entries rather
+// than a host pattern: matching on a pattern would admit every specifier form
+// the pattern happens to cover, which is the review nobody performed.
+const allowedClaudeWebFetchPermissions = new Set([
+  "WebFetch(domain:monitoring.mento.org)",
+]);
+
 // Root `scripts/` and package-local `<package>/scripts/` both count: the React
 // Doctor wrappers live in `ui-dashboard/scripts/`, so a prefix-blind check
 // would route a package-local script permission into the generic branch.
@@ -153,8 +164,29 @@ function validateClaudePermissions(settings, fail) {
   }
 
   for (const permission of allow) {
+    // A non-string entry cannot express a permission rule, so it grants
+    // nothing. Its shape is a JSON schema concern, not a permission one.
     if (typeof permission !== "string") continue;
-    if (!permission.startsWith("Bash(")) continue;
+
+    if (permission.startsWith("WebFetch(")) {
+      if (!allowedClaudeWebFetchPermissions.has(permission)) {
+        fail(
+          `.claude/settings.json: unexpected WebFetch permission; add the exact reviewed entry to the context-check allowlist: ${permission}`,
+        );
+      }
+      continue;
+    }
+
+    // Fail closed on every other kind. Each remaining string is a live grant of
+    // some tool, and no rule shape marks one as harmless, so a classifier that
+    // decided which strings to skip would itself become the bypass. Registering
+    // a kind here is the review step; skipping one is the bug this replaced.
+    if (!permission.startsWith("Bash(")) {
+      fail(
+        `.claude/settings.json: unreviewed permission kind; register it in scripts/context/check-settings-contract.mjs with its own reviewed allowlist before granting it: ${permission}`,
+      );
+      continue;
+    }
 
     if (
       isClaudeSagPermission(permission) &&

--- a/scripts/context/check-settings-contract.test.mjs
+++ b/scripts/context/check-settings-contract.test.mjs
@@ -11,9 +11,16 @@
  * CI:  .github/workflows/ci.yml  (scripts job)
  */
 
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { checkSettingsContract } from "./check-settings-contract.mjs";
 
@@ -297,12 +304,58 @@ test("accepts every reviewed allowlist entry the settings file grants", () => {
   );
 });
 
-test("ignores non-Bash permissions and non-string entries", () => {
+// ── Claude WebFetch and unknown-kind policy ──────────────────────────────────
+//
+// Same control, other tool kinds. `WebFetch` gets its own reviewed set; every
+// remaining kind fails closed, so granting one is a deliberate edit here rather
+// than an entry that nothing grades.
+
+console.log("\nClaude WebFetch and unknown-kind policy");
+
+test("accepts the reviewed Claude WebFetch permission", () => {
   assertNoFailures(
-    runContract({
-      allow: ["Read(docs/**)", "WebFetch(domain:example.com)", 7],
-    }),
+    runContract({ allow: ["WebFetch(domain:monitoring.mento.org)"] }),
   );
+});
+
+test("rejects unreviewed Claude WebFetch permissions", () => {
+  for (const permission of [
+    "WebFetch(domain:example.com)",
+    // Neighbours of the reviewed host on both sides of the label boundary: a
+    // host-pattern check would have to rule on these, an exact set never sees
+    // them as anything but absent.
+    "WebFetch(domain:staging.monitoring.mento.org)",
+    "WebFetch(domain:monitoring.mento.org.example.com)",
+    "WebFetch(url:https://monitoring.mento.org/*)",
+    "WebFetch(*)",
+  ]) {
+    assertFailureContains(
+      runContract({ allow: [permission] }),
+      `.claude/settings.json: unexpected WebFetch permission; add the exact reviewed entry to the context-check allowlist: ${permission}`,
+    );
+  }
+});
+
+test("rejects permission kinds that have no reviewed allowlist", () => {
+  for (const permission of [
+    "Read(docs/**)",
+    "Edit(**)",
+    "WebSearch",
+    // A bare tool name is the widest grant of that tool. `Bash` without a
+    // specifier must not slip past a check keyed on the `Bash(` prefix.
+    "Bash",
+    "mcp__github__create_pull_request",
+    "",
+  ]) {
+    assertFailureContains(
+      runContract({ allow: [permission] }),
+      `.claude/settings.json: unreviewed permission kind; register it in scripts/context/check-settings-contract.mjs with its own reviewed allowlist before granting it: ${permission}`,
+    );
+  }
+});
+
+test("ignores non-string allow entries", () => {
+  assertNoFailures(runContract({ allow: [7, null, { Bash: "*" }] }));
 });
 
 test("rejects a permissions.allow that is not an array", () => {
@@ -315,6 +368,42 @@ test("rejects a permissions.allow that is not an array", () => {
     }),
     ".claude/settings.json: expected permissions.allow array",
   );
+});
+
+// ── tracked settings file invariant ──────────────────────────────────────────
+//
+// The reviewed sets are a verbatim copy of a tracked file, so cases that retype
+// entries only prove the copy agrees with itself. These read the real
+// `.claude/settings.json` and grade what it actually grants. The Bash case is
+// the standing invariant: widening the loop to other kinds must leave every
+// existing Bash grant validating exactly as before.
+
+console.log("\ntracked settings file invariant");
+
+const trackedAllow = JSON.parse(
+  readFileSync(
+    path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../.claude/settings.json",
+    ),
+    "utf8",
+  ),
+).permissions.allow;
+
+test("every Bash entry the tracked settings file grants still validates", () => {
+  const bashEntries = trackedAllow.filter(
+    (permission) =>
+      typeof permission === "string" && permission.startsWith("Bash("),
+  );
+  assert(
+    bashEntries.length > 0,
+    "expected the tracked settings file to grant Bash permissions",
+  );
+  assertNoFailures(runContract({ allow: bashEntries }));
+});
+
+test("every entry the tracked settings file grants validates", () => {
+  assertNoFailures(runContract({ allow: trackedAllow }));
 });
 
 // ── SessionEnd hook wiring ────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- `validateClaudePermissions` graded only entries starting with `Bash(` and
  skipped every other string in `.claude/settings.json`'s `permissions.allow`.
  A `Bash(` grant had to match an exact reviewed allowlist; a `WebFetch(...)`,
  `Read(...)`, or bare `Bash` grant matched nothing and passed.
- The tracked file already carries one such entry,
  `WebFetch(domain:monitoring.mento.org)`. It is intended, but nothing stopped a
  second unreviewed host — or an entire unrestricted tool — from landing beside
  it and passing `pnpm agent:context-check` green.
- The gap was silent. A skipped entry produced no output, so neither the gate
  nor a reviewer reading gate results could tell a reviewed grant from an
  ungraded one.

## The Solution

Every string in `permissions.allow` is now graded. `WebFetch` gets its own exact
reviewed set, seeded with the one entry the repository intends. Every remaining
kind fails closed with a message naming the file to register it in, so adding a
`Read(...)`, an MCP tool, or a bare `Bash` grant is a deliberate edit to the
validator rather than an entry nothing checks.

Benefit: the reviewed-rule property that already covered Bash now covers the
whole allow list, and a new permission kind cannot reach `main` without someone
writing its reviewed set.

Limits and non-goals:

- Bash handling is byte-for-byte unchanged. The `Bash(` branch, its three
  reviewed sets, the `sag` key-path rule, the shell-loop refusal, and the
  deploy-script refusal all keep their exact messages and order.
- Non-string entries in `allow` still skip. A non-string cannot express a
  permission rule, so it grants nothing; its shape belongs to JSON schema
  validation, not to a permission control.
- Only `permissions.allow` in `.claude/settings.json` is in scope.
  `permissions.deny`, `.claude/settings.local.json`, and Codex permissions are
  unchanged.

## Details

- `allowedClaudeWebFetchPermissions` is a `Set` of whole entry strings, checked
  before the `Bash(` filter. It holds entries rather than a host pattern on
  purpose: a pattern would admit every specifier form it happens to cover, which
  is a review nobody performed. Neighbours of the reviewed host on both sides of
  a label boundary (`staging.monitoring.mento.org`,
  `monitoring.mento.org.example.com`) are covered by tests.
- The unknown-kind branch rejects every string that is neither `WebFetch(` nor
  `Bash(` prefixed, rather than classifying "tool-shaped" strings and skipping
  the rest. A classifier that decided which strings were harmless would itself
  become the bypass, and no rule shape marks a grant as harmless. This also
  closes a bare `Bash` entry, which grants the tool unrestricted and would slip
  past any check keyed on the `Bash(` prefix.
- Two tests read the tracked `.claude/settings.json` instead of retyping its
  entries. The reviewed sets in the validator are a verbatim copy of that file,
  so a case that retypes entries only proves the copy agrees with itself. The
  Bash-only case is the standing invariant this change must not move; the
  whole-file case proves the `WebFetch` seed matches what the file grants.
- Docs drift: `docs/adr/0064-scripts-module-directories.md` and
  `docs/notes/spoken-attention-nudge.md` reference `.claude/settings.json` and
  its verbatim copy, but neither describes the Bash-only scope, so both stay
  accurate. No other doc, `AGENTS.md`, or `CLAUDE.md` entry describes the
  validator's per-kind coverage. Nothing to update.

Closes #2051

## Validation

- `node scripts/context/check-settings-contract.test.mjs` — 26 tests passed
  (20 before; 4 new cases plus 2 tracked-file invariant cases, replacing the
  removed `ignores non-Bash permissions and non-string entries` case).
- `node scripts/context/check-agent-context.test.mjs` — 34 tests passed.
- `node scripts/context/check-agent-context.mjs` — passed against the real tree
  (153 managed files), proving the tracked `WebFetch` entry still validates.
- Control probed both ways at the entrypoint, via `NODE_ENV=test` with
  `AGENT_CONTEXT_CLAUDE_SETTINGS_FILE` pointed at copies of the real settings
  file: unmodified passes; `+ WebFetch(domain:evil.example.com)` fails with
  `unexpected WebFetch permission`; `+ Read(**)` and `+ Bash` each fail with
  `unreviewed permission kind`.
- `bash ./scripts/agent-quality-gate.sh --run --parallel 4 --skip-if-fresh
  --base origin/main` — all six mapped commands passed (`pnpm
  agent:context-check`, both context test suites, `./tools/trunk check` on the
  two touched files, `pnpm lint:scripts`, `pnpm tf:test`).

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this tightens an existing control
      inside its established design, adding no new constraint on future work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Claude permission settings.
  * Added support for the reviewed WebFetch permission for `monitoring.mento.org`.
  * Unrecognized permission types are now rejected instead of being silently ignored.
  * Non-string permission entries continue to be safely ignored.

* **Tests**
  * Added coverage for valid, invalid, unknown, and non-string permission entries.
  * Added checks to ensure tracked settings match the approved permission allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->