### PR TITLE
fix(gate): refuse lock reclaims on roots that are not local storage

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -645,13 +645,22 @@ holder's record lets the next waiter publish its own beside work that is still
 running — the overlap this lock exists to prevent. Establish first, on the
 machine that wrote the record, that its `pid` is gone and that its mapped
 commands are gone with it: the holder is named by `pid` and `host`, and its
-commands are tagged with the record's `token`. Then check that nothing is still
-owed for it — `<root>/condemned.d` holds the tokens of runs whose commands the
-next holder must drain, and `<root>/captured.<token>` holds a captured process
-tree — and drain or clear those before the record goes, because deleting the
-record deletes the only handle to them. When the holder cannot be reached to be
-checked, the record stays: waiting costs a wait, and guessing costs the
-guarantee.
+commands carry the tag `agentqg:<token>` from the record's `token` field. That
+token is the reason this is not a plain delete — a gate shell's mapped commands
+outlive it, and the record is the only thing naming them until some run condemns
+it, so removing the record while they run discards the handle as well as the
+exclusion.
+
+The obligations already written for a run are a separate matter, and they are
+not at risk from removing the record: `<root>/condemned.d` and
+`<root>/captured.<token>` sit beside the lock rather than inside it, exactly so
+they outlive the reclaim, and `drain_condemned_runs` finds them by scanning that
+directory rather than by following any record. They are the durable evidence, so
+the hazard runs the other way — clear one only after its processes are confirmed
+gone, and never as part of tidying up the lock.
+
+When the holder cannot be reached to be checked, the record stays: waiting costs
+a wait, and guessing costs the guarantee.
 
 #### Crash points
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -574,6 +574,19 @@ so a freshly written owner file can stay invisible to another client for longer
 than the `AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS` that would otherwise
 authorise taking the lock away.
 
+A remnant left by an interrupted reclaim is left alone there too, rather than
+deleted. `gate_lock_recover_hidden_record` classifies remnants by the same local
+PID lookup, so off local storage it cannot call one dead; deleting it would
+destroy the only copy of a possibly-live holder's record and leave the lock
+ownerless, which is precisely the state such a root can no longer reclaim. A
+remnant naming a locally-live holder is still linked back to the canonical
+path — that direction only restores evidence.
+
+The refusal also owns the wait's ending. A run that timed out because a reclaim
+was refused is told that nothing was reclaimed and that the record may need
+removing by hand, instead of the usual "holder is still alive; let it finish" —
+which would send an operator to wait on a process this run already read as gone.
+
 The cost is that a lock root on network storage no longer self-heals — a holder
 killed there wedges the root until a human removes the record — and that is the
 trade this repo already assumes. One lock root per machine is the documented
@@ -581,6 +594,18 @@ model: concurrent validation from another machine runs against its own checkout
 and its own lock. An operator who really does share a root, and has satisfied
 themselves that no second machine writes into it, restores self-healing with
 `AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1`.
+
+**`df -l` narrows the hazard; it does not prove exclusivity.** It answers
+whether the storage is mounted _from_ elsewhere, not whether anything else
+reaches it. A machine that exports its own disk sees that disk locally, and a
+host bind mount or Docker volume reads local inside every container sharing it —
+so cloned identities in two containers on one host still compare equal on a root
+both read as local. Nothing readable from a single machine detects either case;
+that is the premise issue #2061 starts from. What changed is the remedy: before
+this, `AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=0` only turned off the
+unverified-record reclaim, and a cloned identity under a cloned hostname was
+reclaimed anyway. It now refuses every reclaim on that root, so an operator who
+deliberately shares one has a declaration that actually holds.
 
 **An operator-supplied directory on local storage keeps self-healing.** The
 refusal turns on the storage, never on who named the path. Refusing on every

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -628,6 +628,15 @@ needs a hand: the temp path a reclaim renames into is registered with the exit
 trap **before** the rename creates it, and cleanup restores rather than deletes,
 so an interrupted reclaim puts the record back exactly as it found it.
 
+**That guarantee is local-storage-only**, and so is every row of the table
+below. It has to be: each of those recoveries is a reclaim, and a reclaim rests
+on evidence read through this kernel and this client. Off storage this machine
+mounts itself the gate refuses them all, so a crash there does not self-heal —
+the record or remnant stays where it is, every waiter burns its `--lock-wait`
+budget, and a human removes it. Nothing in this repo runs that way; the model is
+one lock root per machine, and the refusal names it on stderr. Read the rows
+below as "on a root this machine's own", and issue #2061 above for the rest.
+
 #### Crash points
 
 A signal can land between any two of the filesystem operations above, and a
@@ -635,7 +644,9 @@ A signal can land between any two of the filesystem operations above, and a
 made per boundary rather than per function. The boundaries are finite; this is
 all of them. Safe means: at most one process believes it holds the lock, no
 record naming a live holder is invisible to the next reader, and no state
-requires manual cleanup.
+requires manual cleanup. The first two hold on any root. The third is the one
+the qualification above withdraws off local storage: mutual exclusion is what
+the refusal protects, and it protects it by leaving cleanup to a human.
 
 | Crash lands                                                                       | State left behind                                                                                                                   | Next run                                                                                                                                    |
 | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -630,12 +630,28 @@ so an interrupted reclaim puts the record back exactly as it found it.
 
 **That guarantee is local-storage-only**, and so is every row of the table
 below. It has to be: each of those recoveries is a reclaim, and a reclaim rests
-on evidence read through this kernel and this client. Off storage this machine
-mounts itself the gate refuses them all, so a crash there does not self-heal —
-the record or remnant stays where it is, every waiter burns its `--lock-wait`
-budget, and a human removes it. Nothing in this repo runs that way; the model is
-one lock root per machine, and the refusal names it on stderr. Read the rows
-below as "on a root this machine's own", and issue #2061 above for the rest.
+on evidence read through this kernel and this client. Where the root is not
+established as storage only this machine reaches, the gate refuses every one of
+them, so a crash there does not self-heal: the record or remnant stays, and each
+waiter burns its whole `--lock-wait` budget and exits. A shared root fails
+closed by design; the supported self-healing model is one lock root per machine.
+Read the rows below as "on a root this machine's own", and issue #2061 above for
+the rest.
+
+**Clearing such a lock by hand is the one operation that can break mutual
+exclusion**, so it is not a delete. The gate refused the record precisely
+because it could not tell a dead holder from a live one, and removing a live
+holder's record lets the next waiter publish its own beside work that is still
+running — the overlap this lock exists to prevent. Establish first, on the
+machine that wrote the record, that its `pid` is gone and that its mapped
+commands are gone with it: the holder is named by `pid` and `host`, and its
+commands are tagged with the record's `token`. Then check that nothing is still
+owed for it — `<root>/condemned.d` holds the tokens of runs whose commands the
+next holder must drain, and `<root>/captured.<token>` holds a captured process
+tree — and drain or clear those before the record goes, because deleting the
+record deletes the only handle to them. When the holder cannot be reached to be
+checked, the record stays: waiting costs a wait, and guessing costs the
+guarantee.
 
 #### Crash points
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -462,28 +462,30 @@ _different_ sources are not, because a run that reached `ioreg` and a run that
 fell back to `kern.uuid` are almost certainly one machine and reading their
 unequal values as two would reinvent the wedge.
 
