### PR TITLE
docs: add trove history page design plan

### DIFF
--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -231,8 +231,8 @@ type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
   redemptionFeeCredited: BigInt # op 6 only, from RedemptionFeePaidToTrove
   isRebalance: Boolean # op 6 only, tx-target discriminator
   redemptionPrice: BigInt # op 6 only, from branch Redemption event
-  priceAtEvent: BigInt # block-close price from loadLiquityPrice; null when unavailable
-  icrAfterBps: Int # from priceAtEvent, so also block-close; null when price unavailable
+  priceAtEvent: BigInt # block-close price from loadLiquityPrice; never overwritten by event prices; null when unavailable
+  icrAfterBps: Int # from the event-carried price when one exists (op 5/6), else block-close priceAtEvent; null when neither
   timestamp: BigInt!
   blockNumber: BigInt!
   logIndex: Int! # numeric position for same-timestamp ordering
@@ -277,14 +277,16 @@ Writer notes:
   them through the existing batch-replay path, or leave them null with the
   UI's "—" rendering — production has zero batches today, so the seam is
   cheap either way. Collateral snapshots stay non-null.
-- Op 6 rows are written LAST, not from the `TroveOperation` handler:
-  `RedemptionFeePaidToTrove` follows `TroveOperation` in the same tx, so the
-  `TroveOperation` handler only stages the row in short-lived pending state
-  (the pattern the batch replay machinery already uses) and the
-  `RedemptionFeePaidToTrove` handler assembles and sets it once, complete
-  with the fee. `isRebalance` copies the existing tx-target check;
-  `redemptionPrice` copies from the branch `Redemption` row of the same tx,
-  staged the same way. One write per row, never a set-then-patch.
+- Op 6 rows are finalized LAST, by the branch `Redemption` handler: the
+  on-chain order within one tx is the per-trove loop (`TroveUpdated`,
+  `TroveOperation(6)`, `RedemptionFeePaidToTrove` per trove) and THEN one
+  branch `Redemption` aggregate carrying `_redemptionPrice`. So the
+  `TroveOperation` handler stages each hit's deltas, the fee handler stages
+  its fee, and the branch `Redemption` handler assembles and sets every
+  staged row of the tx once, complete with fee and price (the short-lived
+  pending pattern the batch replay machinery already uses). `isRebalance`
+  copies the existing tx-target check. One write per row, never a
+  set-then-patch.
 - Op 5: `debtChange/collChange` are `−entireDebt/−entireColl`; link the
   aggregate `LiquidationEvent` by `txHash` for the SP/redistribution context
   panel. Per-trove split of that aggregate stays a non-goal.
@@ -292,16 +294,20 @@ Writer notes:
   fetches, and label it honestly: an archive `eth_call` at the event's block
   observes post-block state, so the persisted value is the **block-close**
   price — a same-block oracle move after the operation can differ from the
-  operation-time price. Event-carried prices take precedence where they
-  exist (`redemptionPrice` on op 6, `Liquidation._price` on op 5); the UI
-  labels RPC-sampled ICR as at-block-close. There is no "later backfill"
-  option: every indexer deploy re-syncs from `start_block`
-  (`deploy-indexer` skill), so shipping the writer replays all history and
-  either pays the archive `eth_call`s during that sync or suppresses price
-  persistence during replay (fields stay null on historical rows). Forno
-  was observed dropping log ranges and receipts during the ticket
-  reconstruction, so the sync is a deliberate, monitored deploy either
-  way. Nullable-by-design is the degraded mode.
+  operation-time price. Event-carried prices are exact and win for
+  `icrAfterBps` where they exist (`redemptionPrice` on op 6;
+  `Liquidation._price` on op 5, read from the txHash-linked
+  `LiquidationEvent` — no extra field); they never overwrite
+  `priceAtEvent`, which stays the block-close sample, and the UI labels
+  block-close-derived ICR as such. On replay cost: the existing
+  `TroveUpdated` handler already calls `loadLiquityPrice` unconditionally
+  for `Trove.icrBps` (`troveManager.ts:269`), so a from-scratch sync pays
+  the archive `eth_call`s today regardless — "suppress price persistence"
+  only skips storing per-row values, and gating the existing read would
+  also degrade `Trove.icrBps`, a separate decision. Forno was observed
+  dropping log ranges and receipts during the ticket reconstruction, so
+  the sync is a deliberate, monitored deploy either way.
+  Nullable-by-design is the degraded mode.
 - Keep `applySystemDebtDelta` untouched; the new writer only appends rows.
 
 ### Small fixes alongside
@@ -350,7 +356,10 @@ graphql contract test, regenerated via `pnpm indexer:codegen` and
 - `CDP_TROVES_BY_OWNER(address)` — `Trove` rows across markets matching
   `_or: [{owner}, {previousOwner}]`, for the support entry path: close and
   liquidation zero `owner`, so `previousOwner` is how a closed trove is
-  found by the address a user supplies.
+  found by the address a user supplies. The same `limit + 1` sentinel rule
+  applies: an address with more troves than the render limit (a factory,
+  not a person) gets a visible "results capped" disclosure, never a
+  silently shortened list.
 - Timing: dashboard codegen and the GraphQL contract test validate every
   exported query against the in-repo `indexer-envio/schema.graphql`, so
   `CDP_TROVE_LEDGER` can only be added once slice 2's schema change is
@@ -421,7 +430,7 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 ├──────────────────────────────────────────────────────────────────┤
 │ Collateral & debt over time  [range pills]                       │
 │ step chart: coll (USDm), debt (GBPm), event markers;             │
-│ ICR series only where priceAtEvent exists                        │
+│ third % panel for ICR only where price data exists               │
 ├──────────────────────────────────────────────────────────────────┤
 │ Ledger (chronological)                                           │
 │ time·tx │ event badge │ Δdebt │ Δcoll │ fees │ debt→ │ coll→ │…  │
@@ -432,10 +441,14 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 - **Header card** reads `CDP_TROVE_BY_ID`. Status badge uses indexer
   vocabulary with tooltips ("zombie: debt below the market minimum after a
   redemption; unredeemable until adjusted"; "redeemed: fully redeemed to
-  zero"). ICR coloring reuses `icrTextClass` against live `mcrBps`. The debt
-  figure is honest about staleness: recorded-at-last-event plus timestamp. A
-  live `entireDebt` read via the existing `rpc-client.ts` is an optional
-  enhancement, decided at implementation (open question 1).
+  zero"). ICR coloring reuses `icrTextClass` against live `mcrBps`, and the
+  value carries the same "indexed as of <timestamp>, not a live oracle
+  read" disclosure the trove table already attaches (`trove-cells.tsx`) —
+  `Trove.icrBps` is the last event's snapshot, and the oracle has moved
+  since. The debt figure is honest about staleness the same way:
+  recorded-at-last-event plus timestamp. A live `entireDebt` read via the
+  existing `rpc-client.ts` is an optional enhancement, decided at
+  implementation (open question 1).
 - **Redemption impact** computes its totals from `Trove` cumulatives, so
   they work even before the ledger entity ships. Split user vs rebalance
   per the invariants note once per-hit rows exist; until then label totals
@@ -446,9 +459,12 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   the partial view. The one-line explainer carries the ticket's core
   lesson.
 - **Why me** reads the current rate ladder (open troves / brackets already
-  fetched on the market page): rank among open troves by effective rate, and
-  the sum of open debt at strictly lower rates ("shield"). States plainly
-  that historical rank is not tracked. When the open-trove fetch hits
+  fetched on the market page): rank among ACTIVE troves by effective rate,
+  and the sum of active debt at strictly lower rates ("shield"). Zombies
+  are excluded from both — they sit outside the sorted redemption queue and
+  their debt shields nobody (one nuance in prose: a `lastZombieTroveId`
+  remnant is redeemed first on the next redemption). States plainly that
+  historical rank is not tracked. When the open-trove fetch hits
   `CDP_TROVES_DETAIL_LIMIT` (1,000), the dataset is incomplete, so rank and
   shield are suppressed exactly as the market table already suppresses its
   rank column at the cap — never shown as a partial calculation.
@@ -460,8 +476,13 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   (`time-series-chart-card.tsx:283-323`), which would label GBPm/JPYm debt
   as dollars — either extend it with per-series unit formatting and
   subplot support or build a sibling two-panel chart component on the same
