### PR TITLE
docs: guardrail-change separation, anti-overclaim clause, rigour floor

### DIFF
--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -16,13 +16,8 @@ pnpm agent:autoreview $ARGUMENTS
 bundle preparation/verification, runtime-change refusal handling, and other
 adapter mechanics. Follow it rather than duplicating those rules here.
 
-Test the validation claims against what the run actually establishes. On a
-re-run for an open PR, that is its Validation section. On the first pass there
-is no PR yet — the operating card runs this at step 4 and opens the PR at
-step 5 — so apply the same test to the claims you are about to write. Either
-way: every claim names the evidence behind it and the nearest stronger claim
-that evidence does not support, and an unexplained strengthening of a claim is
-a finding.
+Test the validation claims as operating-card step 4 requires; that step owns
+the rule, so every review engine gets it.
 
 Verify every accepted finding before editing. If fixes are made, rerun focused
 checks and autoreview for that batch. Do not pause solely for cycle count before

--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -16,10 +16,13 @@ pnpm agent:autoreview $ARGUMENTS
 bundle preparation/verification, runtime-change refusal handling, and other
 adapter mechanics. Follow it rather than duplicating those rules here.
 
-Check the PR's Validation section against what the run actually establishes.
-Every claim names the evidence behind it and the nearest stronger claim that
-evidence does not support. Raise an unexplained strengthening of a claim as a
-finding.
+Test the validation claims against what the run actually establishes. On a
+re-run for an open PR, that is its Validation section. On the first pass there
+is no PR yet — the operating card runs this at step 4 and opens the PR at
+step 5 — so apply the same test to the claims you are about to write. Either
+way: every claim names the evidence behind it and the nearest stronger claim
+that evidence does not support, and an unexplained strengthening of a claim is
+a finding.
 
 Verify every accepted finding before editing. If fixes are made, rerun focused
 checks and autoreview for that batch. Do not pause solely for cycle count before

--- a/.claude/commands/autoreview.md
+++ b/.claude/commands/autoreview.md
@@ -16,6 +16,11 @@ pnpm agent:autoreview $ARGUMENTS
 bundle preparation/verification, runtime-change refusal handling, and other
 adapter mechanics. Follow it rather than duplicating those rules here.
 
+Check the PR's Validation section against what the run actually establishes.
+Every claim names the evidence behind it and the nearest stronger claim that
+evidence does not support. Raise an unexplained strengthening of a claim as a
+finding.
+
 Verify every accepted finding before editing. If fixes are made, rerun focused
 checks and autoreview for that batch. Do not pause solely for cycle count before
 five review-triggered patch cycles are complete; pause for scope

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,14 @@ invariants, caveats, and scope boundaries here.
 
 ## Validation
 
+<!--
+Name the evidence behind each claim — the command, the run, the artifact that
+establishes it. Then state the nearest stronger claim that evidence does NOT
+support, for example: "the tests prove the parser handles these six shapes;
+they do not prove exhaustiveness". An unexplained strengthening of a claim is
+a review finding.
+-->
+
 - [Commands and results.]
 
 ## Deferrals
@@ -50,5 +58,6 @@ When you keep it, CI requires each item to be "None" or link a GitHub issue.
 - [ ] The opening states any material limit or non-goal that applies.
 - [ ] A reader can understand the opening without reading the diff.
 - [ ] Deeper implementation details come after the opening two sections.
+- [ ] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
 - [ ] Every knowing deferral is listed under Deferrals with a GitHub issue link.
 - [ ] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,13 @@ rule are in
 
 ## Safety Boundaries
 
+- **Never weaken a control that blocks your own work.** Do not widen, disable,
+  or soften the quality gate, the sandbox or permission config, branch
+  protection, or a safety-boundary rule to unblock the change you are making
+  now — an agent that can widen its own gate has no gate. Hand the control
+  change to an independent session through a brief or an agent-ready issue,
+  with the operator's recorded consent. Changing a control as its own claimed
+  task stays allowed.
 - **Secrets are IaC-owned.** Never create, rotate, or overwrite secrets with
   `gh secret set`, `vercel env add`, `gcloud secrets versions add`, or another
   one-off provider command. Model them in the owning Terraform/integration path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,9 @@ rule are in
   protection, or a safety-boundary rule to unblock the change you are making
   now — an agent that can widen its own gate has no gate. Hand the control
   change to an independent session through a brief or an agent-ready issue,
