### PR TITLE
ci: run a small docs-checks job for Markdown-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       terraform: ${{ steps.filter.outputs.terraform }}
       codeHealth: ${{ steps.filter.outputs.codeHealth }}
       rootScripts: ${{ steps.filter.outputs.rootScripts }}
+      docs: ${{ steps.filter.outputs.docs }}
       autoreviewSuite: ${{ steps.filter.outputs.autoreviewSuite }}
       autoreviewRootRuntime: ${{ steps.filter.outputs.autoreviewRootRuntime }}
       versionSkew: ${{ steps.filter.outputs.versionSkew }}
@@ -304,20 +305,42 @@ jobs:
               # job's baseline-diff semantic suite must re-run when the
               # producing action changes.
               - .github/actions/resolve-eslint-baseline/**
-              # Documentation catalog + context-check inputs. The catalog
-              # covers every tracked Markdown file (except runtime mirrors),
-              # while the context checker discovers canonical files and
-              # validates SessionEnd hooks + skill parity. Markdown changes
-              # therefore run this cheap root-scripts job regardless of path.
-              - "*.md"
-              - "**/*.md"
-              # Skill parity and hook checks also consume non-Markdown assets
-              # under the runtime-specific directories.
+              # Skill parity and hook checks consume non-Markdown assets
+              # under the runtime-specific directories. The two Markdown globs
+              # that used to sit here now live in the `docs` filter below
+              # (ADR 0072): a Markdown-only diff runs the small `docs-checks`
+              # job, which carries nine of the eleven checks in this job that
+              # read the Markdown corpus — the two left behind red only when a
+              # carried check reds. Markdown that arrives alongside any path
+              # above still sets both filters, and both jobs run — including a
+              # Markdown-only edit under `.agents/**` or `.claude/skills/**`,
+              # which those globs still route here for their non-Markdown
+              # contents.
               - ".agents/**"
               - ".claude/skills/**"
               - .claude/settings.json
               - .codex/config.toml
               - .codex/hooks.json