-  chrome. The chart reads the same bounded full-history query as the table
-  — one query, no pagination coupling — and renders only from the complete
+  chrome. An ICR series never shares those axes: it gets its own third
+  percentage panel, shown only when price data exists. The debt panel and
+  the interest residual additionally require every row's debt snapshot
+  non-null — a null batch-row snapshot switches them to an explicit "batch
+  data unavailable" state rather than a gapped or zero-coerced series. The
+  chart reads the same bounded full-history query as the table — one
+  query, no pagination coupling — and renders only from the complete
   ledger, never the partial view.
 - **Ledger table**: badge pills reuse `BADGE_STYLES`/`BADGE_LABELS` plus new
   kinds (`rebalanceRedemption` already exists; add `zombie`, `revived`,
@@ -491,10 +512,14 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
    equal the sum of ledger rows of the matching kind — a mismatch is a bug
    surface, not a rendering choice (the ticket reconstruction validated to
    the wei; keep a test). The two reads are independent queries, so
-   reconcile only when they observe the same position — `Trove.
-lastUpdatedBlock` equals the ledger's newest `blockNumber` — and
-   refetch instead of flagging when an event landed between them. The
-   partial view and a truncated history skip this check by design.
+   reconcile only on a ledger-specific watermark: the ledger writer also
+   stamps `Trove.lastLedgerBlock`/`lastLedgerLogIndex`, and the check runs
+   only when that pair equals the newest ledger row's
+   (`blockNumber`, `logIndex`) — block number alone cannot distinguish two
+   same-block transactions, and `lastUpdatedBlock` advances on NFT
+   transfers that write no ledger row. Refetch instead of flagging on a
+   mismatch, and test two distinct same-block transactions. The partial
+   view and a truncated history skip this check by design.
 3. Total redemption figures are never presented as user activity;
    user-driven = total − rebalance.
 4. `priceAtEvent`/`icrAfterBps` are nullable; every consumer renders null as

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -1,0 +1,492 @@
+---
+title: Trove History Page Design
+status: active
+owner: eng
+canonical: false
+last_verified: 2026-08-26
+doc_type: plan
+scope: indexer-envio/ui-dashboard
+review_interval_days: 180
+garden_lane: notes-plans-archive
+---
+
+# Trove History Page Design
+
+Design for a per-trove history page on the monitoring dashboard: click a trove
+on `/cdps/[symbol]` and land on a page that shows everything that happened to
+that position over time, instead of leaving for a block explorer or the Mento
+app. This document is the step-1 design only; no page is implemented yet.
+
+Non-canonical plan. Every code/schema claim below was verified on 2026-08-26
+against `mento-protocol/bold` @ `1649143`, the live indexer schema/handlers,
+and the production GraphQL endpoint. Re-verify before implementing.
+
+## The motivating case (ticket #0754)
+
+> "User said their position has decreased a lot, their initial collateral was
+> 40k USDm and borrowed 25k GBPm. `0xcca0a99b94529493ddffe7c61a3ae454828cd3bb`"
+
+Reconstructing the answer today took ~345 chunked `eth_getLogs` calls against
+forno (5,000-block range cap), manual ABI decoding of three TroveManager
+topics, and cross-checking against indexer cumulatives. The answer:
+
+- Opened 2026-08-06: 39,955 USDm collateral, 25,000 GBPm borrowed
+  (+12.87 GBPm upfront fee) at 0.5% interest — the lowest live rate on the
+  GBPm market, i.e. first in the redemption queue once the lone 0.2% trove
+  ahead of it was exhausted.
+- 2026-08-25, 18:13–21:11 UTC: five protocol rebalancing redemptions
+  (`isRebalance`, via `CDPLiquidityStrategy`) repaid 18,450.82 GBPm of debt
+  and took 25,163.91 USDm of collateral at the oracle GBP/USD rate, crediting
+  12.59 USDm of redemption fees to the trove. Position size fell 63%; net
+  equity at oracle prices rose ~11 USDm (5,814 → 5,825). ICR rose 117% → 165%.
+- 2026-08-26: the user moved the rate to 1.6%, added 30,000 USDm, and
+  reborrowed 21,500 GBPm.
+
+The user experienced a forced deleverage at par, not a loss. The page must
+make that answer visible in one glance: what hit the trove, when, how much,
+why this trove, and what it cost.
+
+The hard part was entirely per-trove redemption attribution: `RedemptionEvent`
+has no trove id, the `Trove` entity stores only lifetime cumulatives, and one
+instance-level redemption split across two troves (block 75,780,824: 9,968.39
+GBPm total, 5,021.78 to this trove). Everything else was a single indexer
+query. That gap defines the indexer work below.
+
+## Goals
+
+1. A support agent or user pastes an owner address or clicks a trove row and
+   gets the full ledger of that trove: opens, adjusts, rate changes, interest,
+   redemptions (user vs rebalance), liquidation, zombie transitions, close.
+2. Each ledger row shows signed debt/coll deltas, fees, the resulting
+   debt/coll after the row, and a tx link.
+3. A redemption-impact summary and a "why me" panel explain the mechanism
+   (queue position by interest rate) in product terms.
+4. The page answers ticket-#0754-class questions with zero RPC archaeology.
+
+### Non-goals (v1)
+
+- Historical redemption-queue rank ("who shielded me at the time"). Only the
+  current rate ladder is reconstructable from indexed entities; rank-at-event
+  needs bracket snapshots that do not exist. Show current rank plus prose.
+- Ownership provenance beyond `owner`/`previousOwner` (NFT transfer history is
+  single-slot today).
+- Per-trove SP-offset vs redistribution split inside a liquidation (on-chain
+  the split is only aggregate per `batchLiquidateTroves` call).
+- Liquidation-surplus claim tracking (CollSurplusPool is not indexed at all;
+  candidate follow-up, not v1).
+- Batch-managed troves get correct rendering of what exists, and nothing
+  more: production has zero `InterestBatch` rows and zero troves with
+  `interestBatchId` set (verified 2026-08-26 on all three markets), so batch
+  ledger work would be speculative. The design keeps a seam for it.
+
+## On-chain event surface (bold fork)
+
+Authority: `contracts/src/Interfaces/ITroveEvents.sol` and
+`contracts/src/TroveManager.sol` in `mento-protocol/bold`. All trove lifecycle
+events are emitted by TroveManager (BorrowerOperations delegates back via
+`on*` callbacks). The fork keeps upstream Liquity v2 event signatures and
+`Operation` ordinals unchanged, so upstream indexer patterns transfer.
+
+Per-trove events, all `_troveId`-indexed:
+
+| Event                      | Carries                                                                                                                           | Emitted on                                      |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `TroveUpdated`             | resulting debt, coll, stake, rate, redist snapshots                                                                               | every non-batched op; zeroed on close/liquidate |
+| `TroveOperation`           | `Operation` enum, signed `_debtChangeFromOperation` / `_collChangeFromOperation`, redist increases, `_debtIncreaseFromUpfrontFee` | every op                                        |
+| `BatchedTroveUpdated`      | batch shares (no debt, no rate), coll, stake                                                                                      | ops on batched troves                           |
+| `RedemptionFeePaidToTrove` | `_ETHFee` = collateral fee credited to the trove                                                                                  | every redemption hit (0 for urgent)             |
+
+Branch-level context events: `Redemption` (aggregate per
+`CollateralRegistry.redeemCollateral*` call: attempted/actual amounts, coll
+sent, fee, `_price`, `_redemptionPrice`), `Liquidation` (aggregate per
+`batchLiquidateTroves` call: SP offset vs redistribution split, gas comp,
+surplus, `_price`), `BatchUpdated`, `BaseRateUpdated`, `ShutDown`.
+
+`Operation` ordinals: 0 openTrove, 1 closeTrove, 2 adjustTrove,
+3 adjustTroveInterestRate, 4 applyPendingDebt, 5 liquidate,
+6 redeemCollateral, 7 openTroveAndJoinBatch, 8 setInterestBatchManager,
+9 removeFromBatch.
+
+Semantics the page depends on:
+
+- `TroveUpdated._debt` is the full resulting debt (accrued interest and redist
+  gains are folded in on every touch; the open row includes the upfront fee).
+- `TroveOperation._debtChangeFromOperation` is the user-requested principal
+  change only. Resulting debt = previous recorded debt + accrued interest +
+  `_debtIncreaseFromRedist` + `_debtIncreaseFromUpfrontFee` + the signed
+  change. Accrued interest is the one term events never carry; it is the
+  residual between consecutive snapshots.
+- A redemption hit emits, per trove in one tx: `TroveUpdated` (or
+  `BatchedTroveUpdated`) with the reduced totals, `TroveOperation(op=6,
+−boldLot, −collLot)`, and `RedemptionFeePaidToTrove(fee)`. The fee stays in
+  the trove as extra collateral — the owner is paid to be redeemed through.
+  The Mento-only `redeemCollateralRebalancing` path (liquidity strategy only,
+  fixed `_troveOwnerFee`, no `baseRate` impact) emits the same events; the
+  discriminator is the transaction target, exactly as
+  `docs/notes/liquity-monitoring-invariants.md` prescribes.
+- Zombie transitions have no event. A redemption that leaves
+  `0 < debt < MIN_DEBT` makes the trove a zombie; `debt == 0` leaves an
+  open, fully-redeemed shell. Revival is `adjustZombieTrove` (surfaces as
+  op 2) or `applyPendingDebt` (op 4). `MIN_DEBT` lives in the upgradeable
+  `SystemParams` proxy with no change events — always read live per-market
+  values, never constants. Live today: GBPm/CHFm minDebt 1,000; JPYm
+  200,000; MCR 110%; CCR 135% — the deploy-script defaults (2,000 / 150%)
+  are wrong for production.
+
+What events alone cannot reconstruct (bounds for the design):
+
+1. Debt between touches — compute client-side as
+   `recordedDebt · rate · Δt / 365d` from the last row, or read
+   `getLatestTroveData` over RPC for "now".
+2. Price/ICR at arbitrary timestamps — `FXPriceFeed.fetchPrice()` emits
+   nothing; only `Liquidation._price` and `Redemption._price` pin prices.
+3. Batched trove debt (share math plus batch accrual) — precise values need
+   `getLatestBatchData`.
+4. Oracle-failure shutdown — `shutdownFromOracleFailure` skips the `ShutDown`
+   event; the only signal is `FXPriceFeedShutdown`, and no FXPriceFeed
+   contract is in the indexer config.
+5. Trove ids are never reused after close
+   (`BorrowerOperations.sol:1171-1176` requires `nonExistent`;
+   `TroveManager.sol:1536` persists closed status), so one `Trove` entity is
+   one lifecycle. The page can rely on this.
+
+## Indexer today: what exists, what blocks the page
+
+Already sufficient (no work needed):
+
+- `Trove` entity: current state plus lifetime cumulatives
+  (`redemptionCount`, `redeemedColl/Debt`, `redemptionFeePaidCum`,
+  `liquidatedColl/Debt`, `collSurplus`, `priceAtLiquidation`, opened/closed
+  timestamps and tx hashes). `owner` is indexed — owner lookup works today.
+- `TroveOperationEvent`: append-only rows for user ops (0,1,2,3,7,8,9) with
+  signed deltas, upfront fee, `owner` denormalized, and before/after
+  snapshot fields.
+- `RedemptionEvent.isRebalance` discrimination, market params in
+  `LiquityCollateral`, rate ladder via `InterestRateBracket` and open troves.
+
+Gaps (each maps to a design item below):
+
+1. **No per-trove redemption rows.** `RedemptionEvent` is instance-level with
+   no trove id, and one redemption provably splits across troves, so adding a
+   nullable `troveId` to it cannot work. `RedemptionFeePaidToTrove` only
+   bumps a cumulative. The per-hit data (debt repaid, coll taken, fee,
+   resulting balances) arrives in handlers today and is discarded.
+2. **`TroveOperationEvent` skips ops 4, 5, 6**
+   (`troveOperationSnapshot.ts:75-80`) — the append-only log has holes
+   exactly where support questions live: redemptions, liquidation, and the
+   interest-fold/zombie-revival op.
+3. **Snapshot before/after bug (live today).** `TroveUpdated` is emitted
+   before `TroveOperation` in every TroveManager function (e.g. L1254 →
+   L1264), so by the time the `TroveOperation` handler captures
+   "pre-operation" state off the `Trove` entity, the `TroveUpdated` handler
+   has already applied the post-op values. The capture comment in
+   `troveOperationSnapshot.ts:6-10` assumes otherwise. Result: `debtBefore`
+   holds the post-op value and `debtAfter` double-counts the delta
+   (ticket trove's open row: `debtBefore` 25,012.87, `debtAfter` 50,025.75).
+   The dashboard's existing before → after transaction cells render these
+   wrong numbers now; the signed `collChange`/`debtChange` fields are
+   correct. Fix is a capture-ordering change plus resync backfill,
+   independent of this feature and worth shipping first.
+4. **No price/ICR history.** `loadLiquityPrice` already `eth_call`s the price
+   feed at every `TroveUpdated` block, uses it for `icrBps`, and discards it.
+5. **No index on `TroveOperationEvent.troveId`** — a per-trove filter scans.
+6. Status transitions (active → zombie → redeemed/revived) mutate `Trove` in
+   place and leave no row. Indexer status vocabulary is
+   `active/zombie/closed/liquidated/redeemed` (`troves.ts:16-22`);
+   `redeemed` means fully-redeemed-to-zero, which stays `zombie` on-chain.
+   The page uses indexer vocabulary and explains it.
+
+## Indexer design
+
+### New entity: `TroveLedgerEvent`
+
+One append-only row per `TroveOperation` event, all ten ops, written in the
+existing `TroveOperation` handler from data it already receives:
+
+```graphql
+type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
+  id: ID! # eventId(chainId, block, logIndex)
+  chainId: Int!
+  instanceId: String! @index
+  troveEntityId: String! # makeTroveId(collateralId, troveId)
+  troveId: String!
+  owner: String! @index
+  operation: Int! # Operation ordinal 0-9
+  collChange: BigInt! # signed, from operation
+  debtChange: BigInt! # signed, from operation
+  debtIncreaseFromUpfrontFee: BigInt!
+  debtIncreaseFromRedist: BigInt!
+  collIncreaseFromRedist: BigInt!
+  annualInterestRate: BigInt!
+  debtBefore: BigInt!
+  debtAfter: BigInt!
+  collBefore: BigInt!
+  collAfter: BigInt!
+  statusBefore: String!
+  statusAfter: String! # surfaces zombie/redeemed/revival flips
+  redemptionFeeCredited: BigInt # op 6 only, from RedemptionFeePaidToTrove
+  isRebalance: Boolean # op 6 only, tx-target discriminator
+  redemptionPrice: BigInt # op 6 only, from branch Redemption event
+  priceAtEvent: BigInt # from loadLiquityPrice; null when unavailable
+  icrAfterBps: Int # null when price unavailable
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  txHash: String!
+}
+```
+
+Why a new entity instead of widening `TroveOperationEvent`: the existing
+entity feeds the market transaction tables, whose redemption and liquidation
+rows come from the dedicated instance-level entities — adding op-5/6 rows to
+it would double-render every redemption in those feeds and change the meaning
+of an entity two tables already consume. A parallel entity keeps the rollout
+introspection-gated and the existing feed untouched. The cost is one more
+writer in a handler that already loads every input.
+
+Writer notes:
+
+- Capture `debtBefore/collBefore/statusBefore` correctly. The robust source
+  is arithmetic, both here and in the fix for the existing snapshot bug:
+  the paired `TroveUpdated`/`BatchedTroveUpdated` in the same tx gives the
+  resulting state, and `after − (sum of evented deltas) = before`, with
+  accrued interest landing as an explicit residual term. Direction matters:
+  derive `before` from `after`, never `after` from a pre-captured `before`.
+- Op 6 enrichment: `RedemptionFeePaidToTrove` follows `TroveOperation` in the
+  same tx; carry the fee onto the ledger row (same short-lived pending
+  pattern the batch replay machinery already uses). `isRebalance` copies the
+  existing tx-target check; `redemptionPrice` copies from the branch
+  `Redemption` row of the same tx.
+- Op 5: `debtChange/collChange` are `−entireDebt/−entireColl`; link the
+  aggregate `LiquidationEvent` by `txHash` for the SP/redistribution context
+  panel. Per-trove split of that aggregate stays a non-goal.
+- `priceAtEvent`/`icrAfterBps`: persist what `loadLiquityPrice` already
+  fetches. Incremental cost for new events is zero; historical rows need a
+  full resync that re-issues archive `eth_call`s from block 60,668,167 —
+  forno was observed dropping log ranges and receipts during the ticket
+  reconstruction, so treat backfill as a deliberate, monitored deploy
+  (`deploy-indexer` skill), and let the fields stay null on old rows if the
+  resync is deferred. Nullable-by-design is the degraded mode.
+- Keep `applySystemDebtDelta` untouched; the new writer only appends rows.
+
+### Small fixes alongside
+
+- Fix `TroveOperationEvent.debtBefore/debtAfter/collBefore/collAfter`
+  (gap 3) with the same arithmetic derivation, in its own slice with its own
+  test proving the open row reads `before = 0`.
+- Add `@index(fields: ["troveId", "timestamp"])` to `TroveOperationEvent`
+  (gap 5) so the interim owner/trove filters stop scanning.
+
+### Deferred, with seams
+
+- `TroveOwnershipTransfer` rows from `TroveNFT.Transfer` (provenance).
+- CollSurplusPool `CollBalanceUpdated`/`CollSent` indexing (claimable vs
+  claimed surplus for liquidated troves).
+- FXPriceFeed subscription for `FXPriceFeedShutdown` (shutdown banner: a shut
+  branch stops accrual at `shutdownTime` and switches redemptions to urgent,
+  fee 0).
+
+## GraphQL contract
+
+New queries in `ui-dashboard/src/lib/queries/liquity.ts`, registered in the
+graphql contract test, regenerated via `pnpm indexer:codegen` and
+`pnpm dashboard:codegen`:
+
+- `CDP_TROVE_BY_ID(troveEntityId)` — one `Trove` row (header card), plus its
+  `LiquityCollateral` params.
+- `CDP_TROVE_LEDGER(troveEntityId, limit)` — `TroveLedgerEvent`
+  `order_by: [{timestamp: asc}, {id: asc}]`. A trove's whole life fits far
+  under the 1,000-row Hasura cap in every observed case; still detect
+  `length === limit` and disclose ("history truncated") per the row-cap
+  discipline.
+- `CDP_TROVES_BY_OWNER(owner)` — `Trove` rows across markets (owner is
+  indexed), for the support entry path.
+- The ledger query ships introspection-gated like the existing
+  `CDP_TROVE_OP_SNAPSHOTS` pattern: the page detects `TroveLedgerEvent` in
+  the schema and falls back to the interim assembly (below) while the
+  indexer rollout is in flight.
+
+Interim assembly (works against today's schema, ships first): merge
+`TroveOperationEvent` filtered by `troveId` (user ops) with `Trove`
+cumulatives (redemption/liquidation totals). This yields a partial ledger —
+user actions plus lifetime redemption totals with a visible "per-redemption
+detail pending indexer rollout" notice. It answers half the ticket
+immediately and exercises the whole UI shell.
+
+## UI design
+
+### Route and entry points
+
+`/cdps/[symbol]/troves/[troveId]`, `troveId` = the on-chain hex id (readable,
+matches explorer links; resolve to `troveEntityId` internally via the
+market's collateral id). Follow the `address-book/[address]` precedent:
+server component validates params and redirects garbage to `/cdps/[symbol]`;
+`error.tsx` with `useReportError`; `loading.tsx` skeleton matching the loaded
+grid. The route is public, like the rest of `/cdps`.
+
+Entry points:
+
+1. Trove tables (`trove-cells.tsx`): the trove-id cell becomes an internal
+   `<Link>` to the history page, on both Open and History tabs. The Mento-app
+   manage link moves to a secondary action on the history page header
+   ("Manage in app ↗") — the dashboard row's primary click should answer
+   questions, and only the owner can manage.
+2. Owner lookup for the support flow (address in hand, market unknown): the
+   `/cdps` overview gets a small owner search that runs
+   `CDP_TROVES_BY_OWNER` and links each hit. Phase 2; the per-market table
+   search already matches owner today.
+3. `AddressLink` stays as-is for owners (explorer, or address-book deep link
+   when signed in).
+
+Add the missing dependency-cruiser route-private rules: `/cdps` has none
+today, so the new `troves/[troveId]/_components` rule lands with the page
+(mirror `dashboard-route-private-pool-detail`).
+
+### Layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ GBPm · Trove 0x8abc…0d7d          [active] [Manage in app ↗]     │
+│ Owner 0xcca0…d3bb   Opened 2026-08-06 (tx)   Rate 1.6% (#2 in    │
+│ Coll 44,791 USDm    Debt 28,081 GBPm†   ICR 117.1% (MCR 110%)    │
+│ † recorded at last event, 2026-08-26 10:38 UTC; interest accrues │
+├──────────────────────────────────────────────────────────────────┤
+│ Redemption impact              │ Why this trove                  │
+│ 5 hits · −18,451 GBPm debt     │ Redemptions repay the lowest-   │
+│ −25,164 USDm coll · +12.59     │ rate troves first. Current      │
+│ USDm fees kept · net equity    │ rate 1.6% = rank #2 of 14;      │
+│ +11 USDm at oracle prices      │ 6,200 GBPm of lower-rate debt   │
+│ Exchanged at par — this is     │ shields this trove today.       │
+│ a deleverage, not a loss.      │ (Historical rank: not tracked.) │
+├──────────────────────────────────────────────────────────────────┤
+│ Collateral & debt over time  [range pills]                       │
+│ step chart: coll (USDm), debt (GBPm), event markers;             │
+│ ICR series only where priceAtEvent exists                        │
+├──────────────────────────────────────────────────────────────────┤
+│ Ledger (chronological)                                           │
+│ time·tx │ event badge │ Δdebt │ Δcoll │ fees │ debt→ │ coll→ │…  │
+│ …rebalance-redemption rows, rate changes, interest rows…         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **Header card** reads `CDP_TROVE_BY_ID`. Status badge uses indexer
+  vocabulary with tooltips ("zombie: debt below the market minimum after a
+  redemption; unredeemable until adjusted"; "redeemed: fully redeemed to
+  zero"). ICR coloring reuses `icrTextClass` against live `mcrBps`. The debt
+  figure is honest about staleness: recorded-at-last-event plus timestamp. A
+  live `entireDebt` read via the existing `rpc-client.ts` is an optional
+  enhancement, decided at implementation (open question 1).
+- **Redemption impact** computes from `Trove` cumulatives, so it works even
+  before the ledger entity ships. Split user vs rebalance per the invariants
+  note once per-hit rows exist; until then label totals as totals. The
+  one-line explainer carries the ticket's core lesson.
+- **Why me** reads the current rate ladder (open troves / brackets already
+  fetched on the market page): rank among open troves by effective rate, and
+  the sum of open debt at strictly lower rates ("shield"). States plainly
+  that historical rank is not tracked.
+- **Chart**: `TimeSeriesChartCard` with series built from ledger
+  `collAfter`/`debtAfter` (step interpolation), `sortedCopy` for ordering,
+  `escapePlotText` on any dynamic text. The chart reads the same bounded
+  full-history query as the table — one query, no pagination coupling.
+- **Ledger table**: badge pills reuse `BADGE_STYLES`/`BADGE_LABELS` plus new
+  kinds (`rebalanceRedemption` already exists; add `zombie`, `revived`,
+  `interest`). Signed deltas use `formatSignedWei`; unsigned totals use
+  `formatTokenAmount` — per-field semantics, exactly as the invariants note
+  requires. Synthetic, clearly-marked "interest accrued ≈ +X" rows render
+  the residual between consecutive rows' recorded debt after subtracting the
+  evented terms; they are derived client-side, labeled as estimates, and
+  excluded from sums. Status flips render from
+  `statusBefore`/`statusAfter`. Default order chronological ascending, id
+  tiebreaker, newest visible via reverse toggle; local-only state
+  (intentional scope: single bounded dataset, no URL pagination).
+
+### Invariants (stateful-data-ui checklist, defined up front)
+
+1. Every ledger row persists `txHash`, `blockNumber`, `timestamp`, and a
+   unique `id`; ordering is deterministic (`timestamp`, `id`).
+2. The ledger is append-only; the `Trove` entity remains the only mutable
+   trove state. Cumulatives shown on the page must equal the sum of ledger
+   rows of the matching kind — a mismatch is a bug surface, not a rendering
+   choice (the ticket reconstruction validated to the wei; keep a test).
+3. Total redemption figures are never presented as user activity;
+   user-driven = total − rebalance.
+4. `priceAtEvent`/`icrAfterBps` are nullable; every consumer renders null as
+   "—", never as zero.
+5. Charts read the full bounded history query, never a paginated slice.
+6. Params (`minDebt`, MCR, CCR) come from `LiquityCollateral` rows, never
+   constants.
+
+### Degraded modes
+
+- `TroveLedgerEvent` absent from schema (pre-rollout, or rollback): page
+  renders header + cumulative cards + user-ops-only ledger with a visible
+  "protocol events pending" notice. No silent gaps.
+- Ledger query fails with header loaded: cards render, table shows the error
+  state with retry; distinct loading vs empty vs error per `swr-state`
+  helpers.
+- Unknown trove id: explicit "not indexed" state with an explorer address
+  link fallback, no redirect loop.
+- Old rows without price fields: chart drops the ICR series and says so.
+- History at the row cap: "truncated" disclosure (invariant: cap detected by
+  `length === limit`).
+
+### Tests
+
+- Indexer: handler tests proving open rows read `before = 0`, redemption
+  rows carry fee/isRebalance/price, status flips produce correct
+  before/after, and the split-redemption case (one instance redemption, two
+  troves) yields two rows whose sums match the branch event.
+- Dashboard: colocated unit tests for ledger merge/derivation (interest
+  residual, badge mapping, formatter choice), the three degraded modes, and
+  entry-link resolution. Fixture-server browser scenario for the route;
+  visual-snapshot baseline optional (no `/cdps` baseline exists today —
+  parity, not regression).
+
+## How the finished page answers ticket #0754
+
+Support pastes the owner address → owner lookup → one GBPm trove → header
+shows active, 44,791 USDm / 28,081 GBPm, ICR 117.1%. The impact card reads
+"5 redemption hits on 2026-08-25: −18,451 GBPm debt, −25,164 USDm collateral,
++12.59 USDm fees kept, net equity +11 USDm — exchanged at oracle par." The
+chart shows the cliff at 18:13 UTC and the rebuild next morning. The ledger
+lists the five rebalance-redemption rows with tx links and the user's three
+follow-up ops. The why-me panel explains the 0.5% rate sat at the front of
+the redemption queue. Total time: one page view.
+
+## Rollout
+
+Sequenced per `docs/pr-checklists/stateful-data-ui.md`; each slice is one PR
+through the quality gate, with `pnpm indexer:codegen` /
+`pnpm dashboard:codegen` where schema or queries change, and the indexer
+slices deployed via the `deploy-indexer` skill (envio branch → verify sync →
+promote):
+
+1. **Fix the existing snapshot bug** (indexer) — independent, user-visible
+   today in the market transaction tables. Requires resync to repair
+   historical rows; the deploy is the backfill.
+2. **`TroveLedgerEvent` + indexes** (indexer) — new entity, writers, tests;
+   decide at implementation whether the price backfill resync rides along or
+   old rows stay null. If the entity-vs-widening choice is judged to
+   constrain future work, record the ADR in this PR.
+3. **Trove history page** (dashboard) — route, header/cards/chart/ledger,
+   introspection-gated ledger query with the interim assembly fallback,
+   dependency-cruiser rules, tests, browser verification per
+   `docs/notes/dashboard-verification.md`.
+4. **Entry points** (dashboard) — trove-table links, owner lookup on
+   `/cdps`, docs/index updates.
+
+Slices 3 and 4 can ship before 2 completes (interim assembly); the page
+upgrades itself when the schema lands, by design of the introspection gate.
+
+## Open questions
+
+1. Live `entireDebt`/ICR on the header via `rpc-client.ts`, or
+   indexed-recorded values only with an honest timestamp? (Recommend
+   indexed-only v1; RPC read as a follow-up if support asks for to-the-second
+   numbers.)
+2. Is the price/ICR backfill worth a monitored full resync now, or do old
+   ledger rows stay price-less until the next scheduled resync? (Recommend
+   defer; the ticket-class questions don't need historical ICR.)
+3. Owner lookup placement: `/cdps` overview search vs a dedicated
+   `/cdps/troves?owner=` route. (Recommend overview search; one less route.)
+4. Should the history tab's closed troves link through to the page from day
+   one? (Recommend yes; closed troves are where support questions end up.)

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -442,8 +442,8 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   vocabulary with tooltips ("zombie: debt below the market minimum after a
   redemption; unredeemable until adjusted"; "redeemed: fully redeemed to
   zero"). ICR coloring reuses `icrTextClass` against live `mcrBps`, and the
-  value carries the same "indexed as of <timestamp>, not a live oracle
-  read" disclosure the trove table already attaches (`trove-cells.tsx`) —
+  value carries the same indexed-as-of-timestamp, not-a-live-oracle-read
+  disclosure the trove table already attaches (`trove-cells.tsx`) —
   `Trove.icrBps` is the last event's snapshot, and the oracle has moved
   since. The debt figure is honest about staleness the same way:
   recorded-at-last-event plus timestamp. A live `entireDebt` read via the

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -332,9 +332,11 @@ graphql contract test, regenerated via `pnpm indexer:codegen` and
   the OLDEST rows drop, never the recent events being investigated. `id` is
   an unpadded string and never participates in ordering. Truncation is
   detected exactly, without aggregates (disabled on hosted Hasura): request
-  `limit + 1` rows, render `limit`, and disclose ("earliest history
-  truncated") only when the sentinel row came back — a history of exactly
-  `limit` rows is complete and says nothing.
+  `limit + 1` rows and render `limit`, keeping the render limit at least
+  one below the 1,000-row Hasura hard cap (render 999, request 1,000) so
+  the capped response can still carry the sentinel row. Disclose ("earliest
+  history truncated") only when the sentinel came back — a history of
+  exactly the render limit is complete and says nothing.
 - `CDP_TROVES_BY_OWNER(address)` — `Trove` rows across markets matching
   `_or: [{owner}, {previousOwner}]`, for the support entry path: close and
   liquidation zero `owner`, so `previousOwner` is how a closed trove is
@@ -496,7 +498,8 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 - History at the row cap: newest rows are kept (desc fetch, reversed
   client-side) and the page discloses "earliest history truncated" (cap
   detected by the `limit + 1` sentinel row, never by `length === limit`
-  alone).
+  alone; the render limit sits below the Hasura hard cap so the sentinel
+  request is never itself capped).
 
 ### Tests
 

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -469,7 +469,12 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   historical rank is not tracked. When the open-trove fetch hits
   `CDP_TROVES_DETAIL_LIMIT` (1,000), the dataset is incomplete, so rank and
   shield are suppressed exactly as the market table already suppresses its
-  rank column at the cap — never shown as a partial calculation.
+  rank column at the cap — never shown as a partial calculation. The ladder
+  renders with column headers — "Interest rate", "Debt at this rate"
+  (spanning the bar and its figure), "Queue position" — and the footnote
+  states that bar length is proportional to the debt at each rate; without
+  them the ladder reads as an unlabeled chart (user feedback on the
+  mockup).
 - **Chart**: two stacked single-unit panels — collateral (USDm) and debt
   (debt-token units) — never one dual-axis plot, with series built from
   ledger `collAfter`/`debtAfter` (step interpolation), `sortedCopy` for

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -59,7 +59,8 @@ query. That gap defines the indexer work below.
    redemptions (user vs rebalance), liquidation, zombie transitions, close.
 2. Each ledger row shows signed debt/coll deltas, fees, the resulting
    debt/coll after the row, and a tx link.
-3. A redemption-impact summary and a "why me" panel explain the mechanism
+3. A redemption-impact summary and a "Redemption queue" panel explain the
+   mechanism
    (queue position by interest rate) in product terms.
 4. The page answers ticket-#0754-class questions with zero RPC archaeology.
 
@@ -420,8 +421,8 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 │ Coll 44,791 USDm    Debt 28,081 GBPm†   ICR 117.1% (MCR 110%)    │
 │ † recorded at last event, 2026-08-26 10:38 UTC; interest accrues │
 ├──────────────────────────────────────────────────────────────────┤
-│ Redemption impact              │ Why this trove                  │
-│ 5 hits · −18,451 GBPm debt     │ Redemptions repay the lowest-   │
+│ Redemption impact              │ Redemption queue                │
+│ 5 redemptions · −18,451 GBPm   │ Redemptions repay the lowest-   │
 │ −25,164 USDm coll · +12.59     │ rate troves first. Current      │
 │ USDm fees kept · net equity    │ rate 1.6% = rank #2 of 14;      │
 │ +11 USDm at oracle prices      │ 6,200 GBPm of lower-rate debt   │
@@ -458,7 +459,8 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   answer — so it renders only from complete ledger rows and is absent in
   the partial view. The one-line explainer carries the ticket's core
   lesson.
-- **Why me** reads the current rate ladder (open troves / brackets already
+- **Redemption queue** (the panel that answers the user's "why me?"): reads
+  the current rate ladder (open troves / brackets already
   fetched on the market page): rank among ACTIVE troves by effective rate,
   and the sum of active debt at strictly lower rates ("shield"). Zombies
   are excluded from both — they sit outside the sorted redemption queue and
@@ -567,12 +569,12 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 
 Support pastes the owner address → owner lookup → one GBPm trove → header
 shows active, 44,791 USDm / 28,081 GBPm, ICR 117.1%. The impact card reads
-"5 redemption hits on 2026-08-25: −18,451 GBPm debt, −25,164 USDm collateral,
+"5 redemptions on 2026-08-25: −18,451 GBPm debt, −25,164 USDm collateral,
 +12.59 USDm fees kept, net equity +11 USDm — exchanged at oracle par." The
 chart shows the cliff at 18:13 UTC and the rebuild next morning. The ledger
 lists the five rebalance-redemption rows with tx links and the user's three
-follow-up ops. The why-me panel explains the 0.5% rate sat at the front of
-the redemption queue. Total time: one page view.
+follow-up ops. The Redemption queue panel explains the 0.5% rate sat at the
+front of the queue. Total time: one page view.
 
 ## Rollout
 

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -583,6 +583,11 @@ front of the queue. Total time: one page view.
 
 ## Rollout
 
+Execution is tracked by epic #2089; its child issues carry the slice
+numbers below (#2080 snapshot fix, #2081 indexes, #2082 ledger entity,
+#2083 page shell, #2084 queue panel, #2085 entry points, #2086 full ledger
+view, #2087 charts, #2088 impact panel).
+
 Sequenced per `docs/pr-checklists/stateful-data-ui.md`; each slice is one PR
 through the quality gate, with `pnpm indexer:codegen` /
 `pnpm dashboard:codegen` where schema or queries change, and the indexer

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -118,8 +118,8 @@ Semantics the page depends on:
   residual between consecutive snapshots. Any before/after pair derived from
   this arithmetic is therefore defined as **post-accrual**: `before` is the
   recorded debt with accrued interest already folded in, immediately before
-  the operation's own change; `after − evented terms` recovers exactly that
-  value, never the pre-accrual figure.
+  the operation's own change; subtracting the terms the events carry from
+  `after` recovers exactly that value, never the pre-accrual figure.
 - A redemption hit emits, per trove in one tx: `TroveUpdated` (or
   `BatchedTroveUpdated`) with the reduced totals, `TroveOperation(op=6,
 −boldLot, −collLot)`, and `RedemptionFeePaidToTrove(fee)`. The fee stays in
@@ -253,11 +253,11 @@ Writer notes:
 - Capture `debtBefore/collBefore` correctly. The robust source is
   arithmetic, both here and in the fix for the existing snapshot bug: the
   paired `TroveUpdated`/`BatchedTroveUpdated` in the same tx gives the
-  resulting state, and `after − (sum of evented deltas) = before`, with
+  resulting state, and `after − (sum of the event-carried deltas) = before`, with
   accrued interest landing as an explicit residual term. Direction matters:
   derive `before` from `after`, never `after` from a pre-captured `before`.
   These snapshots are **post-accrual, pre-operation** (semantics section
-  above): `after − evented terms` recovers the debt with accrued interest
+  above): subtracting the event-carried terms recovers the debt with accrued interest
   already folded in, so the pair is self-consistent and the client-side
   interest residual falls between rows, never inside one. Tests must cover
   both zero elapsed interest (open, same-block ops) and non-zero elapsed
@@ -330,9 +330,11 @@ graphql contract test, regenerated via `pnpm indexer:codegen` and
   `order_by: [{timestamp: desc}, {blockNumber: desc}, {logIndex: desc}]`,
   reversed client-side, so if a trove ever exceeds the 1,000-row Hasura cap
   the OLDEST rows drop, never the recent events being investigated. `id` is
-  an unpadded string and never participates in ordering. Detect
-  `length === limit` and disclose ("earliest history truncated") per the
-  row-cap discipline.
+  an unpadded string and never participates in ordering. Truncation is
+  detected exactly, without aggregates (disabled on hosted Hasura): request
+  `limit + 1` rows, render `limit`, and disclose ("earliest history
+  truncated") only when the sentinel row came back — a history of exactly
+  `limit` rows is complete and says nothing.
 - `CDP_TROVES_BY_OWNER(address)` — `Trove` rows across markets matching
   `_or: [{owner}, {previousOwner}]`, for the support entry path: close and
   liquidation zero `owner`, so `previousOwner` is how a closed trove is
@@ -452,7 +454,7 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   `formatTokenAmount` — per-field semantics, exactly as the invariants note
   requires. Synthetic, clearly-marked "interest accrued ≈ +X" rows render
   the residual between consecutive rows' recorded debt after subtracting the
-  evented terms; they are derived client-side, labeled as estimates,
+  event-carried terms; they are derived client-side, labeled as estimates,
   excluded from sums, and rendered only in complete-ledger mode (the
   partial view suppresses them). Status flips render from
   `statusBefore`/`statusAfter`. Default order chronological ascending with
@@ -493,7 +495,8 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 - Old rows without price fields: chart drops the ICR series and says so.
 - History at the row cap: newest rows are kept (desc fetch, reversed
   client-side) and the page discloses "earliest history truncated" (cap
-  detected by `length === limit`).
+  detected by the `limit + 1` sentinel row, never by `length === limit`
+  alone).
 
 ### Tests
 

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -231,8 +231,8 @@ type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
   redemptionFeeCredited: BigInt # op 6 only, from RedemptionFeePaidToTrove
   isRebalance: Boolean # op 6 only, tx-target discriminator
   redemptionPrice: BigInt # op 6 only, from branch Redemption event
-  priceAtEvent: BigInt # from loadLiquityPrice; null when unavailable
-  icrAfterBps: Int # null when price unavailable
+  priceAtEvent: BigInt # block-close price from loadLiquityPrice; null when unavailable
+  icrAfterBps: Int # from priceAtEvent, so also block-close; null when price unavailable
   timestamp: BigInt!
   blockNumber: BigInt!
   logIndex: Int! # numeric position for same-timestamp ordering
@@ -286,12 +286,19 @@ Writer notes:
   aggregate `LiquidationEvent` by `txHash` for the SP/redistribution context
   panel. Per-trove split of that aggregate stays a non-goal.
 - `priceAtEvent`/`icrAfterBps`: persist what `loadLiquityPrice` already
-  fetches. Incremental cost for new events is zero; historical rows need a
-  full resync that re-issues archive `eth_call`s from block 60,668,167 —
-  forno was observed dropping log ranges and receipts during the ticket
-  reconstruction, so treat backfill as a deliberate, monitored deploy
-  (`deploy-indexer` skill), and let the fields stay null on old rows if the
-  resync is deferred. Nullable-by-design is the degraded mode.
+  fetches, and label it honestly: an archive `eth_call` at the event's block
+  observes post-block state, so the persisted value is the **block-close**
+  price — a same-block oracle move after the operation can differ from the
+  operation-time price. Event-carried prices take precedence where they
+  exist (`redemptionPrice` on op 6, `Liquidation._price` on op 5); the UI
+  labels RPC-sampled ICR as at-block-close. There is no "later backfill"
+  option: every indexer deploy re-syncs from `start_block`
+  (`deploy-indexer` skill), so shipping the writer replays all history and
+  either pays the archive `eth_call`s during that sync or suppresses price
+  persistence during replay (fields stay null on historical rows). Forno
+  was observed dropping log ranges and receipts during the ticket
+  reconstruction, so the sync is a deliberate, monitored deploy either
+  way. Nullable-by-design is the degraded mode.
 - Keep `applySystemDebtDelta` untouched; the new writer only appends rows.
 
 ### Small fixes alongside
@@ -474,7 +481,11 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
    trove state. In complete-ledger mode, cumulatives shown on the page must
    equal the sum of ledger rows of the matching kind — a mismatch is a bug
    surface, not a rendering choice (the ticket reconstruction validated to
-   the wei; keep a test). The partial view skips this check by design.
+   the wei; keep a test). The two reads are independent queries, so
+   reconcile only when they observe the same position — `Trove.
+lastUpdatedBlock` equals the ledger's newest `blockNumber` — and
+   refetch instead of flagging when an event landed between them. The
+   partial view and a truncated history skip this check by design.
 3. Total redemption figures are never presented as user activity;
    user-driven = total − rebalance.
 4. `priceAtEvent`/`icrAfterBps` are nullable; every consumer renders null as
@@ -499,7 +510,9 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   client-side) and the page discloses "earliest history truncated" (cap
   detected by the `limit + 1` sentinel row, never by `length === limit`
   alone; the render limit sits below the Hasura hard cap so the sentinel
-  request is never itself capped).
+  request is never itself capped). A truncated history counts as partial
+  for the derivation gates: interest estimates, net equity, and
+  reconciliation need the full ledger and stay off.
 
 ### Tests
 
@@ -538,10 +551,12 @@ promote):
 1. **Fix the existing snapshot bug** (indexer) — independent, user-visible
    today in the market transaction tables. Requires resync to repair
    historical rows; the deploy is the backfill.
-2. **`TroveLedgerEvent` + indexes** (indexer) — new entity, writers, tests;
-   decide at implementation whether the price backfill resync rides along or
-   old rows stay null. If the entity-vs-widening choice is judged to
-   constrain future work, record the ADR in this PR.
+2. **`TroveLedgerEvent` + indexes** (indexer) — new entity, writers, tests.
+   The deploy's from-scratch sync replays all history, so decide here
+   whether it pays the archive price `eth_call`s or suppresses price
+   persistence during replay (historical rows stay null). If the
+   entity-vs-widening choice is judged to constrain future work, record the
+   ADR in this PR.
 3. **Trove history page** (dashboard) — route, header/cards/chart/ledger,
    introspection-gated ledger query with the interim assembly fallback,
    dependency-cruiser rules, tests, browser verification per
@@ -562,9 +577,10 @@ serves the new entity.
    indexed-recorded values only with an honest timestamp? (Recommend
    indexed-only v1; RPC read as a follow-up if support asks for to-the-second
    numbers.)
-2. Is the price/ICR backfill worth a monitored full resync now, or do old
-   ledger rows stay price-less until the next scheduled resync? (Recommend
-   defer; the ticket-class questions don't need historical ICR.)
+2. During slice 2's from-scratch sync, pay the archive price `eth_call`s
+   for historical rows, or suppress price persistence during replay and
+   leave them null? (Recommend suppress; the ticket-class questions don't
+   need historical ICR, and forno's archive path is the flakiest leg.)
 3. Owner lookup placement: `/cdps` overview search vs a dedicated
    `/cdps/troves?owner=` route. (Recommend overview search; one less route.)
 4. Should the history tab's closed troves link through to the page from day

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -277,11 +277,14 @@ Writer notes:
   them through the existing batch-replay path, or leave them null with the
   UI's "—" rendering — production has zero batches today, so the seam is
   cheap either way. Collateral snapshots stay non-null.
-- Op 6 enrichment: `RedemptionFeePaidToTrove` follows `TroveOperation` in the
-  same tx; carry the fee onto the ledger row (same short-lived pending
-  pattern the batch replay machinery already uses). `isRebalance` copies the
-  existing tx-target check; `redemptionPrice` copies from the branch
-  `Redemption` row of the same tx.
+- Op 6 rows are written LAST, not from the `TroveOperation` handler:
+  `RedemptionFeePaidToTrove` follows `TroveOperation` in the same tx, so the
+  `TroveOperation` handler only stages the row in short-lived pending state
+  (the pattern the batch replay machinery already uses) and the
+  `RedemptionFeePaidToTrove` handler assembles and sets it once, complete
+  with the fee. `isRebalance` copies the existing tx-target check;
+  `redemptionPrice` copies from the branch `Redemption` row of the same tx,
+  staged the same way. One write per row, never a set-then-patch.
 - Op 5: `debtChange/collChange` are `−entireDebt/−entireColl`; link the
   aggregate `LiquidationEvent` by `txHash` for the SP/redistribution context
   panel. Per-trove split of that aggregate stays a non-goal.
@@ -445,7 +448,10 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 - **Why me** reads the current rate ladder (open troves / brackets already
   fetched on the market page): rank among open troves by effective rate, and
   the sum of open debt at strictly lower rates ("shield"). States plainly
-  that historical rank is not tracked.
+  that historical rank is not tracked. When the open-trove fetch hits
+  `CDP_TROVES_DETAIL_LIMIT` (1,000), the dataset is incomplete, so rank and
+  shield are suppressed exactly as the market table already suppresses its
+  rank column at the cap — never shown as a partial calculation.
 - **Chart**: two stacked single-unit panels — collateral (USDm) and debt
   (debt-token units) — never one dual-axis plot, with series built from
   ledger `collAfter`/`debtAfter` (step interpolation), `sortedCopy` for
@@ -477,8 +483,11 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
    `timestamp`, and a unique `id`; ordering is deterministic on the numeric
    triple (`timestamp`, `blockNumber`, `logIndex`). The unpadded string
    `id` never participates in ordering (`_10` sorts before `_2`).
-2. The ledger is append-only; the `Trove` entity remains the only mutable
-   trove state. In complete-ledger mode, cumulatives shown on the page must
+2. The ledger is append-only: each row is assembled from its transaction's
+   own events (pending state within the tx is fine) and never mutated after
+   that transaction is processed — the batch-replay patch for batched debt
+   snapshots is the one named exception. The `Trove` entity remains the
+   only mutable trove state. In complete-ledger mode, cumulatives shown on the page must
    equal the sum of ledger rows of the matching kind — a mismatch is a bug
    surface, not a rendering choice (the ticket reconstruction validated to
    the wei; keep a test). The two reads are independent queries, so

--- a/docs/PLAN-trove-history-page.md
+++ b/docs/PLAN-trove-history-page.md
@@ -115,7 +115,11 @@ Semantics the page depends on:
   change only. Resulting debt = previous recorded debt + accrued interest +
   `_debtIncreaseFromRedist` + `_debtIncreaseFromUpfrontFee` + the signed
   change. Accrued interest is the one term events never carry; it is the
-  residual between consecutive snapshots.
+  residual between consecutive snapshots. Any before/after pair derived from
+  this arithmetic is therefore defined as **post-accrual**: `before` is the
+  recorded debt with accrued interest already folded in, immediately before
+  the operation's own change; `after − evented terms` recovers exactly that
+  value, never the pre-accrual figure.
 - A redemption hit emits, per trove in one tx: `TroveUpdated` (or
   `BatchedTroveUpdated`) with the reduced totals, `TroveOperation(op=6,
 −boldLot, −collLot)`, and `RedemptionFeePaidToTrove(fee)`. The fee stays in
@@ -205,7 +209,7 @@ existing `TroveOperation` handler from data it already receives:
 
 ```graphql
 type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
-  id: ID! # eventId(chainId, block, logIndex)
+  id: ID! # eventId(chainId, block, logIndex) — an UNPADDED string; never sort by it
   chainId: Int!
   instanceId: String! @index
   troveEntityId: String! # makeTroveId(collateralId, troveId)
@@ -218,8 +222,8 @@ type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
   debtIncreaseFromRedist: BigInt!
   collIncreaseFromRedist: BigInt!
   annualInterestRate: BigInt!
-  debtBefore: BigInt!
-  debtAfter: BigInt!
+  debtBefore: BigInt # post-accrual, pre-operation; null on batch-op rows until replay
+  debtAfter: BigInt # null on batch-op rows until replay
   collBefore: BigInt!
   collAfter: BigInt!
   statusBefore: String!
@@ -231,6 +235,7 @@ type TroveLedgerEvent @index(fields: ["troveEntityId", "timestamp"]) {
   icrAfterBps: Int # null when price unavailable
   timestamp: BigInt!
   blockNumber: BigInt!
+  logIndex: Int! # numeric position for same-timestamp ordering
   txHash: String!
 }
 ```
@@ -245,12 +250,33 @@ writer in a handler that already loads every input.
 
 Writer notes:
 
-- Capture `debtBefore/collBefore/statusBefore` correctly. The robust source
-  is arithmetic, both here and in the fix for the existing snapshot bug:
-  the paired `TroveUpdated`/`BatchedTroveUpdated` in the same tx gives the
+- Capture `debtBefore/collBefore` correctly. The robust source is
+  arithmetic, both here and in the fix for the existing snapshot bug: the
+  paired `TroveUpdated`/`BatchedTroveUpdated` in the same tx gives the
   resulting state, and `after − (sum of evented deltas) = before`, with
   accrued interest landing as an explicit residual term. Direction matters:
   derive `before` from `after`, never `after` from a pre-captured `before`.
+  These snapshots are **post-accrual, pre-operation** (semantics section
+  above): `after − evented terms` recovers the debt with accrued interest
+  already folded in, so the pair is self-consistent and the client-side
+  interest residual falls between rows, never inside one. Tests must cover
+  both zero elapsed interest (open, same-block ops) and non-zero elapsed
+  interest (an op days after the last touch).
+- `statusBefore` is NOT recoverable arithmetically: by the time
+  `TroveOperation` is handled, the `TroveUpdated` handler has already
+  classified and persisted the resulting status, and numeric deltas cannot
+  distinguish active/zombie/redeemed or the pre-open placeholder. Capture
+  the prior status into same-tx pending state in the
+  `TroveUpdated`/`BatchedTroveUpdated` handler before it mutates the
+  `Trove`, and let the ledger writer read it from there (the short-lived
+  pending pattern the batch replay machinery already uses).
+- Batch-op rows (ops 7-9 and in-batch adjusts/applies) cannot fill debt
+  snapshots from this handler: `BatchedTroveUpdated` carries shares and
+  collateral, and per-trove debt only becomes derivable when `BatchUpdated`
+  is replayed. Write those rows with null `debtBefore/debtAfter` and patch
+  them through the existing batch-replay path, or leave them null with the
+  UI's "—" rendering — production has zero batches today, so the seam is
+  cheap either way. Collateral snapshots stay non-null.
 - Op 6 enrichment: `RedemptionFeePaidToTrove` follows `TroveOperation` in the
   same tx; carry the fee onto the ledger row (same short-lived pending
   pattern the batch replay machinery already uses). `isRebalance` copies the
@@ -273,8 +299,15 @@ Writer notes:
 - Fix `TroveOperationEvent.debtBefore/debtAfter/collBefore/collAfter`
   (gap 3) with the same arithmetic derivation, in its own slice with its own
   test proving the open row reads `before = 0`.
-- Add `@index(fields: ["troveId", "timestamp"])` to `TroveOperationEvent`
-  (gap 5) so the interim owner/trove filters stop scanning.
+- Add `@index(fields: ["instanceId", "troveId", "timestamp"])` to
+  `TroveOperationEvent` (gap 5) so the interim per-trove filter stops
+  scanning. The raw `troveId` alone is NOT market-unique: it is
+  `keccak(owner, ownerIndex)`, so the same owner and index produce the same
+  id on every branch — every per-trove filter scopes by `instanceId` too.
+- Index `Trove.previousOwner`: the NFT burn handler zeroes `owner` on close
+  and liquidation and moves the last owner into `previousOwner`
+  (`troveNFT.ts`), so an owner lookup over `owner` alone cannot find exactly
+  the closed troves support asks about.
 
 ### Deferred, with seams
 
@@ -294,23 +327,37 @@ graphql contract test, regenerated via `pnpm indexer:codegen` and
 - `CDP_TROVE_BY_ID(troveEntityId)` — one `Trove` row (header card), plus its
   `LiquityCollateral` params.
 - `CDP_TROVE_LEDGER(troveEntityId, limit)` — `TroveLedgerEvent`
-  `order_by: [{timestamp: asc}, {id: asc}]`. A trove's whole life fits far
-  under the 1,000-row Hasura cap in every observed case; still detect
-  `length === limit` and disclose ("history truncated") per the row-cap
-  discipline.
-- `CDP_TROVES_BY_OWNER(owner)` — `Trove` rows across markets (owner is
-  indexed), for the support entry path.
-- The ledger query ships introspection-gated like the existing
-  `CDP_TROVE_OP_SNAPSHOTS` pattern: the page detects `TroveLedgerEvent` in
-  the schema and falls back to the interim assembly (below) while the
-  indexer rollout is in flight.
+  `order_by: [{timestamp: desc}, {blockNumber: desc}, {logIndex: desc}]`,
+  reversed client-side, so if a trove ever exceeds the 1,000-row Hasura cap
+  the OLDEST rows drop, never the recent events being investigated. `id` is
+  an unpadded string and never participates in ordering. Detect
+  `length === limit` and disclose ("earliest history truncated") per the
+  row-cap discipline.
+- `CDP_TROVES_BY_OWNER(address)` — `Trove` rows across markets matching
+  `_or: [{owner}, {previousOwner}]`, for the support entry path: close and
+  liquidation zero `owner`, so `previousOwner` is how a closed trove is
+  found by the address a user supplies.
+- Timing: dashboard codegen and the GraphQL contract test validate every
+  exported query against the in-repo `indexer-envio/schema.graphql`, so
+  `CDP_TROVE_LEDGER` can only be added once slice 2's schema change is
+  merged — it is not an optional-query exclusion. The runtime introspection
+  gate (the `CDP_TROVE_OP_SNAPSHOTS` pattern) covers the remaining window
+  where the schema is merged but hosted Hasura has not yet promoted: the
+  page detects `TroveLedgerEvent` in the live schema and falls back to the
+  interim assembly (below) until it appears.
 
 Interim assembly (works against today's schema, ships first): merge
-`TroveOperationEvent` filtered by `troveId` (user ops) with `Trove`
-cumulatives (redemption/liquidation totals). This yields a partial ledger —
-user actions plus lifetime redemption totals with a visible "per-redemption
-detail pending indexer rollout" notice. It answers half the ticket
-immediately and exercises the whole UI shell.
+`TroveOperationEvent` filtered by `instanceId` AND `troveId` (user ops; raw
+`troveId` collides across markets) with `Trove` cumulatives
+(redemption/liquidation lifetime totals). This is an explicitly **partial**
+view and must say so: protocol rows (redemptions, liquidation, op 4) are
+missing, so the interest-residual estimate, the debt/coll chart, the
+net-equity figure, and the cumulatives-reconciliation check are all
+suppressed — deriving any of them from user ops alone would misclassify
+missing redemption deltas as interest. The partial view shows the header,
+the raw lifetime totals, and the user-op list with a visible
+"per-redemption detail pending indexer rollout" notice. It answers half the
+ticket immediately and exercises the whole UI shell.
 
 ## UI design
 
@@ -343,7 +390,7 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 
 ### Layout
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────┐
 │ GBPm · Trove 0x8abc…0d7d          [active] [Manage in app ↗]     │
 │ Owner 0xcca0…d3bb   Opened 2026-08-06 (tx)   Rate 1.6% (#2 in    │
@@ -375,38 +422,55 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
   figure is honest about staleness: recorded-at-last-event plus timestamp. A
   live `entireDebt` read via the existing `rpc-client.ts` is an optional
   enhancement, decided at implementation (open question 1).
-- **Redemption impact** computes from `Trove` cumulatives, so it works even
-  before the ledger entity ships. Split user vs rebalance per the invariants
-  note once per-hit rows exist; until then label totals as totals. The
-  one-line explainer carries the ticket's core lesson.
+- **Redemption impact** computes its totals from `Trove` cumulatives, so
+  they work even before the ledger entity ships. Split user vs rebalance
+  per the invariants note once per-hit rows exist; until then label totals
+  as totals. The net-equity line requires per-hit `redemptionPrice` — a
+  trove redeemed at different FX prices cannot be valued from lifetime
+  sums, and pricing it at the current rate would fabricate the core support
+  answer — so it renders only from complete ledger rows and is absent in
+  the partial view. The one-line explainer carries the ticket's core
+  lesson.
 - **Why me** reads the current rate ladder (open troves / brackets already
   fetched on the market page): rank among open troves by effective rate, and
   the sum of open debt at strictly lower rates ("shield"). States plainly
   that historical rank is not tracked.
-- **Chart**: `TimeSeriesChartCard` with series built from ledger
-  `collAfter`/`debtAfter` (step interpolation), `sortedCopy` for ordering,
-  `escapePlotText` on any dynamic text. The chart reads the same bounded
-  full-history query as the table — one query, no pagination coupling.
+- **Chart**: two stacked single-unit panels — collateral (USDm) and debt
+  (debt-token units) — never one dual-axis plot, with series built from
+  ledger `collAfter`/`debtAfter` (step interpolation), `sortedCopy` for
+  ordering, `escapePlotText` on any dynamic text. `TimeSeriesChartCard`
+  exposes one y-axis and hardcodes dollar-prefixed hover formatting
+  (`time-series-chart-card.tsx:283-323`), which would label GBPm/JPYm debt
+  as dollars — either extend it with per-series unit formatting and
+  subplot support or build a sibling two-panel chart component on the same
+  chrome. The chart reads the same bounded full-history query as the table
+  — one query, no pagination coupling — and renders only from the complete
+  ledger, never the partial view.
 - **Ledger table**: badge pills reuse `BADGE_STYLES`/`BADGE_LABELS` plus new
   kinds (`rebalanceRedemption` already exists; add `zombie`, `revived`,
   `interest`). Signed deltas use `formatSignedWei`; unsigned totals use
   `formatTokenAmount` — per-field semantics, exactly as the invariants note
   requires. Synthetic, clearly-marked "interest accrued ≈ +X" rows render
   the residual between consecutive rows' recorded debt after subtracting the
-  evented terms; they are derived client-side, labeled as estimates, and
-  excluded from sums. Status flips render from
-  `statusBefore`/`statusAfter`. Default order chronological ascending, id
-  tiebreaker, newest visible via reverse toggle; local-only state
-  (intentional scope: single bounded dataset, no URL pagination).
+  evented terms; they are derived client-side, labeled as estimates,
+  excluded from sums, and rendered only in complete-ledger mode (the
+  partial view suppresses them). Status flips render from
+  `statusBefore`/`statusAfter`. Default order chronological ascending with
+  the `blockNumber`, `logIndex` tiebreakers, newest visible via reverse
+  toggle; local-only state (intentional scope: single bounded dataset, no
+  URL pagination).
 
 ### Invariants (stateful-data-ui checklist, defined up front)
 
-1. Every ledger row persists `txHash`, `blockNumber`, `timestamp`, and a
-   unique `id`; ordering is deterministic (`timestamp`, `id`).
+1. Every ledger row persists `txHash`, `blockNumber`, `logIndex`,
+   `timestamp`, and a unique `id`; ordering is deterministic on the numeric
+   triple (`timestamp`, `blockNumber`, `logIndex`). The unpadded string
+   `id` never participates in ordering (`_10` sorts before `_2`).
 2. The ledger is append-only; the `Trove` entity remains the only mutable
-   trove state. Cumulatives shown on the page must equal the sum of ledger
-   rows of the matching kind — a mismatch is a bug surface, not a rendering
-   choice (the ticket reconstruction validated to the wei; keep a test).
+   trove state. In complete-ledger mode, cumulatives shown on the page must
+   equal the sum of ledger rows of the matching kind — a mismatch is a bug
+   surface, not a rendering choice (the ticket reconstruction validated to
+   the wei; keep a test). The partial view skips this check by design.
 3. Total redemption figures are never presented as user activity;
    user-driven = total − rebalance.
 4. `priceAtEvent`/`icrAfterBps` are nullable; every consumer renders null as
@@ -417,24 +481,29 @@ today, so the new `troves/[troveId]/_components` rule lands with the page
 
 ### Degraded modes
 
-- `TroveLedgerEvent` absent from schema (pre-rollout, or rollback): page
-  renders header + cumulative cards + user-ops-only ledger with a visible
-  "protocol events pending" notice. No silent gaps.
+- `TroveLedgerEvent` absent from schema (pre-rollout, or rollback): the
+  partial view — header, raw cumulative totals, user-ops-only list, visible
+  "protocol events pending" notice; interest estimates, the chart, net
+  equity, and reconciliation stay off. No silent gaps.
 - Ledger query fails with header loaded: cards render, table shows the error
   state with retry; distinct loading vs empty vs error per `swr-state`
   helpers.
 - Unknown trove id: explicit "not indexed" state with an explorer address
   link fallback, no redirect loop.
 - Old rows without price fields: chart drops the ICR series and says so.
-- History at the row cap: "truncated" disclosure (invariant: cap detected by
-  `length === limit`).
+- History at the row cap: newest rows are kept (desc fetch, reversed
+  client-side) and the page discloses "earliest history truncated" (cap
+  detected by `length === limit`).
 
 ### Tests
 
-- Indexer: handler tests proving open rows read `before = 0`, redemption
-  rows carry fee/isRebalance/price, status flips produce correct
-  before/after, and the split-redemption case (one instance redemption, two
-  troves) yields two rows whose sums match the branch event.
+- Indexer: handler tests proving open rows read `before = 0`, snapshots are
+  correct with both zero and non-zero elapsed interest since the last touch,
+  redemption rows carry fee/isRebalance/price, status flips produce correct
+  before/after (including the pending-state capture across the
+  `TroveUpdated` → `TroveOperation` ordering), and the split-redemption case
+  (one instance redemption, two troves) yields two rows whose sums match the
+  branch event.
 - Dashboard: colocated unit tests for ledger merge/derivation (interest
   residual, badge mapping, formatter choice), the three degraded modes, and
   entry-link resolution. Fixture-server browser scenario for the route;
@@ -474,8 +543,12 @@ promote):
 4. **Entry points** (dashboard) — trove-table links, owner lookup on
    `/cdps`, docs/index updates.
 
-Slices 3 and 4 can ship before 2 completes (interim assembly); the page
-upgrades itself when the schema lands, by design of the introspection gate.
+Slices 3 and 4 can ship before 2 completes, but only with the interim
+queries: `CDP_TROVE_LEDGER` cannot be added until slice 2's schema change is
+merged, because dashboard codegen and the contract test validate against the
+in-repo `schema.graphql`. Once both are in, the runtime introspection gate
+covers the deploy window and the page upgrades itself when hosted Hasura
+serves the new entity.
 
 ## Open questions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -240,3 +240,4 @@ Authority: non-canonical
 - [`docs/notes/terraform-cicd-hardening-decisions-2026-05.md`](notes/terraform-cicd-hardening-decisions-2026-05.md) (archived)
 - [`docs/notes/ui-dashboard-performance-plan.md`](notes/ui-dashboard-performance-plan.md) (archived)
 - [`docs/PLAN-ai-review-process.md`](PLAN-ai-review-process.md) (archived)
+- [`docs/PLAN-trove-history-page.md`](PLAN-trove-history-page.md)


### PR DESCRIPTION
## The Problem

- Trove rows on `/cdps/[symbol]` link out to the Mento app and a block explorer; the dashboard has no per-trove view.
- Support questions like ticket #0754 ("position decreased a lot") took ~345 chunked `eth_getLogs` calls and manual ABI decoding to answer, because the indexer keeps only lifetime redemption cumulatives per trove — no per-hit history.
- The one append-only per-trove log (`TroveOperationEvent`) skips redemptions, liquidations, and interest folds, and its before/after snapshot fields render shifted values in the live transaction tables today.

## The Solution

- Adds `docs/PLAN-trove-history-page.md`, a non-canonical design for `/cdps/[symbol]/troves/[troveId]`: header, redemption-impact, and "why me" panels, a full chronological ledger, and a collateral/debt chart — grounded in a verified reconstruction of the ticket #0754 trove (five rebalance redemptions deleveraged it 63% at oracle par, net equity +11 USDm).
- Specifies the indexer work that makes the page possible: an append-only `TroveLedgerEvent` covering all ten operations with per-redemption fee/price/isRebalance enrichment, plus the GraphQL contract, invariants, degraded modes, and a four-slice rollout in which the page ships before the schema lands via an introspection-gated fallback.
- Design only: no application code, schema, or configuration changes in this PR. Material limits are the doc's stated non-goals — no historical redemption-queue rank, no per-trove SP/redistribution split, batch support kept as a seam (production has zero batches today).

## Details

- On-chain event inventory verified against `mento-protocol/bold` @ `1649143`: `ITroveEvents` signatures, `Operation` ordinals, per-function emission sites, zombie mechanics (no event; `MIN_DEBT` rule against live `SystemParams`), and Mento fork deviations including `redeemCollateralRebalancing`.
- Indexer gap analysis verified against `schema.graphql`, the liquity handlers, and the production GraphQL endpoint (live per-market params differ from deploy defaults; owner lookup already indexed; one instance redemption provably splits across two troves, ruling out a nullable `troveId` on `RedemptionEvent`).
- Records the root cause of the live `TroveOperationEvent` before/after shift — `TroveUpdated` is emitted before `TroveOperation`, so the "pre-op" capture reads post-op entity state — as an independent first rollout slice.
- `docs/README.md` catalog line regenerated with `pnpm docs:index --write`.

## Validation

- `pnpm agent:quality-gate --run` — all mapped checks pass (targeted trunk check, `docs:index --check`, `agent:context-check`, `tf:test`, `docs:navigation-eval --check-fixtures`), re-run after fast-forwarding onto `main` @ `1eab152b`.
- `pnpm agent:autoreview` (claude engine fallback) — clean; no accepted/actionable findings.
- Claude Security scan: skipped (docs-only diff; no sensitive surface).

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this is a design plan; the implementing indexer PR records the ADR if the ledger-entity choice constrains future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed design plan for a per-trove history page.
  * Clarified post-accrual debt snapshots, pending statuses, deterministic event ordering, market-scoped indexing, and closed-trove ownership lookup.
  * Documented block-close ledger prices, with event-provided redemption and liquidation prices taking precedence.
  * Added guidance for incomplete rate data, transaction-aware reconciliation, and treating truncated histories as partial when calculating metrics.
  * Updated rollout guidance to reflect full resynchronization and historical price-data options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->