### PR TITLE
fix(gate): skip Trunk when its linter downloads are blocked, not just its CLI

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -46,7 +46,8 @@ rerun the full mapped gate with host access on the same head. The gate reuses
 stamp-eligible fresh successes and runs the blocked commands. A resumed run does
 not write a whole-run stamp. Trunk and the gate self-test are stamp-exempt and
 always run, including during the later pre-push gate; Trunk's one exception is
-an environment that cannot provision the CLI, where the arm is skipped. Other
+an environment that blocks its downloads — the CLI, its plugin sources, or the
+linters a check needs — where the arm is skipped. Other
 eligible successes keep per-command stamps, so the later gate can avoid
 repeating them. Running a command directly proves it but records no per-command
 stamp.
@@ -197,13 +198,28 @@ targeted Trunk checks for faster local iteration. Deleted paths,
 Trunk/tooling changes, package-manager changes, pnpm patches, and
 package-manifest changes still run full-repo Trunk locally. CI also runs a
 required full-repo Trunk check on every
-PR. Where the environment blocks `trunk.io` — a Claude cloud container proxies
-egress and refuses any host outside its allowlist, so `./tools/trunk` cannot
-download the pinned CLI — the gate probes provisioning after the Trunk command
-fails, then reports the arm as `skipped` with a warning naming the allowlist fix
-instead of failing the run, matching the posture `.trunk/hooks` already takes.
-Only a provisioning failure degrades: a provisioned Trunk that finds real
-problems still fails the gate. Normal `--run` mode executes independent
+PR. Where the environment blocks Trunk's downloads — a Claude cloud container
+proxies egress and refuses any host outside its allowlist — the gate reports the
+arm as `skipped` with a warning naming the allowlist fix instead of failing the
+run, matching the posture `.trunk/hooks` already takes. Trunk downloads at two
+stages and the gate classifies both. If the launcher cannot fetch the pinned CLI
+from `trunk.io`, a probe run after the command fails
+(`TRUNK_LAUNCHER_QUIET=true ./tools/trunk --version`) answers that directly. If
+the launcher succeeds but the CLI cannot fetch its plugin sources or the
+hermetic runtimes and linter binaries a check needs — `trunk.io` allowlisted,
+`github.com` and `nodejs.org` not — the gate classifies the check transcript
+instead. That classification never infers "nothing was found": it accepts the
+transcript only when Trunk itself reported no issues, every failure Trunk
+counted is a download step, and the reason each step recorded in its
+`.trunk/out/*.yaml` detail file is one of Trunk's download-failure phrasings.
+The warning replays those reasons so it names the host to allowlist. Everything
+else fails the gate, including a partly-explained failure set and a download
+step that failed for a local reason. Only a provisioning failure degrades: a
+provisioned Trunk that finds real problems still fails the gate, and so does a
+run that mixes real findings with a blocked download. A run whose Trunk arm was
+skipped writes no whole-run success stamp, so the next `--skip-if-fresh` run
+retries Trunk instead of inheriting a pass it never earned. Normal `--run` mode
+executes independent
 quality-phase commands with
 bounded parallelism (`--parallel <n>`, default `auto` capped at 4 workers, or
 `AGENT_QUALITY_PARALLELISM`). Preflight, codegen, post-codegen install,

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -1261,7 +1261,8 @@ quality/serialized/parallel commands are stamped. Prerequisite phases
 generated code, built packages) are invisible to the source fingerprint, so a
 stamp could skip them after their outputs were deleted. The Trunk check, the
 gate self-test, and the advisory ADR reminder also always re-run — the Trunk
-check is skipped, never reused, where the CLI cannot be provisioned.
+check is skipped, never reused, where Trunk's downloads are blocked (the CLI,
+its plugin sources, or the linters a check needs).
 
 Each mapped command has a watchdog (default 1500 seconds; override with
 `--command-timeout <n>` or `AGENT_QUALITY_COMMAND_TIMEOUT_SECONDS`). On timeout

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2530,6 +2530,7 @@ trunk_network_failure_signatures=(
   'Could resolve but could not establish connection to host of'
 )
 
