### PR TITLE
feat(repo-health): pin normative guardrail prose in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,6 +1052,14 @@ jobs:
         run: node scripts/repo-health/check-hermetic-vitest-setup.mjs
       - name: Hermetic Vitest setup consistency suite
         run: node scripts/repo-health/check-hermetic-vitest-setup.test.mjs
+      - name: Guardrail prose pins
+        # The repo's strongest rules live only as prose in AGENTS.md and
+        # docs/notes/pr-operating-card.md. This runs in the required `ci`
+        # sentinel, not only in the local pre-push gate, because the local gate
+        # is the thing an edit that drops one of those sentences would skip.
+        run: node scripts/repo-health/check-guardrail-prose.mjs
+      - name: Guardrail prose pin suite
+        run: node scripts/repo-health/check-guardrail-prose.test.mjs
       - name: Deviation threshold drift suite
         run: node scripts/alerts/check-deviation-threshold-drift.test.mjs
       - name: Agent context checker unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,14 +1052,11 @@ jobs:
         run: node scripts/repo-health/check-hermetic-vitest-setup.mjs
       - name: Hermetic Vitest setup consistency suite
         run: node scripts/repo-health/check-hermetic-vitest-setup.test.mjs
-      - name: Guardrail prose pins
-        # The repo's strongest rules live only as prose in AGENTS.md and
-        # docs/notes/pr-operating-card.md. This runs in the required `ci`
-        # sentinel, not only in the local pre-push gate, because the local gate
-        # is the thing an edit that drops one of those sentences would skip.
-        run: node scripts/repo-health/check-guardrail-prose.mjs
-      - name: Guardrail prose pin suite
-        run: node scripts/repo-health/check-guardrail-prose.test.mjs
+      # The guardrail-prose pins used to run here, one step each. They now run
+      # in the unconditional `guardrail-prose` job above, because this job is
+      # path-gated on `scripts/**` and allowed to skip — so a PR editing only
+      # AGENTS.md or the operating card never reached them. Running them in both
+      # places would add a second copy with no extra signal.
       - name: Deviation threshold drift suite
         run: node scripts/alerts/check-deviation-threshold-drift.test.mjs
       - name: Agent context checker unit tests
@@ -1183,6 +1180,41 @@ jobs:
       # their own output that each one asserted (issue #1779, ADR 0062) — a
       # strictly stronger claim than a step existing. Running them in both jobs
       # cost a second copy of the whole set and let the two paths disagree.
+      - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
+        if: always()
+
+  guardrail-prose:
+    name: Guardrail prose pins
+    # Unconditional by design (no `if:`), like production-infra-contract and
+    # sentry-suites below. These two commands ran as steps of the path-gated
+    # `scripts` job until review found the hole: that job admits on
+    # `rootScripts` (`scripts/**`) and sits in the `ci` sentinel's
+    # `allowed-skips`, so the exact diff this check exists to catch — one that
+    # edits only AGENTS.md, CLAUDE.md or the operating card and drops a pinned
+    # sentence — skipped the job while the required sentinel stayed green. A
+    # guardrail absent precisely when it is needed is worse than none, and the
+    # Sentry suites were moved out of that same job for the same reason.
+    #
+    # The checker and its suite import only `node:` builtins, so this job is a
+    # checkout, a Node, and two sub-second commands — no `pnpm install`.
+    # `check-guardrail-prose.test.mjs` also asserts this job's own wiring: that
+    # it exists, carries no `if:`, runs both commands, and reaches `ci` without
+    # an allowed-skip. Move or rename it and that suite reds.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+      - name: Guardrail prose pins
+        run: node scripts/repo-health/check-guardrail-prose.mjs
+      - name: Guardrail prose pin suite
+        run: node scripts/repo-health/check-guardrail-prose.test.mjs
       - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
         if: always()
 
@@ -1397,6 +1429,7 @@ jobs:
         terraform,
         deps,
         scripts,