+            # Markdown corpus, plus the two non-Markdown inputs the
+            # `docs-checks` job itself is built from. The Markdown globs are
+            # the ones relocated out of `rootScripts` above, byte-identical, so
+            # they match exactly what they matched there: `**/*.md` covers
+            # documents in dot-directories such as `.github/`, and
+            # dorny/paths-filter reports added, modified, renamed and deleted
+            # files alike, so a removed or renamed document still fires the
+            # job. ci.yml holds the job definition and pnpm-install is the
+            # composite its steps run on: without those two entries a PR that
+            # edits the job — its fetch-depth, its permissions, a step command
+            # — would set only `rootScripts`, and the edited job would ship
+            # without ever having run. Every other filter in this file lists
+            # ci.yml for that same reason. Beyond those two, keep this filter
+            # to Markdown: any other non-Markdown input belongs in the filter
+            # of the job that consumes it.
+            docs:
+              - "*.md"
+              - "**/*.md"
+              - .github/workflows/ci.yml
+              - .github/actions/pnpm-install/**
             # The adversarial autoreview suite is intentionally isolated from
             # the broader root-scripts job: it is expensive, path-specific,
             # and runs sequentially in CI for deterministic fixture/process
@@ -1178,6 +1201,122 @@ jobs:
       - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
         if: always()
 
+  docs-checks:
+    name: Documentation corpus checks
+    needs: changes
+    # ADR 0072. The nine checks below are the ones in the `scripts` job above
+    # whose outcome a Markdown-only diff can change. Six read the live tracked
+    # Markdown tree through `git ls-files`; two are unit suites that look like
+    # fixture tests but assert against the real tree as well
+    # (agent:context-budget:test pins the ten AGENTS.md routes,
+    # docs:navigation-eval:test picks the cheapest route by live document
+    # bytes); and the gate routing-table suite asserts that the 23 Markdown
+    # paths its table names still exist.
+    # Three suites stay in `scripts` because they cannot be affected by a
+    # Markdown edit at all: docs:audit:test, docs:garden:test and
+    # check-agent-context.test.mjs build their fixtures in a temporary
+    # repository or stub their inputs.
+    # Two more read this checkout and stay in `scripts` anyway, for a reason
+    # worth writing down:
+    #   - docs:index:test has one live-tree case that builds the inventory
+    #     over the tracked Markdown tree and asserts inventory.errors is
+    #     empty. That is a strict subset of `pnpm docs:index --check` below,
+    #     which fails on errors OR warnings OR broken links, and a deleted or
+    #     non-regular runtime document is rejected by the runtime registry
+    #     that both carried checks import. No Markdown-only diff reds it while
+    #     everything in this job stays green.
+    #   - agent:quality-gate:test pins the targeted-Trunk branch on the
+    #     tracked file docs/deployment.md, which flips to `--all` once that
+    #     path leaves the worktree. docs/deployment.md is also one of the
+    #     routing table's staleness subjects, so the gate routing-table step
+    #     below reds first on the rename or delete that would break it. That
+    #     coupling is transitive, not structural: drop docs/deployment.md from
+    #     the routing table and this suite loses its cover.
+    # Splitting these out lets a Markdown-only PR finish in
+    # minutes instead of waiting on a job capped at 25. Each `run:` string here
+    # is byte-identical to its counterpart in `scripts`, and the steps are NOT
+    # removed from there: a change to the documentation tooling must still run
+    # them against the corpus. A mixed diff runs both jobs and pays for one
+    # duplicate pass, which is the accepted cost of the split.
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Baseline validation reads source blobs from its claimed pre-baseline
+          # commit so results remain reproducible after later doc changes. That
+          # commit is over a thousand commits behind main, so the default
+          # shallow checkout would not hold the object and `git show` would
+          # fail outright rather than degrade.
+          fetch-depth: 0
+      - name: Validate trusted package-script pins
+        # The `scripts` job runs this first for two reasons that apply here
+        # unchanged: `pnpm install` below executes the root lifecycle hooks,
+        # and every step after it invokes a trusted `pnpm` alias
+        # (`agent:context-*`, `docs:*`). Validating first rejects an
+        # unsanctioned `postinstall` before install would run it, and a drifted
+        # alias command before it executes. This job needs its own copy — on a
+        # Markdown-only diff the `scripts` job no longer runs at all.
+        # check-sentry-suites-in-ci.test.mjs pins this ordering for this job by
+        # name, exactly as it does for `scripts`, so moving pnpm-install or an
+        # alias above this step fails required CI.
+        run: node scripts/check-agent-quality-gate-package-scripts.mjs
+      - uses: ./.github/actions/pnpm-install
+      - name: Agent context checker
+        # Discovers canonical files from the tracked tree, so an added, renamed
+        # or removed document changes which files it validates.
+        run: pnpm agent:context-check
+      - name: Documentation catalog drift and link check
+        run: pnpm docs:index --check
+      - name: Agent context budget tests
+        # Not a pure fixture suite: its last case builds the report from
+        # trackedInstructionFiles(repoRoot) against this checkout and pins the
+        # route list to the ten AGENTS.md directories that exist today. Adding
+        # docs/AGENTS.md or deleting alerts/AGENTS.md is a Markdown-only diff
+        # that reds it, and the --strict run below would not catch that: it
+        # only enforces byte caps.
+        run: pnpm agent:context-budget:test
+      - name: Enforce agent context budgets
+        # Corpus-dependent for AGENTS.md and AGENTS.override.md specifically:
+        # it measures their byte sizes per file and per route.
+        run: pnpm agent:context-budget --strict
+      - name: Documentation audit planner dry run
+        run: pnpm docs:audit --dry-run
+      - name: Documentation navigation evaluation tests
+        # Also not a pure fixture suite: it loads the live inventory and
+        # asserts which accepted route is cheapest in real document bytes, so a
+        # content-only edit that grows one document past another flips it. The
+        # --check-fixtures run below only rejects paths missing from the
+        # inventory, so it would not catch that.
+        run: pnpm docs:navigation-eval:test
+      - name: Documentation navigation fixture contract
+        run: pnpm docs:navigation-eval -- --check-fixtures
+      - name: Documentation navigation committed baseline
+        run: >-
+          pnpm docs:navigation-eval -- --validate
+          docs/evals/documentation-navigation-baseline.json
+          --fixtures docs/evals/documentation-navigation-baseline-fixtures.json
+      - name: Gate routing-table suite
+        # ADR 0069's table names 799 repository paths, 23 of them Markdown:
+        # eleven of the twelve docs/pr-checklists/*.md (all but
+        # review-prompt-exclusions.md), README.md, AGENTS.md, BACKLOG.md,
+        # SPEC.md, two ADRs and more. Its staleness check asserts each still
+        # exists, so renaming or deleting one of those documents is a
+        # Markdown-only diff that breaks the gate. Without this step here, such
+        # a PR would merge green and leave the gate pointing reviewers at a
+        # document that is not there. This is one of the two non-documentation
+        # steps of `scripts` that read the Markdown corpus; it also covers the
+        # other one, agent:quality-gate:test, whose docs/deployment.md
+        # assertion depends on a path this staleness check already names.
+        run: pnpm gate:routing-table:test
+      - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
+        if: always()
+
   production-infra-contract:
     name: Production infrastructure contract
     # This required job is deliberately unconditional: tf:test validates
@@ -1389,6 +1528,7 @@ jobs:
         terraform,
         deps,
         scripts,
+        docs-checks,
         production-infra-contract,
         sentry-suites,
         autoreview-suite,
@@ -1405,6 +1545,6 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,autoreview-suite,autoreview-root-runtime,version-skew
+          allowed-skips: shared,ui,indexer,bridge,integration-probes,aegis,alerts,gov-watchdog,terraform,deps,scripts,docs-checks,autoreview-suite,autoreview-root-runtime,version-skew
       - uses: Kesin11/actions-timeline@57fc93f20c6da7fbc14063c6d24a2a5627c799ad # v3.2.0
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,8 +310,8 @@ jobs:
               # that used to sit here now live in the `docs` filter below
               # (ADR 0072): a Markdown-only diff runs the small `docs-checks`
               # job, which carries nine of the eleven checks in this job that
-              # read the Markdown corpus — the two left behind red only when a
-              # carried check reds. Markdown that arrives alongside any path
+              # read the Markdown corpus — the two left behind fail only when a
+              # carried check fails. Markdown that arrives alongside any path
               # above still sets both filters, and both jobs run — including a
               # Markdown-only edit under `.agents/**` or `.claude/skills/**`,
               # which those globs still route here for their non-Markdown
@@ -1223,13 +1223,13 @@ jobs:
     #     empty. That is a strict subset of `pnpm docs:index --check` below,
     #     which fails on errors OR warnings OR broken links, and a deleted or
     #     non-regular runtime document is rejected by the runtime registry
-    #     that both carried checks import. No Markdown-only diff reds it while
+    #     that both carried checks import. No Markdown-only diff fails it while
     #     everything in this job stays green.
     #   - agent:quality-gate:test pins the targeted-Trunk branch on the
     #     tracked file docs/deployment.md, which flips to `--all` once that
     #     path leaves the worktree. docs/deployment.md is also one of the
     #     routing table's staleness subjects, so the gate routing-table step
-    #     below reds first on the rename or delete that would break it. That
+    #     below fails first on the rename or delete that would break it. That
     #     coupling is transitive, not structural: drop docs/deployment.md from
     #     the routing table and this suite loses its cover.
     # Splitting these out lets a Markdown-only PR finish in
@@ -1278,7 +1278,7 @@ jobs:
         # trackedInstructionFiles(repoRoot) against this checkout and pins the
         # route list to the ten AGENTS.md directories that exist today. Adding
         # docs/AGENTS.md or deleting alerts/AGENTS.md is a Markdown-only diff
-        # that reds it, and the --strict run below would not catch that: it
+        # that fails it, and the --strict run below would not catch that: it
         # only enforces byte caps.
         run: pnpm agent:context-budget:test
       - name: Enforce agent context budgets

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,7 @@ Authority: canonical
 - [`docs/adr/0069-gate-routing-table-as-data.md`](adr/0069-gate-routing-table-as-data.md) — The quality gate's routing table is data, compiled by the repo's own bash-case translator
 - [`docs/adr/0070-sentry-requeue-settlement-sentinel.md`](adr/0070-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
 - [`docs/adr/0071-susds-launch-aligned-daily-sampler.md`](adr/0071-susds-launch-aligned-daily-sampler.md) — sUSDS actuals use a launch-aligned bounded daily sampler
+- [`docs/adr/0072-md-only-docs-checks-job.md`](adr/0072-md-only-docs-checks-job.md) — Markdown-only PRs run a small docs-checks CI job instead of the full scripts job
 
 Authority: non-canonical
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,7 +197,7 @@ Authority: canonical
 - [`docs/adr/0069-gate-routing-table-as-data.md`](adr/0069-gate-routing-table-as-data.md) — The quality gate's routing table is data, compiled by the repo's own bash-case translator
 - [`docs/adr/0070-sentry-requeue-settlement-sentinel.md`](adr/0070-sentry-requeue-settlement-sentinel.md) — A withheld terminal label serializes the Sentry archive settlement against the triage re-queue
 - [`docs/adr/0071-susds-launch-aligned-daily-sampler.md`](adr/0071-susds-launch-aligned-daily-sampler.md) — sUSDS actuals use a launch-aligned bounded daily sampler
-- [`docs/adr/0072-md-only-docs-checks-job.md`](adr/0072-md-only-docs-checks-job.md) — Markdown-only PRs run a small docs-checks CI job instead of the full scripts job
+- [`docs/adr/0072-md-only-docs-checks-job.md`](adr/0072-md-only-docs-checks-job.md) — The Markdown globs route to a small docs-checks CI job instead of the scripts job
 
 Authority: non-canonical
 

--- a/docs/adr/0072-md-only-docs-checks-job.md
+++ b/docs/adr/0072-md-only-docs-checks-job.md
@@ -1,0 +1,336 @@
+---
+title: Markdown-only PRs run a small docs-checks CI job instead of the full scripts job
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-26
+scope: ci/process
+date: 2026-08
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0072 — a Markdown-only diff runs `docs-checks`, not the 25-minute `scripts` job
+
+**Status:** Accepted (Aug 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+The `rootScripts` paths-filter carried `*.md` and `**/*.md`, so any Markdown
+edit fired the `scripts` job: 43 steps, `timeout-minutes: 25`, a full-history
+checkout, and a whole-workspace `pnpm install`. A one-line typo fix in a note
+under `docs/notes/` paid the same CI bill as a rewrite of the quality gate.
+
+A review of 11 reflection-family PRs across the mento-protocol repos measured
+what that bought. Ten of the eleven were Markdown-only; the exception also
+touched a workflow file. Across all eleven, the full review and CI machinery
+produced two actionable findings, both cosmetic wording fixes: a percentage
+phrased as "faster" where it described a reduction, and an inclusive-timestamp
+wording. Zero correctness defects. Every one of the eleven ran full-length CI.
+
+The `scripts` job holds twelve documentation-related steps. Six read the live
+tracked Markdown tree through `git ls-files`, so an added, renamed, removed or
+edited document can change their verdict: `agent:context-check`,
+`docs:index --check`, `agent:context-budget --strict`, `docs:audit --dry-run`,
+`docs:navigation-eval -- --check-fixtures`, and the committed-baseline
+`docs:navigation-eval -- --validate`.
+
+Of the other six, three are unit suites that build their fixtures in a temporary
+repository or stub their inputs, so no Markdown edit can change what they
+report: `check-agent-context.test.mjs`, `docs:audit:test` and
+`docs:garden:test`. The other three read this checkout despite looking like
+fixture suites, and all three were misread as synthetic in earlier drafts of
+this decision. Two are carried into the new job:
+
+- `agent:context-budget:test` builds its last case from
+  `trackedInstructionFiles(repoRoot)` against the real root and pins the result
+  to the ten `AGENTS.md` route directories that exist today
+  (`scripts/context/agent-context-budget.test.mjs:33,349`). Adding
+  `docs/AGENTS.md`, or deleting `alerts/AGENTS.md`, is a Markdown-only diff
+  that reds it. `agent:context-budget --strict` would not catch that: it
+  enforces byte caps, not the route list.
+- `docs:navigation-eval:test` loads the live inventory at module scope and
+  asserts which accepted route is cheapest in real document bytes
+  (`scripts/docs/docs-navigation-eval.test.mjs:42,63,440`). `quick-commands.md`
+  is 13,084 bytes against a 24,556-byte alternative, so a content-only edit
+  that grows it past that margin flips the assertion.
+  `docs:navigation-eval -- --check-fixtures` would not catch that either: it
+  rejects paths missing from the inventory, not a changed size ranking.
+
+The third, `docs:index:test`, reads the live tree too — one case resolves the
+real repository root, builds the inventory over every tracked Markdown file and
+asserts `inventory.errors` is empty
+(`scripts/context/docs-index.test.mjs:401-414`) — but it is not carried, for the
+reason given under Alternatives: that assertion is a strict subset of what
+`docs:index --check` already enforces in this job.
+
+Two steps outside the documentation group also read the corpus. The first is
+`gate:routing-table:test`, which checks
+[ADR 0069](0069-gate-routing-table-as-data.md)'s routing data, and its staleness
+assertion calls `existsSync` on all 799 path subjects the table names — 23 of
+them Markdown, including eleven of the twelve `docs/pr-checklists/*.md` (all
+but `review-prompt-exclusions.md`), `README.md`, `AGENTS.md`, `BACKLOG.md`,
+`SPEC.md` and two ADRs. Renaming or deleting one of those documents is a
+Markdown-only diff that breaks the gate.
+
+The second is `agent:quality-gate:test`. The gate's Trunk mapping emits
+`./tools/trunk check <paths>` when every changed path still exists in the
+worktree and `./tools/trunk check --all` when one does not
+(`scripts/gate/mapping/post-passes.mjs:38-55`), and the suite pins the first
+branch on a real tracked document, `docs/deployment.md`
+(`scripts/agent-quality-gate.test.sh:5372-5384`); the contrast case at
+`:5506-5509` runs the gate over `docs/deleted.md` and expects `--all`, so the
+branch turns on worktree existence alone. Deleting or renaming
+`docs/deployment.md` is therefore a Markdown-only diff that reds this suite. It
+is not carried into the new job, because that same file is one of the routing
+table's staleness subjects (`scripts/gate/routing-table/groups-head.mjs:129`),
+so `gate:routing-table:test` reds first on exactly that diff.
+
+Eleven steps in the `scripts` job read the Markdown corpus, then. Nine move into
+the new job. The other two — `docs:index:test` and `agent:quality-gate:test` —
+red only on a diff that also reds a check the new job carries, so they stay
+where they are.
+
+[ADR 0062](0062-sentry-suites-self-run-gate.md) split a check family out of this
+same `scripts` job and reads as precedent, but the two decisions answer
+different questions. ADR 0062 fixed a required-check availability bug: the
+Sentry suites could go permanently un-run on a diff that missed the filter, so
+its new job is unconditional and deliberately absent from `allowed-skips`. This
+decision is cost-motivated. Nothing here is un-run today; the checks simply run
+inside a job an order of magnitude larger than they need. So this job is
+conditional and skippable, the opposite treatment, for the opposite reason.
+
+## Decision
+
+Move `*.md` and `**/*.md` out of `rootScripts` into a new `docs` paths-filter,
+byte-identical, and add a `docs-checks` job gated on it.
+
+- `docs-checks` runs `if: needs.changes.outputs.docs == 'true'` on
+  `blacksmith-2vcpu-ubuntu-2404` with `timeout-minutes: 10` and only
+  `contents: read` plus `actions: read` — none of its nine checks calls the
+  GitHub API.
+- It carries nine of the eleven corpus readers named in the Context above, each
+  `run:` string byte-identical to its counterpart in `scripts`. The other two,
+  `docs:index:test` and `agent:quality-gate:test`, stay behind; see
+  Alternatives.
+- The `docs` filter also lists `.github/workflows/ci.yml` and
+  `.github/actions/pnpm-install/**`, the two files the job is built from. Every
+  other filter in `ci.yml` lists `ci.yml` for the same reason: without it, a PR
+  that edits this job's own definition sets only `rootScripts`, `docs-checks`
+  skips, and the edited job ships without ever having run.
+- Its checkout sets `fetch-depth: 0`. The committed navigation baseline names
+  `repository_base_commit` `a82f8c58`, and the validate step reads source blobs
+  at that commit with `git show`. On the default shallow checkout the object is
+  absent and the step throws rather than degrading.
+- `node scripts/check-agent-quality-gate-package-scripts.mjs` runs before
+  `pnpm install`, as it does in `scripts`. This job invokes the same trusted
+  `pnpm` aliases and runs the same root lifecycle hooks, so it needs its own
+  copy of the pin validator — on a Markdown-only diff, the `scripts` copy never
+  executes. That ordering is machine-pinned, not conventional:
+  `check-sentry-suites-in-ci-lifecycle.test.mjs` hard-coded the job name
+  `"scripts"` at its only call site of `pinValidationOrderBlockers`, and this
+  change parameterizes it over `["scripts", "docs-checks"]`. Both of its probes
+  — drop the validator, move it after install — work unchanged for either name,
+  so a later PR that reorders this job fails required CI the same way it would
+  in `scripts`.
+- All nine steps stay in `scripts` as well. A change to the documentation
+  tooling must still run them against the real corpus. A mixed diff sets both
+  filters, runs both jobs, and pays for one duplicate pass.
+- The three synthetic-fixture documentation suites, `docs:index:test` and
+  `agent:quality-gate:test` stay in `scripts` only.
+- The `ci` sentinel gains `docs-checks` in both `needs` and `allowed-skips`,
+  the treatment every path-gated job gets. No branch-ruleset change: the split
+  lives inside the already-required `ci.yml`.
+- `scripts/sentry/ci-wiring/check-sentry-suites-in-ci-core.mjs` counts the
+  sentinel's path-gated dependencies in prose; that count moves from fourteen
+  to fifteen in the same change.
+
+## Alternatives considered
+
+**Leave it as it is.** Rejected: the measured return on a full `scripts` run
+over a Markdown-only diff was two cosmetic wording findings across eleven PRs,
+and neither came from a CI step.
+
+**Make the `scripts` job faster instead.** Rejected: it is not slow by
+accident. Its 43 steps are load-bearing regression suites for gate routing,
+supply-chain policy, workflow trust, and alert rules, and its own comment
+records that the exact-identity lock suite alone reached 14m45s. Cutting the
+job to fit Markdown PRs would weaken it for the code PRs it exists to guard.
+
+**Put a workflow-level `paths:` filter on `ci.yml`, or promote a separate
+required `docs` workflow with one.** Rejected by
+[ADR 0010](0010-required-checks-no-paths-filters.md) and by
+[the CI workflow gates checklist](../pr-checklists/ci-workflow-gates.md): a
+ruleset-required check that does not run stays pending forever and blocks the
+merge. Path-conditional work runs on every PR and skips inside via `if:`, which
+is what this decision does.
+
+**Make `docs-checks` unconditional, as ADR 0062 did for `sentry-suites`.**
+Rejected: that treatment costs every PR a full install to run checks most of
+them cannot affect, and it buys nothing here. The availability gap 0062 closed
+does not exist for these nine checks — they remain reachable through
+`rootScripts` for every non-Markdown diff that can influence them.
+
+**Move all six documentation unit suites into `docs-checks`.** Rejected for
+four of them, on two different grounds. Three —
+`check-agent-context.test.mjs`, `docs:audit:test` and `docs:garden:test` —
+build their fixtures in a temporary repository or stub their inputs, so a
+Markdown-only PR cannot change their result, and running them here would add
+cost without adding a signal. The fourth, `docs:index:test`, does read the
+tracked tree, but only to assert that `inventory.errors` is empty; the carried
+`docs:index --check` fails on errors, warnings _or_ broken links
+(`hasBlockingProblems`, `scripts/context/docs-index.mjs:74-80`), and a deleted
+or non-regular runtime document is rejected by
+`loadClaudeRuntimeDocumentRegistry`
+(`scripts/context/claude-runtime-document-registry.mjs:312-333`), which both
+`docs:index --check` and `agent:context-check` import. No Markdown-only diff
+was found that reds `docs:index:test` while every check in this job stays
+green, so it is subsumed rather than synthetic. The other two,
+`agent:context-budget:test` and `docs:navigation-eval:test`, are carried: each
+was verified to read this checkout, and each has a concrete Markdown-only diff
+that reds it on `main` while every other check in this job stays green. Leaving
+them out would let such a PR merge and break the `scripts` job for the next
+unrelated code PR.
+
+**Carry `agent:quality-gate:test` too.** Rejected: it is an 11,000-line shell
+suite that drives the whole quality gate, and the single Markdown-only diff
+that reds it — deleting or renaming `docs/deployment.md` — already reds
+`gate:routing-table:test`, which this job does run. The cover is transitive,
+which is why it is stated here and in the job comment rather than left implicit:
+drop `docs/deployment.md` from the routing table in a later `scripts/**` PR —
+which fires `rootScripts` and stays green at the time — and this gap opens with
+nothing to announce it. A maintainer who does that should carry
+`agent:quality-gate:test` into `docs-checks` in the same change.
+
+**Leave `gate:routing-table:test` in `scripts` only and accept the gap.**
+Rejected: renaming `docs/pr-checklists/mutation-testing.md` and regenerating
+`docs/README.md` is a Markdown-only diff. Today it reds the staleness check;
+without this step in `docs-checks` it would merge green with the gate naming a
+document that no longer exists — the quietest failure the check exists to
+prevent, and squarely the docs-gardening workload this change is meant to
+speed up. The suite is offline and needs no extra permissions, so carrying it
+costs a duplicate run on mixed diffs and nothing else.
+
+## Consequences
+
+- **A Markdown-only PR runs a ten-minute-capped job instead of a
+  twenty-five-minute-capped one.** The checks that can actually fail on a
+  Markdown edit are exactly the ones that still run.
+- **A new Markdown-triggered check now has two candidate jobs, not one.**
+  Whoever adds one must decide where it belongs: if it reads the tracked
+  Markdown tree it goes in `docs-checks`, and also in `scripts` when a tooling
+  change must re-run it. The only ground for leaving such a check out of
+  `docs-checks` is that a check already in the job strictly subsumes it — as
+  `docs:index --check` subsumes `docs:index:test`'s live-tree case — and that
+  reasoning must be written down where the exclusion is made. This is the
+  constraint this ADR imposes.
+- **The nine checks now exist in two jobs and must move together.** A step
+  added to one and forgotten in the other silently narrows coverage for one
+  class of diff. Nothing machine-checks that pairing today; the `run:` strings
+  are kept byte-identical so a diff of the two step lists shows the drift.
+- **Membership rests on reading each suite, and that reading is fallible.**
+  Four of the eleven corpus readers — `agent:context-budget:test`,
+  `docs:navigation-eval:test`, `docs:index:test` and `agent:quality-gate:test` —
+  were missed in review across two rounds: three read as synthetic-fixture
+  suites, and the fourth was not read as a corpus reader at all. Each was
+  reclassified only after its assertions were traced to the live tree. A
+  suite that looks like a fixture test can still read this checkout. Adding a
+  step to `scripts` that does so, without also adding it here, reopens the gap
+  this decision closes, and no check will say so.
+- **One of the eleven is covered transitively, not structurally.**
+  `agent:quality-gate:test` stays in `scripts`, and the diff that reds it —
+  removing `docs/deployment.md` — is caught here only because that path is also
+  a routing-table staleness subject. Removing it from the routing table would
+  fire `rootScripts`, pass at the time, and silently open the gap.
+- **A Markdown-only edit under a path that stays in `rootScripts` now costs
+  more, not less.** `.agents/**`, `.claude/skills/**`, `alerts/infra/**` and
+  the other non-Markdown globs keep routing their own Markdown to `scripts`,
+  and such a diff now sets both filters: the unchanged 25-minute job runs
+  exactly as today, plus a second runner repeating nine of its steps. That is
+  about one tracked Markdown file in five — 43 of 201, of which 17 sit under
+  `.agents/` and 15 under `.claude/skills/`, the skills mirror this repo
+  gardens most often. For those PRs this change is pure added cost. Narrowing
+  those globs to their non-Markdown contents would fix it and is deliberately
+  out of scope here: it changes which job sees a skill edit, which is a
+  separate decision from relocating the two Markdown globs.
+- **A Markdown-only PR no longer runs the rest of the `scripts` job**, which
+  includes the three synthetic-fixture documentation suites, `docs:index:test`,
+  and every non-documentation step (ESLint on root scripts, the agent
+  quality-gate routing suite, CodeRabbit config pin, notifier coverage, autofix
+  trust, supply-chain suites). Every remaining step was read for reads of the
+  real Markdown tree; outside the documentation group the two found were
+  `gate:routing-table:test`, which is carried here, and
+  `agent:quality-gate:test`, which is covered through it. The rest take their
+  input from `scripts/**`, `.github/workflows/**`, config files, and their own
+  fixtures, all of which stay in `rootScripts` unchanged, so a diff that can
+  affect them still fires `scripts`.
+- **A skipped `docs-checks` satisfies the `ci` sentinel**, exactly like a
+  skipped `scripts`. Adding it to `needs` without `allowed-skips` would turn
+  the required check red on every non-Markdown PR. That pairing is convention
+  plus alls-green semantics, not a machine check:
+  `check-sentry-suites-in-ci-core.mjs` enforces `allowed-skips` membership only
+  for entries in `TRUSTED_JOBS`, which holds one job mapped to `null`, and the
+  guard reads `trusted.get(name) != null`. Removing `docs-checks` from
+  `allowed-skips` would fail no test — it would turn the required `ci` context
+  red on every non-Markdown PR instead.
+
+## Evidence
+
+- `.github/workflows/ci.yml`: the `scripts` job carries 43 steps and
+  `timeout-minutes: 25`; `docs-checks` carries 13 steps and
+  `timeout-minutes: 10`.
+- `stalenessSubjects(ROUTING_GROUPS)` from `scripts/gate/routing-table/`
+  returns 799 path subjects, 631 distinct, of which 23 are Markdown files —
+  eleven `docs/pr-checklists/` entries, not all twelve tracked there;
+  `docs/pr-checklists/review-prompt-exclusions.md` is not a subject.
+  `scripts/gate/routing-table/routing-table.test.mjs` asserts each exists.
+- `scripts/context/agent-context-budget.test.mjs:33` resolves `repoRoot` to the
+  real repository root, and its case at line 349 pins
+  `report.routes.map(({ route }) => route)` to the ten `AGENTS.md` directories
+  `git ls-files` returns today. `scripts/docs/docs-navigation-eval.test.mjs:42`
+  does the same and its case at line 440 pins two cheapest-route selections to
+  `docs/notes/quick-commands.md`, chosen by live byte size (13,084 bytes,
+  against 24,556 and 24,886 for the two alternatives). Both suites are
+  therefore carried into `docs-checks`.
+- `scripts/context/docs-index.test.mjs:401-414` resolves the real repository
+  root, calls `trackedDocumentationFiles` on it, and asserts
+  `inventory.errors` deep-equals `[]`. `hasBlockingProblems`
+  (`scripts/context/docs-index.mjs:74-80`) fails on `errors`, `warnings` or
+  `broken_links`, so `docs:index --check` is the stricter of the two, and
+  `loadClaudeRuntimeDocumentRegistry`
+  (`scripts/context/claude-runtime-document-registry.mjs:312-333`) — imported by
+  `check-agent-context.mjs:21` and `docs-index-helpers.mjs:12` — rejects a
+  deleted or non-regular runtime document. This is why the suite is left in
+  `scripts`.
+- `addTrunkCheckCommand` (`scripts/gate/mapping/post-passes.mjs:38-55`) selects
+  `./tools/trunk check --all` when any changed path is absent from the
+  worktree. `scripts/agent-quality-gate.test.sh:5372-5384` pins the targeted
+  branch on `docs/deployment.md` twice; `:5506-5509` pins the `--all` branch on
+  `docs/deleted.md`. `scripts/gate/routing-table/groups-head.mjs:129` lists
+  `docs/deployment.md` as a staleness subject, which is what makes
+  `gate:routing-table:test` cover this suite for the diff that would break it.
+- Matching the tracked `*.md` list against the non-Markdown `rootScripts`
+  globs that this change leaves in place gives 43 of 201 files (21%): 17 under
+  `.agents/`, 15 under `.claude/skills/`, 7 under `alerts/`, 2 under
+  `scripts/`, 2 under `terraform/`. A filesystem walk of the checkout
+  reproduces the two largest buckets exactly. Those PRs run both jobs.
+- `pinValidationOrderBlockers` is called from exactly one place,
+  `scripts/sentry/ci-wiring/check-sentry-suites-in-ci-lifecycle.test.mjs`, with
+  the job name `"scripts"` hard-coded. Running it against the candidate with
+  `"docs-checks"` returns `[]`, and both of its probes are rejected for that
+  name, so parameterizing the test is sufficient to pin the new job's ordering.
+- `docs/evals/documentation-navigation-baseline.json` records
+  `run.repository_base_commit` `a82f8c580d145806865f031755c7b5411f89c976`,
+  executed `2026-07-21T21:21:54Z` — over a month of commits behind `main` at
+  the time of this change, so a depth-1 checkout does not hold that object.
+  This is why `fetch-depth: 0` is not optional for this job.
+- `scripts/production-infra-identity-contract/routing.test.mjs` pins
+  `filters.rootScripts` content and the `scripts` job's
+  `needs.changes.outputs.rootScripts == 'true'` condition. Neither Markdown glob
+  appears in anything it requires, so relocating them keeps it green.
+- `actionlint` 1.7.8 with `.trunk/configs/actionlint.yaml`, `yamllint` 1.38.0
+  with `.trunk/configs/.yamllint.yaml`, and `prettier` 3.8.1 — the versions
+  `.trunk/trunk.yaml` pins — all report clean on the edited workflow and on the
+  parameterized lifecycle test.

--- a/docs/adr/0072-md-only-docs-checks-job.md
+++ b/docs/adr/0072-md-only-docs-checks-job.md
@@ -1,5 +1,5 @@
 ---
-title: Markdown-only PRs run a small docs-checks CI job instead of the full scripts job
+title: The Markdown globs route to a small docs-checks CI job instead of the scripts job
 status: active
 owner: eng
 canonical: true
@@ -11,7 +11,7 @@ review_interval_days: 90
 garden_lane: adrs-architecture
 ---
 
-# ADR 0072 — a Markdown-only diff runs `docs-checks`, not the 25-minute `scripts` job
+# ADR 0072 — the Markdown globs route to `docs-checks`, not the 25-minute `scripts` job
 
 **Status:** Accepted (Aug 2026), in force.
 **Scope:** ci/process
@@ -49,7 +49,7 @@ this decision. Two are carried into the new job:
   to the ten `AGENTS.md` route directories that exist today
   (`scripts/context/agent-context-budget.test.mjs:33,349`). Adding
   `docs/AGENTS.md`, or deleting `alerts/AGENTS.md`, is a Markdown-only diff
-  that reds it. `agent:context-budget --strict` would not catch that: it
+  that fails it. `agent:context-budget --strict` would not catch that: it
   enforces byte caps, not the route list.
 - `docs:navigation-eval:test` loads the live inventory at module scope and
   asserts which accepted route is cheapest in real document bytes
@@ -83,14 +83,14 @@ branch on a real tracked document, `docs/deployment.md`
 (`scripts/agent-quality-gate.test.sh:5372-5384`); the contrast case at
 `:5506-5509` runs the gate over `docs/deleted.md` and expects `--all`, so the
 branch turns on worktree existence alone. Deleting or renaming
-`docs/deployment.md` is therefore a Markdown-only diff that reds this suite. It
+`docs/deployment.md` is therefore a Markdown-only diff that fails this suite. It
 is not carried into the new job, because that same file is one of the routing
 table's staleness subjects (`scripts/gate/routing-table/groups-head.mjs:129`),
-so `gate:routing-table:test` reds first on exactly that diff.
+so `gate:routing-table:test` fails first on exactly that diff.
 
 Eleven steps in the `scripts` job read the Markdown corpus, then. Nine move into
 the new job. The other two — `docs:index:test` and `agent:quality-gate:test` —
-red only on a diff that also reds a check the new job carries, so they stay
+fail only on a diff that also fails a check the new job carries, so they stay
 where they are.
 
 [ADR 0062](0062-sentry-suites-self-run-gate.md) split a check family out of this
@@ -186,17 +186,17 @@ or non-regular runtime document is rejected by
 `loadClaudeRuntimeDocumentRegistry`
 (`scripts/context/claude-runtime-document-registry.mjs:312-333`), which both
 `docs:index --check` and `agent:context-check` import. No Markdown-only diff
-was found that reds `docs:index:test` while every check in this job stays
+was found that fails `docs:index:test` while every check in this job stays
 green, so it is subsumed rather than synthetic. The other two,
 `agent:context-budget:test` and `docs:navigation-eval:test`, are carried: each
 was verified to read this checkout, and each has a concrete Markdown-only diff
-that reds it on `main` while every other check in this job stays green. Leaving
+that fails it on `main` while every other check in this job stays green. Leaving
 them out would let such a PR merge and break the `scripts` job for the next
 unrelated code PR.
 
 **Carry `agent:quality-gate:test` too.** Rejected: it is an 11,000-line shell
 suite that drives the whole quality gate, and the single Markdown-only diff
-that reds it — deleting or renaming `docs/deployment.md` — already reds
+that fails it — deleting or renaming `docs/deployment.md` — already fails
 `gate:routing-table:test`, which this job does run. The cover is transitive,
 which is why it is stated here and in the job comment rather than left implicit:
 drop `docs/deployment.md` from the routing table in a later `scripts/**` PR —
@@ -206,7 +206,7 @@ nothing to announce it. A maintainer who does that should carry
 
 **Leave `gate:routing-table:test` in `scripts` only and accept the gap.**
 Rejected: renaming `docs/pr-checklists/mutation-testing.md` and regenerating
-`docs/README.md` is a Markdown-only diff. Today it reds the staleness check;
+`docs/README.md` is a Markdown-only diff. Today it fails the staleness check;
 without this step in `docs-checks` it would merge green with the gate naming a
 document that no longer exists — the quietest failure the check exists to
 prevent, and squarely the docs-gardening workload this change is meant to
@@ -240,7 +240,7 @@ costs a duplicate run on mixed diffs and nothing else.
   step to `scripts` that does so, without also adding it here, reopens the gap
   this decision closes, and no check will say so.
 - **One of the eleven is covered transitively, not structurally.**
-  `agent:quality-gate:test` stays in `scripts`, and the diff that reds it —
+  `agent:quality-gate:test` stays in `scripts`, and the diff that fails it —
   removing `docs/deployment.md` — is caught here only because that path is also
   a routing-table staleness subject. Removing it from the routing table would
   fire `rootScripts`, pass at the time, and silently open the gap.
@@ -267,14 +267,14 @@ costs a duplicate run on mixed diffs and nothing else.
   fixtures, all of which stay in `rootScripts` unchanged, so a diff that can
   affect them still fires `scripts`.
 - **A skipped `docs-checks` satisfies the `ci` sentinel**, exactly like a
-  skipped `scripts`. Adding it to `needs` without `allowed-skips` would turn
-  the required check red on every non-Markdown PR. That pairing is convention
+  skipped `scripts`. Adding it to `needs` without `allowed-skips` would fail
+  the required check on every non-Markdown PR. That pairing is convention
   plus alls-green semantics, not a machine check:
   `check-sentry-suites-in-ci-core.mjs` enforces `allowed-skips` membership only
   for entries in `TRUSTED_JOBS`, which holds one job mapped to `null`, and the
   guard reads `trusted.get(name) != null`. Removing `docs-checks` from
-  `allowed-skips` would fail no test — it would turn the required `ci` context
-  red on every non-Markdown PR instead.
+  `allowed-skips` would fail no test — it would fail the required `ci` context
+  on every non-Markdown PR instead.
 
 ## Evidence
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,7 +81,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0068](0068-sentry-fixture-authoring-policy.md)             | Adversarial fixtures are authored to scan clean; no value or line registry           |
 | [0069](0069-gate-routing-table-as-data.md)                  | The gate's routing table is data, compiled by the repo's own bash-`case` translator  |
 | [0070](0070-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
-| [0072](0072-md-only-docs-checks-job.md)                     | Markdown-only PRs run a small `docs-checks` job, not the full scripts job            |
+| [0072](0072-md-only-docs-checks-job.md)                     | The Markdown globs route to a small `docs-checks` job; some Markdown runs both jobs  |
 
 ### shared-config
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,6 +81,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0068](0068-sentry-fixture-authoring-policy.md)             | Adversarial fixtures are authored to scan clean; no value or line registry           |
 | [0069](0069-gate-routing-table-as-data.md)                  | The gate's routing table is data, compiled by the repo's own bash-`case` translator  |
 | [0070](0070-sentry-requeue-settlement-sentinel.md)          | The archive's terminal label is withheld from the re-queue's shed and read back      |
+| [0072](0072-md-only-docs-checks-job.md)                     | Markdown-only PRs run a small `docs-checks` job, not the full scripts job            |
 
 ### shared-config
 

--- a/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-core.mjs
+++ b/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-core.mjs
@@ -427,7 +427,7 @@ export function sentinelBlockers(workflow, trustedJobs) {
 
   // A skipped job's check run reports success, so a sentinel that can skip
   // stops propagating a red `scripts` job to the required `ci` context. Its
-  // fourteen path-gated dependencies make `always()` load-bearing, not
+  // fifteen path-gated dependencies make `always()` load-bearing, not
   // decorative: without it the sentinel skips on any PR that skips one of them.
   if (sentinel.if !== "always()") {
     blockers.push(

--- a/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-lifecycle.test.mjs
+++ b/scripts/sentry/ci-wiring/check-sentry-suites-in-ci-lifecycle.test.mjs
@@ -41,60 +41,71 @@ import {
 const TRUSTED_ALIASES = new Set(validatorPins().keys());
 const VALIDATOR_RUN = PIN_VALIDATOR_COMMAND.join(" ");
 
-test("the `scripts` job validates pins before pnpm-install and any trusted alias", () => {
-  // The validator makes two surfaces safe only by running first: before
-  // pnpm-install (so a root lifecycle hook is rejected before install runs it,
-  // Codex 3754887736) and before any trusted `pnpm <alias>` step (so a drifted
-  // alias is rejected before it runs an appended command, Codex 3754887737).
-  assert.deepEqual(
-    pinValidationOrderBlockers(
-      CI,
-      "scripts",
-      PIN_VALIDATOR_COMMAND,
-      TRUSTED_ALIASES,
-      INSTALL_ACTION,
-    ),
-    [],
-    "the `scripts` job runs pnpm-install or a trusted alias before the pin validator",
-  );
+// Every job that runs `pnpm install` and then a trusted alias carries its own
+// copy of the validator, so every one of them needs the ordering pinned. ADR
+// 0072 added the second: `docs-checks` runs the same install action and the
+// same `agent:context-*` / `docs:*` aliases on a Markdown-only diff, where the
+// `scripts` job does not run at all.
+const PIN_ORDER_JOBS = ["scripts", "docs-checks"];
 
-  // Probe 1: drop the validator step entirely.
-  const withoutValidator = structuredClone(CI);
-  withoutValidator.jobs.scripts.steps =
-    withoutValidator.jobs.scripts.steps.filter(
+for (const job of PIN_ORDER_JOBS) {
+  test(`the \`${job}\` job validates pins before pnpm-install and any trusted alias`, () => {
+    // The validator makes two surfaces safe only by running first: before
+    // pnpm-install (so a root lifecycle hook is rejected before install runs it,
+    // Codex 3754887736) and before any trusted `pnpm <alias>` step (so a drifted
+    // alias is rejected before it runs an appended command, Codex 3754887737).
+    assert.deepEqual(
+      pinValidationOrderBlockers(
+        CI,
+        job,
+        PIN_VALIDATOR_COMMAND,
+        TRUSTED_ALIASES,
+        INSTALL_ACTION,
+      ),
+      [],
+      `the \`${job}\` job runs pnpm-install or a trusted alias before the pin validator`,
+    );
+
+    // Probe 1: drop the validator step entirely.
+    const withoutValidator = structuredClone(CI);
+    withoutValidator.jobs[job].steps = withoutValidator.jobs[job].steps.filter(
       (step) => step.run !== VALIDATOR_RUN,
     );
-  assert.notDeepEqual(
-    pinValidationOrderBlockers(
-      withoutValidator,
-      "scripts",
-      PIN_VALIDATOR_COMMAND,
-      TRUSTED_ALIASES,
-      INSTALL_ACTION,
-    ),
-    [],
-    "the order check accepts a `scripts` job with no pin validator step",
-  );
+    assert.notDeepEqual(
+      pinValidationOrderBlockers(
+        withoutValidator,
+        job,
+        PIN_VALIDATOR_COMMAND,
+        TRUSTED_ALIASES,
+        INSTALL_ACTION,
+      ),
+      [],
+      `the order check accepts a \`${job}\` job with no pin validator step`,
+    );
 
-  // Probe 2: move the validator to the end, after install and the aliases.
-  const reordered = structuredClone(CI);
-  const steps = reordered.jobs.scripts.steps;
-  const at = steps.findIndex((step) => step.run === VALIDATOR_RUN);
-  assert.ok(at >= 0, "pin validator step is gone — probe would prove nothing");
-  const [validator] = steps.splice(at, 1);
-  steps.push(validator);
-  assert.notDeepEqual(
-    pinValidationOrderBlockers(
-      reordered,
-      "scripts",
-      PIN_VALIDATOR_COMMAND,
-      TRUSTED_ALIASES,
-      INSTALL_ACTION,
-    ),
-    [],
-    "the order check accepts a validator that runs after pnpm-install and the aliases",
-  );
-});
+    // Probe 2: move the validator to the end, after install and the aliases.
+    const reordered = structuredClone(CI);
+    const steps = reordered.jobs[job].steps;
+    const at = steps.findIndex((step) => step.run === VALIDATOR_RUN);
+    assert.ok(
+      at >= 0,
+      "pin validator step is gone — probe would prove nothing",
+    );
+    const [validator] = steps.splice(at, 1);
+    steps.push(validator);
+    assert.notDeepEqual(
+      pinValidationOrderBlockers(
+        reordered,
+        job,
+        PIN_VALIDATOR_COMMAND,
+        TRUSTED_ALIASES,
+        INSTALL_ACTION,
+      ),
+      [],
+      "the order check accepts a validator that runs after pnpm-install and the aliases",
+    );
+  });
+}
 
 test("the pin validator rejects an unsanctioned install lifecycle hook", () => {
   // The real manifest — its one sanctioned `postinstall` and no other hook —


### PR DESCRIPTION
## The Problem

- The `rootScripts` paths-filter carried `*.md` and `**/*.md`, so any Markdown edit fired the `scripts` job: 43 steps, `timeout-minutes: 25`, a full-history checkout and a whole-workspace install. A one-line typo fix in a note paid the same CI bill as a rewrite of the quality gate.
- A review of 11 reflection-family PRs measured the return: 10 of the 11 were Markdown-only, and across all 11 the full review and CI machinery produced two actionable findings, both cosmetic wording fixes. Zero correctness defects, and every one of the 11 ran full-length CI.
- Only eleven of the `scripts` job's 43 steps read the Markdown corpus at all: six documentation checks that read the tracked tree, three unit suites that look synthetic but assert against this checkout, the gate routing-table suite (its staleness assertion names 23 Markdown paths), and the quality-gate routing suite. The other 32 never read the corpus.

## The Solution

The two Markdown globs move out of `rootScripts` into a new `docs` paths-filter, byte-identical, and a new `docs-checks` job runs on it. That job carries nine of the eleven corpus readers — `agent:context-check`, `docs:index --check`, `agent:context-budget:test`, `agent:context-budget --strict`, `docs:audit --dry-run`, both `docs:navigation-eval` modes plus `docs:navigation-eval:test`, and `gate:routing-table:test` — behind a 10-minute cap instead of 25. The two left behind, `docs:index:test` and `agent:quality-gate:test`, fail only on a diff that also fails a carried check; both are explained under Details.

The nine checks are **not** removed from `scripts`. A change to the documentation tooling must still run them against the real corpus, so a diff that sets both filters runs both jobs and pays for one duplicate pass. That duplication is the accepted cost of the split, and it is not only mixed code+docs diffs that pay it: 43 of the 201 tracked `*.md` files also match a non-Markdown `rootScripts` glob, so a Markdown-only edit to, say, `.agents/skills/reflect/SKILL.md` gains nothing and costs one extra runner.

Non-goals and limits: no branch-ruleset change (the split stays inside the already-required `ci.yml` and its `ci` sentinel, per ADR 0010); the `scripts` job's step list is untouched; every non-Markdown entry in `rootScripts` is untouched, so no code-adjacent PR shape loses coverage.

## Details

- **`changes` job.** New `docs` output and a `docs` filter holding `"*.md"` and `"**/*.md"` — the same two strings removed from `rootScripts` — plus `.github/workflows/ci.yml` and `.github/actions/pnpm-install/**`, the two files `docs-checks` is built from. Without those last two, a PR that edits the new job's own definition and no Markdown would set only `rootScripts`, `docs-checks` would skip, and the edited job would ship without ever having run; every other filter in this file lists `ci.yml` for the same reason. `**/*.md` still covers dot-directories such as `.github/`, and dorny/paths-filter reports added, modified, renamed and deleted files alike, so a removed or renamed document still fires the job. The stale `rootScripts` comment ("Markdown changes therefore run this cheap root-scripts job regardless of path") is rewritten to describe what the filter now does.
- **`docs-checks` job.** `if: needs.changes.outputs.docs == 'true'`, `blacksmith-2vcpu-ubuntu-2404`, `timeout-minutes: 10`, permissions `contents: read` + `actions: read` only — none of its checks touches the GitHub API. Its checkout sets `fetch-depth: 0` because the committed navigation baseline names `repository_base_commit` `a82f8c58` and the validate step reads source blobs at that commit with `git show`; on a depth-1 checkout the object is absent and the step throws rather than degrading. `node scripts/check-agent-quality-gate-package-scripts.mjs` runs before `pnpm install`, as in `scripts`: this job runs the same root lifecycle hooks and invokes the same trusted `pnpm` aliases, and on a Markdown-only diff the `scripts` copy of that validator never executes. Every `run:` string is byte-identical to its counterpart in `scripts`, and every action SHA and the closing `actions-timeline` step are copied byte-for-byte from elsewhere in the file.
- **The pin-validator ordering is machine-pinned for the new job, not just asserted in a comment.** `pinValidationOrderBlockers` had exactly one call site, `scripts/sentry/ci-wiring/check-sentry-suites-in-ci-lifecycle.test.mjs`, with the job name `"scripts"` hard-coded — so a later PR could move `pnpm-install` above the validator in `docs-checks`, or drop the validator while keeping the `pnpm docs:*` steps, and CI would stay green. That test is parameterized over `["scripts", "docs-checks"]`; its two probes work unchanged for either name.
- **Two suites that look like fixture tests are carried too.** `agent:context-budget:test` builds its last case from `trackedInstructionFiles(repoRoot)` against the real root and pins the route list to the ten `AGENTS.md` directories that exist today, so adding `docs/AGENTS.md` or deleting `alerts/AGENTS.md` — a Markdown-only diff — fails it while `agent:context-budget --strict` (byte caps only) passes. `docs:navigation-eval:test` loads the live inventory and asserts which accepted route is cheapest in real bytes; `docs/notes/quick-commands.md` is 13,084 bytes against a 24,556-byte alternative, so a content-only edit that grows it past that margin flips the assertion while `--check-fixtures` (missing paths only) passes. Both were classified as synthetic in an earlier draft and reclassified after their assertions were traced; without them, such a PR merges green and breaks `scripts` on `main` for the next unrelated code PR.
- **Why `gate:routing-table:test` is in the new job.** ADR 0069's routing table names 799 repository path subjects, 23 of them Markdown — eleven of the twelve `docs/pr-checklists/*.md` (all but `review-prompt-exclusions.md`), `README.md`, `AGENTS.md`, `BACKLOG.md`, `SPEC.md`, `docs/context-standards.md`, `docs/deployment.md`, three `docs/notes/*.md`, two ADRs and `.github/prompts/sentry-triage.md`. Its staleness test asserts each still exists. Renaming `docs/pr-checklists/mutation-testing.md` and regenerating `docs/README.md` is a Markdown-only diff; without this step in `docs-checks` it would merge green with the gate naming a document that is gone.
- **`ci` sentinel.** `docs-checks` is added to both `needs` and `allowed-skips`, the treatment every path-gated job gets. That pairing is convention plus alls-green semantics, not a machine check: `check-sentry-suites-in-ci-core.mjs` enforces `allowed-skips` membership only for `TRUSTED_JOBS` entries, and that map holds one job mapped to `null` behind a `trusted.get(name) != null` guard. Dropping `docs-checks` from `allowed-skips` would fail no test — it would fail the required `ci` context on every non-Markdown PR. The same file's comment at line 430 says the sentinel has "fourteen path-gated dependencies"; the candidate has fifteen, so it now reads "fifteen".
- **Two corpus readers stay in `scripts` on purpose.** `docs:index:test` has one case that resolves the real repository root and asserts `inventory.errors` is empty over the tracked tree (`scripts/context/docs-index.test.mjs:401-414`) — but that is a strict subset of the carried `docs:index --check`, which fails on errors, warnings *or* broken links (`hasBlockingProblems`, `docs-index.mjs:74-80`), and a deleted or non-regular runtime document is rejected by `loadClaudeRuntimeDocumentRegistry` (`claude-runtime-document-registry.mjs:312-333`), which both `docs:index --check` and `agent:context-check` import. No Markdown-only diff was found that fails it while the carried checks stay green. `agent:quality-gate:test` pins the targeted-Trunk branch on `docs/deployment.md` (`scripts/agent-quality-gate.test.sh:5372-5384`), which flips to `--all` once the path leaves the worktree (`scripts/gate/mapping/post-passes.mjs:38-55`); deleting or renaming that file is a Markdown-only diff that fails it, and it is covered here only because `docs/deployment.md` is also a routing-table staleness subject (`groups-head.mjs:129`), so `gate:routing-table:test` fails first. That cover is transitive, not structural — drop `docs/deployment.md` from the routing table in a later `scripts/**` PR and the gap opens silently — so ADR 0072 and the job comment both record it.
- **What a Markdown-only PR no longer runs**, and why that is accepted: the three documentation suites that build their fixtures in a temporary repository or stub their inputs (`docs:audit:test`, `docs:garden:test`, `check-agent-context.test.mjs`), `docs:index:test`, and every non-documentation step of `scripts`. Each remaining step was read for reads of the real Markdown tree; outside the documentation group the two found were `gate:routing-table:test`, carried into `docs-checks`, and `agent:quality-gate:test`, covered through it. The rest take their input from `scripts/**`, `.github/workflows/**`, config files, and their own fixtures — all still in `rootScripts` — so a diff that can affect any of them still fires `scripts`. That reading is the weak link in this change: four of the eleven readers were missed across two review rounds, three of them because they look like fixture suites.
- **The shape where this change only adds cost.** `.agents/**`, `.claude/skills/**`, `alerts/infra/**` and the other non-Markdown globs stay in `rootScripts` and still route their own Markdown to `scripts`. 43 of the 201 tracked `*.md` files match one of them — 17 under `.agents/`, 15 under `.claude/skills/`, 7 under `alerts/`, 2 under `scripts/`, 2 under `terraform/` — so a Markdown-only edit there sets both filters: the unchanged 25-minute job runs exactly as today, plus a 2-vCPU runner repeating nine of its steps. That is the skills mirror this repo gardens most often. Narrowing those globs to their non-Markdown contents would fix it and is out of scope here: it changes which job sees a skill edit, which is a separate decision from relocating the two Markdown globs.
- **ADR 0072** records the decision, including the explicit contrast with ADR 0062: that split fixed a required-check availability bug and produced an unconditional job; this one is cost-motivated and produces a conditional, skippable job. `docs/adr/README.md` gains its row in the `ci / process` table, as that file's own "Adding an ADR" section requires, and `docs/README.md` gains the one generated catalog line.

## Validation

- **Structural assertions on the candidate `ci.yml`, replicating `scripts/production-infra-identity-contract/routing.test.mjs`** (js-yaml `load`, the same parser that test uses) — 49/49 pass on the final candidate: the `pull_request` and `push` triggers still define no `paths`/`paths-ignore`; `filters.rootScripts` is still an array containing every Terraform stack path from `terraform.stacks.json` plus `.github/workflows/**`, `scripts/**/*.mjs`, `scripts/**/*.sh`, `aegis/bin/deploy.sh`, `aegis/grafana-agent/deploy.sh` and `aegis/grafana-agent/cloudbuild.yaml`; `filters.terraform` still equals `workflowAdmissionPatterns`; and the `scripts` job's `if` still matches `needs.changes.outputs.rootScripts == 'true'`.
- **Filter diff, parsed rather than textual**: comparing the parsed filter maps of `main` and the candidate, the only change to `rootScripts` is the removal of `*.md` and `**/*.md` (nothing added); `filters.docs` deep-equals `["*.md", "**/*.md", ".github/workflows/ci.yml", ".github/actions/pnpm-install/**"]`; every other filter key is deep-equal to `main`; and every filter key has a matching `changes` job output.
- **Step-list assertions**: `docs-checks`'s `run:` strings deep-equal the expected nine checks plus the pin validator, in order; every one of them is a verbatim copy of a step that exists in the `scripts` job; every `uses:` SHA already appears elsewhere in the file; and the `scripts` job's own step list is byte-for-byte unchanged from `main` (43 steps, against 13 in `docs-checks`).
- **Pin-order assertions, run through the repo's own `pinValidationOrderBlockers` and probes module**, over both `"scripts"` and `"docs-checks"` against the candidate: clean returns `[]` for both; dropping the validator step is rejected for both; moving the validator after install and the aliases is rejected for both (18 blockers for `scripts`, 10 for `docs-checks`). This is the same call the parameterized lifecycle test makes.
- **Sentinel assertions**: the candidate is passed to the repo's real `sentinelBlockers()` from `scripts/sentry/ci-wiring/check-sentry-suites-in-ci-core.mjs` with the real `TRUSTED_JOBS` — it returns `[]`. Replicated independently: `jobs:` is exactly `${{ toJSON(needs) }}`, no `allowed-failures`, and every job whose `if` references `needs.changes.outputs.*` (now 15, including `docs-checks`) appears in both `needs` and `allowed-skips`.
- **Corpus-dependence claims, executed or read against the repo**: `stalenessSubjects(ROUTING_GROUPS)` returns 799 subjects (631 distinct), 23 Markdown — the list quoted above, eleven `docs/pr-checklists/` entries out of the twelve tracked. `agent-context-budget.test.mjs:349` was read and confirmed to pin ten live `AGENTS.md` routes; `docs-navigation-eval.test.mjs:440` to pin two cheapest-route selections by live byte size. For the two readers left behind: `docs-index.test.mjs:401-414`, `docs-index.mjs:74-80` and `claude-runtime-document-registry.mjs:312-333` were read to confirm the subset relationship; `post-passes.mjs:38-55`, `agent-quality-gate.test.sh:5372-5384` and `:5506-5509`, and `groups-head.mjs:129` to confirm the transitive cover. The 43-of-201 overlap was measured against the tracked `*.md` list and the surviving `rootScripts` globs; a filesystem walk of the checkout reproduces the two largest buckets (17 `.agents/`, 15 `.claude/skills/`) exactly.
- **actionlint 1.7.8** — the version `.trunk/trunk.yaml` pins — with `.trunk/configs/actionlint.yaml`: exit 0 on the candidate. Negative control: the same `docs-checks` block with an unknown runner label and a bogus expression function was rejected with two findings, proving the linter analyzed the new job rather than skipping it.
- **The repo's own `scripts/workflows/check-github-action-pins.mjs`**, pointed at the candidate via `GITHUB_ACTION_PINS_ROOT`: "All 3 workflow/composite-action YAML files use pinned external actions", exit 0 — so the new job's `uses:` lines carry SHA pins with release-tag comments.
- **yamllint 1.38.0** with `.trunk/configs/.yamllint.yaml`: exit 0. **prettier 3.8.1** `--check` on the workflow, the parameterized lifecycle test, `docs/adr/0072-md-only-docs-checks-job.md` and `docs/adr/README.md`: clean. `docs/README.md` is exempt from prettier by `.trunk/trunk.yaml` because `docs:index` generates it. **markdownlint 0.48.0** with `.trunk/configs/.markdownlint.yaml` on all three Markdown files: clean. ESLint on the edited test file was not run here — it lives at a scratch path, and the `scripts` job lints it on this PR.
- **Catalog entry**: generated by importing the repo's own `scripts/context/docs-index-helpers.mjs` (`buildDocumentationInventory` + `renderDocumentationIndex`) against the new ADR. The emitted line is byte-identical to the single line added to `docs/README.md`, with zero inventory errors and zero metadata warnings; the file's delta against `main` is exactly +1 line. Every relative link the ADR makes was resolved against the real tree: all four exist.
- **This description** was passed to the repo's own `validatePrDescription()` from `scripts/pr/check-pr-description.mjs`: `ok: true`.
- **CI on this PR is the final validator.** This diff touches Markdown, `.github/workflows/ci.yml` and two files under `scripts/`, so it sets both the new `docs` filter and `rootScripts`: `docs-checks` and `scripts` both run here, which exercises the new job and re-proves the unchanged one on the same commit, including the sentry CI-wiring suites that parse the sentinel and now pin both jobs' pin-validator ordering.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link. Nothing was deferred, so the section is omitted.
- [x] Architecture decision? ADR 0072 added (`docs/adr/0072-md-only-docs-checks-job.md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted validation for documentation-only changes, enabling faster CI feedback.
  * Documentation checks now cover formatting, navigation, context, budgets, and routing rules.

* **Documentation**
  * Added an architectural decision record explaining the documentation CI workflow and its validation coverage.
  * Updated the ADR index with the new documentation-check process.

* **Tests**
  * Expanded CI lifecycle validation to cover documentation checks and dependency ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->