### PR TITLE
feat(indexer): add per-trove query indexes for trove history page

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1363,7 +1363,7 @@ type Trove
   collateralId: String! @index
   troveId: String! @index
   owner: String! @index
-  previousOwner: String!
+  previousOwner: String! @index
   status: String! @index
   debt: BigInt!
   coll: BigInt!
@@ -1830,7 +1830,8 @@ type StabilityPoolOperationEvent
 # switch happen without a re-sync.
 type TroveOperationEvent
   @index(fields: ["instanceId", "timestamp"])
-  @index(fields: ["chainId", "owner"]) {
+  @index(fields: ["chainId", "owner"])
+  @index(fields: ["instanceId", "troveId", "timestamp"]) {
   id: ID!
   chainId: Int!
   instanceId: String! @index


### PR DESCRIPTION
## The Problem

- `TroveOperationEvent` has no index matching the shape every per-trove filter actually uses (`instanceId` + `troveId` + `timestamp`), so those queries scan.
- `Trove.previousOwner` is unindexed. Close and liquidation zero `owner`, so the support owner-lookup query (`_or: [{owner}, {previousOwner}]`) scans to find exactly the closed troves it needs.
- Both queries feed the trove history page (epic #2089); without the indexes they degrade as trove and event volume grows.

## The Solution

Two index additions, no handler or entity changes:

- `@index(fields: ["instanceId", "troveId", "timestamp"])` on `TroveOperationEvent`, matching the per-trove filter shape used everywhere (raw `troveId` collides across markets, so every filter scopes by `instanceId` too).
- `@index` on `Trove.previousOwner`, so the owner-lookup query hits an index on both branches of its `_or`.

Benefit: both queries stop scanning once the next indexer deploy serves them from hosted Hasura. Limit: the indexes take effect only after that deploy; this PR does not deploy the indexer.

## Details

Schema-only diff in `indexer-envio/schema.graphql`, regenerated with `pnpm indexer:codegen`. `generated/` is gitignored, so there is no generated output to commit beyond the schema file itself.

## Validation

```
pnpm indexer:codegen                                  # ran clean, no diff outside schema.graphql
pnpm --filter @mento-protocol/indexer-envio test       # 81 passed | 2 skipped (83 files); 1175 passed | 44 skipped (1219 tests)
pnpm agent:quality-gate --run                          # All mapped commands passed (dashboard:codegen, indexer:codegen/testnet/bridge-only, install --frozen-lockfile, trunk check, lint, typecheck, knip, code-health:deps, tf:test, test:coverage)
```

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved indexing for trove ownership history and operation event lookups.
  * Enhanced query efficiency when filtering events by instance, trove, and timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->