+        guardrail-prose,
         production-infra-contract,
         sentry-suites,
         autoreview-suite,

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,7 @@ Authority: canonical
 - [`docs/adr/0069-gate-routing-table-as-data.md`](adr/0069-gate-routing-table-as-data.md) — The quality gate's routing table is data, compiled by the repo's own bash-case translator
 - [`docs/adr/0070-sentry-requeue-settlement-sentinel.md`](adr/0070-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
 - [`docs/adr/0071-susds-launch-aligned-daily-sampler.md`](adr/0071-susds-launch-aligned-daily-sampler.md) — sUSDS actuals use a launch-aligned bounded daily sampler
+- [`docs/adr/0072-guardrail-prose-pinned-in-ci.md`](adr/0072-guardrail-prose-pinned-in-ci.md) — Normative guardrail sentences are pinned in CI, and scripts are not
 
 Authority: non-canonical
 

--- a/docs/adr/0072-guardrail-prose-pinned-in-ci.md
+++ b/docs/adr/0072-guardrail-prose-pinned-in-ci.md
@@ -1,0 +1,155 @@
+---
+title: Normative guardrail sentences are pinned in CI, and scripts are not
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-26
+scope: ci/process
+date: 2026-08
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0072 — normative guardrail sentences are pinned in CI, and scripts are not
+
+**Status:** Accepted (Aug 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+The strongest rules this repository has are prose. "Never merge without the
+user's explicit approval for that specific merge", "Secrets are IaC-owned",
+"Terraform apply requires explicit human approval", "Forensic drafts stay
+local" — each exists as a sentence in `AGENTS.md`, in the `CLAUDE.md` symlink
+beside it, and in `docs/notes/pr-operating-card.md`. Agents read those files as
+ground truth at the start of every session; [ADR 0005](0005-context-as-product.md)
+makes that the point of the context layer.
+
+Nothing enforced their continued existence. Those same files are edited
+constantly — by the documentation garden ([ADR 0040](0040-bounded-documentation-garden-queue.md)),
+by context-budget trimming, by agents fixing a neighbouring paragraph. A rule
+could disappear inside an unrelated cleanup and no check would red. The loss
+would be silent in the worst way: the next session simply would not know the
+rule existed, and the first evidence would be an agent merging a PR nobody
+approved.
+
+The failure mode has a name in this tree. [ADR 0064](0064-scripts-module-directories.md)
+records enumerated path pins whose miss is silent — "the job stops running while
+the required `ci` sentinel stays green" — and [ADR 0062](0062-sentry-suites-self-run-gate.md)
+records a required check proving from output that it actually ran rather than
+merely existing. This is the same class applied to sentences instead of jobs.
+
+## Decision
+
+**A pin list holds each normative sentence, and CI fails when one goes missing.**
+`scripts/repo-health/guardrail-prose.json` maps a repository-relative path to
+the snippets that path must carry;
+`scripts/repo-health/check-guardrail-prose.mjs` reads each file and reports any
+snippet it can no longer find. Removing a rule is then a two-file change — the
+prose and the pin — in one PR, which a reviewer sees. It stays possible, and
+stops being invisible.
+
+**Matching is whitespace-normalized substring, and pins are one clause long.**
+Every whitespace run collapses to a single space on both sides, so a Prettier
+rewrap or a sentence moving across a line break never fails the check; only the
+words changing does. Pins are deliberately short. A pinned paragraph would turn
+every reword into a CI failure and train people to edit the pin without reading
+it, which is the opposite of what this protects.
+
+**The loader fails closed on every unusable shape.** A pin file that is
+missing, unparsable, not an object, empty, holding an empty snippet array, or
+repeating a top-level key is a hard failure, never "no pins to check". The
+duplicate-key case is the subtle one: `JSON.parse` keeps only the last of two
+identical keys and reports nothing, so a repeated path would silently discard
+the earlier block's pins with no deletion anywhere in the diff. A reviver cannot
+see it either — the reviver walks the already-collapsed result. The check reads
+the raw text for duplicate keys instead.
+
+**The job that runs it is unconditional.** `guardrail-prose` in
+`.github/workflows/ci.yml` carries no `if:`, sits in the `ci` sentinel's
+`needs`, and is deliberately absent from its `allowed-skips`. This follows
+[ADR 0010](0010-required-checks-no-paths-filters.md): a skipped required check
+counts as satisfied. The first implementation of this decision put the two
+commands in the path-gated `scripts` job, which admits on `scripts/**` and is
+allowed to skip — so a PR editing only `AGENTS.md` and dropping a pinned
+sentence skipped the check entirely while `ci` stayed green. The Sentry suites
+were moved out of that same job for the same reason. The suite pins its own
+wiring: the job id, both `run:` strings, the sentinel's `needs`, and the absence
+of an allowed-skip, each with a negative control that mutates the real workflow.
+
+**`CLAUDE.md` carries its own pin block.** It is a symlink to `AGENTS.md` and
+`readFileSync` follows it, so both blocks read the same bytes and the
+duplication is free today. It is also the path the Claude runtime loads, and
+nothing else asserts it stays a symlink. The block starts earning its keep the
+moment that link becomes a divergent regular file or is dropped.
+
+## Alternatives considered
+
+**Pin script digests too, or instead.** The obvious generalization: hash the
+gate, the autoreview wrapper and the helper scripts, and fail when a hash moves.
+Rejected, and this is the deliberate scope limit of the decision. Those scripts
+are legitimately agent-maintained and change in most weeks; a digest pin would
+red on every intended edit, so the pin would be updated reflexively as part of
+the commit and would stop carrying information within a month. The repository
+already protects that surface where it matters and where the pin is not noise —
+`agent-autoreview.sh` hashes its own blob against a frozen-HEAD snapshot before
+an explicit-ref review, and `.gitattributes` plus `UPSTASH_MCP_LAUNCHER_SHA256`
+byte-pin one reviewed artifact ([ADR 0065](0065-scripts-file-size-watchlist-scope.md)
+records both). Prose is the surface where a pin is cheap, because normative
+sentences are supposed to be stable: a rule that changes monthly is not a rule.
+
+**Pin whole sections rather than clauses.** Stronger coverage — a rule gutted
+from within its own paragraph would be caught. Rejected on the same reflex
+argument: section-level pins fail on ordinary rewording, and a check that reds
+on legitimate edits gets its expectations updated without being read.
+
+**Rely on review and CODEOWNERS.** No new machinery. Rejected: bots sample
+rather than enumerate, and a deletion inside a large documentation-garden diff
+is exactly what a sampling reviewer misses. Human review of every AGENTS.md
+edit is not the working model here.
+
+**Run the check only in the local pre-push gate.** The gate already routes it
+from both directions — an edit to the checker or the pin list, and an edit to
+any protected prose file, `CLAUDE.md` included. Rejected as the only route: the local gate is
+skippable by anything that does not run it, including a web session or an edit
+landed through the GitHub UI, and the pins are worth exactly what the weakest
+route enforces. It stays as the fast local signal; CI is the binding one.
+
+## Consequences
+
+- Changing a normative rule now costs a same-PR edit to
+  `scripts/repo-health/guardrail-prose.json`. That is the intended friction and
+  the entire mechanism: the pin list becomes a reviewable registry of which
+  sentences the repository considers load-bearing.
+- **The check proves presence, not obedience.** It cannot tell whether an agent
+  followed "never merge without explicit approval"; it only proves the sentence
+  is still there to be read. It also cannot stop a determined removal — a PR
+  that edits both files passes. Visibility is the property being bought, not
+  prevention.
+- Adding a new normative sentence does not pin it. Coverage grows only when
+  someone adds the pin, so the list will trail the prose. The 90-day
+  re-verification on this record is where that gap is reviewed.
+- CI gains one job boot per PR: a checkout, a Node, and two sub-second commands
+  with no `pnpm install`, since the checker and its suite import only `node:`
+  builtins.
+- Moving `AGENTS.md`, `CLAUDE.md`, or the operating card means editing the pin
+  keys in the same PR. `scripts/AGENTS.md` records this pin class under the
+  move-sweep inventory ADR 0064 requires.
+
+## Evidence
+
+- Checker and fail-closed loader:
+  [`scripts/repo-health/check-guardrail-prose.mjs`](../../scripts/repo-health/check-guardrail-prose.mjs)
+- The pinned sentences:
+  [`scripts/repo-health/guardrail-prose.json`](../../scripts/repo-health/guardrail-prose.json)
+- Behaviour, negative controls, and the CI-wiring assertion:
+  [`scripts/repo-health/check-guardrail-prose.test.mjs`](../../scripts/repo-health/check-guardrail-prose.test.mjs)
+- The unconditional job and the `ci` sentinel's needs/allowed-skips:
+  [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+- Local gate routes from the protected prose files, not only from `scripts/`:
+  `scripts/gate/routing-table/groups-head.mjs`,
+  `arms-scripts.mjs`, `arms-agent-modules.mjs`
+- Move-sweep pin inventory: [`scripts/AGENTS.md`](../../scripts/AGENTS.md)
+- Issue: <https://github.com/mento-protocol/monitoring-monorepo/issues/2069>;
+  PR: <https://github.com/mento-protocol/monitoring-monorepo/pull/2073>

--- a/docs/adr/0073-guardrail-prose-pinned-in-ci.md
+++ b/docs/adr/0073-guardrail-prose-pinned-in-ci.md
@@ -91,6 +91,16 @@ in one commit still passes — no check can outlive its own removal — but that
 edit is visible in a single diff, which is the property being bought throughout
 this record. The cost is one duplicate sub-second run on `scripts/**` diffs.
 
+**Present is not the same as enforcing.** A `run:` line proves the command is
+written down, not that its failure stops the job. A step-level `if:` makes the
+step skip, and `continue-on-error` makes its failure advisory; either leaves the
+required `ci` context green over a guardrail that no longer holds, and the
+job-level `if:` above is only the coarsest version of the same move. The suite
+therefore rejects step-level `if:` and `continue-on-error` on every guardrail
+step in both hosts, and `continue-on-error` on the job itself, each with its own
+negative control. Ten controls now mutate the real `ci.yml`, and each asserts
+the mutation changed the file before asserting the check reds.
+
 **`CLAUDE.md` carries its own pin block.** It is a symlink to `AGENTS.md` and
 `readFileSync` follows it, so both blocks read the same bytes and the
 duplication is free today. It is also the path the Claude runtime loads, and

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,6 +81,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0068](0068-sentry-fixture-authoring-policy.md)             | Adversarial fixtures are authored to scan clean; no value or line registry           |
 | [0069](0069-gate-routing-table-as-data.md)                  | The gate's routing table is data, compiled by the repo's own bash-`case` translator  |
 | [0070](0070-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
+| [0072](0072-guardrail-prose-pinned-in-ci.md)                | Normative guardrail sentences are pinned in CI; script digests deliberately are not  |
 
 ### shared-config
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -83,6 +83,7 @@ pnpm adr:check                      # Advisory ADR reminder for architectural ch
 pnpm adr:check:test                 # Offline tests for the ADR reminder trigger logic
 node scripts/workflows/check-github-action-pins.mjs  # Verify workflow/composite-action `uses:` refs are SHA-pinned
 node scripts/repo-health/check-hermetic-vitest-setup.mjs  # Verify all workspace Vitest network guards are byte-identical
+node scripts/repo-health/check-guardrail-prose.mjs  # Verify the guardrail sentences pinned in scripts/repo-health/guardrail-prose.json still appear in AGENTS.md and the operating card
 node scripts/repo-health/file-size-watchlist.mjs  # Refresh source file-size watchlist (package src/ trees + scripts/); use --format issue for GitHub Issues, not BACKLOG.md
 pnpm indexer:testnet:codegen       # Generate types (multichain testnet: Celo Sepolia + Monad testnet + Polygon Amoy)
 pnpm indexer:testnet:dev           # Start indexer (multichain testnet)

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -73,10 +73,11 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `pnpm sentry:project:test` in the projection arm.
   `deploy/deploy-indexer-verify{,-analysis}{,.test}.mjs` and
   `deploy/deploy-indexer-verify-status-identity.mjs` use one any-depth arm;
-  both verifier tests run. The exact `pr/agent-issue-board.mjs`,
-  `pr/agent-issue-board.test.mjs`, and
+  both verifier tests run. The exact `pr/agent-issue-board{,.test}.mjs` and
   `pr/issue-board-{backfill,cli,commands,projects,state,sync,transport}.mjs` set
-  routes to `pnpm issue:board:test`.
+  routes to `pnpm issue:board:test`. Exact
+  `repo-health/check-guardrail-prose{,.test}.mjs` and
+  `repo-health/guardrail-prose.json` route to the guardrail suite.
 - **Gate runtime module pins.** Before `cd`, `agent-quality-gate.sh` loads
   `$script_source_dir/gate/run-handles.sh`; move it with its signature, self-test
   route, and missing-helper fixture. It also pins
@@ -99,19 +100,18 @@ same PR, except the `agent-autoreview.sh` feedback-runtime pins below.
   `.github/workflows/` pin a `scripts/` path, and `sentry-triage-agent.yml`
   stages an exact copy list at runtime; three Terraform filters instead
   copy the broad `workflowAdmissionPatterns` boundary from
-  `terraform.stacks.json`. A miss is silent — the job stops running while the
-  required `ci` sentinel stays green. The enumeration, the `routing.test.mjs`
-  equality contract, and when a module glob is the safer pin are in
+  `terraform.stacks.json`. A miss is silent: the job stops while the required
+  `ci` sentinel stays green. The enumeration, `routing.test.mjs`'s equality
+  contract, and when a module glob is the safer pin are in
   [ADR 0064](../docs/adr/0064-scripts-module-directories.md#sweep-checklist-for-a-move).
 - **Terraform stack registry.** `terraform.stacks.json` `changedPathPatterns`
   pins exact `scripts/` paths per stack. The broad workflow admission boundary
   covers the directory; `pnpm tf:test` enforces subsumption.
 - **Trusted-validator probes.** `pr-description.yml` runs the validator from the
   PR's base ref via the base branch **name**, so it resolves to that branch's
-  tip, never a PR-time snapshot. One probe
-  path is enough once the target path is live on the base branch (issue 1904);
-  a move still needs a temporary dual probe for the commit that performs it.
-  ADR 0064 has the failure mode.
+  tip, never a PR-time snapshot. One probe path is enough once the target is
+  live on the base branch (issue 1904); the commit that performs a move still
+  needs a temporary dual probe. ADR 0064 has the failure mode.
 - **Production infrastructure contract pins.**
   `production-infra-identity-contract/workflow-inventory.mjs` pins exact script
   paths for the workflows it audits.

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3247,10 +3247,17 @@ assert_contains "- node scripts/repo-health/check-skills-mirror.test.mjs (skills
 assert_contains "- node scripts/repo-health/check-skills-mirror.mjs (skills mirror checker changed)"
 
 # The guardrail-prose pins route from BOTH directions: an edit to the checker or
-# its pin list, and an edit to either prose file the pins protect. The second is
+# its pin list, and an edit to any prose file the pins protect. The second is
 # the one that matters — a change dropping a pinned sentence must not reach a
 # push without the check having run.
 run_gate "AGENTS.md"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (agent instruction file holding pinned guardrail prose changed)"
+
+# CLAUDE.md is the AGENTS.md symlink and carries its own pin block. An edit made
+# through the link reports as AGENTS.md, but replacing the link with a regular
+# file reports as CLAUDE.md — the case the pin block exists for — so it must
+# route the check too.
+run_gate "CLAUDE.md"
 assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (agent instruction file holding pinned guardrail prose changed)"
 
 run_gate "docs/notes/pr-operating-card.md"

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -3246,6 +3246,29 @@ assert_contains "- pnpm lint:scripts (root build script changed)"
 assert_contains "- node scripts/repo-health/check-skills-mirror.test.mjs (skills mirror checker changed)"
 assert_contains "- node scripts/repo-health/check-skills-mirror.mjs (skills mirror checker changed)"
 
+# The guardrail-prose pins route from BOTH directions: an edit to the checker or
+# its pin list, and an edit to either prose file the pins protect. The second is
+# the one that matters — a change dropping a pinned sentence must not reach a
+# push without the check having run.
+run_gate "AGENTS.md"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (agent instruction file holding pinned guardrail prose changed)"
+
+run_gate "docs/notes/pr-operating-card.md"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (operating card holding pinned guardrail prose changed)"
+
+run_gate "scripts/repo-health/check-guardrail-prose.mjs"
+assert_contains "- pnpm lint:scripts (root build script changed)"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.test.mjs (guardrail prose checker changed)"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (guardrail prose checker changed)"
+
+# The pin list is a .json, so it reaches no module arm and would otherwise fall
+# through to the bare `scripts/*` catch-all. Its own arm is what keeps an edited
+# pin checked against the prose it claims to pin.
+run_gate "scripts/repo-health/guardrail-prose.json"
+assert_contains "- scripts"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.test.mjs (guardrail prose pin list changed)"
+assert_contains "- node scripts/repo-health/check-guardrail-prose.mjs (guardrail prose pin list changed)"
+
 run_gate ".trunk/trunk.yaml"
 assert_contains "- tooling"
 assert_contains "- node scripts/workflows/check-github-action-pins.mjs (Trunk workflow/action setup changed)"

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -154,6 +154,22 @@ export const AGENT_MODULE_ARMS = [
   },
   {
     patterns: [
+      "scripts/repo-health/check-guardrail-prose.mjs",
+      "scripts/repo-health/check-guardrail-prose.test.mjs",
+    ],
+    effects: [
+      {
+        command: "node scripts/repo-health/check-guardrail-prose.test.mjs",
+        reason: "guardrail prose checker changed",
+      },
+      {
+        command: "node scripts/repo-health/check-guardrail-prose.mjs",
+        reason: "guardrail prose checker changed",
+      },
+    ],
+  },
+  {
+    patterns: [
       "scripts/repo-health/check-skills-mirror.mjs",
       "scripts/repo-health/check-skills-mirror.test.mjs",
     ],

--- a/scripts/gate/routing-table/arms-scripts.mjs
+++ b/scripts/gate/routing-table/arms-scripts.mjs
@@ -311,4 +311,21 @@ export const SCRIPT_ARMS = [
       },
     ],
   },
+  {
+    patterns: ["scripts/repo-health/guardrail-prose.json"],
+    effects: [
+      {
+        why: "The pin list check-guardrail-prose.mjs reads. Like the Sentry manifest above, a .json under scripts/ reaches no module arm — those key off `.mjs` — and would otherwise fall through to the bare `scripts/*` catch-all with no commands at all. Editing a pin IS the deliberate rule change this check exists to surface, so it has to run the checker against the edited list.",
+        surface: "scripts",
+      },
+      {
+        command: "node scripts/repo-health/check-guardrail-prose.test.mjs",
+        reason: "guardrail prose pin list changed",
+      },
+      {
+        command: "node scripts/repo-health/check-guardrail-prose.mjs",
+        reason: "guardrail prose pin list changed",
+      },
+    ],
+  },
 ];

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -103,7 +103,16 @@ export const HEAD_GROUPS = [
         ],
       },
       {
-        patterns: ["AGENTS.md", "*/AGENTS.md", ".codex/config.toml"],
+        // `CLAUDE.md` is the root AGENTS.md symlink and carries its own pin
+        // block. Editing through the symlink shows up as `AGENTS.md`, but
+        // replacing or deleting the link shows up as `CLAUDE.md` — the exact
+        // change the pin exists to catch — so it routes here too.
+        patterns: [
+          "AGENTS.md",
+          "CLAUDE.md",
+          "*/AGENTS.md",
+          ".codex/config.toml",
+        ],
         effects: [
           { surface: "agent-context" },
           {

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -110,6 +110,23 @@ export const HEAD_GROUPS = [
             command: "pnpm agent:context-budget --strict",
             reason: "agent instruction budget input changed",
           },
+          {
+            command: "node scripts/repo-health/check-guardrail-prose.mjs",
+            reason:
+              "agent instruction file holding pinned guardrail prose changed",
+          },
+        ],
+      },
+      {
+        // The operating card carries the Non-negotiables the pin list protects.
+        // It reaches no arm above, so this is the only route that runs the
+        // guardrail-prose check when the card itself is edited.
+        patterns: ["docs/notes/pr-operating-card.md"],
+        effects: [
+          {
+            command: "node scripts/repo-health/check-guardrail-prose.mjs",
+            reason: "operating card holding pinned guardrail prose changed",
+          },
         ],
       },
     ],

--- a/scripts/repo-health/check-guardrail-prose.mjs
+++ b/scripts/repo-health/check-guardrail-prose.mjs
@@ -19,6 +19,13 @@
 // turn every reword into a CI failure and train people to edit the pin without
 // reading it, which is the opposite of what this protects.
 //
+// Root CLAUDE.md is pinned separately even though it is a symlink to AGENTS.md
+// and `readFileSync` follows it, so both key blocks read the same bytes today.
+// CLAUDE.md is the path the Claude runtime actually loads, and nothing else in
+// the repository asserts it stays a symlink. The duplicated block costs four
+// lines and starts failing the moment that link is replaced by a divergent
+// regular file or dropped.
+//
 // NON-GOAL: this check does not pin script digests. The gate and helper scripts
 // in this repo are legitimately agent-maintained and change often; digest pins
 // there would be noise. This protects normative prose only.
@@ -64,6 +71,53 @@ export function normalizeProse(text) {
 }
 
 /**
+ * The top-level keys of a JSON object literal, in source order, duplicates kept.
+ *
+ * `JSON.parse` keeps only the last of two identical keys and reports nothing,
+ * so a pin file that repeats a path silently discards every pin in the earlier
+ * block. Nothing downstream can see it: the parsed object is well formed, the
+ * remaining pins all match, and the check exits 0 while protecting less than
+ * the file says it does. That is the one way this checker could fail open, so
+ * the collision is found in the raw text instead. A `JSON.parse` reviver cannot
+ * do it — the reviver walks the already-collapsed result and is handed the
+ * repeated key once.
+ *
+ * The scan consumes whole string literals, so a snippet containing `:` or a
+ * brace never registers as a key, and only depth 1 counts, so strings inside
+ * the snippet arrays are skipped. Callers run it after `JSON.parse` has
+ * succeeded and the root has been confirmed to be an object.
+ *
+ * @param {string} text raw JSON source
+ * @returns {string[]}
+ */
+export function topLevelKeys(text) {
+  const keys = [];
+  let depth = 0;
+  let index = 0;
+  while (index < text.length) {
+    const char = text[index];
+    if (char === '"') {
+      let end = index + 1;
+      while (end < text.length && text[end] !== '"') {
+        end += text[end] === "\\" ? 2 : 1;
+      }
+      const literal = text.slice(index, end + 1);
+      index = end + 1;
+      if (depth === 1) {
+        let probe = index;
+        while (probe < text.length && /\s/.test(text[probe])) probe += 1;
+        if (text[probe] === ":") keys.push(JSON.parse(literal));
+      }
+      continue;
+    }
+    if (char === "{" || char === "[") depth += 1;
+    else if (char === "}" || char === "]") depth -= 1;
+    index += 1;
+  }
+  return keys;
+}
+
+/**
  * Read and validate the pin file.
  *
  * Fails closed on any shape that is not `{ "<path>": ["<snippet>", ...] }` with
@@ -73,9 +127,11 @@ export function normalizeProse(text) {
  * @returns {{ pins: [string, string[]][], problems: string[] }}
  */
 export function loadPins(pinPath) {
+  let raw;
   let parsed;
   try {
-    parsed = JSON.parse(readFileSync(pinPath, "utf8"));
+    raw = readFileSync(pinPath, "utf8");
+    parsed = JSON.parse(raw);
   } catch (error) {
     return {
       pins: [],
@@ -89,6 +145,20 @@ export function loadPins(pinPath) {
       problems: [
         `pin file ${pinPath} must be an object mapping file paths to snippet arrays`,
       ],
+    };
+  }
+
+  const seen = topLevelKeys(raw);
+  const duplicated = [
+    ...new Set(seen.filter((key, at) => seen.indexOf(key) !== at)),
+  ];
+  if (duplicated.length > 0) {
+    return {
+      pins: [],
+      problems: duplicated.map(
+        (key) =>
+          `pin file ${pinPath}: ${key} is declared more than once; only the last block would be checked and the earlier pins would be dropped silently`,
+      ),
     };
   }
 

--- a/scripts/repo-health/check-guardrail-prose.mjs
+++ b/scripts/repo-health/check-guardrail-prose.mjs
@@ -1,0 +1,209 @@
+// Verifies that the repository's normative guardrail sentences are still where
+// the agent instructions promise they are.
+//
+// The strongest rules this repo has — never merge without explicit approval,
+// secrets are IaC-owned, Terraform apply needs human approval, forensic drafts
+// stay local — exist only as prose in AGENTS.md and
+// docs/notes/pr-operating-card.md. Agents and documentation gardening edit
+// those files routinely, and nothing reds when a load-bearing sentence quietly
+// disappears in an unrelated cleanup. This check pins each sentence so removing
+// one has to be a deliberate, same-PR edit to the pin list rather than an
+// invisible side effect.
+//
+// Pins are matched after whitespace normalization: every run of whitespace in
+// both the file and the snippet collapses to a single space. Prose reflow — a
+// Prettier rewrap, a sentence moving across a line break — therefore never
+// fails the check. Only the words changing does.
+//
+// The pins are deliberately short, one clause each. A pinned paragraph would
+// turn every reword into a CI failure and train people to edit the pin without
+// reading it, which is the opposite of what this protects.
+//
+// NON-GOAL: this check does not pin script digests. The gate and helper scripts
+// in this repo are legitimately agent-maintained and change often; digest pins
+// there would be noise. This protects normative prose only.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.resolve(scriptDir, "../..");
+const DEFAULT_PINS = path.join(scriptDir, "guardrail-prose.json");
+
+const USAGE = `Usage: node scripts/repo-health/check-guardrail-prose.mjs
+
+Verifies that every normative sentence pinned in
+scripts/repo-health/guardrail-prose.json still appears in the file that is
+supposed to carry it. Snippets are compared after whitespace normalization, so
+reflowed prose still passes; only changed words fail.
+
+Exits nonzero and names the file and the missing snippet when a pin no longer
+matches, or when a pinned file is missing or unreadable.
+
+Environment:
+  GUARDRAIL_PROSE_ROOT  Repository root to check. Default: the repo root
+  GUARDRAIL_PROSE_PINS  Pin file to read. Default: scripts/repo-health/guardrail-prose.json
+`;
+
+/** The instruction printed with every failure, so the fix is never guesswork. */
+export const REMEDY =
+  "Restore the sentence, or change the pin in " +
+  "scripts/repo-health/guardrail-prose.json in the same PR as a deliberate " +
+  "rule change.";
+
+/**
+ * Collapse every whitespace run to a single space and trim.
+ *
+ * Applied to both sides of the comparison. This is what makes a pin survive
+ * prose reflow: a snippet written on one line still matches the same sentence
+ * wrapped across three, and Markdown list indentation stops mattering.
+ */
+export function normalizeProse(text) {
+  return String(text).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Read and validate the pin file.
+ *
+ * Fails closed on any shape that is not `{ "<path>": ["<snippet>", ...] }` with
+ * non-empty strings throughout. A malformed pin file must never read as "no
+ * pins to check" — that is a check that passes while protecting nothing.
+ *
+ * @returns {{ pins: [string, string[]][], problems: string[] }}
+ */
+export function loadPins(pinPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(pinPath, "utf8"));
+  } catch (error) {
+    return {
+      pins: [],
+      problems: [`cannot read pin file ${pinPath}: ${error.message}`],
+    };
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      pins: [],
+      problems: [
+        `pin file ${pinPath} must be an object mapping file paths to snippet arrays`,
+      ],
+    };
+  }
+
+  const problems = [];
+  const pins = [];
+  for (const [file, snippets] of Object.entries(parsed)) {
+    if (!Array.isArray(snippets) || snippets.length === 0) {
+      problems.push(
+        `pin file ${pinPath}: ${file} must list at least one snippet`,
+      );
+      continue;
+    }
+    const invalid = snippets.filter(
+      (snippet) =>
+        typeof snippet !== "string" || normalizeProse(snippet) === "",
+    );
+    if (invalid.length > 0) {
+      problems.push(
+        `pin file ${pinPath}: ${file} has a snippet that is not a non-empty string`,
+      );
+      continue;
+    }
+    pins.push([file, snippets]);
+  }
+
+  if (pins.length === 0 && problems.length === 0) {
+    problems.push(`pin file ${pinPath} declares no pins`);
+  }
+  return { pins, problems };
+}
+
+/**
+ * Check every pinned snippet against the file that must carry it.
+ *
+ * @param {string} root repository root the pinned paths are relative to
+ * @param {[string, string[]][]} pins
+ * @returns {{ file: string, kind: "unreadable" | "missing-snippet", detail: string }[]}
+ */
+export function checkGuardrailProse(root, pins) {
+  const failures = [];
+  for (const [file, snippets] of pins) {
+    let contents;
+    try {
+      contents = readFileSync(path.join(root, file), "utf8");
+    } catch (error) {
+      failures.push({
+        file,
+        kind: "unreadable",
+        detail: `pinned file is missing or unreadable (${error.code ?? error.message})`,
+      });
+      continue;
+    }
+    const haystack = normalizeProse(contents);
+    for (const snippet of snippets) {
+      if (!haystack.includes(normalizeProse(snippet))) {
+        failures.push({ file, kind: "missing-snippet", detail: snippet });
+      }
+    }
+  }
+  return failures;
+}
+
+/** The failure report, as the lines it should be printed on. */
+export function formatFailures(failures) {
+  const lines = ["check-guardrail-prose: pinned guardrail prose is missing:"];
+  for (const failure of failures) {
+    lines.push(
+      failure.kind === "unreadable"
+        ? `  ${failure.file}: ${failure.detail}`
+        : `  ${failure.file}: missing snippet: ${failure.detail}`,
+    );
+  }
+  lines.push("", REMEDY);
+  return lines;
+}
+
+function main(argv) {
+  const [flag] = argv;
+  if (flag === "-h" || flag === "--help") {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+  if (flag !== undefined) {
+    process.stderr.write(USAGE);
+    return 1;
+  }
+
+  const root = process.env.GUARDRAIL_PROSE_ROOT ?? DEFAULT_ROOT;
+  const pinPath = process.env.GUARDRAIL_PROSE_PINS ?? DEFAULT_PINS;
+
+  const { pins, problems } = loadPins(pinPath);
+  if (problems.length > 0) {
+    process.stderr.write(
+      `${["check-guardrail-prose: the pin list itself is unusable:", ...problems.map((problem) => `  ${problem}`)].join("\n")}\n`,
+    );
+    return 1;
+  }
+
+  const failures = checkGuardrailProse(root, pins);
+  if (failures.length > 0) {
+    process.stderr.write(`${formatFailures(failures).join("\n")}\n`);
+    return 1;
+  }
+
+  const snippetCount = pins.reduce(
+    (total, [, snippets]) => total + snippets.length,
+    0,
+  );
+  process.stdout.write(
+    `check-guardrail-prose: ${snippetCount} pinned sentences present across ${pins.length} files\n`,
+  );
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/scripts/repo-health/check-guardrail-prose.test.mjs
+++ b/scripts/repo-health/check-guardrail-prose.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, test } from "node:test";
+
+import {
+  checkGuardrailProse,
+  loadPins,
+  normalizeProse,
+  REMEDY,
+} from "./check-guardrail-prose.mjs";
+
+const CHECKER = fileURLToPath(
+  new URL("./check-guardrail-prose.mjs", import.meta.url),
+);
+
+const workspace = mkdtempSync(path.join(tmpdir(), "guardrail-prose-"));
+after(() => rmSync(workspace, { recursive: true, force: true }));
+
+let fixtureCounter = 0;
+
+const PINNED_SENTENCE =
+  "**Never merge without explicit approval** for that specific merge.";
+
+/**
+ * A throwaway repository holding one pinned file and one pin file.
+ *
+ * `files` maps repo-relative paths to contents; `pins` is the pin object
+ * verbatim, so a test can hand the checker a malformed one.
+ */
+function newFixture({ files, pins }) {
+  fixtureCounter += 1;
+  const root = path.join(workspace, `fixture-${fixtureCounter}`);
+  mkdirSync(root, { recursive: true });
+  for (const [relative, contents] of Object.entries(files)) {
+    const absolute = path.join(root, relative);
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, contents);
+  }
+  const pinPath = path.join(root, "pins.json");
+  writeFileSync(pinPath, `${JSON.stringify(pins, null, 2)}\n`);
+  return { root, pinPath };
+}
+
+function runChecker({ root, pinPath }, args = []) {
+  const result = spawnSync(process.execPath, [CHECKER, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GUARDRAIL_PROSE_ROOT: root,
+      GUARDRAIL_PROSE_PINS: pinPath,
+    },
+  });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+test("a present pinned sentence exits 0", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": `# Rules\n\n- ${PINNED_SENTENCE}\n` },
+    pins: { "AGENTS.md": [PINNED_SENTENCE] },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.equal(status, 0, output);
+  assert.match(output, /1 pinned sentences present across 1 files/);
+});
+
+test("a removed pinned sentence exits nonzero, names it, and says how to fix it", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": "# Rules\n\n- Something else entirely.\n" },
+    pins: { "AGENTS.md": [PINNED_SENTENCE] },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.notEqual(status, 0);
+  assert.match(output, /AGENTS\.md: missing snippet: /);
+  assert.ok(
+    output.includes(PINNED_SENTENCE),
+    "the report must quote the snippet that went missing",
+  );
+  assert.ok(
+    output.includes(REMEDY),
+    "the report must tell the reader to restore the sentence or move the pin",
+  );
+});
+
+test("a reflowed pinned sentence still passes", () => {
+  // The same words, rewrapped across lines with list indentation — exactly what
+  // a Prettier rewrap or a manual edit to the surrounding paragraph produces.
+  const reflowed = [
+    "# Rules",
+    "",
+    "- **Never merge without explicit approval** for",
+    "  that specific",
+    "  merge.",
+    "",
+  ].join("\n");
+  const fixture = newFixture({
+    files: { "AGENTS.md": reflowed },
+    pins: { "AGENTS.md": [PINNED_SENTENCE] },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.equal(status, 0, output);
+});
+
+test("a pinned sentence written multi-line in the pin file also passes", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": `# Rules\n\n- ${PINNED_SENTENCE}\n` },
+    pins: {
+      "AGENTS.md": [
+        "**Never merge without explicit approval**\n   for that specific merge.",
+      ],
+    },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.equal(status, 0, output);
+});
+
+test("a missing pinned file exits nonzero and names the file", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": `# Rules\n\n- ${PINNED_SENTENCE}\n` },
+    pins: { "docs/notes/pr-operating-card.md": [PINNED_SENTENCE] },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.notEqual(status, 0);
+  assert.match(
+    output,
+    /docs\/notes\/pr-operating-card\.md: pinned file is missing/,
+  );
+});
+
+test("only the missing pin of several is reported", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": `# Rules\n\n- ${PINNED_SENTENCE}\n` },
+    pins: { "AGENTS.md": [PINNED_SENTENCE, "Secrets are IaC-owned."] },
+  });
+  const { status, output } = runChecker(fixture);
+  assert.notEqual(status, 0);
+  assert.match(output, /missing snippet: Secrets are IaC-owned\./);
+  assert.equal(
+    output.match(/missing snippet:/g).length,
+    1,
+    "the present pin must not be reported",
+  );
+});
+
+test("an empty or malformed pin list fails closed rather than passing", () => {
+  for (const pins of [{}, { "AGENTS.md": [] }, { "AGENTS.md": [""] }]) {
+    const fixture = newFixture({
+      files: { "AGENTS.md": `- ${PINNED_SENTENCE}\n` },
+      pins,
+    });
+    const { status, output } = runChecker(fixture);
+    assert.notEqual(
+      status,
+      0,
+      `${JSON.stringify(pins)} must not read as "nothing to check": ${output}`,
+    );
+    assert.match(output, /pin list itself is unusable/);
+  }
+});
+
+test("--help exits 0 and an unknown argument exits 1", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": `- ${PINNED_SENTENCE}\n` },
+    pins: { "AGENTS.md": [PINNED_SENTENCE] },
+  });
+  const help = runChecker(fixture, ["--help"]);
+  assert.equal(help.status, 0);
+  assert.match(help.output, /GUARDRAIL_PROSE_PINS/);
+
+  const unknown = runChecker(fixture, ["--bogus"]);
+  assert.equal(unknown.status, 1);
+  assert.match(unknown.output, /Usage:/);
+});
+
+test("normalizeProse collapses whitespace runs and trims", () => {
+  assert.equal(normalizeProse("  a\n\n  b\tc  "), "a b c");
+});
+
+test("loadPins rejects a non-object pin file", () => {
+  const fixture = newFixture({ files: {}, pins: ["AGENTS.md"] });
+  const { problems } = loadPins(fixture.pinPath);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /must be an object mapping file paths/);
+});
+
+test("checkGuardrailProse reports findings without touching process state", () => {
+  const fixture = newFixture({
+    files: { "AGENTS.md": "# Rules\n" },
+    pins: { "AGENTS.md": [PINNED_SENTENCE] },
+  });
+  const failures = checkGuardrailProse(fixture.root, [
+    ["AGENTS.md", [PINNED_SENTENCE]],
+  ]);
+  assert.deepEqual(failures, [
+    { file: "AGENTS.md", kind: "missing-snippet", detail: PINNED_SENTENCE },
+  ]);
+});
+
+test("the committed pin list matches the repository it protects", () => {
+  // The negative control for the live pin list: with the real pins loaded but
+  // an empty repository underneath, every pinned file must be reported. If this
+  // ever passes, the checker is not reading the committed pins at all.
+  const empty = mkdtempSync(path.join(workspace, "empty-"));
+  const result = spawnSync(process.execPath, [CHECKER], {
+    encoding: "utf8",
+    env: { ...process.env, GUARDRAIL_PROSE_ROOT: empty },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /AGENTS\.md: pinned file is missing/);
+
+  // And against the real tree it passes, so the committed pins are current.
+  const live = spawnSync(process.execPath, [CHECKER], { encoding: "utf8" });
+  assert.equal(live.status, 0, `${live.stdout}${live.stderr}`);
+});

--- a/scripts/repo-health/check-guardrail-prose.test.mjs
+++ b/scripts/repo-health/check-guardrail-prose.test.mjs
@@ -335,6 +335,51 @@ function jobBody(workflow, jobId) {
 }
 
 /**
+ * The lines of the one step running `command`, or null when no step does.
+ *
+ * A step opens with `      - ` and its remaining keys sit at eight spaces, so
+ * the block runs from that list item to the next one or the end of the job.
+ */
+function stepBlockFor(jobLines, command) {
+  const at = jobLines.findIndex((line) => line.trim() === `run: ${command}`);
+  if (at === -1) return null;
+  let start = at;
+  while (start > 0 && !/^ {6}- /.test(jobLines[start])) start -= 1;
+  let end = at + 1;
+  while (end < jobLines.length && !/^ {6}- /.test(jobLines[end])) end += 1;
+  return jobLines.slice(start, end);
+}
+
+/**
+ * Ways a step can still be present and still gate nothing.
+ *
+ * Asserting that a `run:` line exists proves the command is written down, not
+ * that its failure stops the job. A step-level `if:` makes it skip, and
+ * `continue-on-error` makes its failure advisory; either leaves the required
+ * `ci` sentinel green over a guardrail that no longer holds. The job-level
+ * `if:` checked separately is only the coarsest version of the same move.
+ *
+ * @returns {string[]} empty when the step runs and can fail the job
+ */
+function stepEnforcementProblems(jobLines, jobId, command) {
+  const step = stepBlockFor(jobLines, command);
+  if (!step) return [`the \`${jobId}\` job no longer runs \`${command}\``];
+
+  const problems = [];
+  if (step.some((line) => /^ {8}if:/.test(line))) {
+    problems.push(
+      `the \`${command}\` step in \`${jobId}\` carries a step-level \`if:\`, so it can skip while the job still passes`,
+    );
+  }
+  if (step.some((line) => /^ {8}continue-on-error:/.test(line))) {
+    problems.push(
+      `the \`${command}\` step in \`${jobId}\` sets \`continue-on-error\`, so its failure would not fail the job`,
+    );
+  }
+  return problems;
+}
+
+/**
  * The second host that keeps the wiring assertion from dying with its subject.
  *
  * The assertion below runs inside `guardrail-prose`, so on its own it is
@@ -351,12 +396,12 @@ function jobBody(workflow, jobId) {
 function suiteHostProblems(workflow) {
   const host = jobBody(workflow, SUITE_HOST_JOB);
   if (!host) return [`ci.yml defines no \`${SUITE_HOST_JOB}\` job`];
-  if (!host.some((line) => line.trim() === `run: ${SUITE_COMMAND}`)) {
+  if (!stepBlockFor(host, SUITE_COMMAND)) {
     return [
       `the \`${SUITE_HOST_JOB}\` job no longer runs \`${SUITE_COMMAND}\`, leaving \`${GUARDRAIL_JOB}\` as the only witness to its own wiring`,
     ];
   }
-  return [];
+  return stepEnforcementProblems(host, SUITE_HOST_JOB, SUITE_COMMAND);
 }
 
 /**
@@ -380,12 +425,13 @@ function guardrailWiringProblems(workflow) {
       `the \`${GUARDRAIL_JOB}\` job carries a job-level \`if:\`; a skipped required check counts as satisfied`,
     );
   }
+  if (job.some((line) => /^ {4}continue-on-error:/.test(line))) {
+    problems.push(
+      `the \`${GUARDRAIL_JOB}\` job sets \`continue-on-error\`, so it reports success however it ends`,
+    );
+  }
   for (const command of GUARDRAIL_COMMANDS) {
-    if (!job.some((line) => line.trim() === `run: ${command}`)) {
-      problems.push(
-        `the \`${GUARDRAIL_JOB}\` job no longer runs \`${command}\``,
-      );
-    }
+    problems.push(...stepEnforcementProblems(job, GUARDRAIL_JOB, command));
   }
 
   const sentinel = jobBody(workflow, "ci");
@@ -468,6 +514,44 @@ test("the wiring assertion reds on each way that wiring could rot", () => {
           "      - name: Deviation threshold drift suite\n",
         ),
       /the `scripts` job no longer runs/,
+    ],
+    [
+      // A step present but skipped is the cheaper version of deleting it, and
+      // the job-level `if:` control above does not cover it.
+      "the checker step is gated behind a step-level if",
+      (text) =>
+        text.replace(
+          "      - name: Guardrail prose pins\n        run: node scripts/repo-health/check-guardrail-prose.mjs\n",
+          "      - name: Guardrail prose pins\n        if: false\n        run: node scripts/repo-health/check-guardrail-prose.mjs\n",
+        ),
+      /carries a step-level `if:`/,
+    ],
+    [
+      "the suite step is made advisory with continue-on-error",
+      (text) =>
+        text.replace(
+          "      - name: Guardrail prose pins\n        run: node scripts/repo-health/check-guardrail-prose.mjs\n      - name: Guardrail prose pin suite\n        run: node scripts/repo-health/check-guardrail-prose.test.mjs\n",
+          "      - name: Guardrail prose pins\n        run: node scripts/repo-health/check-guardrail-prose.mjs\n      - name: Guardrail prose pin suite\n        continue-on-error: true\n        run: node scripts/repo-health/check-guardrail-prose.test.mjs\n",
+        ),
+      /sets `continue-on-error`/,
+    ],
+    [
+      "the second host's step is gated behind a step-level if",
+      (text) =>
+        text.replace(
+          "      - name: Guardrail prose pin suite\n        run: node scripts/repo-health/check-guardrail-prose.test.mjs\n      - name: Deviation threshold drift suite\n",
+          "      - name: Guardrail prose pin suite\n        if: false\n        run: node scripts/repo-health/check-guardrail-prose.test.mjs\n      - name: Deviation threshold drift suite\n",
+        ),
+      /step in `scripts` carries a step-level `if:`/,
+    ],
+    [
+      "the whole job is made advisory with continue-on-error",
+      (text) =>
+        text.replace(
+          "  guardrail-prose:\n    name: Guardrail prose pins\n",
+          "  guardrail-prose:\n    name: Guardrail prose pins\n    continue-on-error: true\n",
+        ),
+      /job sets `continue-on-error`/,
     ],
     [
       "the sentinel stops needing it",

--- a/scripts/repo-health/check-guardrail-prose.test.mjs
+++ b/scripts/repo-health/check-guardrail-prose.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,11 +18,28 @@ import {
   loadPins,
   normalizeProse,
   REMEDY,
+  topLevelKeys,
 } from "./check-guardrail-prose.mjs";
 
 const CHECKER = fileURLToPath(
   new URL("./check-guardrail-prose.mjs", import.meta.url),
 );
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+/**
+ * The parent environment with the checker's own overrides stripped.
+ *
+ * Every spawn below either sets the root and pin path it wants or deliberately
+ * exercises the defaults. Inheriting an ambient `GUARDRAIL_PROSE_ROOT` or
+ * `GUARDRAIL_PROSE_PINS` — trivially present in a shell that just ran the
+ * checker by hand — would silently redirect the default-environment cases at
+ * another tree and fail this suite for a reason that has nothing to do with the
+ * code under test. Sanitizing once here keeps every spawn on the same footing.
+ */
+const BASE_ENV = { ...process.env };
+delete BASE_ENV.GUARDRAIL_PROSE_ROOT;
+delete BASE_ENV.GUARDRAIL_PROSE_PINS;
 
 const workspace = mkdtempSync(path.join(tmpdir(), "guardrail-prose-"));
 after(() => rmSync(workspace, { recursive: true, force: true }));
@@ -29,9 +53,11 @@ const PINNED_SENTENCE =
  * A throwaway repository holding one pinned file and one pin file.
  *
  * `files` maps repo-relative paths to contents; `pins` is the pin object
- * verbatim, so a test can hand the checker a malformed one.
+ * verbatim, so a test can hand the checker a malformed one. `pinText` writes
+ * the pin file byte for byte instead, which is the only way to express a shape
+ * `JSON.stringify` cannot round-trip — a duplicated key.
  */
-function newFixture({ files, pins }) {
+function newFixture({ files, pins, pinText }) {
   fixtureCounter += 1;
   const root = path.join(workspace, `fixture-${fixtureCounter}`);
   mkdirSync(root, { recursive: true });
@@ -41,7 +67,7 @@ function newFixture({ files, pins }) {
     writeFileSync(absolute, contents);
   }
   const pinPath = path.join(root, "pins.json");
-  writeFileSync(pinPath, `${JSON.stringify(pins, null, 2)}\n`);
+  writeFileSync(pinPath, pinText ?? `${JSON.stringify(pins, null, 2)}\n`);
   return { root, pinPath };
 }
 
@@ -49,7 +75,7 @@ function runChecker({ root, pinPath }, args = []) {
   const result = spawnSync(process.execPath, [CHECKER, ...args], {
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...BASE_ENV,
       GUARDRAIL_PROSE_ROOT: root,
       GUARDRAIL_PROSE_PINS: pinPath,
     },
@@ -161,6 +187,43 @@ test("an empty or malformed pin list fails closed rather than passing", () => {
   }
 });
 
+test("a duplicated pin-list key fails closed instead of dropping a block", () => {
+  // The fail-open this guards. `JSON.parse` keeps only the last "AGENTS.md"
+  // block, so the absent sentence in the first block would never be looked for
+  // and the run would exit 0 having checked one pin instead of two — with no
+  // deletion anywhere in the diff to notice.
+  const fixture = newFixture({
+    files: { "AGENTS.md": `# Rules\n\n- ${PINNED_SENTENCE}\n` },
+    pinText: [
+      "{",
+      '  "AGENTS.md": ["A sentence that appears nowhere in the file."],',
+      `  "AGENTS.md": ${JSON.stringify([PINNED_SENTENCE])}`,
+      "}",
+      "",
+    ].join("\n"),
+  });
+  const { status, output } = runChecker(fixture);
+  assert.notEqual(status, 0, output);
+  assert.match(output, /pin list itself is unusable/);
+  assert.match(output, /AGENTS\.md is declared more than once/);
+});
+
+test("topLevelKeys reads the raw text without mistaking snippets for keys", () => {
+  // The scanner has to consume whole string literals, or a snippet holding a
+  // colon or a brace reads as a key and the duplicate check reports nonsense.
+  const text = [
+    "{",
+    '  "AGENTS.md": ["a: b", "{\\"nested\\": 1}", "trailing brace }"],',
+    '  "docs/notes/pr-operating-card.md": ["c"]',
+    "}",
+  ].join("\n");
+  assert.deepEqual(topLevelKeys(text), [
+    "AGENTS.md",
+    "docs/notes/pr-operating-card.md",
+  ]);
+  assert.deepEqual(topLevelKeys('{"a":[1],"a":[2]}'), ["a", "a"]);
+});
+
 test("--help exits 0 and an unknown argument exits 1", () => {
   const fixture = newFixture({
     files: { "AGENTS.md": `- ${PINNED_SENTENCE}\n` },
@@ -206,12 +269,194 @@ test("the committed pin list matches the repository it protects", () => {
   const empty = mkdtempSync(path.join(workspace, "empty-"));
   const result = spawnSync(process.execPath, [CHECKER], {
     encoding: "utf8",
-    env: { ...process.env, GUARDRAIL_PROSE_ROOT: empty },
+    env: { ...BASE_ENV, GUARDRAIL_PROSE_ROOT: empty },
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /AGENTS\.md: pinned file is missing/);
 
   // And against the real tree it passes, so the committed pins are current.
-  const live = spawnSync(process.execPath, [CHECKER], { encoding: "utf8" });
+  const live = spawnSync(process.execPath, [CHECKER], {
+    encoding: "utf8",
+    env: BASE_ENV,
+  });
   assert.equal(live.status, 0, `${live.stdout}${live.stderr}`);
+});
+
+test("root CLAUDE.md is pinned and still resolves to AGENTS.md", () => {
+  // CLAUDE.md is the path the Claude runtime loads and is a symlink to
+  // AGENTS.md, so `readFileSync` gives the pins the same bytes. That is what
+  // makes the duplicated key block cheap — and what makes it worth having: the
+  // day the link becomes a divergent regular file, the pins go on being checked
+  // against the file agents actually read.
+  const { pins, problems } = loadPins(
+    path.join(REPO_ROOT, "scripts/repo-health/guardrail-prose.json"),
+  );
+  assert.deepEqual(problems, []);
+  const pinned = new Map(pins);
+  assert.ok(pinned.has("CLAUDE.md"), "CLAUDE.md must carry its own pin block");
+  assert.deepEqual(
+    pinned.get("CLAUDE.md"),
+    pinned.get("AGENTS.md"),
+    "the CLAUDE.md block must repeat the AGENTS.md snippets verbatim",
+  );
+  assert.equal(
+    readlinkSync(path.join(REPO_ROOT, "CLAUDE.md")),
+    "AGENTS.md",
+    "CLAUDE.md is expected to be the AGENTS.md symlink",
+  );
+});
+
+const CI_WORKFLOW = path.join(REPO_ROOT, ".github/workflows/ci.yml");
+const GUARDRAIL_JOB = "guardrail-prose";
+const GUARDRAIL_COMMANDS = [
+  "node scripts/repo-health/check-guardrail-prose.mjs",
+  "node scripts/repo-health/check-guardrail-prose.test.mjs",
+];
+
+/**
+ * The body lines of one top-level workflow job, or null when it is absent.
+ *
+ * A bounded text scan rather than a YAML parse, because this suite runs inside
+ * the very job it is checking and that job installs no dependencies, so
+ * `js-yaml` is out of reach. Job keys sit at two spaces and everything within
+ * them at four or more, so the next two-space key ends the block.
+ */
+function jobBody(workflow, jobId) {
+  const lines = workflow.split("\n");
+  const start = lines.indexOf(`  ${jobId}:`);
+  if (start === -1) return null;
+  let end = start + 1;
+  while (end < lines.length && !/^ {2}[A-Za-z0-9_-]+:/.test(lines[end])) {
+    end += 1;
+  }
+  return lines.slice(start + 1, end);
+}
+
+/**
+ * Every way the guardrail check could stop running without anyone noticing.
+ *
+ * The pins protect prose; nothing protected the job that reads them. A later
+ * `ci.yml` edit could delete a step, gate the job behind a paths filter, or add
+ * it to the sentinel's `allowed-skips`, and the required `ci` context would go
+ * on reporting green over a check that no longer runs — the same silent-drop
+ * failure the pins exist to prevent, one layer up.
+ *
+ * @returns {string[]} empty when the wiring is intact
+ */
+function guardrailWiringProblems(workflow) {
+  const job = jobBody(workflow, GUARDRAIL_JOB);
+  if (!job) return [`ci.yml defines no \`${GUARDRAIL_JOB}\` job`];
+
+  const problems = [];
+  if (job.some((line) => /^ {4}if:/.test(line))) {
+    problems.push(
+      `the \`${GUARDRAIL_JOB}\` job carries a job-level \`if:\`; a skipped required check counts as satisfied`,
+    );
+  }
+  for (const command of GUARDRAIL_COMMANDS) {
+    if (!job.some((line) => line.trim() === `run: ${command}`)) {
+      problems.push(
+        `the \`${GUARDRAIL_JOB}\` job no longer runs \`${command}\``,
+      );
+    }
+  }
+
+  const sentinel = jobBody(workflow, "ci");
+  if (!sentinel) return [...problems, "ci.yml defines no `ci` sentinel job"];
+
+  const needsAt = sentinel.findIndex((line) => /^ {4}needs:/.test(line));
+  if (needsAt === -1) {
+    problems.push("the `ci` sentinel declares no `needs:` list");
+  } else {
+    const closesAt = sentinel.findIndex(
+      (line, at) => at > needsAt && line.includes("]"),
+    );
+    const needs = sentinel
+      .slice(needsAt, closesAt === -1 ? sentinel.length : closesAt + 1)
+      .join(" ");
+    if (!new RegExp(`\\b${GUARDRAIL_JOB}\\b`).test(needs)) {
+      problems.push(
+        `the \`ci\` sentinel does not need \`${GUARDRAIL_JOB}\`, so the job cannot block a merge`,
+      );
+    }
+  }
+
+  const skipLine =
+    sentinel.find((line) => line.includes("allowed-skips:")) ?? "";
+  const skips = skipLine
+    .slice(skipLine.indexOf(":") + 1)
+    .split(",")
+    .map((entry) => entry.trim());
+  if (skips.includes(GUARDRAIL_JOB)) {
+    problems.push(
+      `\`${GUARDRAIL_JOB}\` sits in the \`ci\` sentinel's allowed-skips, which lets a skip read as success`,
+    );
+  }
+  return problems;
+}
+
+test("the guardrail check is wired into CI where it cannot be skipped", () => {
+  const problems = guardrailWiringProblems(readFileSync(CI_WORKFLOW, "utf8"));
+  assert.deepEqual(problems, [], problems.join("\n"));
+});
+
+test("the wiring assertion reds on each way that wiring could rot", () => {
+  // Negative controls. Each mutation is applied to the real ci.yml and asserted
+  // to have changed it, so a rename that silently stops matching fails here
+  // rather than leaving a control that proves nothing.
+  const workflow = readFileSync(CI_WORKFLOW, "utf8");
+  const mutations = [
+    [
+      "the job is renamed",
+      (text) =>
+        text.replace("\n  guardrail-prose:\n", "\n  moved-elsewhere:\n"),
+      /defines no `guardrail-prose` job/,
+    ],
+    [
+      "the job gains a paths filter",
+      (text) =>
+        text.replace(
+          "  guardrail-prose:\n    name: Guardrail prose pins\n",
+          "  guardrail-prose:\n    name: Guardrail prose pins\n    if: needs.changes.outputs.rootScripts == 'true'\n",
+        ),
+      /carries a job-level `if:`/,
+    ],
+    [
+      "a run step is dropped",
+      (text) =>
+        text.replace(
+          "      - name: Guardrail prose pin suite\n        run: node scripts/repo-health/check-guardrail-prose.test.mjs\n",
+          "",
+        ),
+      /no longer runs `node scripts\/repo-health\/check-guardrail-prose\.test\.mjs`/,
+    ],
+    [
+      "the sentinel stops needing it",
+      (text) => text.replace("\n        guardrail-prose,", ""),
+      /does not need `guardrail-prose`/,
+    ],
+    [
+      "the sentinel is allowed to skip it",
+      (text) =>
+        text.replace(
+          "allowed-skips: shared,",
+          "allowed-skips: guardrail-prose,shared,",
+        ),
+      /allowed-skips/,
+    ],
+  ];
+
+  for (const [label, mutate, expected] of mutations) {
+    const mutated = mutate(workflow);
+    assert.notEqual(
+      mutated,
+      workflow,
+      `${label}: the mutation matched nothing, so this control proves nothing`,
+    );
+    const problems = guardrailWiringProblems(mutated);
+    assert.ok(
+      problems.some((problem) => expected.test(problem)),
+      `${label}: expected ${expected}, got ${JSON.stringify(problems)}`,
+    );
+  }
 });

--- a/scripts/repo-health/guardrail-prose.json
+++ b/scripts/repo-health/guardrail-prose.json
@@ -5,6 +5,12 @@
     "**Terraform apply requires explicit human approval.** Plan first.",
     "**Forensic drafts stay local.** Use the `forensic-report` skill"
   ],
+  "CLAUDE.md": [
+    "Never merge without the user's explicit approval for that specific merge.",
+    "**Secrets are IaC-owned.** Never create, rotate, or overwrite secrets",
+    "**Terraform apply requires explicit human approval.** Plan first.",
+    "**Forensic drafts stay local.** Use the `forensic-report` skill"
+  ],
   "docs/notes/pr-operating-card.md": [
     "**Never merge a PR without the user's explicit, direct approval of that specific merge.**",
     "**Never merge without explicit approval** for that specific merge",

--- a/scripts/repo-health/guardrail-prose.json
+++ b/scripts/repo-health/guardrail-prose.json
@@ -1,0 +1,14 @@
+{
+  "AGENTS.md": [
+    "Never merge without the user's explicit approval for that specific merge.",
+    "**Secrets are IaC-owned.** Never create, rotate, or overwrite secrets",
+    "**Terraform apply requires explicit human approval.** Plan first.",
+    "**Forensic drafts stay local.** Use the `forensic-report` skill"
+  ],
+  "docs/notes/pr-operating-card.md": [
+    "**Never merge a PR without the user's explicit, direct approval of that specific merge.**",
+    "**Never merge without explicit approval** for that specific merge",
+    "**Knowingly deferred work needs a GitHub issue first**, linked from `## Deferrals`.",
+    "**Package-script, package-manager, and lockfile changes require explicit acknowledgement** through the gate; never bypass the refusal."
+  ]
+}


### PR DESCRIPTION
## The Problem

- The repository's strongest rules — never merge without the user's explicit approval, secrets are IaC-owned, Terraform apply requires human approval, forensic drafts stay local — existed only as sentences inside `AGENTS.md` and `docs/notes/pr-operating-card.md`. Nothing verified they were still there.
- Agents and documentation gardening rewrite both files routinely. A load-bearing sentence could vanish inside an unrelated cleanup and every check stayed green, because no check read those files for content.
- The next agent reads the trimmed file as ground truth, so a deleted guardrail is simply a guardrail that no longer exists — with no diff anyone was prompted to look at twice.

## The Solution

`scripts/repo-health/check-guardrail-prose.mjs` reads a pin list of normative sentences and fails when one is no longer present in the file that is supposed to carry it. Twelve sentences are pinned today across `AGENTS.md`, the `CLAUDE.md` symlink beside it, and the operating card. The check runs in its own unconditional CI job and from the local quality gate, routing from **both** directions: editing the checker or its pin list, and editing any prose file the pins protect.

The benefit is that removing a rule now costs a visible, same-PR edit to `scripts/repo-health/guardrail-prose.json`. A reviewer sees the rule being dropped instead of inferring it from a paragraph that quietly got shorter. The failure message names the file, quotes the missing snippet, and states the two legitimate fixes: restore the sentence, or move the pin deliberately. [ADR 0073](docs/adr/0073-guardrail-prose-pinned-in-ci.md) records the policy, the rejected alternative, and the scope limit.

Material limits, so nobody reads more into this than it does:

- **Non-goal: no digest pinning of scripts.** The gate and helper scripts here are legitimately agent-maintained and change constantly; digest pins there would be noise that gets updated reflexively. This protects normative prose only, and the ADR argues why prose is the surface where a pin stays honest.
- Pins are compared after whitespace normalization, so the check proves the **words** are present. It cannot prove anyone follows the rule, and it does not stop a PR that edits the prose and the pin together — making that edit explicit is the whole mechanism.
- Pins are deliberately one clause each. A pinned paragraph would turn every reword into a CI failure and train people to edit the pin without reading it.
- Coverage grows only when someone adds a pin, so the list will trail the prose. The ADR's 90-day re-verification is where that gap gets reviewed.

## Details

**Checker.** Node built-ins only, matching the sibling `scripts/repo-health/` style. `guardrail-prose.json` maps a repo-relative path to an array of required snippets. Both the file text and each snippet run through `normalizeProse()`, which collapses every whitespace run to a single space and trims, so a Prettier rewrap or a sentence moving across a line break never false-positives. `GUARDRAIL_PROSE_ROOT` and `GUARDRAIL_PROSE_PINS` exist so the suite can point the checker at fixture repositories.

**The loader fails closed on every unusable shape**, including a duplicated top-level key. `JSON.parse` keeps only the last of two identical keys and reports nothing, so a repeated path silently discarded the earlier block's pins with no deletion visible in the diff — the one fail-open in an otherwise fail-closed loader, and exactly the silent-drop failure this check exists to prevent. A reviver cannot catch it either: V8 collapses the duplicate before the reviver runs, which a probe here confirmed. `topLevelKeys()` scans the raw JSON text instead, consuming whole string literals so a snippet containing `:` or a brace never registers as a key.

**The pins.** Each snippet was verified against the exact text on `origin/main` before being pinned. Root `CLAUDE.md` now carries its own block repeating the `AGENTS.md` snippets. It is a symlink and `readFileSync` follows it, so both blocks read the same bytes today and the duplication is free; it is also the path the Claude runtime actually loads, and nothing else asserted it stays a symlink. The block starts earning its keep the moment that link becomes a divergent regular file or is dropped. The Non-negotiables never-merge pin deliberately stops before `(step 8)` so renumbering the card is not a CI failure.

**Registration — this changed after review.** The two commands first ran as steps of the path-gated `scripts` job, which admits on `rootScripts` (`scripts/**`) and sits in the `ci` sentinel's `allowed-skips`. CodeRabbit caught the hole: a PR editing only `AGENTS.md` or the operating card and dropping a pinned sentence skipped the job entirely while the required `ci` context stayed green — the check was absent exactly when it was needed. They now run in a dedicated `guardrail-prose` job with no `if:`, present in the sentinel's `needs` and deliberately absent from its `allowed-skips`, per [ADR 0010](docs/adr/0010-required-checks-no-paths-filters.md). The Sentry suites were moved out of that same job for the same reason. Because the checker and its suite import only `node:` builtins, the job is a checkout, a Node and two sub-second commands, with no `pnpm install`.

**Two hosts, after a second review round.** The suite asserts that job's own CI wiring, and at first it ran only inside that job — so the single edit deleting the job deleted its own witness and left `ci` green over nothing. The suite now also runs as a step of the `scripts` job, whose `rootScripts` filter includes `.github/workflows/**`, so any edit able to remove the unconditional job admits `scripts` and reds there; the suite asserts that second host too, so dropping the extra step reds in `guardrail-prose`. Deleting both at once still passes — no check outlives its own removal — but that edit is visible in one diff. The gate's `ci.yml` arm now routes the suite as well, matching the Sentry CI wiring contract already there.

**The suite pins its own CI wiring.** Nothing protected the job that reads the pins, so a later `ci.yml` edit could delete a step, gate the job, or add it to `allowed-skips` and leave `ci` green over a check that no longer runs. `guardrailWiringProblems()` asserts the job exists, carries no job-level `if:`, runs both exact commands, reaches the sentinel's `needs`, and is not allowed to skip. It is a bounded text scan rather than a `js-yaml` parse because the job installs no dependencies; ten negative controls mutate the real `ci.yml` for each rot mode and assert the mutation landed first, so a control that stops matching fails loudly instead of passing vacuously. The second review round proved that guard's worth: once the suite step existed in two jobs, the dropped-step control's `String.replace` began matching the `scripts` copy and passing for the wrong reason. It is re-anchored on the checker step above it.

**Present is not enforcing.** The closeout review then found the assertion still too weak: a `run:` line proves the command is written down, not that its failure stops the job, so a step-level `if:` or `continue-on-error` (or `continue-on-error` on the job) would leave `ci` green over a guardrail that no longer held. The suite now resolves the step block around each guardrail `run:` line and rejects both keys, in the unconditional job and in the `scripts` host alike, each with its own control.

**Gate routing** adds four arms: the `AGENTS.md` arm and an operating-card arm in `documentation-contracts`, a module arm for the checker and its suite, and a dedicated arm for `guardrail-prose.json`. The last is separate because a `.json` under `scripts/` reaches no module arm — those key off `.mjs` — and would otherwise fall through to the bare `scripts/*` catch-all with no commands at all. The closeout review then caught that `CLAUDE.md` was pinned but not routed: an edit made through the symlink reports as `AGENTS.md`, but replacing the link with a regular file reports as `CLAUDE.md`, which is the case the pin block exists for. `CLAUDE.md` now joins the `AGENTS.md` arm, with a gate-test assertion.

**Docs.** `docs/notes/quick-commands.md` gains the command line beside the sibling repo-health checks. ADR 0073 is added and indexed in `docs/adr/README.md`, with `pnpm docs:index --write` run for `docs/README.md`. `scripts/AGENTS.md` records the new path pins in its Gate routing pins class, as its move-sweep inventory requires. That file sits at its scoped context cap, so the entry was paid for by relocating depth into ADR 0064 and ADR 0069 — both already cited bare elsewhere in the same file — and by tightening neighbouring sentences; no fact was removed, and the budget passes with 9 bytes of headroom. Any future pin added there will need the inventory relocated rather than extended. No package scripts, package manager, or lockfile changed, so the gate needed no `--allow-package-script-changes`.

## Validation

Commands run in a dedicated clone at this branch's head; results are what the commands printed, not inference.

- `node scripts/repo-health/check-guardrail-prose.mjs` — `12 pinned sentences present across 3 files`.
- `node scripts/repo-health/check-guardrail-prose.test.mjs` — 17 tests, 0 failures. Beyond the original cases: a duplicated pin-list key fails closed and names the repeated path; `topLevelKeys` ignores snippet strings holding a colon or a brace; `CLAUDE.md` is pinned and still resolves to `AGENTS.md`; the CI wiring assertion passes against the real `ci.yml` and reds on all five rot mutations.
- Duplicate-key fail-open, proven both ways: a pin file repeating `"AGENTS.md"` exited 0 before this change while silently dropping an absent-snippet pin; it now exits 1 naming the duplicate.
- Ambient-environment fix, proven both ways: with `GUARDRAIL_PROSE_ROOT` set in the parent shell, the pre-fix suite failed 1 of 12 tests for a reason unrelated to the code; the sanitized-env suite passes 17 of 17 under the same variable.
- Live negative control from the first round, still valid: reworded `**Forensic drafts stay local.**` in a copy of the real `AGENTS.md`, confirmed the mutation landed, and the checker exited 1 naming that snippet.
- Cross-check on the hand-rolled scanner: a real `js-yaml` parse of `ci.yml` agrees with it on all four facts — the job exists, has no `if:` key, runs both commands, is in `ci`'s `needs`, and is not in `allowed-skips`.
- `pnpm agent:context-budget --strict`, `pnpm agent:context-check`, `pnpm docs:index --check`, `pnpm adr:check` — all exit 0.
- `pnpm gate:routing-table:test` — 73 tests, 0 failures. `pnpm agent:quality-gate:test` covers the new `CLAUDE.md` route.
- `bash scripts/agent-quality-gate.sh --run --lock-wait 3600` — `All mapped commands passed`. The `ci.yml` edit routes the full monorepo set, so this covered turbo lint/typecheck/knip, every package coverage suite, `forge test`, size-limit, all six Terraform stacks, `pnpm tf:test`, and both guardrail commands. The pre-push hook ran the same gate again against the moved base and also passed.
- `pnpm agent:autoreview` — `no accepted/actionable findings`, overall *patch is correct* (0.88). An earlier pass on this branch was **not** clean: it raised the unrouted `CLAUDE.md` path as P2, which is the fix described above. Source review only — it runs no tests and proves no behaviour.

What this evidence does **not** establish: that the pinned rules are obeyed, only that the sentences are present; that the pin list covers every normative sentence, only the twelve listed; and that the wiring assertion would survive a `ci.yml` restructure that changes YAML indentation, since it scans text at fixed indent depths rather than parsing.

## Deferrals

- None

Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcpGL6S9z7AW3QaoYSophE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation-specific CI checks for Markdown changes.
  * Added guardrail prose validation for key repository guidance and operational documents.
  * Added detection for duplicate configuration entries and invalid guardrail pinning.

* **Bug Fixes**
  * Improved CI routing and failure detection for documentation and guardrail checks.
  * Distinguishes skippable environment failures from genuine provisioning errors.

* **Documentation**
  * Added guidance for running guardrail validation.
  * Documented the guardrail prose CI policy and updated process references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
