### PR TITLE
fix(docs): restore the navigation-eval headroom reserve

### DIFF
--- a/docs/pr-checklists/terraform-cloudrun.md
+++ b/docs/pr-checklists/terraform-cloudrun.md
@@ -153,16 +153,19 @@ New GCP project, Cloud Function, or versioned-bucket stacks ship WITH retention 
 
 ## 9. Lessons already paid for
 
-- PR #199 — `/healthz` returned a Google-branded 404 because Cloud Run v2 reserves the path; moved bridge health to `/health`
-- PR #197 — bootstrap IAM only gated API enablement, not the project-level grants the impersonated SA needed
-- PR #198 — Cloud Run rejected `256Mi` because `cpu_idle = false` requires `≥512Mi`
-- PR #200 — Workload Identity Federation deploy failed at `getAccessToken` because deployer SA lacked `roles/iam.serviceAccountTokenCreator` on the runtime SA
-- PR #201 — removing `count` without `moved` blocks would have planned destroy
-  on a `deletion_protection = true` service; the bootstrap image/probe contract
-  and revision suffix rules needed explicit verification
-- PR #835 — governance-watchdog's auto-created `gcf-artifacts` repo had accumulated 64 build images (~1.9 GB) with no retention; the first lifecycle attempt used `num_newer_versions`, which never fires for hash-named source zips — replaced with age-based expiry in review
-- PR #995 — metrics-bridge Cloud Build failed because root
-  `pnpm.patchedDependencies` referenced `patches/@lhci__utils@0.15.1.patch`,
-  but the Dockerfile's reduced context did not copy `patches/` before
-  `pnpm install`; the deploy workflow also needed `patches/**` in its path
-  filter so patch-only dependency changes rebuild the image.
+Each incident is why the section it names exists; that section, not this list,
+states the current requirement.
+
+- PR #199 — `/healthz` 404 on Cloud Run v2; bridge health moved to `/health` (§2)
+- PR #197 — bootstrap IAM gated API enablement but not the project-level
+  grants the impersonated SA needed (§5)
+- PR #198 — `256Mi` rejected under `cpu_idle = false` (§2)
+- PR #200 — Workload Identity Federation failed at `getAccessToken`, missing
+  `roles/iam.serviceAccountTokenCreator` (§5)
+- PR #201 — `count` removed without `moved` blocks, against a
+  `deletion_protection = true` service (§1)
+- PR #835 — `gcf-artifacts` retention, and the `num_newer_versions` rule that
+  never fires for hash-named zips (§7)
+- PR #995 — metrics-bridge Cloud Build missed `patches/`
+  (`patches/@lhci__utils@0.15.1.patch`) in the Docker context and the deploy
+  workflow path filter (§4)

--- a/indexer-envio/README.md
+++ b/indexer-envio/README.md
@@ -295,40 +295,22 @@ Phase 7 checks for the affected production API, dashboard page, and browser
 console. Promotion alone does not complete the rollout.
 
 Replay-integrity v3 replaces traffic-scaled exact `medianTimestamp` reads with
-a persisted, event-sourced `OracleFeedState`. On the first tracked
-`OracleReported` or `OracleReportRemoved`, processing performs one
-exact-boundary `getTimestamps` bootstrap and obtains raw/effective expiry
-configuration from that same boundary. It validates the
-reporter/timestamp arrays, computes SortedOracles' upper median, then applies
-`OracleReported` upserts and `OracleReportRemoved` deletions in block/log order.
-`MedianUpdated` consumes that state but does not renew freshness itself. When
-no currently referencing pool row predates the initialization block, exact
-block-close state absorbs that block's logs so a report before deployment or
-feed self-heal cannot be stranded outside a parent snapshot; later blocks use
-log order. `OracleExpiryState` stores raw global/token and effective expiry at
-the same bootstrap boundary, then applies both expiry events by block/log
-cursor. A zero token value derives the persisted global fallback without a
-block-close RPC inside the event, and never-tracked feeds create no state.
-Missing or malformed bootstrap data fails before entity writes. This is a
+a persisted, event-sourced `OracleFeedState` plus `OracleExpiryState`. The
+bootstrap boundary, ordered apply rules, zero-token expiry fallback, and
+fail-before-write conditions are owned by
+[ADR 0046](../docs/adr/0046-event-sourced-oracle-freshness.md). This is a
 full-replay boundary: v1 and v2 candidates are incompatible with v3 even when
 their final pool rows happen to look healthy.
 
 The inherited replay-integrity v2 requirement still applies: effect eligibility
