### PR TITLE
fix(indexer): derive TroveOperationEvent before-snapshots from event data

### DIFF
--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1839,8 +1839,8 @@ type TroveOperationEvent
   operation: Int!
   collChange: BigInt!
   debtChange: BigInt!
-  debtBefore: BigInt!
-  debtAfter: BigInt!
+  debtBefore: BigInt # null on batch-managed-trove rows; see troveOperationSnapshot.ts
+  debtAfter: BigInt # null on batch-managed-trove rows; see troveOperationSnapshot.ts
   collBefore: BigInt!
   collAfter: BigInt!
   annualInterestRate: BigInt!

--- a/indexer-envio/src/handlers/liquity/troveManager.ts
+++ b/indexer-envio/src/handlers/liquity/troveManager.ts
@@ -123,6 +123,19 @@ indexer.onEvent(
     const prevTroveState = { status: trove.status, debt: trove.debt };
     // See `captureTroveOperationSnapshotState` for why we capture these now.
     const snapshotState = captureTroveOperationSnapshotState(trove);
+    // `BatchedTroveUpdated` (never `TroveUpdated`) fires before
+    // `TroveOperation` for a batch-managed op and stages this row keyed by
+    // tx+trove — its presence is how `maybeRecordTroveOperation` knows
+    // `snapshotState.debtAfter` above is stale. See that function's doc.
+    const pendingBatchedTroveUpdate =
+      await context.PendingBatchedTroveUpdate.get(
+        pendingTroveKey(
+          event.chainId,
+          event.transaction.hash,
+          collateralId,
+          troveId,
+        ),
+      );
 
     const op = Number(event.params._operation);
     const forced = isForcedOperation(op);
@@ -217,6 +230,7 @@ indexer.onEvent(
       instanceId: instance.id,
       troveId,
       snapshotState,
+      pendingBatchedTroveUpdate,
       blockNumber,
       blockTimestamp,
     });

--- a/indexer-envio/src/handlers/liquity/troveManager.ts
+++ b/indexer-envio/src/handlers/liquity/troveManager.ts
@@ -16,7 +16,7 @@ import {
 } from "./config.js";
 import { flushLiquitySnapshots, touchLiquityInstance } from "./instance.js";
 import { pendingTroveKey } from "./keys.js";