-**Where the lock root lives decides what a local PID lookup is allowed to
-conclude**, and how that is settled depends on who chose the root: evidence for
-the root the gate chose, a declaration for the root an operator chose.
+**Where the lock root lives decides what a local reading is allowed to
+conclude**, and the root is asked two questions from two kinds of evidence.
 
-The default candidates — `$HOME/.cache/agent-quality-gate`, then
-`$TMPDIR/agent-quality-gate-<uid>` — are nobody's deliberate coordination
-point, so the only open question is whether the storage under them is mounted
-from elsewhere, and the filesystem answers it. `df -l` lists local filesystems
-and omits network ones — NFS, SMB, AFS, an autofs map — on both the BSD and GNU
-implementations, and the row it prints for a path, not its exit status, is the
-answer. Every failure to answer means "may be shared": no `df`, an unreadable
-path, an implementation without `-l`. That direction is the one that keeps
-waiting.
+_Is the storage under it this machine's own?_ The filesystem answers that, for
+every root — the one an operator named as much as the one the gate resolved for
+itself — because the question is about the storage and not about who chose the
+path. `df -l` lists local filesystems and omits network ones — NFS, SMB, AFS,
+an autofs map — on both the BSD and GNU implementations, and the row it prints
+for a path, not its exit status, is the answer. Every failure to answer means
+"may be shared": no `df`, an unreadable path, an implementation without `-l`.
+That direction is the one that keeps waiting.
 
+_Is the root established as this machine's alone?_ That is strictly stronger,
+and only the unverified-record rule below needs it. The default candidates —
+`$HOME/.cache/agent-quality-gate`, then `$TMPDIR/agent-quality-gate-<uid>` —
+are nobody's deliberate coordination point, so local storage settles it there.
 `AGENT_QUALITY_GATE_LOCK_DIR` is the opposite case. `resolve_gate_lock_root`
 treats it as a coordination contract precisely because it can name a directory
 more than one machine reaches, and a local mount is no evidence against that —
 a machine can export its own disk. So an override is possibly-shared until its
-owner says otherwise, and every reclaim on this path is refused there.
+owner says otherwise, and the unverified-record reclaim is refused there.
 `AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE` is that declaration, and it
-overrides both branches: `1` where an override directory is this machine's
-alone, `0` where even a default root is exported to other machines.
+answers both questions: `1` where a directory is this machine's alone, `0`
+where even a default root is exported to other machines.
 
 The verdict then has three values. **Same machine** — matching identities, or
 no identity on one side and a matching hostname — runs the liveness rules
@@ -540,6 +542,52 @@ The field is additive in both directions: an older gate on the same machine
 ignores it and reads the record exactly as it always did, and this gate reads
 that older gate's record through the unverified path. Once both gates on a
 shared root write identities, that path is unreachable there.
+
+**Off storage the machine mounts itself, nothing is reclaimed at all** (GitHub
+issue #2061). Every rule above answers "was this record written here?" from the
+record's own machine identity and hostname, and both of those fields can be
+cloned. Two containers built from one image carry the same `/etc/machine-id`
+_and_ the same hostname; on a lock root they share, each reads the other's
+record as its own, finds the holder's PID absent from its own PID namespace,
+and authorises the overlap the lock exists to prevent. Every field the
+comparison could use is self-reported, and a PID lookup only answers about this
+kernel, so nothing available locally separates that case from a machine that
+renamed itself.
+
+So the locality of the root is the last word on every reclaim, not only on the
+unverified one. Where `df -l` cannot show the root as local storage and no
+declaration says otherwise, a record that looks reclaimable is left where it is
+and the run waits out its `--lock-wait` budget. The refusal says so on stderr:
+the root is not established as this machine's, self-healing is off there, and
+each machine should be given its own `AGENT_QUALITY_GATE_LOCK_DIR` on its own
+local storage.
+
+It refuses the reclaim, not the lock. Taking the lock on a shared root is still
+sound — a waiter queueing behind a live holder is what the lock is for — and
+failing acquisition outright would turn a working configuration into a hard
+error over a hazard that only bites when a holder dies. The one operation that
+acts on local evidence about a process elsewhere is the one that stops.
+
+That covers the record with no holder at all. "No complete record here" is as
+local a reading as a PID lookup: a network client caches directory attributes,
+so a freshly written owner file can stay invisible to another client for longer
+than the `AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS` that would otherwise
+authorise taking the lock away.
+
+The cost is that a lock root on network storage no longer self-heals — a holder
+killed there wedges the root until a human removes the record — and that is the
+trade this repo already assumes. One lock root per machine is the documented
+model: concurrent validation from another machine runs against its own checkout
+and its own lock. An operator who really does share a root, and has satisfied
+themselves that no second machine writes into it, restores self-healing with
+`AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1`.
+
+**An operator-supplied directory on local storage keeps self-healing.** The
+refusal turns on the storage, never on who named the path. Refusing on every
+`AGENT_QUALITY_GATE_LOCK_DIR` would take the dead-holder reclaim away from
+ordinary single-machine use of the override — a worktree pointing runs at a
+shared cache directory, a CI job placing the lock somewhere writable — and
+that is the wedge class issue #2055 removed.
 
 A killed holder cannot release its own lock, so recovery is explicit rather
 than time-based: a waiter that finds the recorded holder gone takes the record

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -582,10 +582,16 @@ ownerless, which is precisely the state such a root can no longer reclaim. A
 remnant naming a locally-live holder is still linked back to the canonical
 path — that direction only restores evidence.
 
-The refusal also owns the wait's ending. A run that timed out because a reclaim
-was refused is told that nothing was reclaimed and that the record may need
-removing by hand, instead of the usual "holder is still alive; let it finish" —
-which would send an operator to wait on a process this run already read as gone.
+The refusal also owns the wait's ending. A run that timed out on a record it
+refused is told that nothing was reclaimed, which state it refused, and that the
+lock may need removing by hand — instead of the usual "holder is still alive;
+let it finish", which would send an operator to wait on a process this run
+already read as gone. That diagnosis is decided per pass, not once per
+acquisition: a creator that stalls past the owner grace is refused and then
+publishes a live record, and the timeout has to name that live holder rather
+than advise removing a lock somebody is holding. It names the lock's state
+rather than its holder, because the states it covers include a lock with no
+holder recorded at all.
 
 The cost is that a lock root on network storage no longer self-heals — a holder
 killed there wedges the root until a human removes the record — and that is the

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -67,7 +67,10 @@ Environment:
   AGENT_QUALITY_GATE_LOCK_DIR
                       Directory holding the cross-run lock. Default:
                       $HOME/.cache/agent-quality-gate, falling back to
-                      $TMPDIR/agent-quality-gate-<uid>.
+                      $TMPDIR/agent-quality-gate-<uid>. Give each machine its
+                      own: on a root the filesystem reports as network storage
+                      the gate reclaims nothing, so a lock left behind there is
+                      waited out rather than healed.
   AGENT_QUALITY_GATE_LOCK_MACHINE_ID
                       Names the machine a lock record belongs to, in place of
                       the hardware identity the gate reads for itself. Set it
@@ -78,14 +81,16 @@ Environment:
                       established must be before a dead holder in it is
                       reclaimed. Default: 600.
   AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE
-                      Declares whether only this machine reaches the lock root.
-                      Unset, a root the gate resolved for itself is asked of
-                      the filesystem (df -l) and an AGENT_QUALITY_GATE_LOCK_DIR
-                      is assumed shared. Where the root may be shared, a lock
-                      record that cannot be tied to this machine is never
-                      reclaimed. Set 1 for an override directory this machine
-                      alone reaches; set 0 where this machine exports the lock
-                      root and another machine's gate locks in it.
+                      Declares whether only this machine reaches the lock root,
+                      in place of what the filesystem says about it. Unset,
+                      every root is asked of the filesystem (df -l), and off
+                      local storage no lock record is reclaimed at all; on
+                      local storage a record that cannot be tied to this
+                      machine is reclaimed only where the root is not an
+                      AGENT_QUALITY_GATE_LOCK_DIR, which is assumed shared. Set
+                      1 for a directory this machine alone reaches; set 0 where
+                      this machine exports the lock root and another machine's
+                      gate locks in it.
 USAGE
 }
 