-must be derived independently in both Envio passes. Never carry preload
-decisions in any module-scoped mutable marker because hosted preload and
-processing workers, and restarted processes, do not share that memory. The
-code-health invariant follows every `onEvent`, `onBlock`, and
-`contractRegister` callback plus imported helpers. It rejects direct and
-symbol-propagated assignment, update, deletion, object/record write, and native
-collection/array mutator forms for top-level bindings, including primitive,
-object, array, native-collection, and factory-result state. Returned module-
-state aliases and custom receiver methods that mutate through `this` remain a
-manual-review requirement tracked in
-[#1462](https://github.com/mento-protocol/monitoring-monorepo/issues/1462).
-Narrow processing-only exceptions require an adjacent `phase-state-exempt`
-reason and tracking issue at each mutation. Rebuildable optimization caches
-whose loss can only repeat authoritative/idempotent work use an adjacent
-`phase-state-cache` reason at each write.
+must be derived independently in both Envio passes, because hosted preload and
+processing workers, and restarted processes, do not share memory. The blocking
+code-health invariant over handler callbacks and imported helpers, its
+`phase-state-exempt` and `phase-state-cache` call-site escape hatches, and the
+manual-review gap tracked in
+[#1462](https://github.com/mento-protocol/monitoring-monorepo/issues/1462) are
+owned by
+[`indexer-handler-invariants.md`](../docs/pr-checklists/indexer-handler-invariants.md#rpc-cache-and-freshness).
 
 The `mento` project on Envio Cloud watches this branch. Envio registers
 deployments under the short commit hash, and the registration can lag the Git


### PR DESCRIPTION
## The Problem

- The navigation-eval reserve is what any new document spends: `pnpm docs:index
  --write` adds an index line to `docs/README.md` for every new document, and
  `docs/README.md` is a bootstrap source counted in every route, so each new
  document costs ~144 bytes of headroom.
- #2072 pushed the cheapest accepted route union past that reserve and turned
  the required `ci` aggregate red on `main` through two jobs that both run
  `Documentation navigation evaluation tests`. #2100 has since trimmed
  `docs/notes/quick-commands.md` and restored the contract, so `main` is green
  again.
- It is green by 15 bytes. `main` at `1762ae1f` leaves 32,783 bytes of headroom
  against the 32,768-byte reserve, so the next single document sinks it again —
  including the pending backlog-sweep PR, which adds ~144 bytes of index lines.

## The Solution

Two routed sources restated rules that another document already owns. This PR
removes the restatement and points at the owner instead, reclaiming 1,782 real
bytes on top of #2100. Headroom goes from 32,783 to **34,565** bytes — a
**1,797-byte surplus** over the reserve, or roughly twelve more documents
instead of zero.

No budget moved. `max_total_unique_source_bytes` (262,000) and
`min_total_unique_source_headroom_bytes` (32,768) are untouched, no document was
removed from the eval, and the reported `fixture_digest` is unchanged at
`b4d510c4`.

This is buffer, not a hotfix: #2100 already cleared the failure. The limit worth
naming is that a byte reserve only holds until documentation grows again — this
buys about twelve documents, and the mechanism that spends it is unchanged.

## Details

Per-document, with the byte count and where each fact survives:

- `docs/pr-checklists/terraform-cloudrun.md`, −430 bytes. Section 9 "Lessons
  already paid for" restated rules that sections 1–7 already state, and partly
  duplicated their provenance too — section 5 already names PRs #197 and #200,
  and section 7 already carries #835 with its 64 images / ~1.9 GB. Every PR
  number, figure, and outcome is kept, each now naming the section that owns the
  rule.
- `indexer-envio/README.md`, −1,352 bytes. The replay-integrity v3 paragraph
  restated the bootstrap boundary, ordered apply rules, zero-token expiry
  fallback, and fail-before-write conditions that ADR 0046's Decision section
  owns nearly sentence-for-sentence. The v2 paragraph restated the
  phase-bridging rules — including the same `#1462` link and the same
  `phase-state-exempt` and `phase-state-cache` directive names — that
  `docs/pr-checklists/indexer-handler-invariants.md` owns and that
  `indexer-envio/AGENTS.md` already names it as owning. The operative claims
  that live only in the README are kept: that v1 and v2 candidates are
  incompatible with v3 even when their final pool rows look healthy, and that
  the passes do not share memory.

Both documents keep every command, flag, path, number, and cross-reference. The
four sentences pinned in `scripts/repo-health/guardrail-prose.json` live in
`AGENTS.md`, `CLAUDE.md`, and `docs/notes/pr-operating-card.md`, none of which
this PR touches.

`origin/main` is merged in at `1762ae1f`; #2100 touched only
`docs/notes/quick-commands.md`, so there was no overlap with either file here.

Candidates found and deliberately not taken, to keep the diff small once the
reserve was comfortably restored: ~712 bytes in
`.agents/skills/deploy-indexer/SKILL.md`, ~591 in
`docs/pr-checklists/ci-workflow-gates.md`, ~680 in
`docs/pr-checklists/stateful-data-ui.md`, ~410 in
`docs/notes/worktree-and-web-setup.md`.

## Validation

Run in a clean clone at the merged branch head:

- `pnpm docs:navigation-eval -- --check-fixtures --json` → `"valid": true`,
  `total_unique_route_bytes` 227,435, `total_unique_headroom_bytes` 34,565,
  `total_unique_reserve_surplus_bytes` 1,797, `fixture_digest` `b4d510c4…`
  unchanged from `main`.
- The same measurement against `origin/main` `1762ae1f`, taken with the eval's
  own historical inventory builder: 229,217 bytes, 32,783 headroom, 15 surplus.
  The 1,782-byte difference is exactly this PR's two trims.
- `pnpm docs:navigation-eval:test` — 34 of 34 pass.
- `pnpm docs:index --check`, `pnpm agent:context-check` (159 managed files),
  `node scripts/repo-health/check-guardrail-prose.mjs` (12 pinned sentences
  across 3 files), `pnpm agent:context-budget --strict` — all pass.
- `bash scripts/agent-quality-gate.sh --run` on the merged head — all mapped
  checks pass, including the routed indexer lint/typecheck/test:coverage/knip
  and `pnpm tf:test`.
- `pnpm agent:autoreview` — clean, no accepted or actionable findings.

What this evidence does not establish: it proves the fixture contract and the
byte budgets hold, and that the trimmed text is restated in the documents named
above. It does not prove a model still navigates to these documents as well —
that is the monthly `--validate` run against a scored result, which this PR does
not execute. The twelve-document figure is 1,797 divided by the ~144 bytes two
index lines cost; a document with a longer path or an added lane costs more.

## Deferrals

- #2104 — `--validate` applies the forward-looking reserve to historical
  inventories, so a branch that restores the reserve fails its own
  `docs:navigation-eval:test` while `main` is still underwater. That bit this PR
  before #2100 landed and no longer does, since the merge-base is green. The
  defect is real and unfixed, so it stays filed for grooming rather than changed
  inside a documentation PR.

Closes #2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcpGL6S9z7AW3QaoYSophE
