### PR TITLE
fix(gate): accept the measured cloud plugin-download 403 as blocked

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -3,7 +3,7 @@ title: Agent Quality Gate — Mechanics
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-23
+last_verified: 2026-08-26
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -201,7 +201,7 @@ required full-repo Trunk check on every
 PR. Where the environment blocks Trunk's downloads — a Claude cloud container
 proxies egress and refuses any host outside its allowlist, and its credential
 proxy gates `github.com` per session on top of that — the gate reports the
-arm as `skipped` with a warning naming the allowlist fix instead of failing the
+arm as `skipped` with a warning naming a remedy instead of failing the
 run, matching the posture `.trunk/hooks` already takes. Trunk downloads at two
 stages and the gate classifies both. If the launcher cannot fetch the pinned CLI
 from `trunk.io`, a probe run after the command fails
@@ -221,7 +221,11 @@ the transcript on a cold cache. That 403 is pinned to the plugin source
 `.trunk/trunk.yaml` names, because a 403 from anywhere else is more likely
 revoked credentials than a session gate. A 404 keeps failing the gate too: a
 removed or renamed artifact is a broken pin the operator has to fix, not an
-allowlist to widen. The warning replays those reasons so it names the host to allowlist.
+allowlist to widen. Each shape gets its own warning, and both replay Trunk's
+recorded reasons so they name the host. The plugin warning says Trunk never
+reached a linter, and that a credential proxy gating the host per session is not
+something an allowed-domains entry can lift — there the remedy is a prewarmed
+`~/.cache/trunk` or CI.
 Everything else fails the gate, including a partly-explained failure set and a
 download step that failed for a local reason. Only a provisioning failure
 degrades: a provisioned Trunk that finds real problems still fails the gate, and

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -199,24 +199,32 @@ Trunk/tooling changes, package-manager changes, pnpm patches, and
 package-manifest changes still run full-repo Trunk locally. CI also runs a
 required full-repo Trunk check on every
 PR. Where the environment blocks Trunk's downloads — a Claude cloud container
-proxies egress and refuses any host outside its allowlist — the gate reports the
+proxies egress and refuses any host outside its allowlist, and its credential
+proxy gates `github.com` per session on top of that — the gate reports the
 arm as `skipped` with a warning naming the allowlist fix instead of failing the
 run, matching the posture `.trunk/hooks` already takes. Trunk downloads at two
 stages and the gate classifies both. If the launcher cannot fetch the pinned CLI
 from `trunk.io`, a probe run after the command fails
 (`TRUNK_LAUNCHER_QUIET=true ./tools/trunk --version`) answers that directly. If
 the launcher succeeds but the CLI cannot fetch its plugin sources or the
-hermetic runtimes and linter binaries a check needs — `trunk.io` allowlisted,
-`github.com` and `nodejs.org` not — the gate classifies the check transcript
-instead. That classification never infers "nothing was found": it accepts the
-transcript only when Trunk itself reported no issues, every failure Trunk
-counted is a download step, and the reason each step recorded in its
-`.trunk/out/*.yaml` detail file is one of Trunk's download-failure phrasings.
-The warning replays those reasons so it names the host to allowlist. Everything
-else fails the gate, including a partly-explained failure set and a download
-step that failed for a local reason. Only a provisioning failure degrades: a
-provisioned Trunk that finds real problems still fails the gate, and so does a
-run that mixes real findings with a blocked download. A run whose Trunk arm was
+hermetic runtimes and linter binaries a check needs, the gate classifies the
+check transcript instead. That classification never infers "nothing was found".
+For a blocked runtime or linter install it accepts the transcript only when
+Trunk itself reported no issues, every failure Trunk counted is a download step,
+and the reason each step recorded in its `.trunk/out/*.yaml` detail file is one
+of Trunk's download-failure phrasings. For a blocked plugin source Trunk aborts
+before linting anything and states the cause inline, so the gate accepts those
+same phrasings plus the measured
+`Unable to download plugin <url>: HTTP 403 '<url>'` — what a session-gated
+`github.com` returns — and ignores the launcher's own progress lines, which lead
+the transcript on a cold cache. A 404 keeps failing the gate: a removed or
+renamed artifact is a broken pin the operator has to fix, not an allowlist to
+widen. The warning replays those reasons so it names the host to allowlist.
+Everything else fails the gate, including a partly-explained failure set and a
+download step that failed for a local reason. Only a provisioning failure
+degrades: a provisioned Trunk that finds real problems still fails the gate, and
+so does a run that mixes real findings with a blocked download. A run whose
+Trunk arm was
 skipped writes no whole-run success stamp, so the next `--skip-if-fresh` run
 retries Trunk instead of inheriting a pass it never earned. Normal `--run` mode
 executes independent

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -225,7 +225,8 @@ allowlist to widen. Each shape gets its own warning, and both replay Trunk's
 recorded reasons so they name the host. The plugin warning says Trunk never
 reached a linter, and that a credential proxy gating the host per session is not
 something an allowed-domains entry can lift — there the remedy is a prewarmed
-`~/.cache/trunk` or CI.
+Trunk cache (`$TRUNK_CACHE`, else `$XDG_CACHE_HOME/trunk`, else
+`~/.cache/trunk`) or CI.
 Everything else fails the gate, including a partly-explained failure set and a
 download step that failed for a local reason. Only a provisioning failure
 degrades: a provisioned Trunk that finds real problems still fails the gate, and

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -217,9 +217,11 @@ before linting anything and states the cause inline, so the gate accepts those
 same phrasings plus the measured
 `Unable to download plugin <url>: HTTP 403 '<url>'` — what a session-gated
 `github.com` returns — and ignores the launcher's own progress lines, which lead
-the transcript on a cold cache. A 404 keeps failing the gate: a removed or
-renamed artifact is a broken pin the operator has to fix, not an allowlist to
-widen. The warning replays those reasons so it names the host to allowlist.
+the transcript on a cold cache. That 403 is pinned to the plugin source
+`.trunk/trunk.yaml` names, because a 403 from anywhere else is more likely
+revoked credentials than a session gate. A 404 keeps failing the gate too: a
+removed or renamed artifact is a broken pin the operator has to fix, not an
+allowlist to widen. The warning replays those reasons so it names the host to allowlist.
 Everything else fails the gate, including a partly-explained failure set and a
 download step that failed for a local reason. Only a provisioning failure
 degrades: a provisioned Trunk that finds real problems still fails the gate, and

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -86,14 +86,34 @@ each run, so a failed or degraded bootstrap leaves a diagnosable trace on
 disk even though the hook still routes that same output only to stderr to
 keep it out of the agent's context.
 