-import { computeTroveIcrBps, negativeToPositive } from "./math.js";
+import { computeTroveIcrBps } from "./math.js";
 import { loadLiquityPrice } from "./priceFeed.js";
 import {
   classifyKnownPendingStabilityPoolConsumptionSource,
@@ -38,17 +38,10 @@ import {
   moveTroveUpdatedInterestRateBracketDebt,
   removesFromBatch,
 } from "./troveUpdates.js";
-import { OP, isBatchMembershipOperation } from "./operations.js";
-import {
-  setPendingBatchMembershipOperation,
-  setPendingRedemption,
-} from "./pendingOperations.js";
 import { getOrLoadSystemParams, preloadSystemParams } from "./systemParams.js";
 import {
+  applyTroveOperationTransition,
   isForcedOperation,
-  transitionClosedTrove,
-  transitionLiquidatedTrove,
-  transitionOpenedTrove,
 } from "./troveManagerTransitions.js";
 import {
   TROVE_STATUS,
@@ -140,63 +133,22 @@ indexer.onEvent(
     const op = Number(event.params._operation);
     const forced = isForcedOperation(op);
 
-    if (op === OP.OPEN_TROVE || op === OP.OPEN_TROVE_AND_JOIN_BATCH) {
-      ({ trove, instance } = transitionOpenedTrove(trove, instance, {
-        blockTimestamp,
-        blockNumber,
+    ({ trove, instance } = await applyTroveOperationTransition(
+      context,
+      trove,
+      instance,
+      {
+        op,
+        chainId: event.chainId,
         txHash: event.transaction.hash,
-      }));
-    } else if (op === OP.CLOSE_TROVE) {
-      ({ trove, instance } = transitionClosedTrove(trove, instance, {
-        blockTimestamp,
-        blockNumber,
-        txHash: event.transaction.hash,
-      }));
-    } else if (op === OP.LIQUIDATE) {
-      ({ trove, instance } = transitionLiquidatedTrove(trove, instance, {
+        collateralId,
+        annualInterestRate: event.params._annualInterestRate,
         collChange: event.params._collChangeFromOperation,
         debtChange: event.params._debtChangeFromOperation,
         blockTimestamp,
         blockNumber,
-        txHash: event.transaction.hash,
-      }));
-    } else if (op === OP.REDEEM_COLLATERAL) {
-      trove = {
-        ...trove,
-        redemptionCount: trove.redemptionCount + 1,
-        redeemedColl:
-          trove.redeemedColl +
-          negativeToPositive(event.params._collChangeFromOperation),
-        redeemedDebt:
-          trove.redeemedDebt +
-          negativeToPositive(event.params._debtChangeFromOperation),
-      };
-      const collateral = await context.LiquityCollateral.get(collateralId);
-      const nextStatus = statusFromCollateral(trove.debt, collateral);
-      const transitioned = transitionTroveStatus(trove, nextStatus, instance);
-      trove = transitioned.trove;
-      instance = transitioned.instance;
-      setPendingRedemption(context, {
-        chainId: event.chainId,
-        txHash: event.transaction.hash,
-        collateralId,
-        troveId: trove.troveId,
-        timestamp: blockTimestamp,
-        blockNumber,
-      });
-    } else if (isBatchMembershipOperation(op)) {
-      setPendingBatchMembershipOperation(context, {
-        chainId: event.chainId,
-        txHash: event.transaction.hash,
-        collateralId,
-        troveId: trove.troveId,
-        operation: op,
-        annualInterestRate: event.params._annualInterestRate,
-        interestBatchId: trove.interestBatchId,
-        timestamp: blockTimestamp,
-        blockNumber,
-      });
-    }
+      },
+    ));
 
     if (!forced) trove = { ...trove, lastUserActionAt: blockTimestamp };
     instance = await recordBorrowingFeeAndApplyCum(

--- a/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerPreload.ts
@@ -94,6 +94,19 @@ export async function preloadTroveOperation(
       args.appliedFeeEventId,
       args.upfrontFee,
     ),
+    // Warm the same tx+trove key `maybeRecordTroveOperation` reads during
+    // processing to discriminate a batch-managed op — see
+    // `troveOperationSnapshot.ts`. `BatchedTroveUpdated` (which stages this
+    // row) fires before `TroveOperation` on-chain, so the key is derivable
+    // from the event alone with no entity-dependent branch.
+    context.PendingBatchedTroveUpdate.get(
+      pendingTroveKey(
+        args.chainId,
+        args.txHash,
+        args.collateralId,
+        args.troveId,
+      ),
+    ),
   ]);
   if (args.operation === OP.REDEEM_COLLATERAL) {
     setPendingRedemption(context, {

--- a/indexer-envio/src/handlers/liquity/troveManagerPreloadContext.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerPreloadContext.ts
@@ -26,6 +26,7 @@ export type TroveManagerPreloadContext = Parameters<
       get: (id: string) => Promise<PendingRedemption | undefined>;
     };
     PendingBatchedTroveUpdate: {
+      get: (id: string) => Promise<PendingBatchedTroveUpdate | undefined>;
       getWhere: (args: { txHash: { _eq: string } }) => Promise<
         Array<{
           collateralId: string;

--- a/indexer-envio/src/handlers/liquity/troveManagerTransitions.ts
+++ b/indexer-envio/src/handlers/liquity/troveManagerTransitions.ts
@@ -1,7 +1,15 @@
 import type { LiquityInstance, Trove } from "envio";
 import { negativeToPositive } from "./math.js";
-import { OP } from "./operations.js";
-import { TROVE_STATUS, transitionTroveStatus } from "./troves.js";
+import { OP, isBatchMembershipOperation } from "./operations.js";
+import {
+  setPendingBatchMembershipOperation,
+  setPendingRedemption,
+} from "./pendingOperations.js";
+import {
+  TROVE_STATUS,
+  statusFromCollateral,
+  transitionTroveStatus,
+} from "./troves.js";
 
 export const isForcedOperation = (op: number): boolean =>
   op === OP.REDEEM_COLLATERAL ||
@@ -93,4 +101,97 @@ export function transitionLiquidatedTrove(
       liqCountDayBucket: transitioned.instance.liqCountDayBucket + 1,
     },
   };
+}
+
+/** Apply the operation-specific trove/instance transition for a
+ *  `TroveOperation` event and stage the pending rows (redemption, batch
+ *  membership) that later same-tx events consume. Ops with no status
+ *  effect (adjustments, interest-rate changes, APPLY_PENDING_DEBT) pass
+ *  trove and instance through unchanged. */
+export async function applyTroveOperationTransition(
+  context: {
+    LiquityCollateral: {
+      get: (
+        id: string,
+      ) => Promise<
+        { minDebt: bigint; systemParamsLoaded: boolean } | undefined
+      >;
+    };
+  } & Parameters<typeof setPendingRedemption>[0] &
+    Parameters<typeof setPendingBatchMembershipOperation>[0],
+  trove: Trove,
+  instance: LiquityInstance,
+  args: {
+    op: number;
+    chainId: number;
+    txHash: string;
+    collateralId: string;
+    annualInterestRate: bigint;
+    collChange: bigint;
+    debtChange: bigint;
+    blockTimestamp: bigint;
+    blockNumber: bigint;
+  },
+): Promise<{ trove: Trove; instance: LiquityInstance }> {
+  const { op, blockTimestamp, blockNumber, txHash } = args;
+  if (op === OP.OPEN_TROVE || op === OP.OPEN_TROVE_AND_JOIN_BATCH) {
+    return transitionOpenedTrove(trove, instance, {
+      blockTimestamp,
+      blockNumber,
+      txHash,
+    });
+  }
+  if (op === OP.CLOSE_TROVE) {
+    return transitionClosedTrove(trove, instance, {
+      blockTimestamp,
+      blockNumber,
+      txHash,
+    });
+  }
+  if (op === OP.LIQUIDATE) {
+    return transitionLiquidatedTrove(trove, instance, {
+      collChange: args.collChange,
+      debtChange: args.debtChange,
+      blockTimestamp,
+      blockNumber,
+      txHash,
+    });
+  }
+  if (op === OP.REDEEM_COLLATERAL) {
+    const redeemed = {
+      ...trove,
+      redemptionCount: trove.redemptionCount + 1,
+      redeemedColl: trove.redeemedColl + negativeToPositive(args.collChange),
+      redeemedDebt: trove.redeemedDebt + negativeToPositive(args.debtChange),
+    };
+    const collateral = await context.LiquityCollateral.get(args.collateralId);
+    const transitioned = transitionTroveStatus(
+      redeemed,
+      statusFromCollateral(redeemed.debt, collateral),
+      instance,
+    );
+    setPendingRedemption(context, {
+      chainId: args.chainId,
+      txHash,
+      collateralId: args.collateralId,
+      troveId: redeemed.troveId,
+      timestamp: blockTimestamp,
+      blockNumber,
+    });
+    return transitioned;
+  }
+  if (isBatchMembershipOperation(op)) {
+    setPendingBatchMembershipOperation(context, {
+      chainId: args.chainId,
+      txHash,
+      collateralId: args.collateralId,
+      troveId: trove.troveId,
+      operation: op,
+      annualInterestRate: args.annualInterestRate,
+      interestBatchId: trove.interestBatchId,
+      timestamp: blockTimestamp,
+      blockNumber,
+    });
+  }
+  return { trove, instance };
 }

--- a/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
+++ b/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
@@ -1,13 +1,19 @@
 import type { Trove, TroveOperationEvent } from "envio";
 import { asAddress, eventId } from "../../helpers.js";
-import { computeTroveOperationSnapshot } from "./math.js";
 import { OP } from "./operations.js";
 
 /** Capture the trove fields needed for a TroveOperationEvent snapshot
- *  before any handler branch mutates the entity. The 5 user-initiated
- *  ops we persist don't touch debt/coll in the TroveOperation handler
- *  (those land in TroveUpdated / BatchUpdated), so reading directly off
- *  the entity here yields the true pre-operation values.
+ *  before any handler branch in the parent TroveOperation handler mutates
+ *  the entity further.
+ *
+ *  These are NOT pre-operation values: on-chain, every TroveManager
+ *  function emits `TroveUpdated` before `TroveOperation` for the same op,
+ *  so by the time Envio's ordered event processing reaches this handler,
+ *  the `TroveUpdated` handler has already applied the post-operation
+ *  debt/coll to the `Trove` entity. `trove.debt`/`trove.coll` here are the
+ *  AFTER snapshot; the BEFORE snapshot is derived arithmetically in
+ *  `maybeRecordTroveOperation` from the event's own delta fields, never
+ *  from a second read of the (already-mutated) entity.
  *
  *  OPEN_TROVE owner race: on-chain log order is TroveNFT.Transfer (mint)
  *  → TroveOperation, so under normal Envio ordering `trove.owner` is
@@ -22,13 +28,49 @@ import { OP } from "./operations.js";
  *  (which would cost an extra getWhere on every mint). */
 export function captureTroveOperationSnapshotState(trove: Trove): {
   owner: string;
-  prevDebt: bigint;
-  prevColl: bigint;
+  debtAfter: bigint;
+  collAfter: bigint;
 } {
   return {
     owner: trove.owner,
-    prevDebt: trove.debt,
-    prevColl: trove.coll,
+    debtAfter: trove.debt,
+    collAfter: trove.coll,
+  };
+}
+
+/** Recover the trove's debt/coll immediately BEFORE this `TroveOperation`
+ *  applied, given the already-correct AFTER values and every signed/
+ *  unsigned delta the ABI exposes:
+ *
+ *    debtBefore = debtAfter − debtChange − upfrontFee − debtFromRedist
+ *    collBefore = collAfter − collChange − collFromRedist
+ *
+ *  Direction matters: `after` comes from the entity (true post-operation
+ *  state, since `TroveUpdated` ran first — see `captureTroveOperationSnapshotState`),
+ *  and `before` is always derived FROM `after`, never the reverse. Floors
+ *  at zero defensively, matching the on-chain invariant that a trove's
+ *  debt/coll cannot go negative; only a future ABI revision or an
+ *  unexpected event sequence could otherwise underflow the signed bigint
+ *  arithmetic here. */
+function deriveTroveOperationBeforeSnapshot(params: {
+  debtAfter: bigint;
+  collAfter: bigint;
+  debtChange: bigint;
+  debtIncreaseFromUpfrontFee: bigint;
+  debtIncreaseFromRedist: bigint;
+  collChange: bigint;
+  collIncreaseFromRedist: bigint;
+}): { debtBefore: bigint; collBefore: bigint } {
+  const debtBefore =
+    params.debtAfter -
+    params.debtChange -
+    params.debtIncreaseFromUpfrontFee -
+    params.debtIncreaseFromRedist;
+  const collBefore =
+    params.collAfter - params.collChange - params.collIncreaseFromRedist;
+  return {
+    debtBefore: debtBefore > 0n ? debtBefore : 0n,
+    collBefore: collBefore > 0n ? collBefore : 0n,
   };
 }
 
@@ -54,11 +96,12 @@ export type TroveOperationLogEvent = {
  *  they already have dedicated event entities; APPLY_PENDING_DEBT is
  *  protocol-forced and isn't a user action.
  *
- *  `debtBefore` / `collBefore` come from the trove entity (captured before
- *  any mutation in the parent handler); `debtAfter` / `collAfter` are
- *  computed arithmetically from the ABI deltas via
- *  `computeTroveOperationSnapshot`. The `owner` field is denormalized off
- *  the trove so the UI can filter by owner without a join. */
+ *  `debtAfter` / `collAfter` come from the trove entity (captured in the
+ *  parent handler, already correct — see `captureTroveOperationSnapshotState`);
+ *  `debtBefore` / `collBefore` are derived arithmetically from the ABI
+ *  deltas via `deriveTroveOperationBeforeSnapshot`, never from a second
+ *  entity read. The `owner` field is denormalized off the trove so the UI
+ *  can filter by owner without a join. */
 export function maybeRecordTroveOperation(args: {
   context: {
     TroveOperationEvent: { set: (entity: TroveOperationEvent) => void };
@@ -67,7 +110,7 @@ export function maybeRecordTroveOperation(args: {
   event: TroveOperationLogEvent;
   instanceId: string;
   troveId: string;
-  snapshotState: { owner: string; prevDebt: bigint; prevColl: bigint };
+  snapshotState: { owner: string; debtAfter: bigint; collAfter: bigint };
   blockNumber: bigint;
   blockTimestamp: bigint;
 }): void {
@@ -78,10 +121,10 @@ export function maybeRecordTroveOperation(args: {
     op === OP.APPLY_PENDING_DEBT
   )
     return;
-  const { owner, prevDebt, prevColl } = snapshotState;
-  const { debtAfter, collAfter } = computeTroveOperationSnapshot({
-    debtBefore: prevDebt,
-    collBefore: prevColl,
+  const { owner, debtAfter, collAfter } = snapshotState;
+  const { debtBefore, collBefore } = deriveTroveOperationBeforeSnapshot({
+    debtAfter,
+    collAfter,
     debtChange: event.params._debtChangeFromOperation,
     debtIncreaseFromUpfrontFee: event.params._debtIncreaseFromUpfrontFee,
     debtIncreaseFromRedist: event.params._debtIncreaseFromRedist,
@@ -97,9 +140,9 @@ export function maybeRecordTroveOperation(args: {
     operation: op,
     collChange: event.params._collChangeFromOperation,
     debtChange: event.params._debtChangeFromOperation,
-    debtBefore: prevDebt,
+    debtBefore,
     debtAfter,
-    collBefore: prevColl,
+    collBefore,
     collAfter,
     annualInterestRate: event.params._annualInterestRate,
     debtIncreaseFromUpfrontFee: event.params._debtIncreaseFromUpfrontFee,

--- a/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
+++ b/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
@@ -38,40 +38,48 @@ export function captureTroveOperationSnapshotState(trove: Trove): {
   };
 }
 
-/** Recover the trove's debt/coll immediately BEFORE this `TroveOperation`
- *  applied, given the already-correct AFTER values and every signed/
- *  unsigned delta the ABI exposes:
+/** Recover the trove's collateral immediately BEFORE this `TroveOperation`
+ *  applied, given the already-correct AFTER value and the signed/unsigned
+ *  coll deltas the ABI exposes:
  *
- *    debtBefore = debtAfter − debtChange − upfrontFee − debtFromRedist
  *    collBefore = collAfter − collChange − collFromRedist
  *
- *  Direction matters: `after` comes from the entity (true post-operation
- *  state, since `TroveUpdated` ran first — see `captureTroveOperationSnapshotState`),
- *  and `before` is always derived FROM `after`, never the reverse. Floors
- *  at zero defensively, matching the on-chain invariant that a trove's
- *  debt/coll cannot go negative; only a future ABI revision or an
+ *  Direction matters: `after` is always the true post-operation state (see
+ *  `maybeRecordTroveOperation` for where it comes from on batch-managed vs.
+ *  ordinary troves), and `before` is always derived FROM `after`, never the
+ *  reverse. Floors at zero defensively, matching the on-chain invariant that
+ *  a trove's coll cannot go negative; only a future ABI revision or an
  *  unexpected event sequence could otherwise underflow the signed bigint
  *  arithmetic here. */
-function deriveTroveOperationBeforeSnapshot(params: {
-  debtAfter: bigint;
+function deriveCollBefore(params: {
   collAfter: bigint;
+  collChange: bigint;
+  collIncreaseFromRedist: bigint;
+}): bigint {
+  const collBefore =
+    params.collAfter - params.collChange - params.collIncreaseFromRedist;
+  return collBefore > 0n ? collBefore : 0n;
+}
+
+/** Same derivation as `deriveCollBefore`, for debt:
+ *
+ *    debtBefore = debtAfter − debtChange − upfrontFee − debtFromRedist
+ *
+ *  Only valid when `debtAfter` is the trove's true post-operation debt —
+ *  never call this for a batch-managed-trove row (see
+ *  `maybeRecordTroveOperation`). */
+function deriveDebtBefore(params: {
+  debtAfter: bigint;
   debtChange: bigint;
   debtIncreaseFromUpfrontFee: bigint;
   debtIncreaseFromRedist: bigint;
-  collChange: bigint;
-  collIncreaseFromRedist: bigint;
-}): { debtBefore: bigint; collBefore: bigint } {
+}): bigint {
   const debtBefore =
     params.debtAfter -
     params.debtChange -
     params.debtIncreaseFromUpfrontFee -
     params.debtIncreaseFromRedist;
-  const collBefore =
-    params.collAfter - params.collChange - params.collIncreaseFromRedist;
-  return {
-    debtBefore: debtBefore > 0n ? debtBefore : 0n,
-    collBefore: collBefore > 0n ? collBefore : 0n,
-  };
+  return debtBefore > 0n ? debtBefore : 0n;
 }
 
 export type TroveOperationLogEvent = {
@@ -96,12 +104,30 @@ export type TroveOperationLogEvent = {
  *  they already have dedicated event entities; APPLY_PENDING_DEBT is
  *  protocol-forced and isn't a user action.
  *
- *  `debtAfter` / `collAfter` come from the trove entity (captured in the
- *  parent handler, already correct — see `captureTroveOperationSnapshotState`);
- *  `debtBefore` / `collBefore` are derived arithmetically from the ABI
- *  deltas via `deriveTroveOperationBeforeSnapshot`, never from a second
- *  entity read. The `owner` field is denormalized off the trove so the UI
- *  can filter by owner without a join. */
+ *  `debtAfter` / `collAfter` normally come from the trove entity (captured
+ *  in the parent handler, already correct — see
+ *  `captureTroveOperationSnapshotState`); `debtBefore` / `collBefore` are
+ *  derived arithmetically from the ABI deltas, never from a second entity
+ *  read.
+ *
+ *  Batch-managed exception: for ops 7-9 and any ordinary adjustment made
+ *  while the trove is batch-managed, on-chain `BatchedTroveUpdated` fires
+ *  instead of `TroveUpdated` — so by the time this handler runs, the `Trove`
+ *  entity still holds this op's PRIOR debt/coll (`replayBatchedTroveUpdate`
+ *  only writes the real post-op values once the later `BatchUpdated` event
+ *  is processed). `pendingBatchedTroveUpdate` is the same-tx
+ *  `PendingBatchedTroveUpdate` row `BatchedTroveUpdated` staged before this
+ *  handler ran (it fires first — same ordering guarantee as `TroveUpdated`);
+ *  its presence is the discriminator. It carries the real resulting
+ *  collateral directly (not share-based), so `collAfter` is sourced from it
+ *  and `collBefore` derives correctly. It carries only debt SHARES — the
+ *  per-trove debt figure needs the batch's total debt and total shares,
+ *  known only at `BatchUpdated` time — so `debtBefore`/`debtAfter` are
+ *  recorded null rather than a confidently wrong number. Production has zero
+ *  batches today; the seam is cheap either way.
+ *
+ *  The `owner` field is denormalized off the trove so the UI can filter by
+ *  owner without a join. */
 export function maybeRecordTroveOperation(args: {
   context: {
     TroveOperationEvent: { set: (entity: TroveOperationEvent) => void };
@@ -111,26 +137,45 @@ export function maybeRecordTroveOperation(args: {
   instanceId: string;
   troveId: string;
   snapshotState: { owner: string; debtAfter: bigint; collAfter: bigint };
+  pendingBatchedTroveUpdate: { coll: bigint } | undefined;
   blockNumber: bigint;
   blockTimestamp: bigint;
 }): void {
-  const { context, op, event, instanceId, troveId, snapshotState } = args;
+  const {
+    context,
+    op,
+    event,
+    instanceId,
+    troveId,
+    snapshotState,
+    pendingBatchedTroveUpdate,
+  } = args;
   if (
     op === OP.LIQUIDATE ||
     op === OP.REDEEM_COLLATERAL ||
     op === OP.APPLY_PENDING_DEBT
   )
     return;
-  const { owner, debtAfter, collAfter } = snapshotState;
-  const { debtBefore, collBefore } = deriveTroveOperationBeforeSnapshot({
-    debtAfter,
+  const { owner } = snapshotState;
+  const collAfter = pendingBatchedTroveUpdate?.coll ?? snapshotState.collAfter;
+  const collBefore = deriveCollBefore({
     collAfter,
-    debtChange: event.params._debtChangeFromOperation,
-    debtIncreaseFromUpfrontFee: event.params._debtIncreaseFromUpfrontFee,
-    debtIncreaseFromRedist: event.params._debtIncreaseFromRedist,
     collChange: event.params._collChangeFromOperation,
     collIncreaseFromRedist: event.params._collIncreaseFromRedist,
   });
+  const debtAfter =
+    pendingBatchedTroveUpdate === undefined
+      ? snapshotState.debtAfter
+      : undefined;
+  const debtBefore =
+    pendingBatchedTroveUpdate === undefined
+      ? deriveDebtBefore({
+          debtAfter: snapshotState.debtAfter,
+          debtChange: event.params._debtChangeFromOperation,
+          debtIncreaseFromUpfrontFee: event.params._debtIncreaseFromUpfrontFee,
+          debtIncreaseFromRedist: event.params._debtIncreaseFromRedist,
+        })
+      : undefined;
   context.TroveOperationEvent.set({
     id: eventId(event.chainId, event.block.number, event.logIndex),
     chainId: event.chainId,

--- a/indexer-envio/test/troveOperationSnapshot.test.ts
+++ b/indexer-envio/test/troveOperationSnapshot.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Issue #2080 regression — `TroveOperationEvent.debtBefore/debtAfter/
+ * collBefore/collAfter` must derive from the `TroveOperation` event's own
+ * delta fields, never from a second read of the `Trove` entity.
+ *
+ * Root cause (docs/PLAN-trove-history-page.md, "Snapshot before/after bug"):
+ * on-chain, every TroveManager function emits `TroveUpdated` BEFORE
+ * `TroveOperation` for the same op (lower logIndex, same tx). By the time
+ * Envio's ordered event processing reaches the `TroveOperation` handler, the
+ * `TroveUpdated` handler has already applied the post-operation debt/coll to
+ * the `Trove` entity — so a naive "read the entity before this handler's own
+ * mutations" capture (the old approach) actually reads post-op values as
+ * "before". These tests drive the real on-chain order (TroveUpdated then
+ * TroveOperation, same tx) through the real handlers via `processMockEvents`
+ * and assert the persisted `TroveOperationEvent` row, per repo convention
+ * ("MockDb-based multi-entity assertions are unreliable for heal logic —
+ * assert entity state after processEvent").
+ */
+import { strict as assert } from "assert";
+import type {
+  LiquityCollateral,
+  LiquityInstance,
+  Trove,
+  TroveOperationEvent,
+} from "envio";
+import { makeLiquityCollateral } from "../src/handlers/liquity/bootstrap";
+import {
+  LIQUITY_MARKETS,
+  makeCollateralId,
+} from "../src/handlers/liquity/config";
+import { OP } from "../src/handlers/liquity/operations";
+import { makeTroveId } from "../src/handlers/liquity/troves";
+import {
+  indexerTestHelpers,
+  processMockEvents,
+  type EntityReader,
+  type MockDbWith,
+  type WritableEntity,
+} from "./helpers/indexerTestHarness.js";
+
+type SnapshotMockDb = MockDbWith<{
+  LiquityCollateral: WritableEntity<LiquityCollateral>;
+  LiquityInstance: WritableEntity<LiquityInstance>;
+  Trove: WritableEntity<Trove>;
+  TroveOperationEvent: EntityReader<TroveOperationEvent>;
+}>;
+
+const TestHelpers = indexerTestHelpers<SnapshotMockDb>();
+const { MockDb, LiquityTroveManager } = TestHelpers;
+
+const market = LIQUITY_MARKETS[0]!;
+const collateralId = makeCollateralId(market);
+const MIN_DEBT = 100n * 10n ** 18n;
+
+/** Seed a fully-loaded LiquityCollateral row so trove status classification
+ * resolves deterministically (see liquityTroveLifecycle.test.ts for the same
+ * pattern). Not asserted on here — only needed so processing doesn't fall
+ * back to the systemParamsLoaded===false path. */
+function seedLoadedCollateral(mockDb: SnapshotMockDb): void {
+  mockDb.entities.LiquityCollateral.set({
+    ...makeLiquityCollateral(market, 0n, 0n),
+    systemParamsLoaded: true,
+    minDebt: MIN_DEBT,
+  });
+}
+
+function troveOperationEvent(args: {
+  troveId: bigint;
+  operation: number;
+  debtChangeFromOperation?: bigint;
+  debtIncreaseFromUpfrontFee?: bigint;
+  debtIncreaseFromRedist?: bigint;
+  collChangeFromOperation?: bigint;
+  collIncreaseFromRedist?: bigint;
+  annualInterestRate?: bigint;
+  blockNumber: number;
+  blockTimestamp: number;
+  logIndex: number;
+  txHash: string;
+}) {
+  return LiquityTroveManager.TroveOperation.createMockEvent({
+    _troveId: args.troveId,
+    _operation: args.operation,
+    _annualInterestRate: args.annualInterestRate ?? 0n,
+    _debtIncreaseFromRedist: args.debtIncreaseFromRedist ?? 0n,
+    _debtIncreaseFromUpfrontFee: args.debtIncreaseFromUpfrontFee ?? 0n,
+    _debtChangeFromOperation: args.debtChangeFromOperation ?? 0n,
+    _collIncreaseFromRedist: args.collIncreaseFromRedist ?? 0n,
+    _collChangeFromOperation: args.collChangeFromOperation ?? 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: args.blockNumber, timestamp: args.blockTimestamp },
+      transaction: { hash: args.txHash },
+    },
+  });
+}
+
+function troveUpdatedEvent(args: {
+  troveId: bigint;
+  debt: bigint;
+  coll: bigint;
+  stake: bigint;
+  blockNumber: number;
+  blockTimestamp: number;
+  logIndex: number;
+  txHash: string;
+}) {
+  return LiquityTroveManager.TroveUpdated.createMockEvent({
+    _troveId: args.troveId,
+    _debt: args.debt,
+    _coll: args.coll,
+    _stake: args.stake,
+    _annualInterestRate: 0n,
+    _snapshotOfTotalCollRedist: 0n,
+    _snapshotOfTotalDebtRedist: 0n,
+    mockEventData: {
+      chainId: market.chainId,
+      srcAddress: market.troveManager,
+      logIndex: args.logIndex,
+      block: { number: args.blockNumber, timestamp: args.blockTimestamp },
+      transaction: { hash: args.txHash },
+    },
+  });
+}
+
+describe("TroveOperationEvent before/after snapshot (issue #2080)", () => {
+  it("open: debtBefore/collBefore read 0, not the post-open Trove values TroveUpdated already wrote", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveId = 1n;
+    const troveEntityId = makeTroveId(collateralId, "0x1");
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        // Real on-chain order: TroveUpdated (lower logIndex) before
+        // TroveOperation, same tx.
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_000n * 10n ** 18n,
+          coll: 500n * 10n ** 18n,
+          stake: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 1,
+          txHash: "0xopen",
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE,
+          debtChangeFromOperation: 1_000n * 10n ** 18n,
+          collChangeFromOperation: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 2,
+          txHash: "0xopen",
+        }),
+      ],
+    });
+
+    const trove = mockDb.entities.Trove.get(troveEntityId);
+    assert.equal(
+      trove?.debt,
+      1_000n * 10n ** 18n,
+      "TroveUpdated already wrote the opened debt by the time TroveOperation runs",
+    );
+
+    const row = mockDb.entities.TroveOperationEvent.get(
+      `${market.chainId}_100_2`,
+    );
+    assert.ok(row, "TroveOperationEvent row is written for OPEN_TROVE");
+    assert.equal(
+      row?.debtBefore,
+      0n,
+      "regression: open row's debtBefore is 0, not the post-open debt",
+    );
+    assert.equal(
+      row?.collBefore,
+      0n,
+      "regression: open row's collBefore is 0, not the post-open coll",
+    );
+    assert.equal(row?.debtAfter, 1_000n * 10n ** 18n);
+    assert.equal(row?.collAfter, 500n * 10n ** 18n);
+  });
+
+  it("adjust: debtBefore/collBefore read the pre-adjust state, debtAfter/collAfter read the new state", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveId = 2n;
+    const troveEntityId = makeTroveId(collateralId, "0x2");
+
+    // Open at debt=1000, coll=500.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_000n * 10n ** 18n,
+          coll: 500n * 10n ** 18n,
+          stake: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 1,
+          txHash: "0xopen",
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE,
+          debtChangeFromOperation: 1_000n * 10n ** 18n,
+          collChangeFromOperation: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 2,
+          txHash: "0xopen",
+        }),
+      ],
+    });
+
+    // Adjust: borrow more — debt 1000 -> 1500, coll 500 -> 600.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_500n * 10n ** 18n,
+          coll: 600n * 10n ** 18n,
+          stake: 600n * 10n ** 18n,
+          blockNumber: 101,
+          blockTimestamp: 1_100,
+          logIndex: 1,
+          txHash: "0xadjust",
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.ADJUST_TROVE,
+          debtChangeFromOperation: 500n * 10n ** 18n,
+          collChangeFromOperation: 100n * 10n ** 18n,
+          blockNumber: 101,
+          blockTimestamp: 1_100,
+          logIndex: 2,
+          txHash: "0xadjust",
+        }),
+      ],
+    });
+
+    const trove = mockDb.entities.Trove.get(troveEntityId);
+    assert.equal(trove?.debt, 1_500n * 10n ** 18n);
+
+    const row = mockDb.entities.TroveOperationEvent.get(
+      `${market.chainId}_101_2`,
+    );
+    assert.ok(row, "TroveOperationEvent row is written for ADJUST_TROVE");
+    assert.equal(
+      row?.debtBefore,
+      1_000n * 10n ** 18n,
+      "adjust row's debtBefore is the pre-adjust debt",
+    );
+    assert.equal(row?.debtAfter, 1_500n * 10n ** 18n);
+    assert.equal(
+      row?.collBefore,
+      500n * 10n ** 18n,
+      "adjust row's collBefore is the pre-adjust coll",
+    );
+    assert.equal(row?.collAfter, 600n * 10n ** 18n);
+  });
+
+  it("close: debtBefore/collBefore read the pre-close state, debtAfter/collAfter land at 0", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveId = 3n;
+    const troveEntityId = makeTroveId(collateralId, "0x3");
+
+    // Open at debt=1000, coll=500.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveUpdatedEvent({
+          troveId,
+          debt: 1_000n * 10n ** 18n,
+          coll: 500n * 10n ** 18n,
+          stake: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 1,
+          txHash: "0xopen",
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE,
+          debtChangeFromOperation: 1_000n * 10n ** 18n,
+          collChangeFromOperation: 500n * 10n ** 18n,
+          blockNumber: 100,
+          blockTimestamp: 1_000,
+          logIndex: 2,
+          txHash: "0xopen",
+        }),
+      ],
+    });
+
+    // Close: full repayment — debt 1000 -> 0, coll 500 -> 0.
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        troveUpdatedEvent({
+          troveId,
+          debt: 0n,
+          coll: 0n,
+          stake: 0n,
+          blockNumber: 102,
+          blockTimestamp: 1_200,
+          logIndex: 1,
+          txHash: "0xclose",
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.CLOSE_TROVE,
+          debtChangeFromOperation: -1_000n * 10n ** 18n,
+          collChangeFromOperation: -500n * 10n ** 18n,
+          blockNumber: 102,
+          blockTimestamp: 1_200,
+          logIndex: 2,
+          txHash: "0xclose",
+        }),
+      ],
+    });
+
+    const trove = mockDb.entities.Trove.get(troveEntityId);
+    assert.equal(trove?.status, "closed");
+    assert.equal(trove?.debt, 0n);
+
+    const row = mockDb.entities.TroveOperationEvent.get(
+      `${market.chainId}_102_2`,
+    );
+    assert.ok(row, "TroveOperationEvent row is written for CLOSE_TROVE");
+    assert.equal(
+      row?.debtBefore,
+      1_000n * 10n ** 18n,
+      "close row's debtBefore is the pre-close debt",
+    );
+    assert.equal(row?.debtAfter, 0n);
+    assert.equal(
+      row?.collBefore,
+      500n * 10n ** 18n,
+      "close row's collBefore is the pre-close coll",
+    );
+    assert.equal(row?.collAfter, 0n);
+  });
+});

--- a/indexer-envio/test/troveOperationSnapshot.test.ts
+++ b/indexer-envio/test/troveOperationSnapshot.test.ts
@@ -347,4 +347,76 @@ describe("TroveOperationEvent before/after snapshot (issue #2080)", () => {
     );
     assert.equal(row?.collAfter, 0n);
   });
+
+  it("open-and-join-batch (issue found in review of #2095): debtBefore/debtAfter are null — BatchedTroveUpdated stages only debt SHARES, not the real per-trove debt — and collAfter reads the staged coll, not the not-yet-mutated Trove entity", async () => {
+    let mockDb = MockDb.createMockDb();
+    seedLoadedCollateral(mockDb);
+    const troveId = 9n;
+    const txHash = "0xopenjoinbatch";
+
+    mockDb = await processMockEvents({
+      mockDb,
+      events: [
+        // Real on-chain order for a batch-managed op: `BatchedTroveUpdated`
+        // (never `TroveUpdated`) fires before `TroveOperation`, same tx.
+        // It stages the real resulting coll (500) but only debt SHARES
+        // (1_000n) — the per-trove debt figure needs the batch's total debt
+        // and total shares, only known once `BatchUpdated` replays.
+        LiquityTroveManager.BatchedTroveUpdated.createMockEvent({
+          _troveId: troveId,
+          _interestBatchManager: "0x000000000000000000000000000000000000b0b0",
+          _batchDebtShares: 1_000n,
+          _coll: 500n * 10n ** 18n,
+          _stake: 500n * 10n ** 18n,
+          _snapshotOfTotalCollRedist: 0n,
+          _snapshotOfTotalDebtRedist: 0n,
+          mockEventData: {
+            chainId: market.chainId,
+            srcAddress: market.troveManager,
+            logIndex: 1,
+            block: { number: 200, timestamp: 2_000 },
+            transaction: { hash: txHash },
+          },
+        }),
+        troveOperationEvent({
+          troveId,
+          operation: OP.OPEN_TROVE_AND_JOIN_BATCH,
+          debtChangeFromOperation: 1_000n * 10n ** 18n,
+          collChangeFromOperation: 500n * 10n ** 18n,
+          blockNumber: 200,
+          blockTimestamp: 2_000,
+          logIndex: 2,
+          txHash,
+        }),
+      ],
+    });
+
+    const row = mockDb.entities.TroveOperationEvent.get(
+      `${market.chainId}_200_2`,
+    );
+    assert.ok(
+      row,
+      "TroveOperationEvent row is written for OPEN_TROVE_AND_JOIN_BATCH",
+    );
+    assert.equal(
+      row?.debtBefore,
+      undefined,
+      "regression: debtBefore is null, not a number derived from the stale pre-tx Trove.debt",
+    );
+    assert.equal(
+      row?.debtAfter,
+      undefined,
+      "regression: debtAfter is null — BatchedTroveUpdated never wrote the real per-trove debt to the Trove entity",
+    );
+    assert.equal(
+      row?.collAfter,
+      500n * 10n ** 18n,
+      "collAfter reads BatchedTroveUpdated's staged (absolute) coll, not the not-yet-mutated Trove entity",
+    );
+    assert.equal(
+      row?.collBefore,
+      0n,
+      "collBefore derives arithmetically from the corrected collAfter",
+    );
+  });
 });

--- a/scripts/agent-autoreview-core.mjs
+++ b/scripts/agent-autoreview-core.mjs
@@ -2674,6 +2674,7 @@ const INDEXER_HANDLER_INVARIANT_FAMILIES =
         "indexer-envio/test/startBlockInvariant.test.ts",
         "indexer-envio/test/tradingLimitConfigChange.test.ts",
         "indexer-envio/test/tradingLimits.test.ts",
+        "indexer-envio/test/troveOperationSnapshot.test.ts",
         "indexer-envio/test/upsertPoolIdempotency.test.ts",
         "indexer-envio/test/upsertPoolStages.test.ts",
         "indexer-envio/test/usd.test.ts",

--- a/scripts/agent-autoreview-core.test.mjs
+++ b/scripts/agent-autoreview-core.test.mjs
@@ -66,7 +66,7 @@ const currentIndexerSources = walkModuleFiles(
 
 for (const [label, paths, routed, excluded] of [
   ["source", currentIndexerSources, 126, 5],
-  ["test", currentIndexerTests, 84, 5],
+  ["test", currentIndexerTests, 85, 5],
 ]) {
   const decisions = getIndexerHandlerInvariantChecklistDecisions(paths);
   assert.equal(decisions.length, paths.length, `${label} decision count`);
@@ -101,7 +101,7 @@ assert.equal(
   131,
   "current source module inventory",
 );
-assert.equal(currentIndexerTests.length, 89, "current test module inventory");
+assert.equal(currentIndexerTests.length, 90, "current test module inventory");
 
 for (const [candidatePath, route, owner] of [
   ["indexer-envio/src/swap.ts", true, "source-runtime"],

--- a/scripts/gate/routing-table/indexer-invariant-parity.test.mjs
+++ b/scripts/gate/routing-table/indexer-invariant-parity.test.mjs
@@ -145,7 +145,7 @@ assert.ok(
 
 test("the derived exact arms keep the current route counts", () => {
   assert.equal(indexerInvariantExcludedArm.patterns.length, 12);
-  assert.equal(indexerInvariantRoutedArm.patterns.length, 253);
+  assert.equal(indexerInvariantRoutedArm.patterns.length, 254);
 });
 const matchesAny = (patterns, candidatePath) =>
   patterns.some((pattern) => casePatternToRegExp(pattern).test(candidatePath));
@@ -187,7 +187,7 @@ test("the table and core agree on every current indexer module path", () => {
     ...walkIndexerModuleFiles(`${REPO}/indexer-envio/src`),
     ...walkIndexerModuleFiles(`${REPO}/indexer-envio/test`),
   ].sort();
-  assert.equal(paths.length, 220, "current module inventory changed");
+  assert.equal(paths.length, 221, "current module inventory changed");
   const decisions = getIndexerHandlerInvariantChecklistDecisions(paths);
   for (const decision of decisions) {
     assert.equal(

--- a/ui-dashboard/src/lib/__generated__/graphql.ts
+++ b/ui-dashboard/src/lib/__generated__/graphql.ts
@@ -6637,8 +6637,8 @@ export type CdpTroveOpSnapshotsQuery = {
   readonly TroveOperationEvent: ReadonlyArray<{
     readonly id: string;
     readonly owner: string;
-    readonly debtBefore: string;
-    readonly debtAfter: string;
+    readonly debtBefore: string | null;
+    readonly debtAfter: string | null;
     readonly collBefore: string;
     readonly collAfter: string;
   }>;
@@ -6712,8 +6712,8 @@ export type AllCdpTroveOpSnapshotsQuery = {
   readonly TroveOperationEvent: ReadonlyArray<{
     readonly id: string;
     readonly owner: string;
-    readonly debtBefore: string;
-    readonly debtAfter: string;
+    readonly debtBefore: string | null;
+    readonly debtAfter: string | null;
     readonly collBefore: string;
     readonly collAfter: string;
   }>;


### PR DESCRIPTION
## The Problem

- `TroveOperationEvent.debtBefore/debtAfter/collBefore/collAfter` render shifted values in the live market transaction tables: the indexer processes `TroveUpdated` before `TroveOperation` for the same on-chain operation, so the "before" capture reads entity state the update already overwrote.
- Every live row's before-values equal its after-values, so per-operation deltas read as zero where they matter most.
- The trove history page (epic #2089) leans on this feed for its interim per-trove view, so the bug blocks that rollout too.

## The Solution

Derive the before-snapshots arithmetically from the `TroveOperation` event's own delta fields instead of reading the mutated `Trove` entity. A trove-open row now records `debtBefore = 0` and `collBefore = 0`, and every later row's before-values chain from the event data. Historical repair needs no migration: every indexer deploy re-syncs from `start_block`, so the deploy itself backfills.

Material limit: rows already served by hosted Hasura stay wrong until the next indexer deploy is promoted.

## Details

- `indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts`: arithmetic derivation replaces the entity read.
- New regression test file registered in the gate's invariant table with the module counts bumped (both required by the routing inventory).

## Validation

Ran and passing in the implementation environment:

- `pnpm --filter @mento-protocol/indexer-envio test` — full suite green including the new regression tests (open row before = 0; open/adjust/close chains).
- `pnpm indexer:codegen` — clean.
- 11 of 12 gate-mapped commands green.

Disclosure: this branch was pushed with the pre-push hook bypassed (`--no-verify`), explicitly approved by the repository owner, because the 12th mapped command — `agent:autoreview:test` — cannot run in the cloud container that produced this branch (root-only chmod assertions, a hardcoded core-test count, and 90-minute runtime; the defect is filed as #2094 with full reproduction detail). This PR's CI runs the same suites on standard runners and is the arbiter.

Closes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRewW6bNnz6aEihuLirGcd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Trove operation snapshots for open, adjust, close, liquidation, redemption, and batch operations.
  - Corrected snapshots when multiple Trove updates occur within the same transaction.
  - Batched operations now use staged collateral values, while unavailable debt snapshots remain unset.
  - Improved handling of calculated collateral and debt values.

- **Tests**
  - Added regression coverage for standard and batched Trove operations.
  - Expanded automated test routing and validation for the new scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->