@@ -630,6 +635,26 @@ case "$gate_lock_root_per_machine_override" in
     exit 2
     ;;
 esac
+# Whether the storage under the lock root is this machine's own, kept apart
+# from the question above because the two authorise different things. This one
+# is the weaker claim and the wider gate: without it, no reclaim on this root
+# is sound at all, because every reason a record looks reclaimable is read
+# through this kernel and this client (GitHub issue #2061). Resolved in
+# acquire_gate_run_lock once the root is known; 0 until then, which is the
+# direction that keeps waiting.
+gate_lock_root_is_local_storage=0
+# Test-only, gated like the other lock-test hooks. The refusal this drives
+# turns on what `df -l` says about the lock root, and a self-test cannot mount
+# a network filesystem to make it say the interesting thing, so this makes the
+# probe answer "not local" for every path. It only ever withdraws a reclaim —
+# there is no setting of it that authorises one — so the failure it can cause
+# is a wait, not an overlap. Refused outside NODE_ENV=test all the same, so it
+# is never a quiet way to change how a real run behaves.
+gate_lock_test_force_not_local="${AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL:-}"
+if [[ -n "$gate_lock_test_force_not_local" && "${NODE_ENV:-}" != "test" ]]; then
+  echo "error: AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL is a test-only override and requires NODE_ENV=test." >&2
+  exit 2
+fi
 # The lock root, kept once resolved: outstanding obligations live beside the
 # lock rather than inside it, because the lock directory is what gets reclaimed
 # and the obligation has to outlive that.