+### Measured host reality in a hosted container
+
+Measured on 2026-08-26 in a live cloud session (issue #2057), with `trunk.io`,
+`*.trunk.io`, and `cdn.playwright.dev` added to the Custom allowlist on top of
+the Trusted defaults:
+
+- `trunk.io`, `nodejs.org`, and `registry.npmjs.org` answer 200. Trunk's
+  hermetic runtimes and its npm-sourced linters download normally.
+- `github.com` does not. The platform's credential proxy intercepts it and
+  gates it per session, answering 403 with "GitHub access to this repository
+  is not enabled for this session". No allowlist entry lifts that.
+- That reaches Trunk's plugin archive (`github.com/trunk-io/plugins`) and its
+  GitHub-release linters. A cold `~/.cache/trunk` therefore fails the check
+  with `Unable to download plugin <url>: HTTP 403 '<url>'`. The image ships a
+  prewarmed cache holding both, which masks the block on a warm run.
+- The quality gate classifies that cold-cache 403 as environment-blocked and
+  skips its Trunk arm instead of hard-failing; a 404 stays a hard failure. See
+  [agent-quality-gate-mechanics.md](agent-quality-gate-mechanics.md).
+
 If the container's Node major is older than the repo's `.node-version` (for
 example, an image shipping Node v22 against a `.node-version` of `24`), the
 bootstrap does not attempt to switch the running interpreter — corepack only
 manages package-manager shims, not Node itself, and `pnpm env use --global`
-would need `nodejs.org` network access this environment does not grant, plus
-it would not reach the agent's later, separate shell invocations even if it
-succeeded. The script instead prints one clear WARN naming the mismatch and
-how to fix it env-side (rebuild/select a Node-24 container image); the
+would only repoint the `node` inside pnpm's managed area for that subprocess,
+never reaching the agent's later, separate shell invocations. The download
+itself would work — `nodejs.org` is reachable, per the measurements above. The
+script instead prints one clear WARN naming the mismatch and how to fix it
+env-side (rebuild/select a Node-24 container image); the
 mismatch itself only produces non-fatal pnpm engine-range warnings, since no
 root `.npmrc` sets `engine-strict`.
 

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -98,9 +98,12 @@ the Trusted defaults:
   gates it per session, answering 403 with "GitHub access to this repository
   is not enabled for this session". No allowlist entry lifts that.
 - That reaches Trunk's plugin archive (`github.com/trunk-io/plugins`) and its
-  GitHub-release linters. A cold `~/.cache/trunk` therefore fails the check
-  with `Unable to download plugin <url>: HTTP 403 '<url>'`. The image ships a
+  GitHub-release linters. A cold Trunk cache therefore fails the check with
+  `Unable to download plugin <url>: HTTP 403 '<url>'`. The image ships a
   prewarmed cache holding both, which masks the block on a warm run.
+  `tools/trunk` reads `$TRUNK_CACHE`, else `$XDG_CACHE_HOME/trunk`, else
+  `~/.cache/trunk`, so prewarming only the last one misses a session that sets
+  either override.
 - The quality gate classifies that cold-cache 403 as environment-blocked and
   skips its Trunk arm instead of hard-failing; a 404 stays a hard failure. See
   [agent-quality-gate-mechanics.md](agent-quality-gate-mechanics.md).

--- a/docs/notes/worktree-and-web-setup.md
+++ b/docs/notes/worktree-and-web-setup.md
@@ -3,7 +3,7 @@ title: New Worktree / Clone Setup and Claude Code on the Web Setup
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-29
+last_verified: 2026-08-26
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -109,11 +109,12 @@ If the container's Node major is older than the repo's `.node-version` (for
 example, an image shipping Node v22 against a `.node-version` of `24`), the
 bootstrap does not attempt to switch the running interpreter — corepack only
 manages package-manager shims, not Node itself, and `pnpm env use --global`
-would only repoint the `node` inside pnpm's managed area for that subprocess,
-never reaching the agent's later, separate shell invocations. The download
-itself would work — `nodejs.org` is reachable, per the measurements above. The
-script instead prints one clear WARN naming the mismatch and how to fix it
-env-side (rebuild/select a Node-24 container image); the
+would install that Node under `PNPM_HOME` rather than change the running
+interpreter. A later shell picks it up only when its `PATH` carries the
+pnpm-managed bin directory, and nothing here puts it there, so the agent's
+separate Bash tool shells keep the image's Node. The download itself would work
+— `nodejs.org` is reachable, per the measurements above. The script instead
+prints one clear WARN naming the mismatch and how to fix it env-side (rebuild/select a Node-24 container image); the
 mismatch itself only produces non-fatal pnpm engine-range warnings, since no
 root `.npmrc` sets `engine-strict`.
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2940,16 +2940,22 @@ trunk_text_has_network_failure_signature() {
 # before linting anything. The cause it prints is
 # `Unable to download plugin <url>: HTTP 403 '<url>'`.
 #
-# Two limits, both deliberate:
+# Three limits, all deliberate:
 #
 # - Plugin-scoped. The detail-YAML side was never measured with a 403, so adding
 #   `HTTP 403` to trunk_network_failure_signatures would excuse a shape nobody
 #   has seen. This acceptance reaches only `plugincause=` lines.
-# - 403 only, in the whole measured shape. This is the same rule that keeps the
-#   bare `Curl Error:` prefix out of the list above: a 404 — or any other status
-#   — is a removed or renamed artifact, a broken pin the operator has to fix, and
-#   must keep failing the gate rather than reading as an allowlist to widen.
-trunk_plugin_http_403_cause_pattern=$'^Unable to download plugin [^[:space:]]+: HTTP 403 \'[^[:space:]]+\'$'
+# - 403 only. This is the same rule that keeps the bare `Curl Error:` prefix out
+#   of the list above: a 404 — or any other status — is a removed or renamed
+#   artifact, a broken pin the operator has to fix, and must keep failing the
+#   gate rather than reading as an allowlist to widen.
+# - The measured plugin source only, which is the `uri:` .trunk/trunk.yaml pins
+#   (the `ref:` is the version in the path, so a ref bump still matches). A 403
+#   from some other plugin source is far more likely to be revoked credentials
+#   or a misconfigured private source than a session gate, and that has to stay
+#   visible. Both URLs in the phrase must be the same one, because that is the
+#   shape Trunk emits.
+trunk_plugin_http_403_cause_pattern=$'^Unable to download plugin (https://github\\.com/trunk-io/plugins/[^[:space:]]+): HTTP 403 \'([^[:space:]]+)\'$'
 
 # True when the inline cause Trunk printed for a failed plugin download is a
 # measured environment block.
@@ -2958,7 +2964,8 @@ trunk_plugin_cause_is_environment_blocked() {
 
   trunk_text_has_network_failure_signature "$cause" && return 0
 
-  [[ "$cause" =~ $trunk_plugin_http_403_cause_pattern ]]
+  [[ "$cause" =~ $trunk_plugin_http_403_cause_pattern ]] || return 1
+  [[ "${BASH_REMATCH[1]}" == "${BASH_REMATCH[2]}" ]]
 }
 
 # Read the `report:` lines of one Trunk failure-detail YAML and say whether the

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2930,6 +2930,37 @@ trunk_text_has_network_failure_signature() {
   return 1
 }
 
+# Trunk states a failed PLUGIN download inline, in the check output itself, and
+# never writes a detail YAML for it. That inline cause has its own measured
+# phrasing, so it gets its own acceptance rather than widening the shared list.
+#
+# Measured 2026-08-26 in a real Claude cloud container (Trunk 1.25.0, cold
+# TRUNK_CACHE): the platform's credential proxy intercepts github.com and gates
+# it per session, so Trunk's plugin archive comes back 403 and the CLI aborts
+# before linting anything. The cause it prints is
+# `Unable to download plugin <url>: HTTP 403 '<url>'`.
+#
+# Two limits, both deliberate:
+#
+# - Plugin-scoped. The detail-YAML side was never measured with a 403, so adding
+#   `HTTP 403` to trunk_network_failure_signatures would excuse a shape nobody
+#   has seen. This acceptance reaches only `plugincause=` lines.
+# - 403 only, in the whole measured shape. This is the same rule that keeps the
+#   bare `Curl Error:` prefix out of the list above: a 404 — or any other status
+#   — is a removed or renamed artifact, a broken pin the operator has to fix, and
+#   must keep failing the gate rather than reading as an allowlist to widen.
+trunk_plugin_http_403_cause_pattern=$'^Unable to download plugin [^[:space:]]+: HTTP 403 \'[^[:space:]]+\'$'
+
+# True when the inline cause Trunk printed for a failed plugin download is a
+# measured environment block.
+trunk_plugin_cause_is_environment_blocked() {
+  local cause="$1"
+
+  trunk_text_has_network_failure_signature "$cause" && return 0
+
+  [[ "$cause" =~ $trunk_plugin_http_403_cause_pattern ]]
+}
+
 # Read the `report:` lines of one Trunk failure-detail YAML and say whether the
 # reason it records is a download failure. The path comes from Trunk's own
 # output, so it is accepted only in the exact shape Trunk emits — a plain file
@@ -2984,7 +3015,8 @@ is_trunk_detail_yaml_path() {
 #                         and exactly N rows were download steps naming a
 #                         detail YAML.
 #   yaml=<path>           one per such row.
-#   shape=plugin          every non-blank line was a plugin-download error.
+#   shape=plugin          every line that was not launcher progress chrome was a
+#                         plugin-download error.
 #   plugincause=<text>    one per such line.
 # It emits nothing when the transcript shows findings, an unexplained failure,
 # or any line it cannot account for.
@@ -3009,6 +3041,20 @@ summarize_trunk_check_transcript() {
       line = strip($0)
       sub(/[ \t]+$/, "", line)
       if (line ~ /^[ \t]*$/) next
+
+      # tools/trunk is the launcher, and on a cold cache it installs the pinned
+      # CLI before running it, so the check transcript opens with the launcher
+      # progress lines. They are chrome, not a claim about the code, and the
+      # shape-2 rule below requires the transcript to hold nothing else.
+      #
+      # Ignored only in the exact grammar tools/trunk emits (mark, one of its
+      # own step messages, ellipsis, optional " done"). A launcher step that
+      # FAILED does not match and still disqualifies; the launcher probe is what
+      # covers that case.
+      if (line ~ ("^[^ ]+ (Downloading Trunk [^ ]+|Verifying Trunk sha256|" \
+        "Unpacking Trunk|Downloading latest Trunk Flaky Tests CLI|" \
+        "Unpacking Trunk Flaky Tests CLI)\\.\\.\\.( done)?$")) next
+
       nonblank++
 
       trimmed = line
@@ -3073,7 +3119,8 @@ summarize_trunk_check_transcript() {
       }
 
       # Shape 2: Trunk could not fetch its plugin sources, so it never linted
-      # anything. Accepted only when the transcript holds nothing else at all.
+      # anything. Accepted only when the transcript holds nothing else at all,
+      # launcher progress chrome aside.
       if (plugins >= 1 && declared < 0 && rows == 0) {
         for (i = 1; i <= nonblank; i++) {
           if (!(i in pluginline)) exit 0
@@ -3108,7 +3155,7 @@ trunk_check_output_is_environment_blocked() {
         ;;
       plugincause=*)
         value="${line#plugincause=}"
-        trunk_text_has_network_failure_signature "$value" || return 1
+        trunk_plugin_cause_is_environment_blocked "$value" || return 1
         evidence=$((evidence + 1))
         ;;
     esac

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -2723,8 +2723,13 @@ trunk_provisioning_state=""
 # own output. Drives the closing note and the whole-run stamp guard.
 trunk_arm_environment_blocked=false
 # Which provisioning stage blocked the arm currently being classified:
-# "launcher" (no CLI at all) or "linters" (CLI ran, its downloads failed).
+# "launcher" (no CLI at all), "plugin" (CLI ran, could not fetch its plugin
+# sources, never reached a linter), or "linters" (CLI ran and linted, its
+# runtime or linter downloads failed). Each names a different remedy.
 trunk_environment_blocked_kind=""
+# The transcript shape trunk_check_output_is_environment_blocked accepted, which
+# is what separates the last two.
+trunk_check_blocked_shape=""
 
 format_duration() {
   local seconds="$1"
@@ -3036,8 +3041,29 @@ summarize_trunk_check_transcript() {
       gsub(/\r/, "", s)
       return s
     }
+    # True for a tools/trunk progress line, and nothing else. Both halves are
+    # read off that tracked script: the mark is one it emits for a step in
+    # progress or a step that succeeded, and the message is one of its own,
+    # closed by the ellipsis it appends and an optional " done".
+    #
+    # The mark set is why the failure mark is absent: a launcher step that
+    # FAILED is not chrome, and it must keep disqualifying the transcript.
+    function is_launcher_progress(l,   i, rest) {
+      for (i = 1; i <= launcher_mark_count; i++) {
+        if (index(l, launcher_marks[i]) != 1) continue
+        rest = substr(l, length(launcher_marks[i]) + 1)
+        if (rest ~ ("^ (Downloading Trunk [^ ]+|Verifying Trunk sha256|" \
+          "Unpacking Trunk|Downloading latest Trunk Flaky Tests CLI|" \
+          "Unpacking Trunk Flaky Tests CLI)\\.\\.\\.( done)?$")) return 1
+      }
+      return 0
+    }
     BEGIN {
       cross = "\342\234\226"
+      # tools/trunk SUCCESS_MARK, then the eight PROGRESS_MARKS it cycles.
+      launcher_mark_count = split("\342\234\224 \342\241\277 \342\242\277 " \
+        "\342\243\273 \342\243\275 \342\243\276 \342\243\267 \342\243\257 " \
+        "\342\243\237", launcher_marks, " ")
       disqualified = 0
       declared = -1
       rows = 0
@@ -3053,14 +3079,7 @@ summarize_trunk_check_transcript() {
       # CLI before running it, so the check transcript opens with the launcher
       # progress lines. They are chrome, not a claim about the code, and the
       # shape-2 rule below requires the transcript to hold nothing else.
-      #
-      # Ignored only in the exact grammar tools/trunk emits (mark, one of its
-      # own step messages, ellipsis, optional " done"). A launcher step that
-      # FAILED does not match and still disqualifies; the launcher probe is what
-      # covers that case.
-      if (line ~ ("^[^ ]+ (Downloading Trunk [^ ]+|Verifying Trunk sha256|" \
-        "Unpacking Trunk|Downloading latest Trunk Flaky Tests CLI|" \
-        "Unpacking Trunk Flaky Tests CLI)\\.\\.\\.( done)?$")) next
+      if (is_launcher_progress(line)) next
 
       nonblank++
 
@@ -3140,13 +3159,16 @@ summarize_trunk_check_transcript() {
 }
 
 # True when a failed `trunk check` is provably an environment provisioning
-# failure with no lint findings behind it.
+# failure with no lint findings behind it. Publishes the accepted shape in
+# trunk_check_blocked_shape, because the two shapes need different remedies.
 trunk_check_output_is_environment_blocked() {
   local output_file="$1"
   local shape=""
   local line
   local value
   local evidence=0
+
+  trunk_check_blocked_shape=""
 
   [[ -n "$output_file" && -s "$output_file" ]] || return 1
 
@@ -3168,7 +3190,9 @@ trunk_check_output_is_environment_blocked() {
     esac
   done < <(summarize_trunk_check_transcript "$output_file")
 
-  [[ -n "$shape" && "$evidence" -ge 1 ]]
+  [[ -n "$shape" && "$evidence" -ge 1 ]] || return 1
+  trunk_check_blocked_shape="$shape"
+  return 0
 }
 
 # The single question both run paths ask about a failed Trunk arm. Sets
@@ -3182,7 +3206,14 @@ trunk_arm_is_environment_blocked() {
   if trunk_provisioning_is_blocked; then
     trunk_environment_blocked_kind=launcher
   elif trunk_check_output_is_environment_blocked "$output_file"; then
-    trunk_environment_blocked_kind=linters
+    # The plugin shape gets its own warning: Trunk aborted before it downloaded
+    # a single linter, so the linter warning would describe the wrong failure
+    # and name a remedy that does not apply.
+    if [[ "$trunk_check_blocked_shape" == plugin ]]; then
+      trunk_environment_blocked_kind=plugin
+    else
+      trunk_environment_blocked_kind=linters
+    fi
   else
     return 1
   fi
@@ -3195,12 +3226,37 @@ print_trunk_environment_blocked_warning() {
   local command="$1"
   local output_file="${2:-}"
 
+  if [[ "$trunk_environment_blocked_kind" == plugin ]]; then
+    print_trunk_plugin_environment_blocked_warning "$command" "$output_file"
+    return
+  fi
+
   if [[ "$trunk_environment_blocked_kind" == linters ]]; then
     print_trunk_linter_environment_blocked_warning "$command" "$output_file"
     return
   fi
 
   print_trunk_launcher_environment_blocked_warning "$command"
+}
+
+# Trunk fetches its plugin sources before it lints anything, so this failure
+# happened before any linter existed to run. The remedy differs too: the
+# measured cloud case is a credential proxy gating github.com per session, and
+# widening the environment's allowed domains cannot lift that.
+print_trunk_plugin_environment_blocked_warning() {
+  local command="$1"
+  local output_file="$2"
+
+  echo "warning: skipping ${command} — Trunk could not fetch its plugin sources." >&2
+  echo "  The CLI itself is installed — the launcher probe succeeded — but Trunk downloads the" >&2
+  echo "  linter definitions it needs before it lints anything, and that download failed. It" >&2
+  echo "  aborted before running a single linter, so no finding is being discarded here." >&2
+  echo "  Where the host below is simply not allowlisted, add it to the environment's allowed" >&2
+  echo "  domains. A Claude cloud session is the exception: its credential proxy gates" >&2
+  echo "  github.com per session and answers HTTP 403, and no allowed-domains entry lifts that." >&2
+  echo "  There the fix is the container image's prewarmed ~/.cache/trunk, or CI." >&2
+  print_trunk_provisioning_failure_causes "$output_file"
+  echo "  CI still enforces Trunk on the PR (.github/workflows/trunk.yml)." >&2
 }
 
 print_trunk_linter_environment_blocked_warning() {

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3254,7 +3254,8 @@ print_trunk_plugin_environment_blocked_warning() {
   echo "  Where the host below is simply not allowlisted, add it to the environment's allowed" >&2
   echo "  domains. A Claude cloud session is the exception: its credential proxy gates" >&2
   echo "  github.com per session and answers HTTP 403, and no allowed-domains entry lifts that." >&2
-  echo "  There the fix is the container image's prewarmed ~/.cache/trunk, or CI." >&2
+  echo "  There the fix is a prewarmed Trunk cache — \$TRUNK_CACHE, else \$XDG_CACHE_HOME/trunk," >&2
+  echo "  else ~/.cache/trunk — or CI." >&2
   print_trunk_provisioning_failure_causes "$output_file"
   echo "  CI still enforces Trunk on the PR (.github/workflows/trunk.yml)." >&2
 }

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5088,6 +5088,140 @@ assert_contains "Unable to download plugin https://github.com/trunk-io/plugins/a
 assert_contains "All mapped commands passed."
 assert_not_contains "mapped command(s) failed."
 
+# The same shape as measured in a real Claude cloud container on 2026-08-26
+# (issue #2057): the platform's credential proxy gates github.com per session,
+# so Trunk's plugin archive answers 403 and the CLI aborts. Two things about
+# this transcript are what the fixture exists to pin:
+#
+# - The cause is `HTTP 403 '<url>'`, which matches none of the `Curl Error:`
+#   phrasings the detail-YAML side records.
+# - The cache was cold, so tools/trunk installed the CLI first and its progress
+#   lines lead the transcript. The shape-2 rule requires the transcript to hold
+#   nothing but plugin errors, so that chrome has to be recognized as chrome.
+trunk_cloud_plugin_403_repo="$(mktemp -d)"
+(
+  cd "$trunk_cloud_plugin_403_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+printf '\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0...\n'
+printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0... done\n'
+printf '\033[0;32m\342\234\224\033[0m Unpacking Trunk...\n'
+printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Unpacking Trunk... done\n'
+printf '\n'
+printf "\033[0G\033[2K\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\033[0m\n"
+exit 2
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+)
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+# The warning has to replay the cause, or it names neither the host to allowlist
+# nor the status that made this an environment block rather than a broken pin.
+assert_contains "Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403"
+assert_contains "- skipped "
+assert_contains "All mapped commands passed."
+assert_not_contains "mapped command(s) failed."
+
+# Same stamp rule as every other blocked-Trunk path: a skipped arm leaves no
+# clean whole-run stamp, so the next --skip-if-fresh run retries Trunk.
+(
+  cd "$trunk_cloud_plugin_403_repo"
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run --skip-if-fresh > "$output_file" 2>&1
+)
+rm -rf "$trunk_cloud_plugin_403_repo"
+assert_not_contains "skipping mapped commands"
+assert_contains "All mapped commands passed."
+assert_contains "Note: the Trunk arm was skipped"
+
+# The 403 acceptance is scoped to that one measured status on purpose. A 404 is
+# a removed or renamed plugin archive — a broken pin the operator has to fix —
+# and it must keep failing the gate. The transcript is otherwise byte-identical
+# to the accepted one, so the status is the only thing deciding the verdict.
+trunk_cloud_plugin_404_repo="$(mktemp -d)"
+(
+  cd "$trunk_cloud_plugin_404_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+printf '\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0...\n'
+printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0... done\n'
+printf '\033[0;32m\342\234\224\033[0m Unpacking Trunk...\n'
+printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Unpacking Trunk... done\n'
+printf '\n'
+printf "\033[0G\033[2K\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 404 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\033[0m\n"
+exit 2
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_cloud_plugin_404_repo"
+assert_contains "1 mapped command(s) failed."
+assert_not_contains "- skipped "
+assert_not_contains "Trunk could not provision its linters."
+
+# A launcher step that FAILED is not chrome, and it must not be swallowed as
+# such. Here the launcher never produced a CLI, so nothing downstream can be
+# classified: the run has to fail rather than read as a plugin block.
+trunk_launcher_failed_line_repo="$(mktemp -d)"
+(
+  cd "$trunk_launcher_failed_line_repo"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Quality Gate Test"
+  printf 'fixture\n' > fixture.txt
+  mkdir -p tools
+  cat > tools/trunk <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+printf '\033[0;31m\342\234\230\033[0m Downloading Trunk 1.25.0... FAILED (see /tmp/launcher-download.log)\n'
+printf "\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\033[0m\n"
+exit 2
+STUB
+  chmod +x tools/trunk
+  git add .
+  git commit -qm init
+  printf 'changed\n' >> fixture.txt
+  set +e
+  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" -ne 0 ]]
+)
+rm -rf "$trunk_launcher_failed_line_repo"
+assert_contains "1 mapped command(s) failed."
+assert_contains "Downloading Trunk 1.25.0... FAILED"
+assert_not_contains "- skipped "
+
 # The invariant, restated against the new path: a Trunk that found a real problem
 # must fail the gate even when a linter download failed in the same run. This is
 # the transcript that would break the invariant if the classifier inferred "no

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5083,7 +5083,11 @@ STUB
   "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
 )
 rm -rf "$trunk_blocked_plugin_repo"
-assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+# The plugin shape gets its own warning. Trunk never reached a linter here, so
+# the linter warning would describe a failure that did not happen.
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not fetch its plugin sources."
+assert_contains "aborted before running a single linter"
+assert_not_contains "Trunk could not provision its linters."
 assert_contains "Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip"
 assert_contains "All mapped commands passed."
 assert_not_contains "mapped command(s) failed."
@@ -5112,9 +5116,10 @@ if [[ "${1:-}" == "--version" ]]; then
   echo "1.25.0"
   exit 0
 fi
-printf '\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0...\n'
+printf '\342\241\277 Downloading Trunk 1.25.0...\n'
+printf '\033[1F\033[0K\342\242\277 Downloading Trunk 1.25.0...\n'
 printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Downloading Trunk 1.25.0... done\n'
-printf '\033[0;32m\342\234\224\033[0m Unpacking Trunk...\n'
+printf '\342\241\277 Unpacking Trunk...\n'
 printf '\033[1F\033[0K\033[0;32m\342\234\224\033[0m Unpacking Trunk... done\n'
 printf '\n'
 printf "\033[0G\033[2K\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\033[0m\n"
@@ -5126,10 +5131,13 @@ STUB
   printf 'changed\n' >> fixture.txt
   "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
 )
-assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not provision its linters."
+assert_contains "warning: skipping ./tools/trunk check fixture.txt — Trunk could not fetch its plugin sources."
 # The warning has to replay the cause, or it names neither the host to allowlist
 # nor the status that made this an environment block rather than a broken pin.
 assert_contains "Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403"
+# And it has to name a remedy that can work. Widening the allowed domains cannot
+# lift a credential proxy that gates the host per session.
+assert_contains "no allowed-domains entry lifts that"
 assert_contains "- skipped "
 assert_contains "All mapped commands passed."
 assert_not_contains "mapped command(s) failed."
@@ -5226,41 +5234,46 @@ STUB
   assert_not_contains "Trunk could not provision its linters."
 done
 
-# A launcher step that FAILED is not chrome, and it must not be swallowed as
-# such. Here the launcher never produced a CLI, so nothing downstream can be
-# classified: the run has to fail rather than read as a plugin block.
-trunk_launcher_failed_line_repo="$(mktemp -d)"
-(
-  cd "$trunk_launcher_failed_line_repo"
-  git init -q
-  git config user.email test@example.invalid
-  git config user.name "Quality Gate Test"
-  printf 'fixture\n' > fixture.txt
-  mkdir -p tools
-  cat > tools/trunk <<'STUB'
+# Only the launcher's OWN marks make a line chrome. A failed launcher step keeps
+# disqualifying the transcript, and so does a line that merely carries the same
+# progress text behind an unrecognized mark — otherwise any unaccounted line
+# could dress itself as chrome and let a following plugin 403 skip the arm.
+for trunk_not_chrome_line in \
+  '\033[0;31m\342\234\230\033[0m Downloading Trunk 1.25.0... FAILED (see /tmp/launcher-download.log)' \
+  'ERROR Downloading Trunk 1.25.0... done'; do
+  trunk_not_chrome_repo="$(mktemp -d)"
+  (
+    cd "$trunk_not_chrome_repo"
+    git init -q
+    git config user.email test@example.invalid
+    git config user.name "Quality Gate Test"
+    printf 'fixture\n' > fixture.txt
+    mkdir -p tools
+    cat > tools/trunk <<STUB
 #!/usr/bin/env bash
-if [[ "${1:-}" == "--version" ]]; then
+if [[ "\${1:-}" == "--version" ]]; then
   echo "1.25.0"
   exit 0
 fi
-printf '\033[0;31m\342\234\230\033[0m Downloading Trunk 1.25.0... FAILED (see /tmp/launcher-download.log)\n'
-printf "\033[1m\033[31m\342\234\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\033[0m\n"
+printf '${trunk_not_chrome_line}\\n'
+printf "\\033[1m\\033[31m\\342\\234\\226 Unable to download plugin https://github.com/trunk-io/plugins/archive/v1.7.5.zip: HTTP 403 'https://github.com/trunk-io/plugins/archive/v1.7.5.zip'\\033[0m\\n"
 exit 2
 STUB
-  chmod +x tools/trunk
-  git add .
-  git commit -qm init
-  printf 'changed\n' >> fixture.txt
-  set +e
-  "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
-  exit_code=$?
-  set -e
-  [[ "$exit_code" -ne 0 ]]
-)
-rm -rf "$trunk_launcher_failed_line_repo"
-assert_contains "1 mapped command(s) failed."
-assert_contains "Downloading Trunk 1.25.0... FAILED"
-assert_not_contains "- skipped "
+    chmod +x tools/trunk
+    git add .
+    git commit -qm init
+    printf 'changed\n' >> fixture.txt
+    set +e
+    "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+    exit_code=$?
+    set -e
+    [[ "$exit_code" -ne 0 ]]
+  )
+  rm -rf "$trunk_not_chrome_repo"
+  assert_contains "1 mapped command(s) failed."
+  assert_contains "Downloading Trunk 1.25.0..."
+  assert_not_contains "- skipped "
+done
 
 # The invariant, restated against the new path: a Trunk that found a real problem
 # must fail the gate even when a linter download failed in the same run. This is

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -5186,6 +5186,46 @@ assert_contains "1 mapped command(s) failed."
 assert_not_contains "- skipped "
 assert_not_contains "Trunk could not provision its linters."
 
+# The acceptance is pinned to the plugin source .trunk/trunk.yaml names. A 403
+# from anywhere else is far more likely to be revoked credentials or a
+# misconfigured private source than a session gate, so it must stay visible.
+# Same for a phrase naming two different URLs, which is not a shape Trunk emits.
+for trunk_foreign_403_case in \
+  "https://plugins.example.invalid/archive/v1.7.5.zip|https://plugins.example.invalid/archive/v1.7.5.zip" \
+  "https://github.com/trunk-io/plugins/archive/v1.7.5.zip|https://github.com/trunk-io/plugins/archive/v9.9.9.zip"; do
+  trunk_foreign_403_repo="$(mktemp -d)"
+  (
+    cd "$trunk_foreign_403_repo"
+    git init -q
+    git config user.email test@example.invalid
+    git config user.name "Quality Gate Test"
+    printf 'fixture\n' > fixture.txt
+    mkdir -p tools
+    cat > tools/trunk <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+  echo "1.25.0"
+  exit 0
+fi
+printf "\\033[1m\\033[31m\\342\\234\\226 Unable to download plugin ${trunk_foreign_403_case%%|*}: HTTP 403 '${trunk_foreign_403_case##*|}'\\033[0m\\n"
+exit 2
+STUB
+    chmod +x tools/trunk
+    git add .
+    git commit -qm init
+    printf 'changed\n' >> fixture.txt
+    set +e
+    "$repo_root/scripts/agent-quality-gate.sh" --base HEAD --run > "$output_file" 2>&1
+    exit_code=$?
+    set -e
+    [[ "$exit_code" -ne 0 ]]
+  )
+  rm -rf "$trunk_foreign_403_repo"
+  assert_contains "1 mapped command(s) failed."
+  assert_not_contains "- skipped "
+  assert_not_contains "Trunk could not provision its linters."
+done
+
 # A launcher step that FAILED is not chrome, and it must not be swallowed as
 # such. Here the launcher never produced a CLI, so nothing downstream can be
 # classified: the run has to fail rather than read as a plugin block.

--- a/scripts/bootstrap/claude-code-web-setup.sh
+++ b/scripts/bootstrap/claude-code-web-setup.sh
@@ -81,12 +81,12 @@ echo "==> Checking Node major version against .node-version"
 #   - `pnpm env use --global <major>` downloads a full Node build from
 #     nodejs.org. That host is reachable (see the Trunk section above), so the
 #     download itself would work — the reason below is what rules it out.
-#   - The download would only repoint the `node` resolved inside pnpm's own
-#     managed area for THIS subprocess. It would not retroactively change the
-#     Node binary already on PATH for the agent's later, separate Bash tool
-#     invocations in the same session — those are independent shells, not
-#     children of this script — so a switch performed here would not reliably
-#     reach the place the mismatch actually matters.
+#   - It installs that Node under PNPM_HOME rather than changing the running
+#     interpreter, and a later shell picks it up only when its PATH carries the
+#     pnpm-managed bin directory. Nothing here puts it there, so the agent's
+#     later, separate Bash tool invocations — independent shells, not children
+#     of this script — keep the image's Node, and a switch performed here would
+#     not reach the place the mismatch actually matters.
 # Given both levers are either absent or illusory for the surface that
 # matters, attempting an automatic switch would be speculative rather than
 # robust. Warn once with a precise, actionable message instead, and never

--- a/scripts/bootstrap/claude-code-web-setup.sh
+++ b/scripts/bootstrap/claude-code-web-setup.sh
@@ -52,8 +52,10 @@ echo "==> Prewarming Trunk CLI and linters"
 # it per session, answering 403 "GitHub access to this repository is not enabled
 # for this session". No allowlist entry lifts that. It reaches Trunk's plugin
 # archive (github.com/trunk-io/plugins) and its GitHub-release linters, so a
-# COLD ~/.cache/trunk fails `trunk check` outright; the image ships a prewarmed
-# cache holding both, which is what masks the block on a warm run.
+# COLD Trunk cache fails `trunk check` outright; the image ships a prewarmed
+# cache holding both, which is what masks the block on a warm run. The prewarm
+# below fills whichever cache tools/trunk resolves — $TRUNK_CACHE, else
+# $XDG_CACHE_HOME/trunk, else ~/.cache/trunk.
 # Non-fatal: if trunk.io is still blocked the hooks degrade gracefully (see
 # .trunk/hooks) and CI still enforces Trunk on the PR, so warn and continue
 # rather than aborting the whole bootstrap.

--- a/scripts/bootstrap/claude-code-web-setup.sh
+++ b/scripts/bootstrap/claude-code-web-setup.sh
@@ -37,18 +37,23 @@ pnpm --version
 echo "==> Prewarming Trunk CLI and linters"
 # Trunk powers the git pre-commit/pre-push hooks (.trunk/hooks) and `trunk fmt`.
 # The launcher self-downloads the pinned CLI from trunk.io, which is NOT in the
-# default Trusted allowlist for Claude Code on the web. Everything else Trunk
-# needs (node/python runtimes, prettier/markdownlint via npm, checkov/codespell/
-# yamllint via PyPI, trufflehog/osv-scanner/actionlint via GitHub releases, tool
-# binaries on *.amazonaws.com) is already covered by the Trusted defaults. The
-# current operating allowlist beyond the Trusted defaults is trunk.io,
-# *.trunk.io, and (optional, for the Playwright Chromium fallback download
-# below when the image has no /opt/pw-browsers preinstall) cdn.playwright.dev.
-# In the environment's network settings choose "Custom", keep "include
-# defaults", and add:
+# default Trusted allowlist for Claude Code on the web. The current operating
+# allowlist beyond the Trusted defaults is trunk.io, *.trunk.io, and (optional,
+# for the Playwright Chromium fallback download below when the image has no
+# /opt/pw-browsers preinstall) cdn.playwright.dev. In the environment's network
+# settings choose "Custom", keep "include defaults", and add:
 #     trunk.io
 #     *.trunk.io
 #     cdn.playwright.dev   # optional; see the Playwright step below
+# Measured in a live cloud container on 2026-08-26 with that allowlist in force
+# (issue #2057): trunk.io, nodejs.org and registry.npmjs.org all answer 200, so
+# Trunk's hermetic runtimes and its npm-sourced linters download normally.
+# github.com does not — the platform's credential proxy intercepts it and gates
+# it per session, answering 403 "GitHub access to this repository is not enabled
+# for this session". No allowlist entry lifts that. It reaches Trunk's plugin
+# archive (github.com/trunk-io/plugins) and its GitHub-release linters, so a
+# COLD ~/.cache/trunk fails `trunk check` outright; the image ships a prewarmed
+# cache holding both, which is what masks the block on a warm run.
 # Non-fatal: if trunk.io is still blocked the hooks degrade gracefully (see
 # .trunk/hooks) and CI still enforces Trunk on the PR, so warn and continue
 # rather than aborting the whole bootstrap.
@@ -74,18 +79,14 @@ echo "==> Checking Node major version against .node-version"
 #   - corepack only manages package-manager shims (pnpm/yarn/npm), never the
 #     Node runtime itself, so it has no lever here.
 #   - `pnpm env use --global <major>` downloads a full Node build from
-#     nodejs.org. That host is not part of this bootstrap's documented
-#     network reality (see the Trunk section above and
-#     docs/notes/worktree-and-web-setup.md for the full allowlist), so the
-#     call would predictably fail with a network block in the standard
-#     hosted-session profile.
-#   - Even where the download succeeded, it would only repoint the `node`
-#     resolved inside pnpm's own managed area for THIS subprocess. It would
-#     not retroactively change the Node binary already on PATH for the
-#     agent's later, separate Bash tool invocations in the same session —
-#     those are independent shells, not children of this script — so a
-#     switch performed here would not reliably reach the place the mismatch
-#     actually matters.
+#     nodejs.org. That host is reachable (see the Trunk section above), so the
+#     download itself would work — the reason below is what rules it out.
+#   - The download would only repoint the `node` resolved inside pnpm's own
+#     managed area for THIS subprocess. It would not retroactively change the
+#     Node binary already on PATH for the agent's later, separate Bash tool
+#     invocations in the same session — those are independent shells, not
+#     children of this script — so a switch performed here would not reliably
+#     reach the place the mismatch actually matters.
 # Given both levers are either absent or illusory for the surface that
 # matters, attempting an automatic switch would be speculative rather than
 # robust. Warn once with a precise, actionable message instead, and never


### PR DESCRIPTION
## The Problem

- Issue #2057 asked for the linter-download degradation from #2058 to be
  measured in a real Claude cloud container. It was, on 2026-08-26, and the gate
  hard-failed.
- On a cold Trunk cache the container's credential proxy gates `github.com` per
  session and answers Trunk's plugin archive with 403, so the CLI aborts with
  `Unable to download plugin <url>: HTTP 403 '<url>'`. That phrasing matches
  none of the three signatures the classifier ships, so an agent in that
  container still could not get a green gate with nothing wrong in the diff.
- The measurement also corrected the allowlist notes: `trunk.io`, `nodejs.org`,
  and `registry.npmjs.org` are all reachable there. `github.com` is not, and no
  allowlist entry can change that.

## The Solution

The gate now recognizes that one measured cause and reports the Trunk arm as
`skipped` with a warning, instead of failing a run that has no lint finding
behind it. The operator gets a runnable gate in a hosted container, and a
warning that names a remedy which can actually work.

The acceptance is deliberately narrow in three ways, and each is the point:

- **Plugin-scoped.** It reaches only the cause Trunk prints inline for a failed
  plugin download. The detail-YAML side was never measured with a 403, so
  widening the shared signature list would excuse a shape nobody has seen.
- **403 only.** A 404 — or any other status — is a removed or renamed artifact,
  a broken pin the operator has to fix, and it keeps failing the gate. This is
  the same rule that already keeps the bare `Curl Error:` prefix out of the
  shared list, and it now has its own test.
- **The configured plugin source only.** A 403 from any other source is more
  likely revoked credentials or a misconfigured private source than a session
  gate, and that has to stay visible.

The standing invariant is untouched: a provisioned Trunk that finds real
problems still fails the gate, and every existing fail-closed case still fails.

Material limit: the 403 was measured on the plugin path only. A GitHub-release
linter blocked the same way would record its cause in a `.trunk/out/*.yaml`
detail file, and that path is unchanged — it would still hard-fail until someone
measures it.

## Details

Three changes, all in the classifier and its warning.

**The cause pattern.** `trunk_plugin_cause_is_environment_blocked` is the new
question asked about a `plugincause=` line. It accepts the existing measured
phrasings plus one pattern, anchored end to end and pinned to the `uri:` that
`.trunk/trunk.yaml` declares:

```
^Unable to download plugin (https://github\.com/trunk-io/plugins/[^[:space:]]+): HTTP 403 '([^[:space:]]+)'$
```

Both captured URLs must be the same one, because that is the shape Trunk emits.
The `ref:` is the version inside the path, so a ref bump still matches. Detail-
YAML reasons keep going through `trunk_text_has_network_failure_signature`
unchanged, so nothing about the tools shape moves.

**Launcher chrome.** `summarize_trunk_check_transcript` now skips `tools/trunk`'s
own progress lines. This is needed, not cosmetic: on a cold cache the launcher
installs the pinned CLI before running it, so `Downloading Trunk <version>...`
and `Unpacking Trunk... done` lead the transcript — and the plugin shape only
accepts a transcript that holds nothing but plugin errors. A line counts as
chrome only when its mark is one `tools/trunk` emits (its eight spinner glyphs
or its success mark) and its text is one of that script's own step messages,
closed by the ellipsis it appends and an optional ` done`. The failure mark is
absent from that set, so a launcher step that printed `FAILED` still
disqualifies the transcript.

**Its own warning.** The plugin block used to report as kind `linters`, which
described hermetic runtime and linter downloads that never happened and told the
operator to widen the environment's allowed domains — a remedy a credential
proxy cannot honor. The plugin shape now has its own kind and its own warning:
Trunk aborted before reaching a linter, add the host to the allowed domains when
that is all it is, and use the prewarmed `~/.cache/trunk` or CI when the cause is
a session gate.

The measurement itself is recorded on issue #2057, including the proxy's 403
body, the per-host probe results, and the `logs/cli.log` line.

## Validation

- `bash scripts/agent-quality-gate.test.sh` — full suite passes.
  New cases in the `failure-output` family: the measured cloud transcript
  (spinner and success-marked launcher lines + `✖ … HTTP 403 …`) degrades to
  `skipped` with the plugin warning and writes no clean whole-run stamp; the
  same transcript with `HTTP 404` fails; a 403 for a plugin URL on another host
  fails; a 403 whose two URLs differ fails; a launcher `FAILED` line and an
  `ERROR …` line carrying the same progress text both fail rather than reading
  as chrome.
- Drove both directions end to end against a throwaway fixture repo before
  writing the tests: the 403 shape reports `- skipped` with the cause replayed
  in the warning, the 404 shape reports `1 mapped command(s) failed.`
- `bash scripts/agent-quality-gate.sh --run --parallel 4 --skip-if-fresh --base origin/main`
  — passes.
- `./tools/trunk check --no-fix` on all five touched files — no issues.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this extends an existing
      degradation path under its existing invariant.

Closes #2057


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Trunk download verification to distinguish launcher, plugin-source, and runtime failures.
  - Added stricter validation for approved plugin downloads while keeping unrelated failures blocked.
  - Added clearer warnings and remediation guidance for credential proxies and cache-related issues.

- **Documentation**
  - Updated guidance for Node version management, network access, Trunk caching, and hosted web environments.
  - Clarified how download behavior and environment changes affect later sessions.

- **Tests**
  - Expanded coverage for valid and invalid plugin-download scenarios, including URL mismatches and misleading progress output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->