+# True when any measured download-failure phrasing appears in the given text.
 trunk_text_has_network_failure_signature() {
   local text="$1"
   local signature
@@ -2549,6 +2550,12 @@ trunk_text_has_network_failure_signature() {
 # reason it records is a download failure. The path comes from Trunk's own
 # output, so it is accepted only in the exact shape Trunk emits — a plain file
 # directly under .trunk/out — and never followed anywhere else.
+#
+# Scoped to `report:` and nothing else. This is one of the two checks that decide
+# whether a failure may be excused, and the classifier's rule is to verify
+# exactly rather than infer: a bullet under some other key must never be able to
+# supply the signature that `report:` did not. A `report:` block Trunk writes in
+# some other shape yields nothing here, which rejects.
 trunk_detail_yaml_reports_network_failure() {
   local yaml_path="$1"
   local report
@@ -2556,12 +2563,29 @@ trunk_detail_yaml_reports_network_failure() {
   is_trunk_detail_yaml_path "$yaml_path" || return 1
   [[ -f "$yaml_path" ]] || return 1
 
-  report="$(awk '/^[[:space:]]*- /{print}' "$yaml_path" 2>/dev/null || true)"
+  report="$(trunk_detail_yaml_report_lines "$yaml_path")"
   [[ -n "$report" ]] || return 1
 
   trunk_text_has_network_failure_signature "$report"
 }
 
+# The bullet lines under this YAML's top-level `report:` key, in order. A
+# top-level key is one that starts in column 0, so the block ends at the next
+# one.
+trunk_detail_yaml_report_lines() {
+  local yaml_path="$1"
+
+  awk '
+    /^[^[:space:]]/ {
+      in_report = ($0 ~ /^report:[[:space:]]*$/)
+      next
+    }
+    in_report && /^[[:space:]]+-[[:space:]]/ { print }
+  ' "$yaml_path" 2>/dev/null || true
+}
+
+# True when the path is exactly the shape Trunk writes its failure details to:
+# a plain file directly under .trunk/out, with no traversal.
 is_trunk_detail_yaml_path() {
   local yaml_path="$1"
 
@@ -2792,10 +2816,12 @@ print_trunk_provisioning_failure_causes() {
       printed=$((printed + 1))
       printf '  %.240s\n' "  ${detail}" >&2
     done < <(
-      awk '
-        /^title:/ { sub(/^title:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; next }
-        /^[[:space:]]*- / { sub(/^[[:space:]]*-[[:space:]]*/, ""); gsub(/^"|"$/, ""); print }
-      ' "$yaml_path" 2>/dev/null | head -n 4
+      {
+        awk '/^title:/ { sub(/^title:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; exit }' \
+          "$yaml_path" 2>/dev/null || true
+        trunk_detail_yaml_report_lines "$yaml_path" |
+          sed -e 's/^[[:space:]]*-[[:space:]]*//' -e 's/^"//' -e 's/"$//'
+      } | head -n 4
     )
   done < <(summarize_trunk_check_transcript "$output_file")
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2521,12 +2521,17 @@ trunk_provisioning_is_blocked() {
 # Trunk's own wording for a failed download, as recorded in the detail YAML the
 # failed step writes. Measured against Trunk 1.25.0 with the download forced to
 # fail three ways: connection refused, a 403-returning forward proxy (what an
-# egress allowlist does), and an unresolvable proxy host. The first two produce
-# `Curl Error: ...`; the third produced the longer phrasing. A cause Trunk
-# phrases some other way stays unclassified on purpose — an unrecognized reason
-# fails the gate instead of being excused.
+# egress allowlist does), and an unresolvable proxy host.
+#
+# Each entry is a whole measured phrase, never the bare `Curl Error:` prefix.
+# Trunk reports a removed or renamed artifact under that same prefix, and a 404
+# is a broken pin the operator has to fix, not an allowlist to widen — matching
+# the prefix would excuse it. A cause Trunk phrases some other way stays
+# unclassified on purpose: an unrecognized reason fails the gate rather than
+# being excused, and the fix is to measure it and add it here.
 trunk_network_failure_signatures=(
-  'Curl Error:'
+  'Curl Error: Failure when receiving data from the peer'
+  'Curl Error: Could not resolve proxy name'
   'Could resolve but could not establish connection to host of'
 )
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2337,6 +2337,15 @@ failure_output_tail_lines=20
 # Trunk launcher provisioning verdict for this run: "" (not probed yet), "ok",
 # or "blocked". Probed at most once, and only after a Trunk command failed.
 trunk_provisioning_state=""
+# True once any Trunk arm in this run was downgraded to "skipped" because the
+# environment blocked provisioning. Separate from trunk_provisioning_state
+# because the launcher probe answers a question about the LAUNCHER and is
+# cached, while a blocked linter download is classified per arm from that arm's
+# own output. Drives the closing note and the whole-run stamp guard.
+trunk_arm_environment_blocked=false
+# Which provisioning stage blocked the arm currently being classified:
+# "launcher" (no CLI at all) or "linters" (CLI ran, its downloads failed).
+trunk_environment_blocked_kind=""
 
 format_duration() {
   local seconds="$1"
@@ -2495,7 +2504,308 @@ trunk_provisioning_is_blocked() {
   [[ "$trunk_provisioning_state" == blocked ]]
 }
 
+# Trunk downloads more than its own CLI. The launcher self-installs the pinned
+# CLI from trunk.io; that CLI then fetches plugin sources from github.com and,
+# on every check, the hermetic runtimes and linter binaries the enabled linters
+# need (nodejs.org, each linter's release host). An environment that allowlists
+# trunk.io but not those hosts provisions the launcher — `--version` succeeds,
+# so the probe above reports "ok" — and still fails every `trunk check`.
+#
+# Classifying that from the check output has one hard requirement: a real lint
+# finding must never be excused as an environment failure. So the classifier
+# never infers "nothing was found"; it only accepts output in which Trunk
+# ITSELF states that it found nothing and that every failure it counted was a
+# download step. Anything it cannot account for exactly leaves the failure
+# standing.
+#
+# Trunk's own wording for a failed download, as recorded in the detail YAML the
+# failed step writes. Measured against Trunk 1.25.0 with the download forced to
+# fail three ways: connection refused, a 403-returning forward proxy (what an
+# egress allowlist does), and an unresolvable proxy host. The first two produce
+# `Curl Error: ...`; the third produced the longer phrasing. A cause Trunk
+# phrases some other way stays unclassified on purpose — an unrecognized reason
+# fails the gate instead of being excused.
+trunk_network_failure_signatures=(
+  'Curl Error:'
+  'Could resolve but could not establish connection to host of'
+)
+
+trunk_text_has_network_failure_signature() {
+  local text="$1"
+  local signature
+
+  for signature in "${trunk_network_failure_signatures[@]}"; do
+    case "$text" in
+      *"$signature"*)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+# Read the `report:` lines of one Trunk failure-detail YAML and say whether the
+# reason it records is a download failure. The path comes from Trunk's own
+# output, so it is accepted only in the exact shape Trunk emits — a plain file
+# directly under .trunk/out — and never followed anywhere else.
+trunk_detail_yaml_reports_network_failure() {
+  local yaml_path="$1"
+  local report
+
+  is_trunk_detail_yaml_path "$yaml_path" || return 1
+  [[ -f "$yaml_path" ]] || return 1
+
+  report="$(awk '/^[[:space:]]*- /{print}' "$yaml_path" 2>/dev/null || true)"
+  [[ -n "$report" ]] || return 1
+
+  trunk_text_has_network_failure_signature "$report"
+}
+
+is_trunk_detail_yaml_path() {
+  local yaml_path="$1"
+
+  [[ "$yaml_path" =~ ^\.trunk/out/[A-Za-z0-9._-]+\.yaml$ ]] || return 1
+  [[ "$yaml_path" == *".."* ]] && return 1
+  return 0
+}
+
+# Reduce a failed `trunk check` transcript to the facts the classifier needs.
+# Emits, on stdout, zero or more of:
+#   shape=tools           Trunk reported zero issues and N counted failures,
+#                         and exactly N rows were download steps naming a
+#                         detail YAML.
+#   yaml=<path>           one per such row.
+#   shape=plugin          every non-blank line was a plugin-download error.
+#   plugincause=<text>    one per such line.
+# It emits nothing when the transcript shows findings, an unexplained failure,
+# or any line it cannot account for.
+summarize_trunk_check_transcript() {
+  local output_file="$1"
+
+  awk '
+    function strip(s) {
+      gsub(/\033\[[0-9;?]*[a-zA-Z]/, "", s)
+      gsub(/\r/, "", s)
+      return s
+    }
+    BEGIN {
+      cross = "\342\234\226"
+      disqualified = 0
+      declared = -1
+      rows = 0
+      plugins = 0
+      nonblank = 0
+    }
+    {
+      line = strip($0)
+      sub(/[ \t]+$/, "", line)
+      if (line ~ /^[ \t]*$/) next
+      nonblank++
+
+      trimmed = line
+      sub(/^[ \t]+/, "", trimmed)
+
+      # These section headers appear only when Trunk has something to report
+      # about the code itself. Their presence alone disqualifies the run.
+      if (trimmed == "ISSUES" || trimmed == "AUTOFIXES") {
+        disqualified = 1
+        next
+      }
+
+      if (index(line, cross) == 1) {
+        rest = substr(line, length(cross) + 1)
+        sub(/^ /, "", rest)
+
+        if (rest ~ /^No issues, [0-9]+ failures?$/) {
+          if (declared >= 0) { disqualified = 1; next }
+          n = rest
+          sub(/^No issues, /, "", n)
+          sub(/ failures?$/, "", n)
+          declared = n + 0
+          next
+        }
+
+        if (rest ~ /^Unable to download plugin .+: .+$/) {
+          plugins++
+          # Kept whole: the URL names the host that has to be allowlisted, and
+          # the reason after it is what the signature check reads.
+          causes[plugins] = rest
+          pluginline[nonblank] = 1
+          next
+        }
+
+        # Any other verdict line is a claim about the code. Stop.
+        disqualified = 1
+        next
+      }
+
+      # A FAILURES-table row for a step that had to fetch something. The last
+      # field is the detail YAML Trunk wrote for it.
+      if (line ~ /^[ \t]/ &&
+          (index(line, "Installing hermetic tool ") > 0 ||
+           index(line, "Downloading hermetic ") > 0)) {
+        $0 = line
+        if ($NF ~ /^\.trunk\/out\/[A-Za-z0-9._-]+\.yaml$/) {
+          rows++
+          yamls[rows] = $NF
+          next
+        }
+      }
+    }
+    END {
+      if (disqualified) exit 0
+
+      # Shape 1: Trunk ran, found nothing, and every failure it counted is a
+      # download step we recognized. An unaccounted failure means rows < declared.
+      if (declared >= 1 && rows == declared) {
+        print "shape=tools"
+        for (i = 1; i <= rows; i++) print "yaml=" yamls[i]
+        exit 0
+      }
+
+      # Shape 2: Trunk could not fetch its plugin sources, so it never linted
+      # anything. Accepted only when the transcript holds nothing else at all.
+      if (plugins >= 1 && declared < 0 && rows == 0) {
+        for (i = 1; i <= nonblank; i++) {
+          if (!(i in pluginline)) exit 0
+        }
+        print "shape=plugin"
+        for (i = 1; i <= plugins; i++) print "plugincause=" causes[i]
+      }
+    }
+  ' "$output_file"
+}
+
+# True when a failed `trunk check` is provably an environment provisioning
+# failure with no lint findings behind it.
+trunk_check_output_is_environment_blocked() {
+  local output_file="$1"
+  local shape=""
+  local line
+  local value
+  local evidence=0
+
+  [[ -n "$output_file" && -s "$output_file" ]] || return 1
+
+  while IFS= read -r line; do
+    case "$line" in
+      shape=*)
+        shape="${line#shape=}"
+        ;;
+      yaml=*)
+        value="${line#yaml=}"
+        trunk_detail_yaml_reports_network_failure "$value" || return 1
+        evidence=$((evidence + 1))
+        ;;
+      plugincause=*)
+        value="${line#plugincause=}"
+        trunk_text_has_network_failure_signature "$value" || return 1
+        evidence=$((evidence + 1))
+        ;;
+    esac
+  done < <(summarize_trunk_check_transcript "$output_file")
+
+  [[ -n "$shape" && "$evidence" -ge 1 ]]
+}
+
+# The single question both run paths ask about a failed Trunk arm. Sets
+# trunk_environment_blocked_kind for the warning and latches the run-level flag
+# the closing note and the stamp guard read.
+trunk_arm_is_environment_blocked() {
+  local output_file="$1"
+
+  trunk_environment_blocked_kind=""
+
+  if trunk_provisioning_is_blocked; then
+    trunk_environment_blocked_kind=launcher
+  elif trunk_check_output_is_environment_blocked "$output_file"; then
+    trunk_environment_blocked_kind=linters
+  else
+    return 1
+  fi
+
+  trunk_arm_environment_blocked=true
+  return 0
+}
+
 print_trunk_environment_blocked_warning() {
+  local command="$1"
+  local output_file="${2:-}"
+
+  if [[ "$trunk_environment_blocked_kind" == linters ]]; then
+    print_trunk_linter_environment_blocked_warning "$command" "$output_file"
+    return
+  fi
+
+  print_trunk_launcher_environment_blocked_warning "$command"
+}
+
+print_trunk_linter_environment_blocked_warning() {
+  local command="$1"
+  local output_file="$2"
+
+  echo "warning: skipping ${command} — Trunk could not provision its linters." >&2
+  echo "  The CLI itself is installed — the launcher probe succeeded — but Trunk downloads each" >&2
+  echo "  hermetic runtime and linter binary it needs, and every step that had to fetch one" >&2
+  echo "  failed with a download error. Trunk reported no issues, so no finding is being" >&2
+  echo "  discarded here; it never got a linter to run." >&2
+  echo "  This is what an environment that allows 'trunk.io' but not the download hosts does." >&2
+  echo "  Add the hosts named below to the environment's allowed domains to run it here." >&2
+  print_trunk_provisioning_failure_causes "$output_file"
+  echo "  CI still enforces Trunk on the PR (.github/workflows/trunk.yml)." >&2
+}
+
+# Replay what Trunk recorded for each failed download step. The step row names
+# only the step; the host and the reason live in the detail YAML, and without
+# them the warning cannot say which domain to allowlist. Bounded on every axis
+# because the text comes from a subprocess.
+print_trunk_provisioning_failure_causes() {
+  local output_file="$1"
+  local line
+  local yaml_path
+  local detail
+  local printed=0
+
+  [[ -n "$output_file" && -s "$output_file" ]] || return 0
+
+  while IFS= read -r line; do
+    [[ "$printed" -lt 8 ]] || break
+    case "$line" in
+      yaml=*)
+        yaml_path="${line#yaml=}"
+        ;;
+      plugincause=*)
+        printed=$((printed + 1))
+        printf '  %.240s\n' "  ${line#plugincause=}" >&2
+        continue
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    is_trunk_detail_yaml_path "$yaml_path" || continue
+    [[ -f "$yaml_path" ]] || continue
+    while IFS= read -r detail; do
+      [[ "$printed" -lt 8 ]] || break
+      printed=$((printed + 1))
+      printf '  %.240s\n' "  ${detail}" >&2
+    done < <(
+      awk '
+        /^title:/ { sub(/^title:[[:space:]]*/, ""); gsub(/^"|"$/, ""); print; next }
+        /^[[:space:]]*- / { sub(/^[[:space:]]*-[[:space:]]*/, ""); gsub(/^"|"$/, ""); print }
+      ' "$yaml_path" 2>/dev/null | head -n 4
+    )
+  done < <(summarize_trunk_check_transcript "$output_file")
+
+  # The parallel run path calls this under `set -e`, and it is not the last
+  # statement in its caller. A loop that ends on a failed match would otherwise
+  # abort the run at the exact moment the gate is trying to degrade gracefully.
+  return 0
+}
+
+print_trunk_launcher_environment_blocked_warning() {
   local command="$1"
   echo "warning: skipping ${command} — the Trunk CLI could not be provisioned." >&2
   echo "  The launcher self-downloads the pinned CLI from trunk.io and could not produce a" >&2
@@ -2956,9 +3266,9 @@ run_mapped_command() {
   fi
 
   if [[ "$timed_out" != true ]] && is_trunk_command "$command" &&
-    trunk_provisioning_is_blocked; then
+    trunk_arm_is_environment_blocked "$output_file"; then
     record_command_summary "skipped" "$elapsed" "$command"
-    print_trunk_environment_blocked_warning "$command"
+    print_trunk_environment_blocked_warning "$command" "$output_file"
     rm -f "$output_file"
     return 0
   fi
@@ -3277,9 +3587,9 @@ run_mapped_entries_parallel() {
         fi
         echo "✓ ${command} ($(format_duration "$elapsed"))"
       elif [[ "$timed_out" != true ]] && is_trunk_command "$command" &&
-        trunk_provisioning_is_blocked; then
+        trunk_arm_is_environment_blocked "$output_file"; then
         record_command_summary "skipped" "$elapsed" "$command"
-        print_trunk_environment_blocked_warning "$command"
+        print_trunk_environment_blocked_warning "$command" "$output_file"
       else
         failures=$((failures + 1))
         record_command_summary "fail" "$elapsed" "$command"
@@ -3460,10 +3770,10 @@ log_duration_line "ok" "$gate_total_elapsed" "__run_total__" "run" || true
 
 echo
 echo "All mapped commands passed."
-if [[ "$trunk_provisioning_state" == blocked ]]; then
-  echo "Note: the Trunk arm was skipped because the CLI could not be provisioned here; CI still enforces it."
+if [[ "$trunk_arm_environment_blocked" == true ]]; then
+  echo "Note: the Trunk arm was skipped because it could not be provisioned here; CI still enforces it."
 fi
-if [[ "${stamp_reuse_count:-0}" -eq 0 && "$trunk_provisioning_state" != "blocked" ]]; then
+if [[ "${stamp_reuse_count:-0}" -eq 0 && "$trunk_arm_environment_blocked" != true ]]; then
   # Only a fully-executed green run earns the whole-run fast-path stamp. A
   # resumed run reused work whose real age lives in the per-command stamps;
   # re-dating it here would let --skip-if-fresh extend validation reuse past

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -4968,6 +4968,304 @@ rm -rf "$trunk_blocked_stamp_repo"
 assert_not_contains "skipping mapped commands"
 assert_contains "All mapped commands passed."
 assert_contains "Note: the Trunk arm was skipped"
+
+# The launcher is only Trunk's FIRST download. Once it has produced a CLI, that
+# CLI fetches plugin sources and, per check, the hermetic runtimes and linter
+# binaries the enabled linters need. An environment that allowlists trunk.io but
+# not those hosts answers the provisioning probe with a working `--version` and
+# still fails every check, which used to hard-fail the gate with no way out.
+#
+# Every transcript below is the real output of Trunk 1.25.0, captured by seeding
+# a hermetic TRUNK_CACHE with the CLI and then forcing its downloads to fail
+# (connection refused, a 403-returning forward proxy, an unresolvable proxy
+# host). The stubs replay it byte for byte, ANSI included, because the classifier
+# reads that text.
+trunk_blocked_linter_repo="$(mktemp -d)"
+(
+  cd "$trunk_blocked_linter_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools .trunk
+  # Trunk writes its failure details into .trunk/out, which every Trunk repo
+  # ignores (see this repo's .trunk/.gitignore). The fixture is run more than
+  # once, so it has to ignore them too or the second run would map a different
+  # command set than the first.
+  printf '*out\n' > .trunk/.gitignore
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+# A provisioned CLI: the launcher probe succeeds, so only the check verdict is
+# in question. The check then fails because it could not install a linter.
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/ERGzk.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+report:
+  - "Curl Error: Failure when receiving data from the peer for https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\n\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' \033[1mshellcheck\033[22m  \033[1mInstalling hermetic tool shellcheck v0.11.0\033[22m  .trunk/out/ERGzk.yaml\n'
+printf '\n\033[1m\033[30m\033[107m  NOTICES  \033[0m\n\n'
+printf ' A tool failed to run. You can open the details yaml file for more information.\n'
+printf '\nChecked 0 files\n'
+printf '\033[1m\033[91m\342\234\226 No issues, 1 failure\033[0m\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+)
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+assert_contains "The CLI itself is installed — the launcher probe succeeded"
+# The warning must say what it established and nothing more. Trunk stated it
+# found no issues, and that statement is why the downgrade is safe.
+assert_contains "Trunk reported no issues, so no finding is being"
+# The failure row names only the step; the host that has to be allowlisted lives
+# in the detail YAML, so the warning replays it or it names no fix at all.
+assert_contains "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+assert_contains "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/"
+assert_contains "- skipped "
+assert_contains "All mapped commands passed."
+assert_contains "Note: the Trunk arm was skipped"
+assert_not_contains "mapped command(s) failed."
+
+# Same degradation on the sequential path.
+(
+  cd "$trunk_blocked_linter_repo"
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run --fail-fast > "$output_file" 2>&1
+)
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+assert_contains "All mapped commands passed."
+assert_not_contains "Stopping after first failed mapped command (--fail-fast)."
+
+# Same stamp rule as the launcher case: a run that skipped Trunk because its
+# linters could not be downloaded must not leave a clean whole-run stamp, or the
+# next --skip-if-fresh run would inherit a pass Trunk never gave.
+(
+  cd "$trunk_blocked_linter_repo"
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run --skip-if-fresh > "$output_file" 2>&1
+)
+rm -rf "$trunk_blocked_linter_repo"
+assert_not_contains "skipping mapped commands"
+assert_contains "All mapped commands passed."
+assert_contains "Note: the Trunk arm was skipped"
+
+# Trunk aborts before linting anything when it cannot fetch its plugin sources,
+# so that transcript holds one error line and nothing else. Real output, exit 2.
+trunk_blocked_plugin_repo="$(mktemp -d)"
+(
+  cd "$trunk_blocked_plugin_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+printf '\033[0G\033[2K\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: Could resolve but could not establish connection to host of https://github.com/trunk-io/plugins/archive/v1.7.5.zip\033[0m\n'
+exit 2
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+)
+rm -rf "$trunk_blocked_plugin_repo"
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+assert_contains "Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip"
+assert_contains "All mapped commands passed."
+assert_not_contains "mapped command(s) failed."
+
+# The invariant, restated against the new path: a Trunk that found a real problem
+# must fail the gate even when a linter download failed in the same run. This is
+# the transcript that would break the invariant if the classifier inferred "no
+# findings" from the presence of a download failure instead of reading Trunk's
+# own verdict — here Trunk never says "No issues", and it reports both counts.
+trunk_mixed_failure_repo="$(mktemp -d)"
+(
+  cd "$trunk_mixed_failure_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/DgQ3M.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+report:
+  - "Curl Error: Failure when receiving data from the peer for https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\033[1m\033[30m\033[107m  ISSUES  \033[0m\n\nfixture.js\n'
+printf " -:-  fmt  trunk-real-problem, autoformat by running 'trunk fmt'  prettier\n"
+printf '\n\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' shellcheck  Installing hermetic tool shellcheck v0.11.0  .trunk/out/DgQ3M.yaml\n'
+printf '\nChecked 1 file\n'
+printf '\033[1m\033[91m\342\234\226 1 unformatted file\033[0m\n'
+printf '\033[1m\033[91m\342\234\226 1 failure\033[0m\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_mixed_failure_repo"
+assert_contains "1 mapped command(s) failed."
+assert_contains "trunk-real-problem"
+assert_not_contains "- skipped "
+assert_not_contains "Trunk could not provision its linters."
+
+# Fail closed on anything the classifier cannot account for exactly. Trunk
+# counted two failures and only one of them is a download step, so the other is
+# an unexplained failure and the run must fail.
+trunk_partial_failure_repo="$(mktemp -d)"
+(
+  cd "$trunk_partial_failure_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/ERGzk.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+report:
+  - "Curl Error: Failure when receiving data from the peer for https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' shellcheck    Installing hermetic tool shellcheck v0.11.0  .trunk/out/ERGzk.yaml\n'
+printf ' markdownlint  markdownlint exited with code 134            .trunk/out/zzzzz.yaml\n'
+printf '\nChecked 0 files\n'
+printf '\342\234\226 No issues, 2 failures\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_partial_failure_repo"
+assert_contains "1 mapped command(s) failed."
+assert_contains "markdownlint exited with code 134"
+assert_not_contains "- skipped "
+
+# Fail closed on a cause Trunk did not phrase as a download failure. The step is
+# a download step and Trunk found nothing, but a checksum mismatch is a local
+# problem the operator has to see, not an allowlist to widen.
+trunk_local_cause_repo="$(mktemp -d)"
+(
+  cd "$trunk_local_cause_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/ERGzk.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+report:
+  - "sha256 mismatch for shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' shellcheck  Installing hermetic tool shellcheck v0.11.0  .trunk/out/ERGzk.yaml\n'
+printf '\nChecked 0 files\n'
+printf '\342\234\226 No issues, 1 failure\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_local_cause_repo"
+assert_contains "1 mapped command(s) failed."
+# The transcript is otherwise identical to the accepted one, so the only thing
+# that kept the failure standing is the cause recorded in the detail YAML.
+assert_contains "Installing hermetic tool shellcheck v0.11.0"
+assert_not_contains "- skipped "
+assert_not_contains "Trunk could not provision its linters."
+
+# Fail closed on a plain non-zero exit that says nothing at all. No verdict, no
+# failure table, nothing to classify — the failure stands.
+trunk_silent_failure_repo="$(mktemp -d)"
+(
+  cd "$trunk_silent_failure_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+echo "trunk-ambiguous-exit"
+exit 3
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_silent_failure_repo"
+assert_contains "1 mapped command(s) failed."
+assert_contains "trunk-ambiguous-exit"
+assert_not_contains "- skipped "
 } # end family: failure-output
 
 # family: routing-docs

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5233,6 +5233,55 @@ assert_contains "Installing hermetic tool shellcheck v0.11.0"
 assert_not_contains "- skipped "
 assert_not_contains "Trunk could not provision its linters."
 
+# The signature has to come from the step's own recorded reason, so a bullet
+# under some other key must not be able to supply it. Same transcript as the
+# accepted case; the only difference is that the download-failure phrasing sits
+# under an unrelated list-valued key while `report:` records a local cause. The
+# run must fail.
+trunk_foreign_key_signature_repo="$(mktemp -d)"
+(
+  cd "$trunk_foreign_key_signature_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/ERGzk.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+related_files:
+  - "Curl Error: this bullet is not the recorded reason"
+report:
+  - "sha256 mismatch for shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' shellcheck  Installing hermetic tool shellcheck v0.11.0  .trunk/out/ERGzk.yaml\n'
+printf '\nChecked 0 files\n'
+printf '\342\234\226 No issues, 1 failure\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_foreign_key_signature_repo"
+assert_contains "1 mapped command(s) failed."
+assert_not_contains "- skipped "
+assert_not_contains "Trunk could not provision its linters."
+
 # Fail closed on a plain non-zero exit that says nothing at all. No verdict, no
 # failure table, nothing to classify — the failure stands.
 trunk_silent_failure_repo="$(mktemp -d)"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5233,6 +5233,52 @@ assert_contains "Installing hermetic tool shellcheck v0.11.0"
 assert_not_contains "- skipped "
 assert_not_contains "Trunk could not provision its linters."
 
+# Trunk reports a removed or renamed artifact under the same `Curl Error:`
+# prefix as a blocked connection. A 404 is a broken pin the operator has to fix,
+# so the accepted signatures are whole measured phrases and this one is not among
+# them: the run must fail.
+trunk_http_error_cause_repo="$(mktemp -d)"
+(
+  cd "$trunk_http_error_cause_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+mkdir -p .trunk/out
+cat > .trunk/out/ERGzk.yaml <<'YAML'
+trunk_cli_version: 1.25.0
+title: "Error while executing: Installing hermetic tool shellcheck v0.11.0"
+report:
+  - "Curl Error: HTTP response code said error for https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.x86_64.tar.xz"
+YAML
+printf '\033[1m\033[30m\033[107m  FAILURES  \033[0m\n\n'
+printf ' shellcheck  Installing hermetic tool shellcheck v0.11.0  .trunk/out/ERGzk.yaml\n'
+printf '\nChecked 0 files\n'
+printf '\342\234\226 No issues, 1 failure\n'
+exit 1
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_http_error_cause_repo"
+assert_contains "1 mapped command(s) failed."
+assert_not_contains "- skipped "
+assert_not_contains "Trunk could not provision its linters."
+
 # The signature has to come from the step's own recorded reason, so a bullet
 # under some other key must not be able to supply it. Same transcript as the
 # accepted case; the only difference is that the download-failure phrasing sits


### PR DESCRIPTION
## The Problem

- The gate could downgrade a failed `./tools/trunk check` to `skipped` only when
  the launcher could not download the pinned CLI. That covers one of Trunk's two
  download stages.
- Trunk downloads again after the launcher succeeds: the CLI fetches its plugin
  sources from `github.com`, and each check installs the hermetic runtimes and
  linter binaries the enabled linters need. An environment that allowlists
  `trunk.io` but not those hosts answers the provisioning probe with a working
  `--version` and still fails every check.
- In that environment the gate hard-failed with no way out — an agent in a Claude
  cloud container could not get a green gate at all, even with nothing wrong in
  the diff.

## The Solution

The gate now also classifies the failed check's own transcript, and reports the
arm as `skipped` with a warning naming the hosts to allowlist when that
transcript is provably a blocked download. The operator gets a runnable gate in a
restricted container instead of a failure they cannot act on, and the warning
quotes Trunk's own reason for each failed download so it names the exact host.

The standing invariant is unchanged and is the constraint the classifier is built
around: a provisioned Trunk that finds real problems still fails the gate. The
classifier never infers "nothing was found". It accepts a transcript only when
Trunk itself reported no issues, every failure Trunk counted is a download step,
and the reason each step recorded is one of Trunk's download-failure phrasings.
Anything it cannot account for exactly leaves the failure standing, so a run that
mixes real findings with a blocked download fails, and so does a download that
failed for a local reason such as a checksum mismatch.

Material limit: the detection strings come from a local forced-block repro, not
from a live Claude cloud container. See Deferrals.

## Details

Detection extends the existing degradation machinery rather than adding a
parallel path. `trunk_arm_is_environment_blocked` is the single question both the
sequential and parallel run paths ask about a failed Trunk arm: it asks the
cached launcher probe first, then falls back to classifying that arm's output.

The classifier (`summarize_trunk_check_transcript` plus
`trunk_check_output_is_environment_blocked`) accepts two transcript shapes:

- **Blocked runtime or linter install.** Trunk printed `✖ No issues, N failure(s)`
  — its own statement that it found nothing — and exactly N rows in its FAILURES
  table are download steps (`Installing hermetic tool …`, `Downloading hermetic
  …`) naming a `.trunk/out/*.yaml` detail file. Every one of those files must
  record a download failure in its `report:` lines.
- **Blocked plugin source.** Trunk aborted before linting anything, so every
  non-blank line in the transcript is `✖ Unable to download plugin <url>: <cause>`
  with a download-failure cause.

Everything else fails the gate. The disqualifiers are explicit: an `ISSUES` or
`AUTOFIXES` section header, any other `✖` verdict line, a failure count larger
than the number of recognized download rows, a detail file whose recorded reason
is not a download failure, and a bare non-zero exit with nothing to classify.
ANSI escapes are stripped before matching, because Trunk emits them even when its
output is a pipe.

The accepted reason strings are `Curl Error:` and `Could resolve but could not
establish connection to host of`. Both are measured, not guessed — see
Validation. A reason Trunk phrases some other way stays unclassified on purpose:
an unrecognized reason fails the gate rather than being excused as "environment".

Detail-file paths come from Trunk's own output, so they are accepted only in the
exact shape Trunk emits (a plain file directly under `.trunk/out`) and are never
followed anywhere else. The replayed reasons are bounded in count and line
length because the text comes from a subprocess.

The whole-run stamp rule is preserved and now keyed on a run-level flag
(`trunk_arm_environment_blocked`) rather than the launcher probe's cached
verdict, so a run skipped for either reason writes no clean whole-run stamp and
the next `--skip-if-fresh` run retries Trunk instead of inheriting a pass it
never earned. The launcher probe stays cached per run; the linter classification
is per arm, so one blocked arm cannot silently excuse a later arm that could
still have found something.

`docs/notes/agent-quality-gate-mechanics.md` is updated in both places that
described the old single-stage behavior.

## Validation

- Captured the real failure output first, from Trunk 1.25.0 driven against a
  hermetic `TRUNK_CACHE`, rather than guessing strings. Seeding the cache with
  the CLI and then blocking downloads reproduces exactly the reported failure
  mode: `TRUNK_LAUNCHER_QUIET=true ./tools/trunk --version` exits 0 while
  `./tools/trunk check` fails.
- Forced the downloads to fail three ways to widen the measured reason set:
  connection refused (`HTTPS_PROXY=http://127.0.0.1:9`), a 403-returning forward
  proxy (what an egress allowlist does), and an unresolvable proxy host. The
  first two produce `Curl Error: …`; the third produced the longer phrasing.
  Both strings in the implementation come from those transcripts.
- Captured the two control transcripts the invariant depends on: a fully
  provisioned Trunk reporting real findings, and a mixed run where one linter
  found a real problem while another linter's download was blocked. The gate
  fails on both.
- `bash scripts/agent-quality-gate.test.sh` — full suite passes. New cases in the
  `failure-output` family: blocked linter install degrades on both the parallel
  and `--fail-fast` paths; the skipped run writes no clean whole-run stamp;
  blocked plugin source degrades; the mixed real-finding transcript fails; a
  partly-explained failure set fails; a download step with a local cause fails;
  a bare non-zero exit fails.
- `bash scripts/agent-quality-gate.sh --run --parallel 4 --base origin/main` —
  passes; all ten mapped commands green, including the full gate self-test. The
  pre-push hook ran the same gate again against the pushed head.
- `./tools/trunk check --no-fix` on all touched files — no issues.

## Deferrals

- #2057 — measuring this in a live Claude cloud container is deferred to the next
  cloud session, because this session cannot launch one. The evidence will appear
  in `.claude/logs/web-setup.log` and in the gate's skip warning, which names the
  host and the reason Trunk recorded — enough to confirm the reason string
  matches, or to add the one it does not.
- #2059 — `.trunk/hooks/pre-commit` and `.trunk/hooks/pre-push` still classify
  only the launcher, so a blocked download can still reject a commit or push on a
  tree the gate now passes. Raised in review. Deferred because the fix is a
  different surface with its own design question (extract a shared classifier vs
  duplicate it) and its own `TRUNK_HOOK_REQUIRE` semantics.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this extends an existing
      degradation path under its existing invariant.

Closes #2043


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quality-gate handling of download failures by distinguishing environment-related network issues from missing or renamed artifacts.
  * HTTP errors, including missing downloads, now correctly fail the quality gate instead of being skipped.
  * Runs skipped due to recognized environment download problems no longer receive freshness stamps.

* **Documentation**
  * Expanded guidance for download-blocked environments and quality-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->