-  with the operator's recorded consent. Changing a control as its own claimed
-  task stays allowed.
+  with the operator's recorded consent. Changing a control stays allowed when it
+  is its own claimed task and does not unblock the same session's current work;
+  reclassifying the blocking change as a separate task does not qualify.
 - **Secrets are IaC-owned.** Never create, rotate, or overwrite secrets with
   `gh secret set`, `vercel env add`, `gcloud secrets versions add`, or another
   one-off provider command. Model them in the owning Terraform/integration path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,14 +45,9 @@ rule are in
 
 ## Safety Boundaries
 
-- **Never weaken a control that blocks your own work.** Do not widen, disable,
-  or soften the quality gate, the sandbox or permission config, branch
-  protection, or a safety-boundary rule to unblock the change you are making
-  now — an agent that can widen its own gate has no gate. Hand the control
-  change to an independent session through a brief or an agent-ready issue,
-  with the operator's recorded consent. Changing a control stays allowed when it
-  is its own claimed task and does not unblock the same session's current work;
-  reclassifying the blocking change as a separate task does not qualify.
+- **Never weaken a control that blocks your own work** — an agent that can
+  widen its own gate has no gate. The exception and the hand-off procedure are
+  in the [operating card](docs/notes/pr-operating-card.md).
 - **Secrets are IaC-owned.** Never create, rotate, or overwrite secrets with
   `gh secret set`, `vercel env add`, `gcloud secrets versions add`, or another
   one-off provider command. Model them in the owning Terraform/integration path

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -379,6 +379,14 @@ These bind regardless of which step you are on:
 - **`Closes #N` only when Done means is fully met**, else `Refs #N`.
 - **Knowingly deferred work needs a GitHub issue first**, linked from
   `## Deferrals`. An evidence-backed won't-fix is not a deferral.
+- **Never weaken a control that is blocking your own work.** Do not widen,
+  disable, or soften the quality gate, the sandbox or permission config, branch
+  protection, or a safety-boundary rule to unblock the change you are making
+  now — an agent that can widen its own gate has no gate. Stop and hand the
+  control change to an independent session through a brief or an agent-ready
+  issue, with the operator's recorded consent. Routine control maintenance
+  stays allowed when it is its own claimed task and does not unblock the same
+  session's current work.
 - **Package-script, package-manager, and lockfile changes require explicit
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -110,8 +110,11 @@ even when you never open an authority.
    pass there is no PR yet, so apply the same test to the claims you are about
    to write. Either way every claim names the evidence behind it and the
    nearest stronger claim that evidence does not support, and an unexplained
-   strengthening of a claim is a finding. This lives here rather than in one
-   engine's command wrapper, because every review engine reaches this step. Outside an active
+   strengthening of a claim is a finding. **This is the running agent's job,
+   not the bundled reviewer's**: the prepared bundle carries the diff and the
+   selected checklists, not the PR body or the command output behind a claim,
+   so a reviewer confined to it cannot see the claims to test. Do it where the
+   claims and their evidence are both in hand. Outside an active
    Codex session — the standalone helper or `--engine claude` — a bare
    `pnpm agent:autoreview` is the closeout, matching root
    [`AGENTS.md`](../../AGENTS.md). The skill routers defer to this step rather
@@ -396,6 +399,18 @@ These bind regardless of which step you are on:
   stays allowed when it is its own claimed task and does not unblock the same
   session's current work; reclassifying the blocking change as a separate task
   does not qualify.
+
+  **When the control blocks its own repair** — broken branch protection
+  rejecting the PR that fixes it, a gate whose own bug fails every run — the
+  hand-off alone deadlocks: the receiving session is blocked by the same
+  control, and its fix would unblock its own task. That case needs the
+  operator's explicit consent to the specific repair, recorded on the issue or
+  PR, and the repair stays narrowly scoped to restoring the control. It is
+  still reviewed: use the last independently reviewed pre-change runtime for
+  the gate, or an independent reviewer for the diff. Widening the control
+  beyond the repair, or using this path for anything the control was correctly
+  refusing, is the thing this rule exists to prevent.
+
 - **Package-script, package-manager, and lockfile changes require explicit
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -103,7 +103,15 @@ even when you never open an authority.
 4. **Autoreview.** Freeze the scope baseline first — the initial request,
    target/owner, changed-file set, and non-test changed-line count — as the
    reference Babysit (step 6) checks new additions against. Then, for a