@@ -1080,6 +1105,7 @@ gate_lock_machine_verdict() {
 gate_lock_path_is_local_filesystem() {
   local dir="$1"
   local row
+  [[ -z "$gate_lock_test_force_not_local" ]] || return 1
   [[ -n "$dir" ]] || return 1
   command -v df > /dev/null 2>&1 || return 1
   row="$(df -l -- "$dir" 2>/dev/null | tail -n +2 | tr -d '[:space:]' || true)"
@@ -1737,6 +1763,7 @@ acquire_gate_run_lock() {
   local announced=0
   local ownerless_since=""
   local unverified_warned=0
+  local nonlocal_root_warned=0
   local this_host this_machine
   case "$gate_lock_enabled" in
     0|false|no) return 0 ;;
@@ -1765,24 +1792,39 @@ acquire_gate_run_lock() {
   this_host="$(uname -n)"
   gate_lock_resolve_machine_id
   this_machine="$gate_lock_machine_id_cached"
-  # Evidence for the root this gate chose, a declaration for the root an
-  # operator chose. The default candidates are this user's own cache and temp
-  # directories, which nothing points at deliberately, so the only open
-  # question there is whether the storage under them is mounted from elsewhere
-  # — and the filesystem answers that. AGENT_QUALITY_GATE_LOCK_DIR is the
-  # opposite: resolve_gate_lock_root treats it as a coordination contract
-  # precisely because it can name a directory more than one machine reaches,
-  # and a local mount is no evidence against that — a machine can export its
-  # own disk. So an override is possibly-shared until its owner says otherwise,
-  # which is what the declaration is for.
+  # Two questions about the root, answered from different evidence.
+  #
+  # Is the storage under it this machine's own? Every reason a record can look
+  # reclaimable is read through this kernel and this client, so nothing on this
+  # root is safe to take away without it, and the filesystem is what answers —
+  # for the root an operator named as much as for the one the gate chose,
+  # because the question is about the storage rather than about who picked the
+  # path. Unanswerable means "may be shared", the direction that keeps waiting.
+  #
+  # Is the root established as this machine's alone? That is strictly stronger,
+  # and it is what the unverified-record rule below needs, because that rule
+  # reclaims a record it cannot attribute at all. An
+  # AGENT_QUALITY_GATE_LOCK_DIR cannot earn it from the filesystem: a machine
+  # can export its own local disk, and resolve_gate_lock_root treats the
+  # override as a coordination contract precisely because it can name a
+  # directory more than one machine reaches. So an override stays
+  # possibly-shared until its owner says otherwise.
+  #
+  # The declaration answers both, since "only this machine reaches it" implies
+  # "this machine mounts the storage".
+  if [[ -n "$gate_lock_root_per_machine_override" ]]; then
+    gate_lock_root_is_local_storage="$gate_lock_root_per_machine_override"
+  elif gate_lock_path_is_local_filesystem "$root"; then
+    gate_lock_root_is_local_storage=1
+  else
+    gate_lock_root_is_local_storage=0
+  fi
   if [[ -n "$gate_lock_root_per_machine_override" ]]; then
     gate_lock_root_is_per_machine="$gate_lock_root_per_machine_override"
   elif [[ -n "${AGENT_QUALITY_GATE_LOCK_DIR:-}" ]]; then
     gate_lock_root_is_per_machine=0
-  elif gate_lock_path_is_local_filesystem "$root"; then
-    gate_lock_root_is_per_machine=1
   else
-    gate_lock_root_is_per_machine=0
+    gate_lock_root_is_per_machine="$gate_lock_root_is_local_storage"
   fi
   wait_started_at="$(gate_wall_millis)"
 
@@ -1925,6 +1967,37 @@ acquire_gate_run_lock() {
           stale_reason=""
         fi
       fi
+    fi
+
+    # The last word on every reclaim above, and the one that does not depend on
+    # reading the record right. Each of those reasons is evidence gathered
+    # locally — a PID looked up in this kernel, a record this client cannot see
+    # — and each is worth only as much as the claim that the record was written
+    # here. That claim rests on the record's own machine identity and hostname,
+    # and both can be cloned: two containers built from one image carry the
+    # same `/etc/machine-id` and the same hostname, so on a root they share
+    # each reads the other's record as its own, finds the holder's PID absent
+    # from its own PID namespace, and reclaims a lock whose holder is running
+    # next door — the overlap the lock exists to prevent (GitHub issue #2061).
+    # Nothing available locally tells those two apart, so the reclaim is
+    # refused wherever the storage is not this machine's own, and the run waits
+    # out its lock budget instead. Refusing the reclaim rather than the lock is
+    # deliberate: waiting is still correct on a shared root, and a run that
+    # simply queued is a run that still validated.
+    #
+    # This covers the record with no holder at all as well. A network client's
+    # view of a directory is cached, so "no complete record here" is as local a
+    # reading as a PID lookup: NFS attribute caching can hide a freshly written
+    # owner file from another client for longer than the grace that authorises
+    # taking it.
+    if [[ -n "$stale_reason" && "$gate_lock_root_is_local_storage" -ne 1 ]]; then
+      if [[ "$nonlocal_root_warned" -eq 0 ]]; then
+        nonlocal_root_warned=1
+        echo "warning: the gate run lock at ${lock} looks reclaimable (${stale_reason}), and this run refuses to reclaim it." >&2
+        echo "  Its root ${root} is not established as storage only this machine reaches, and on a shared root that evidence proves nothing: a machine identity and a hostname can both be cloned — two containers built from one image carry the same values — so a holder alive on another machine reads as a dead PID here. Self-healing is disabled on such a root; this run waits out its lock budget instead." >&2
+        echo "  Give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage. If this root really is this machine's alone, declare it with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
+      fi
+      stale_reason=""
     fi
 
     if [[ -n "$stale_reason" ]]; then

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1978,6 +1978,11 @@ acquire_gate_run_lock() {
             echo "  This lock root is not established as storage only this machine reaches, so it may be shared and that record may belong to a live run elsewhere. This run waits it out." >&2
             echo "  If that directory is this machine's alone, set AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1 to let a dead holder in it be reclaimed." >&2
           fi
+          # This is a refusal on where the root lives, exactly like the guard
+          # below, so it owes the timeout the same answer. Without this the
+          # reason stays empty and the wait ends on "holder pid N is still
+          # alive; let it finish" — for a PID this pass just read as gone.
+          nonlocal_refusal_reason="$stale_reason"
           stale_reason=""
         elif [[ -n "$record_age" &&
           "$record_age" -ge "$gate_lock_unverified_machine_grace_seconds" ]]; then

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2130,7 +2130,14 @@ acquire_gate_run_lock() {
         # its holder, because the state it covers includes a lock with no
         # holder recorded at all.
         echo "Nothing was reclaimed: this run refused to act on the lock (${nonlocal_refusal_reason}), because its root is not established as storage only this machine reaches." >&2
-        echo "If no run holds it, remove ${lock} by hand. Then give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage, or declare this root with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
+        # Deliberately not "delete it and move on". Removing the directory
+        # removes the record, and the record's token is the handle the next run
+        # would have used to find and stop the dead holder's mapped commands —
+        # which outlive their gate shell. So a delete on a still-running holder
+        # both starts this run beside that work and throws away the only way to
+        # notice. Name the checks, and point at the note that owns them.
+        echo "Clearing it by hand is not a plain delete: on the machine that wrote the record, confirm its holder pid is gone AND that its mapped commands are gone with it — they carry the tag agentqg:<the record's token> — because deleting the record discards that token and the next run then starts beside whatever it named." >&2
+        echo "docs/notes/agent-quality-gate-mechanics.md has the full procedure. Then give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage, or declare this root with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
       else
         echo "Holder pid ${owner_pid:-unknown} is still alive; let it finish, then retry." >&2
       fi

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -1775,6 +1775,15 @@ acquire_gate_run_lock() {
   local ownerless_since=""
   local unverified_warned=0
   local nonlocal_root_warned=0
+  # Why THIS pass refused to act on the record it is looking at now, or empty.
+  # Re-decided every pass, unlike the warned flag beside it: that one is sticky
+  # because its job is to say the thing once, and this one feeds the timeout
+  # diagnosis, which has to describe the lock as it stands when the budget runs
+  # out. A refusal early in the wait says nothing about a record published
+  # afterwards — a stalled creator can leave the lock ownerless past the grace,
+  # be refused, and then publish a perfectly live record — and a sticky flag
+  # would answer for that live holder with "remove it by hand".
+  local nonlocal_refusal_reason=""
   local this_host this_machine
   case "$gate_lock_enabled" in
     0|false|no) return 0 ;;
@@ -1897,6 +1906,7 @@ acquire_gate_run_lock() {
     )"
 
     stale_reason=""
+    nonlocal_refusal_reason=""
     [[ -n "$owner_token_value" ]] && ownerless_since=""
     if [[ -z "$owner_token_value" ]]; then
       # No complete record: either no file at all, or one a run was killed
@@ -2014,6 +2024,7 @@ acquire_gate_run_lock() {
         echo "  Its root ${root} is not established as storage only this machine reaches, and on a shared root that evidence proves nothing: a machine identity and a hostname can both be cloned — two containers built from one image carry the same values — so a holder alive on another machine reads as a dead PID here. Self-healing is disabled on such a root; this run waits out its lock budget instead." >&2
         echo "  Give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage. If this root really is this machine's alone, declare it with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
       fi
+      nonlocal_refusal_reason="$stale_reason"
       stale_reason=""
     fi
 
@@ -2111,12 +2122,14 @@ acquire_gate_run_lock() {
 
     if [[ "$waited" -ge "$gate_lock_wait_seconds" ]]; then
       echo "error: timed out after ${waited}s waiting for the gate run lock at ${lock}." >&2
-      if [[ "$nonlocal_root_warned" -eq 1 ]]; then
-        # This wait ended because a reclaim was refused, not because a holder
-        # was seen running. Telling the operator to let that holder finish
-        # would send them to wait on a process this run already read as gone,
-        # and the wait would never end. Say what actually happened instead.
-        echo "Nothing was reclaimed: the recorded holder could not be judged from this machine, and this lock root is not established as storage only this machine reaches." >&2
+      if [[ -n "$nonlocal_refusal_reason" ]]; then
+        # This wait ended on a record this run refused to act on, not on a
+        # holder it saw running. Repeating the line below would send the
+        # operator to wait for a process this pass already read as gone, and
+        # that wait never ends. The refusal names the lock's state rather than
+        # its holder, because the state it covers includes a lock with no
+        # holder recorded at all.
+        echo "Nothing was reclaimed: this run refused to act on the lock (${nonlocal_refusal_reason}), because its root is not established as storage only this machine reaches." >&2
         echo "If no run holds it, remove ${lock} by hand. Then give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage, or declare this root with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
       else
         echo "Holder pid ${owner_pid:-unknown} is still alive; let it finish, then retry." >&2

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -550,6 +550,17 @@ gate_lock_recover_hidden_record() {
       # If the link failed the canonical path already holds something. This
       # copy still names a live process, so it stays: a record naming a live
       # holder is evidence, and only a verified-dead one may be deleted.
+    elif [[ "$gate_lock_root_is_local_storage" -ne 1 ]]; then
+      # Off storage this machine mounts itself, "dead" above is not a verdict:
+      # the PID was looked up in this kernel, and the process may be running on
+      # another machine that reaches the same root (GitHub issue #2061).
+      # Deleting the remnant would destroy the only copy of a live holder's
+      # record and leave the lock ownerless — and an ownerless lock is exactly
+      # what a root like this can no longer reclaim, so the wedge would be
+      # permanent rather than healed after the owner grace. The remnant stays
+      # where it is: waiters refuse this lock anyway, and the record is what
+      # the holder that owns it, and the operator who has to clean up, need.
+      :
     else
       # Dead holder — but "dead run" is not the same as "nothing running". Its
       # commands outlive it, and this record is the last thing that names them.
@@ -1800,6 +1811,12 @@ acquire_gate_run_lock() {
   # for the root an operator named as much as for the one the gate chose,
   # because the question is about the storage rather than about who picked the
   # path. Unanswerable means "may be shared", the direction that keeps waiting.
+  # `df -l` narrows the answer without proving it: it says the storage is not
+  # mounted FROM elsewhere, not that nothing else reaches it. A machine can
+  # export its own disk, and a host bind mount or Docker volume reads local
+  # inside every container sharing it. Those are deliberate acts of sharing,
+  # and the declaration below is how they are told; nothing readable from here
+  # can detect them.
   #
   # Is the root established as this machine's alone? That is strictly stronger,
   # and it is what the unverified-record rule below needs, because that rule
@@ -2094,7 +2111,16 @@ acquire_gate_run_lock() {
 
     if [[ "$waited" -ge "$gate_lock_wait_seconds" ]]; then
       echo "error: timed out after ${waited}s waiting for the gate run lock at ${lock}." >&2
-      echo "Holder pid ${owner_pid:-unknown} is still alive; let it finish, then retry." >&2
+      if [[ "$nonlocal_root_warned" -eq 1 ]]; then
+        # This wait ended because a reclaim was refused, not because a holder
+        # was seen running. Telling the operator to let that holder finish
+        # would send them to wait on a process this run already read as gone,
+        # and the wait would never end. Say what actually happened instead.
+        echo "Nothing was reclaimed: the recorded holder could not be judged from this machine, and this lock root is not established as storage only this machine reaches." >&2
+        echo "If no run holds it, remove ${lock} by hand. Then give each machine its own AGENT_QUALITY_GATE_LOCK_DIR on that machine's local storage, or declare this root with AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1." >&2
+      else
+        echo "Holder pid ${owner_pid:-unknown} is still alive; let it finish, then retry." >&2
+      fi
       echo "Running the gate directly? --no-lock starts anyway and accepts the contention." >&2
       # The pre-push hook passes a fixed command line and Trunk strips the
       # environment, so neither escape hatch is reachable from a failed push.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -7775,6 +7775,56 @@ STUB
     fail "a verified-dead remnant on local storage must still be discarded"
   rm -rf "$gate_lock_root/run.lock"
 
+  # The refusal is re-decided every pass, so a record published after one is
+  # judged on its own terms. A creator that stalls between taking the lock
+  # directory and writing its record leaves the lock ownerless past the grace
+  # and is refused — and then publishes a perfectly live record. The timeout
+  # has to name that live holder; telling the operator to remove a lock
+  # somebody is holding is the one piece of advice this diagnosis must never
+  # give. The early refusal is asserted too, so the case cannot pass by never
+  # reaching the branch it is about.
+  mkdir -p "$gate_lock_root/run.lock"
+  rm -f "$gate_lock_root/run.lock/owner"
+  sleep 60 &
+  late_holder_pid=$!
+  (
+    # Published by rename, so the waiter never reads a half-written record and
+    # mistakes it for the ownerless state this case starts from.
+    sleep 3
+    {
+      printf 'pid=%s\n' "$late_holder_pid"
+      printf 'host=%s\n' "$(uname -n)"
+      printf 'machine=override:machine-a\n'
+      printf 'started_at=%s\n' "$(date +%s)"
+      printf 'worktree=%s\n' "$gate_lock_repo"
+      printf 'token=fixture-holder-1-1\n'
+    } > "$gate_lock_root/run.lock/owner.staged"
+    mv "$gate_lock_root/run.lock/owner.staged" "$gate_lock_root/run.lock/owner"
+  ) &
+  late_publisher_pid=$!
+  set +e
+  NODE_ENV=test \
+    AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+    AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' \
+    AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS=0 \
+    AGENT_QUALITY_GATE_LOCK=1 \
+    AGENT_QUALITY_GATE_LOCK_HELD='' \
+    AGENT_QUALITY_GATE_LOCK_DIR="$gate_lock_root" \
+    AGENT_QUALITY_GATE_LOCK_POLL_SECONDS=1 \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+    --base HEAD --run --lock-wait 8 \
+    > "$output_file" 2>&1
+  late_publish_exit=$?
+  set -e
+  wait "$late_publisher_pid" 2>/dev/null || true
+  kill "$late_holder_pid" 2>/dev/null || true
+  [[ "$late_publish_exit" == "2" ]] ||
+    fail "a live holder published after a refusal must still be waited out, got $late_publish_exit"
+  assert_contains "refuses to reclaim it."
+  assert_contains "Holder pid ${late_holder_pid} is still alive; let it finish"
+  assert_not_contains "Nothing was reclaimed:"
+  rm -rf "$gate_lock_root/run.lock"
+
   # The limit of the refusal, and the reason it turns on the storage rather
   # than on who named the directory. This suite's root IS an
   # AGENT_QUALITY_GATE_LOCK_DIR, and it is on local storage. Refusing there

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -7688,6 +7688,11 @@ STUB
     assert_contains "Self-healing is disabled on such a root"
     assert_contains "Give each machine its own AGENT_QUALITY_GATE_LOCK_DIR"
     assert_contains "timed out after"
+    # The wait ended because a reclaim was refused, not because a holder was
+    # seen running. Repeating the usual line would send an operator to wait on
+    # a process this very run read as gone, and that wait never ends.
+    assert_contains "Nothing was reclaimed:"
+    assert_not_contains "is still alive; let it finish"
     assert_not_contains "reclaiming it."
     [[ -d "$gate_lock_root/run.lock" ]] ||
       fail "a record on a shared lock root must be left where it is (round ${shared_storage_round})"
@@ -7714,6 +7719,60 @@ STUB
   assert_not_contains "reclaiming it."
   [[ -d "$gate_lock_root/run.lock" ]] ||
     fail "an ownerless lock on a shared root must be left where it is"
+  rm -rf "$gate_lock_root/run.lock"
+
+  # A remnant from an interrupted reclaim is classified by the same local PID
+  # lookup, so off local storage it cannot be called dead either. Deleting it
+  # would destroy the only copy of a possibly-live holder's record and leave
+  # the lock ownerless — the one state this root can no longer reclaim — so the
+  # wedge would be permanent instead of healed after the owner grace. Both
+  # directions are asserted, because a check that only ever preserves would
+  # pass while proving nothing about the rule.
+  write_remnant_record() {
+    mkdir -p "$gate_lock_root/run.lock"
+    rm -f "$gate_lock_root/run.lock/owner"
+    {
+      printf 'pid=%s\n' "$1"
+      printf 'host=%s\n' "$(uname -n)"
+      printf 'machine=override:machine-a\n'
+      printf 'started_at=%s\n' "$(($(date +%s) - 7200))"
+      printf 'worktree=%s\n' "$gate_lock_repo"
+      printf 'token=fixture-holder-1-1\n'
+    } > "$gate_lock_root/run.lock/owner.reclaiming.9999"
+  }
+
+  remnant_shared_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the shared-root remnant case"
+  write_remnant_record "$remnant_shared_pid"
+  remnant_shared_exit="$(
+    NODE_ENV=test \
+      AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+      AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' \
+      AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS=0 \
+      run_locked_gate
+  )"
+  [[ "$remnant_shared_exit" == "2" ]] ||
+    fail "a remnant on a shared lock root must be waited out, got $remnant_shared_exit"
+  [[ -e "$gate_lock_root/run.lock/owner.reclaiming.9999" ]] ||
+    fail "a remnant on a shared lock root must not be deleted"
+  assert_contains "refuses to reclaim it."
+  rm -rf "$gate_lock_root/run.lock"
+
+  # The control: the same remnant on storage this machine mounts itself is a
+  # verified-dead record, and the pre-existing path deletes it and heals the
+  # lock.
+  remnant_local_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the local remnant case"
+  write_remnant_record "$remnant_local_pid"
+  remnant_local_exit="$(
+    AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' \
+      AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS=0 \
+      run_locked_gate
+  )"
+  [[ "$remnant_local_exit" == "0" ]] ||
+    fail "a dead remnant on local storage must still heal the lock, got $remnant_local_exit"
+  [[ ! -e "$gate_lock_root/run.lock/owner.reclaiming.9999" ]] ||
+    fail "a verified-dead remnant on local storage must still be discarded"
   rm -rf "$gate_lock_root/run.lock"
 
   # The limit of the refusal, and the reason it turns on the storage rather

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -7787,10 +7787,24 @@ STUB
   rm -f "$gate_lock_root/run.lock/owner"
   sleep 60 &
   late_holder_pid=$!
+  # Truncated before the publisher starts watching it, because earlier cases in
+  # this family wrote the same refusal line into this file and a stale match
+  # would let the publisher fire before the gate had looked at anything.
+  : > "$output_file"
   (
     # Published by rename, so the waiter never reads a half-written record and
-    # mistakes it for the ownerless state this case starts from.
-    sleep 3
+    # mistakes it for the ownerless state this case starts from. Ordered
+    # against the gate's own output rather than a fixed sleep: the point of the
+    # case is a record published AFTER a refusal, and a slow runner that had
+    # not reached the refusal yet would fail it with no defect to show for it.
+    # A publisher that never sees the refusal exits non-zero and fails the case
+    # rather than publishing anyway and asserting against a sequence that never
+    # happened.
+    late_deadline=$(($(date +%s) + 8))
+    until grep -Fq "refuses to reclaim it." "$output_file"; do
+      [[ "$(date +%s)" -lt "$late_deadline" ]] || exit 1
+      sleep 1
+    done
     {
       printf 'pid=%s\n' "$late_holder_pid"
       printf 'host=%s\n' "$(uname -n)"
@@ -7812,12 +7826,15 @@ STUB
     AGENT_QUALITY_GATE_LOCK_DIR="$gate_lock_root" \
     AGENT_QUALITY_GATE_LOCK_POLL_SECONDS=1 \
     "$repo_root/scripts/agent-quality-gate.sh" \
-    --base HEAD --run --lock-wait 8 \
+    --base HEAD --run --lock-wait 12 \
     > "$output_file" 2>&1
   late_publish_exit=$?
+  wait "$late_publisher_pid"
+  late_publisher_exit=$?
   set -e
-  wait "$late_publisher_pid" 2>/dev/null || true
   kill "$late_holder_pid" 2>/dev/null || true
+  [[ "$late_publisher_exit" == "0" ]] ||
+    fail "the gate never printed a refusal for the publisher to follow, so this case proved nothing"
   [[ "$late_publish_exit" == "2" ]] ||
     fail "a live holder published after a refusal must still be waited out, got $late_publish_exit"
   assert_contains "refuses to reclaim it."

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -7623,6 +7623,119 @@ STUB
       fail "the locality probe must not read ${gate_lock_nonlocal_path} as local, got '$gate_lock_probe_remote'"
   fi
 
+  # --- A shared lock root refuses every reclaim (GitHub issue #2061) ---------
+  # The forcing hook first, because every case below rests on it. It has to
+  # reach the same probe the refusal reads, or those cases would pass for some
+  # other reason; the unforced reading of this very directory is asserted
+  # `local` above, so the pair is two-sided.
+  gate_lock_probe_forced="$(
+    NODE_ENV=test \
+      AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+      AGENT_QUALITY_GATE_LOCK_PROBE_PATH="$gate_lock_root" \
+      "$repo_root/scripts/agent-quality-gate.sh" 2>&1
+  )" || true
+  [[ "$gate_lock_probe_forced" == "not-local" ]] ||
+    fail "the forced locality probe must answer not-local, got '$gate_lock_probe_forced'"
+
+  # …and it is refused outside the self-test, like every other test-only hook,
+  # so it can never quietly change how a real run behaves.
+  set +e
+  AGENT_QUALITY_GATE_LOCK=1 \
+    AGENT_QUALITY_GATE_LOCK_HELD='' \
+    AGENT_QUALITY_GATE_LOCK_DIR="$gate_lock_root" \
+    NODE_ENV='' \
+    AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+    "$repo_root/scripts/agent-quality-gate.sh" \
+    --base HEAD --run --lock-wait 2 \
+    > "$output_file" 2>&1
+  forced_probe_outside_test_exit=$?
+  set -e
+  [[ "$forced_probe_outside_test_exit" == "2" ]] ||
+    fail "the locality forcing hook outside NODE_ENV=test must exit 2, got $forced_probe_outside_test_exit"
+  assert_contains "AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL is a test-only override and requires NODE_ENV=test"
+
+  # The residual PR 2060 left. A machine identity and a hostname are the two
+  # fields that say a record was written here, and both can be cloned: two
+  # containers built from one image carry the same /etc/machine-id and the same
+  # hostname. On a lock root they share, each reads the other's record as its
+  # own, finds the holder's PID absent from its own PID namespace, and used to
+  # reclaim a lock whose holder was running next door. Nothing available
+  # locally tells those two apart, so off storage this machine mounts itself no
+  # record is reclaimed at all, however old it is and however dead its PID
+  # reads.
+  #
+  # Both containers are simulated with one identity override and this machine's
+  # real hostname — the indistinguishable pair the issue describes — and the
+  # only field that differs between them is the holder PID, which is exactly
+  # the field that reads wrong across the boundary. So the case runs in both
+  # directions: each container in turn is the one reading the other's record,
+  # and neither takes it.
+  for shared_storage_round in 1 2; do
+    shared_storage_dead_pid="$(fresh_dead_pid)" ||
+      fail "could not obtain a reaped PID that reads as dead for cloned-machine round ${shared_storage_round}"
+    write_machine_lock_owner \
+      "$shared_storage_dead_pid" "$(uname -n)" "override:machine-a" \
+      "$(($(date +%s) - 7200))"
+    shared_storage_exit="$(
+      NODE_ENV=test \
+        AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+        AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' \
+        run_locked_gate
+    )"
+    [[ "$shared_storage_exit" == "2" ]] ||
+      fail "a cloned machine must wait out the other's dead-looking record (round ${shared_storage_round}), got $shared_storage_exit"
+    assert_contains "looks reclaimable (holder pid ${shared_storage_dead_pid} is gone), and this run refuses to reclaim it."
+    assert_contains "Self-healing is disabled on such a root"
+    assert_contains "Give each machine its own AGENT_QUALITY_GATE_LOCK_DIR"
+    assert_contains "timed out after"
+    assert_not_contains "reclaiming it."
+    [[ -d "$gate_lock_root/run.lock" ]] ||
+      fail "a record on a shared lock root must be left where it is (round ${shared_storage_round})"
+    rm -rf "$gate_lock_root/run.lock"
+  done
+
+  # The refusal covers the record with no holder at all, for the same reason:
+  # "no complete record here" is as local a reading as a PID lookup. A network
+  # client caches directory attributes, so a freshly written owner file can
+  # stay invisible to another client for longer than the grace that would
+  # otherwise authorise taking the lock away.
+  mkdir -p "$gate_lock_root/run.lock"
+  rm -f "$gate_lock_root/run.lock/owner"
+  ownerless_shared_exit="$(
+    NODE_ENV=test \
+      AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL=1 \
+      AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' \
+      AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS=0 \
+      run_locked_gate
+  )"
+  [[ "$ownerless_shared_exit" == "2" ]] ||
+    fail "an ownerless lock on a shared root must be waited out, got $ownerless_shared_exit"
+  assert_contains "looks reclaimable (its holder never recorded a complete identity), and this run refuses to reclaim it."
+  assert_not_contains "reclaiming it."
+  [[ -d "$gate_lock_root/run.lock" ]] ||
+    fail "an ownerless lock on a shared root must be left where it is"
+  rm -rf "$gate_lock_root/run.lock"
+
+  # The limit of the refusal, and the reason it turns on the storage rather
+  # than on who named the directory. This suite's root IS an
+  # AGENT_QUALITY_GATE_LOCK_DIR, and it is on local storage. Refusing there
+  # too would take self-healing away from every operator-supplied root and
+  # bring back the wedge class issue #2055 removed, so the same record — same
+  # cloned identity, same hostname, same dead PID — is reclaimed once the
+  # storage is the machine's own.
+  local_override_dead_pid="$(fresh_dead_pid)" ||
+    fail "could not obtain a reaped PID that reads as dead for the local-override case"
+  write_machine_lock_owner \
+    "$local_override_dead_pid" "$(uname -n)" "override:machine-a" \
+    "$(($(date +%s) - 7200))"
+  local_override_exit="$(AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE='' run_locked_gate)"
+  [[ "$local_override_exit" == "0" ]] ||
+    fail "an operator lock dir on local storage must keep self-healing, got $local_override_exit"
+  assert_contains "is stale (holder pid ${local_override_dead_pid} is gone); reclaiming it."
+  assert_not_contains "refuses to reclaim it"
+  [[ ! -d "$gate_lock_root/run.lock" ]] ||
+    fail "the run that reclaimed on a local operator root must release its own"
+
   unset AGENT_QUALITY_GATE_LOCK_MACHINE_ID
 )
 rm -rf "$gate_lock_repo" "$gate_lock_root"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -7562,6 +7562,11 @@ STUB
   assert_contains "not established as storage only this machine reaches"
   assert_contains "AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1"
   assert_not_contains "reclaiming it."
+  # This is a refusal on where the root lives, so the wait owes the same
+  # answer as the guard below it: the holder PID read as gone on this pass, and
+  # sending an operator to let it finish is a wait that never ends.
+  assert_contains "Nothing was reclaimed:"
+  assert_not_contains "is still alive; let it finish"
   [[ -d "$gate_lock_root/run.lock" ]] ||
     fail "a record on a possibly shared lock root must never be reclaimed"
   rm -rf "$gate_lock_root/run.lock"


### PR DESCRIPTION
## The Problem

- The gate's run lock decides "is this record mine?" from the machine identity
  and hostname in the record. Both can be cloned: two containers or VMs built
  from one image carry the same `/etc/machine-id` **and** the same hostname.
- On a lock root those machines share, each reads the other's record as its own.
  The holder's PID is absent from the reader's PID namespace, so it reads dead,
  the liveness rules authorise a reclaim, and two gate runs execute mapped
  commands at once — the overlap the lock exists to prevent.
- Nothing available locally separates that case from a machine that renamed
  itself. Identity and hostname are both self-reported; a PID lookup only
  answers about this kernel.

## The Solution

The gate now refuses the reclaim on any lock root it cannot show is this
machine's own storage. Where `df -l` does not list the root as local and no
declaration says otherwise, a record that looks reclaimable is left where it is
and the run waits out its `--lock-wait` budget. The refusal prints once, on
stderr, naming the root, saying self-healing is disabled there, and telling the
operator to give each machine its own `AGENT_QUALITY_GATE_LOCK_DIR` on that
machine's local storage.

It refuses the reclaim, not the lock. Waiting on a shared root is still sound —
a waiter queueing behind a live holder is what the lock is for — and failing
acquisition outright would turn a working configuration into a hard error over a
hazard that only bites when a holder dies.

The limits are worth stating plainly:

- **A lock root on network storage no longer self-heals.** A holder killed there
  wedges the root until a human removes the record. That is the trade the repo's
  model already assumes: one lock root per machine, and concurrent validation
  from another machine runs against its own checkout and its own lock. An
  operator who really does share a root restores self-healing with
  `AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=1`.
- **An operator-supplied directory on local storage keeps self-healing.** The
  refusal turns on the storage, never on who named the path. Refusing on every
  `AGENT_QUALITY_GATE_LOCK_DIR` would take the dead-holder reclaim away from
  ordinary single-machine use of the override, which is the wedge class PR 2060
  removed for issue 2055.
- **This is not a liveness signal.** The issue's heartbeat option would let a
  shared root self-heal; it is not implemented here, because nothing in this
  repo asks for a shared root and a heartbeat costs a periodic write from the
  holder plus its own crash-point analysis.
- **`df -l` narrows the hazard, it does not prove exclusivity.** It answers
  whether the storage is mounted _from_ elsewhere, not whether anything else
  reaches it. A machine exporting its own disk, or two containers sharing a host
  bind mount, both read the root as local. Nothing readable from one machine
  detects either case — that is issue 2061's premise. What changed is the
  remedy: `AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE=0` previously turned off
  only the unverified-record reclaim and a cloned identity under a cloned
  hostname was reclaimed anyway; it now refuses every reclaim on that root.
  Tracked as issue 2066.

## Details

`gate_lock_root_is_local_storage` is resolved once in `acquire_gate_run_lock`
and is deliberately separate from the existing `gate_lock_root_is_per_machine`.
The two answer different questions:

- _Is the storage under the root this machine's own?_ Asked of `df -l` for every
  root, the operator's as much as the gate's, because the question is about the
  storage and not about who chose the path. This is the new, wider gate.
- _Is the root established as this machine's alone?_ Strictly stronger, and only
  the unverified-record rule from PR 2060 needs it. An
  `AGENT_QUALITY_GATE_LOCK_DIR` still cannot earn it from the filesystem, since
  a machine can export its own local disk.

`AGENT_QUALITY_GATE_LOCK_DIR_IS_PER_MACHINE` answers both, so
`gate_lock_root_is_per_machine == 1` implies
`gate_lock_root_is_local_storage == 1`. Every prior value of
`gate_lock_root_is_per_machine` is preserved.

The refusal sits at the single `stale_reason` chokepoint, after the
unverified-record branch, so exactly one message is printed per acquisition and
the two branches cannot both fire.

It covers the record with no holder at all as well. "No complete record here" is
as local a reading as a PID lookup: a network client caches directory
attributes, so a freshly written owner file can stay invisible to another client
for longer than `AGENT_QUALITY_GATE_LOCK_OWNER_GRACE_SECONDS` allows before the
lock is taken away.

Two paths outside that chokepoint needed the same treatment:

- `gate_lock_recover_hidden_record` classifies an `owner.reclaiming.*` remnant
  by the same local PID lookup and deletes it when the holder reads dead. Off
  local storage it now leaves the remnant alone: deleting it would destroy the
  only copy of a possibly-live holder's record and leave the lock ownerless,
  which is exactly the state such a root can no longer reclaim, so the wedge
  would be permanent instead of healed after the owner grace. A remnant naming a
  locally-live holder is still linked back to the canonical path.
- The wait's timeout diagnostic said "Holder pid N is still alive; let it
  finish". After a refused reclaim that sends an operator to wait on a process
  the run already read as gone. It now names the state it refused and says the
  lock may need removing by hand. That decision is made per pass, not once per
  acquisition: a creator that stalls past the owner grace is refused while the
  lock is ownerless and can then publish a live record, and the timeout has to
  name that live holder rather than advise removing a lock somebody holds.

`AGENT_QUALITY_GATE_LOCK_TEST_FORCE_NOT_LOCAL` is a new test-only hook. The
suite cannot mount a network filesystem to make `df -l` say the interesting
thing, so this makes the probe answer `not-local`. It only ever withdraws a
reclaim — no setting of it authorises one — and it is refused outside
`NODE_ENV=test`, with a test for that refusal.

Reasoning is recorded in `docs/notes/agent-quality-gate-mechanics.md`, the file
issue 2061 names, next to the PR 2060 sections it qualifies.

No ADR: this is a bug fix inside an existing subsystem whose rationale is
canonical in that note, matching the precedent set by issues 2055 and 1802.

## Validation

- `bash scripts/agent-quality-gate.test.sh` — passes (`agent quality gate tests
  passed`), including the new cases:
  - two simulated machines with identical machine identity and identical
    hostname sharing one lock root, in both directions: neither reclaims the
    other's dead-looking record, both wait out the budget, both print the
    refusal;
  - an ownerless lock on the same root is also left in place;
  - the same record on the same operator-supplied root, unforced and therefore
    on local storage, **is** reclaimed — the negative control that pins the
    refusal to the storage rather than to the override;
  - an `owner.reclaiming.*` remnant on the forced-shared root survives the run,
    and the same remnant on local storage is still discarded — the two-sided
    control for the recovery change;
  - the refused wait's timeout prints "Nothing was reclaimed" and never "is
    still alive; let it finish";
  - a live record published three seconds after a refusal reverses that: the
    timeout names the live holder and "Nothing was reclaimed" is absent, with
    the earlier refusal asserted present in the same output so the case cannot
    pass by never reaching the branch;
  - the forcing hook flips the locality probe from `local` to `not-local`, and
    is refused outside `NODE_ENV=test`.
- Measured against `origin/main` on the exact configuration the review raised
  (operator lock dir, cloned machine identity, cloned hostname, dead holder PID):

  | root | `main` | this branch |
  | --- | --- | --- |
  | `AGENT_QUALITY_GATE_LOCK_DIR`, no declaration | reclaims | reclaims (unchanged) |
  | `AGENT_QUALITY_GATE_LOCK_DIR`, `IS_PER_MACHINE=0` | reclaims | waits (newly refused) |

  The patch subtracts reclaims and adds none.
- `bash scripts/agent-quality-gate.sh --run --parallel 4 --skip-if-fresh --base
  origin/main --lock-wait 3600` — passes.
- `./tools/trunk check scripts/agent-quality-gate.sh
  scripts/agent-quality-gate.test.sh docs/notes/agent-quality-gate-mechanics.md`
  — no issues.

Closes #2061

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2066 — `df -l`
  cannot see a locally-mounted root that two machines or PID namespaces share
  (an exported disk, a container bind mount). Pre-existing and unchanged by this
  PR; closing it means a heartbeat or making every operator root shared by
  default, both larger than this scope.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — bug fix inside an existing
      subsystem; the rationale is canonical in
      `docs/notes/agent-quality-gate-mechanics.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lock timeout diagnostics by reporting the current reclaim refusal reason, including ownerless locks.
  - Prevented stale recovery messages when lock conditions change.
  - Shared locks now fail safely when local crash recovery cannot be verified.

- **Documentation**
  - Added guidance for manually clearing locks, including verifying holders, commands, and outstanding cleanup obligations.
  - Clarified when owner records must be retained if verification is unavailable.

- **Tests**
  - Strengthened shared-lock race coverage and validation of recovery status and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->