-   non-trivial completed batch, run the closeout review. Outside an active
+   non-trivial completed batch, run the closeout review.
+
+   **Test the validation claims against what the run actually establishes.**
+   On a re-run for an open PR that is its `## Validation` section; on the first
+   pass there is no PR yet, so apply the same test to the claims you are about
+   to write. Either way every claim names the evidence behind it and the
+   nearest stronger claim that evidence does not support, and an unexplained
+   strengthening of a claim is a finding. This lives here rather than in one
+   engine's command wrapper, because every review engine reaches this step. Outside an active
    Codex session — the standalone helper or `--engine claude` — a bare
    `pnpm agent:autoreview` is the closeout, matching root
    [`AGENTS.md`](../../AGENTS.md). The skill routers defer to this step rather
@@ -386,7 +394,8 @@ These bind regardless of which step you are on:
   control change to an independent session through a brief or an agent-ready
   issue, with the operator's recorded consent. Routine control maintenance
   stays allowed when it is its own claimed task and does not unblock the same
-  session's current work.
+  session's current work; reclassifying the blocking change as a separate task
+  does not qualify.
 - **Package-script, package-manager, and lockfile changes require explicit
   acknowledgement** through the gate; never bypass the refusal.
 - **Background long `--run` gates and pushes**; do not run them in a 600s

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -27,9 +27,12 @@ lowers the cost of being wrong; it does not lower the standard of evidence.
 - Where a claim rests on a measurement — a benchmark, a fuzz run, a coverage or
   timing number — establish the baseline before changing anything, so breakage
   can be attributed. During a read-only review pass, where the change already
-  exists, the equivalent is a deterministic comparison against the parent
-  revision; a baseline that could only have been taken earlier is not a finding
-  against the PR.
+  exists, the equivalent is a deterministic comparison against the **merge
+  base**, or an explicitly recorded pre-change baseline. Not the commit parent:
+  a PR carries review-fix commits and is never amended, so `HEAD^` already
+  contains the change being measured and would show no regression while
+  omitting the baseline entirely. A baseline that could only have been taken
+  earlier is not a finding against the PR.
 - Settle each candidate fix against the code, not on paper: apply it when you
   are implementing, and check it against the code you are reading when the pass
   is read-only, such as the closeout review this checklist is loaded into.

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -24,8 +24,12 @@ link are inline-canonical and are candidates for future extraction.
 Applies to every pattern below, in any repository, sandboxed or not. A sandbox
 lowers the cost of being wrong; it does not lower the standard of evidence.
 
-- Establish the baseline before changing anything, so breakage can be
-  attributed.
+- Where a claim rests on a measurement — a benchmark, a fuzz run, a coverage or
+  timing number — establish the baseline before changing anything, so breakage
+  can be attributed. During a read-only review pass, where the change already
+  exists, the equivalent is a deterministic comparison against the parent
+  revision; a baseline that could only have been taken earlier is not a finding
+  against the PR.
 - Settle each candidate fix against the code, not on paper: apply it when you
   are implementing, and check it against the code you are reading when the pass
   is read-only, such as the closeout review this checklist is loaded into.

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -26,7 +26,9 @@ lowers the cost of being wrong; it does not lower the standard of evidence.
 
 - Establish the baseline before changing anything, so breakage can be
   attributed.
-- Apply each candidate fix to the code instead of arguing it on paper.
+- Settle each candidate fix against the code, not on paper: apply it when you
+  are implementing, and check it against the code you are reading when the pass
+  is read-only, such as the closeout review this checklist is loaded into.
 - Classify failures rather than counting them.
 - Pin boundaries deterministically rather than quoting a fuzz counterexample.
 - State what a measurement does not establish.

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -19,6 +19,19 @@ link are inline-canonical and are candidates for future extraction.
 
 ## Patterns
 
+### Rigour floor
+
+Applies to every pattern below, in any repository, sandboxed or not. A sandbox
+lowers the cost of being wrong; it does not lower the standard of evidence.
+
+- Establish the baseline before changing anything, so breakage can be
+  attributed.
+- Apply each candidate fix to the code instead of arguing it on paper.
+- Classify failures rather than counting them.
+- Pin boundaries deterministically rather than quoting a fuzz counterexample.
+- State what a measurement does not establish.
+- When a test passes, check that it passed for the reason claimed.
+
 ### Architecture decisions — [checklist](architecture-decisions.md)
 
 tldr: if a PR makes an architectural decision (constrains future work · had a


### PR DESCRIPTION
## The Problem

- Nothing written told a session it must not widen, disable, or soften the
  quality gate, the sandbox or permission config, branch protection, or a
  safety-boundary rule in order to unblock the change it was making right then.
  That is the edit an agent has the strongest motive to make and the least
  standing to judge, and the repository was silent on it.
- The PR template asked Validation for "commands and results" and stopped there.
  A narrow run could sit next to a broad claim with nothing connecting them, and
  a reviewer who noticed the gap had no written rule to cite.
- The recurring-review-patterns checklist named specific hazard classes but set
  no floor under the evidence itself, so the same measurement mistakes kept
  coming back: no baseline to attribute breakage against, candidate fixes argued
  on paper, failures counted instead of classified.

## The Solution

Three rules, adapted from the guardrails in the `shoggoth-interceptor` harness
we reviewed, now sit in the documents the sessions they bind already read.

**Guardrail-change separation of duties.** A session must not weaken a control
that is blocking its own current work — an agent that can widen its own gate has
no gate. It hands the control change to an independent session through a brief
or an agent-ready issue, with the operator's recorded consent. The rule states
its own boundary so it does not freeze maintenance: changing a control stays
allowed when that is its own claimed task and does not unblock the same
session's current work. It is written into the operating card's Non-negotiables,
which bind on every step, and into AGENTS.md Safety Boundaries.

**Anti-overclaim clause.** Each Validation claim now names the evidence that
establishes it and the nearest stronger claim that evidence does not support —
"the tests prove the parser handles these six shapes; they do not prove
exhaustiveness". An unexplained strengthening is a review finding, which gives
the reviewer a rule to point at instead of an argument to win. It lands in the
PR template's Validation guidance and checklist, and in the autoreview closeout
command, so the author and the reviewer are held to the same standard.

**Rigour floor.** A short subsection at the top of the recurring-review-patterns
checklist, scoped to every pattern below it: baseline before change, apply the
fix instead of arguing it, classify failures rather than count them, pin
boundaries deterministically, state what a measurement does not establish, and
check that a passing test passed for the reason claimed. A sandbox lowers the
cost of being wrong; it does not lower the standard of evidence.

The limit is worth stating plainly, since two of these three rules are about not
overstating a control. This PR is prose. No script, hook, CI check, or
permission rule enforces any of the three, and none is added here. The
separation-of-duties rule binds a session that reads the operating card; nothing
in the repository refuses a guardrail edit, and a session that ignores the rule
meets no mechanical resistance. The anti-overclaim clause is likewise a norm for
authors and reviewers — `scripts/pr/check-pr-description.mjs` validates the
opening two sections and the Deferrals format, and never parses Validation. What
changes is that all three now have a written, citable home instead of living in
whichever session happened to remember them.

## Details

- `docs/notes/pr-operating-card.md`: one bullet added to Non-negotiables,
  between the deferral rule and the package-script rule.
- `AGENTS.md`: the matching bullet added as the first entry under Safety
  Boundaries. Root `CLAUDE.md` is a symlink to `AGENTS.md` in this repository
  (`ls -la` shows `CLAUDE.md -> AGENTS.md`), so the single edit covers both
  filenames the issue named; no separate `CLAUDE.md` change exists or is needed.
- The two copies of the exception are worded to the same effect on purpose. The
  first draft of the AGENTS.md bullet said only that changing a control as its
  own claimed task stays allowed, omitting the same-session condition the
  operating card carries. Since agents read AGENTS.md as direct instruction,
  that shorter wording let a session reclassify the blocking control change as a
  separate task and proceed. Both conditions are now stated there, and the
  reclassification move is named as not qualifying.
- `.github/PULL_REQUEST_TEMPLATE.md`: guidance added under `## Validation` as an
  HTML comment, following the pattern already used by the other three sections,
  plus one line in the Checklist. Being a comment, it instructs the author
  without appearing in the rendered description.
- `.claude/commands/autoreview.md`: three sentences added to the closeout
  instructions, directing the review to check the Validation section against
  what the run actually establishes and to raise an unexplained strengthening as
  a finding. Prose in the command file only; `scripts/agent-autoreview*` is
  untouched, so no review-engine behavior changes.
- `docs/pr-checklists/recurring-review-patterns.md`: a `### Rigour floor`
  subsection placed at the head of `## Patterns` so its scope line — "applies to
  every pattern below" — is literally true.
- No documentation file was added, renamed, or removed, so `docs:index` needed
  no rewrite; the gate's `docs:index --check` confirms this.
- The branch was behind `main` by two commits, so `origin/main` was merged in
  (merge commit `5b055cf3`, no conflicts, and no file overlap between the two
  change sets) before the gate ran. Every check below ran against the merged
  head. The merge does not alter the effective diff against `origin/main`.

## Validation

- `bash scripts/agent-quality-gate.sh --run --lock-wait 3600` against head
  `84b29715`: all 7 mapped commands passed. It ran the commands its path
  mapping selected for this change set — targeted `trunk check` on the five
  files, `pnpm docs:index --check`, `pnpm agent:context-budget --strict`,
  `pnpm agent:context-check`, `node scripts/pr/check-adr-reminder.mjs`,
  `pnpm tf:test`, and `pnpm docs:navigation-eval -- --check-fixtures`. This
  establishes that the edited documents lint, that the docs index is consistent
  with them, that the agent-context budget still holds, and that the
  documentation-navigation fixtures still resolve. It does not establish
  anything about the rules' content: no check in this repository distinguishes a
  correct normative rule from an incorrect one, and none tests whether a session
  obeys one. An earlier identical run passed against the pre-fix head
  `5b055cf3`; the run quoted here is the one bound to the head being pushed.
- `pnpm agent:autoreview` against `84b29715`: clean — no accepted or actionable
  findings, verdict "patch is correct" at 0.94 confidence. The preceding run
  against `5b055cf3` was not clean: it raised one P2 at `AGENTS.md:55`, the
  same-session loophole described under Details, at 0.94 confidence. That
  finding was fixed rather than waived, and the run quoted here is the re-review
  of the fix. Autoreview is source review only — it runs no tests and proves no
  behavior, and it states so itself.
- `git diff origin/main...HEAD --stat` reports 5 files, 43 insertions, 0
  deletions, matching the intended scope. This proves the change is additive
  prose in five known files; it is not evidence that the additions read well,
  which stays a reviewer judgement.
- The `CLAUDE.md` symlink claim above was verified by running `ls -la` on both
  paths, not inferred from the commit message.
- The claim that the description checker ignores Validation was verified by
  reading `scripts/pr/check-pr-description.mjs`: it matches `## The Problem`,
  `## The Solution`, and `## Deferrals` headings only. That is evidence about
  this checker; other CI jobs were not audited for Validation parsing.
- No test suite covers this change, because it adds no executable behavior.
  Prose-only is a claim about the diff, which the stat above supports; it is not
  a claim that the repository is unaffected, since agents and reviewers act on
  these documents, and changing how they act is the point.
- Claude Security scan: skipped (the diff touches no authn/authz, secrets,
  injection, network-facing, or deploy path; the plugin is not declared in this
  repository).

Closes #2068

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcpGL6S9z7AW3QaoYSophE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated pull request guidance to require evidence for each validation claim and identify unsupported stronger claims.
  - Clarified safeguards for narrowly scoped, operator-approved repairs when controls block their own repair.
  - Added independent review requirements and prohibited broader control weakening or reclassification.
  - Refined review guidance to use deterministic comparisons against the merge base or a recorded pre-change baseline.
  - Clarified that missing earlier baselines are not findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->