### PR TITLE
Harden review evaluation evidence checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,7 +1139,7 @@ jobs:
       - name: Review skill fixture contract
         run: pnpm review:eval -- --check-fixtures --offline
       - name: Review skill committed ledger
-        run: pnpm review:eval -- --check-ledger --require-base
+        run: pnpm review:eval -- --check-ledger --require-base --revalidate-appended
       - name: Agent context budget tests
         run: pnpm agent:context-budget:test
       - name: Enforce agent context budgets

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,17 +105,15 @@ jobs:
     # injected diff could steer the reviewer into posting misleading
     # commentary, which is worse than no review. Codex review and the human
     # merge gate still cover autofix PRs.
-    # Also skip review-skill evaluation PRs (head eval/review-skill-*): their
-    # diff is the scorecard of this same reviewer, so auto-reviewing one lets
-    # the reviewer under test comment on its own measurement. That is circular
-    # and spends a review on a file of committed numbers.
+    # A later step skips review-skill evaluation PRs only after it verifies that
+    # every changed path is generated score evidence. The branch name alone is
+    # author-controlled and cannot grant a review exemption.
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft != true &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]' &&
-      !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/') &&
-      !startsWith(github.event.pull_request.head.ref, 'eval/review-skill-')
+      !startsWith(github.event.pull_request.head.ref, 'sentry-autofix/')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
@@ -128,8 +126,25 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+      - name: Verify review-eval scorecard-only scope
+        id: review-scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          skip=false
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA" || true)"
+          if [[ "$HEAD_REF" == eval/review-skill-* && -n "$merge_base" ]] &&
+            git diff --quiet "$merge_base" "$HEAD_SHA" -- . \
+              ':(exclude)docs/evals/review-skill-ledger.jsonl' \
+              ':(exclude)docs/evals/review-skill-runs/**'; then
+            skip=true
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
       - uses: anthropics/claude-code-action@459ad358ae43fea66bfefd0a1f8d840b4b9791fb # v1.0.194
+        if: steps.review-scope.outputs.skip != 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true

--- a/docs/evals/review-skill-result.schema.json
+++ b/docs/evals/review-skill-result.schema.json
@@ -84,6 +84,11 @@
           "required": ["baseline_executed_at", "mcnemar"],
           "properties": {
             "baseline_executed_at": { "$ref": "#/$defs/instant" },
+            "selection": {
+              "type": "string",
+              "enum": ["automatic", "explicit"],
+              "description": "How the scorer selected this baseline. explicit means --against named it; automatic means append-order resolution selected it."
+            },
             "baseline_comparability_key": { "$ref": "#/$defs/digest" },
             "mcnemar": {
               "description": "null when the baseline carries a different comparability_key: that pair is never ranked.",

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -360,8 +360,8 @@ against the anchor with the version drift named beside it.
 
 `scorer_digest` covers every file that can move a recorded number or a recorded
 verdict — the CLI scoring orchestration, the scorer, the per-condition fold,
-the recompute, and the verdict rules — not the extraction alone. It also covers
-the two fixture helpers:
+the recompute, timestamp validation, and the verdict rules — not the extraction
+alone. It also covers the two fixture helpers:
 `review-eval-fixtures.mjs` picks the matrix, the truth file and the recall
 denominator, and `build-fixture.sh` materializes the checkout the contestant
 reviews and carries the checks that verify it, so an edit to either moves what
@@ -392,21 +392,21 @@ would recompute its verdict against a truth index and thresholds the run never
 saw. The default selection is the newest row of this contract, and `--row` on an
 older one is refused; pass `--contract` with the archived contract to read it.
 
-| drift vector      | control                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------- |
-| fixture content   | eval tags plus a tree-hash check in `build-fixture.sh`, whose bytes are in `scorerDigest()`          |
-| truth content     | committed verbatim, per-file `sha256`, never re-derived from the API                                 |
-| scorable set      | explicit frozen id list in the contract                                                              |
-| run prompts       | frozen files with `sha256` in the contract                                                           |
-| scoring pipeline  | `scorerDigest()` over the scorer, run, result-shape, report and fixture files and every judge prompt |
-| judge model       | model id and CLI version in the row, plus 40 calibration pairs every run                             |
-| calibration set   | its `sha256` is bound into `comparability_key`                                                       |
-| reviewed model    | isolated by the `control` condition; model id and CLI version recorded                               |
-| skill text        | `skill_digest` over every file in the skill directory, symlinks refused — this is the treatment      |
-| finder command    | `argv` pinned in the contract; `finder_argv_digest` records what a cell spawned                      |
-| orchestrator      | `orchestrator_digest` over `run-eval.sh`: in the key and in every cell fingerprint                   |
-| machine and shell | host, CLI versions, `--setting-sources ""`, clean worktree of `origin/main`                          |
-| CLI upgrade       | versions in every cell fingerprint; a pair across one is labelled in the verdict, not in the key     |
+| drift vector      | control                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| fixture content   | eval tags plus a tree-hash check in `build-fixture.sh`, whose bytes are in `scorerDigest()`                  |
+| truth content     | committed verbatim, per-file `sha256`, never re-derived from the API                                         |
+| scorable set      | explicit frozen id list in the contract                                                                      |
+| run prompts       | frozen files with `sha256` in the contract                                                                   |
+| scoring pipeline  | `scorerDigest()` over the scorer, run, result-shape, ledger, report and fixture files and every judge prompt |
+| judge model       | model id and CLI version in the row, plus 40 calibration pairs every run                                     |
+| calibration set   | its `sha256` is bound into `comparability_key`                                                               |
+| reviewed model    | isolated by the `control` condition; model id and CLI version recorded                                       |
+| skill text        | `skill_digest` over every file in the skill directory, symlinks refused — this is the treatment              |
+| finder command    | `argv` pinned in the contract; `finder_argv_digest` records what a cell spawned                              |
+| orchestrator      | `orchestrator_digest` over `run-eval.sh`: in the key and in every cell fingerprint                           |
+| machine and shell | host, CLI versions, `--setting-sources ""`, clean worktree of `origin/main`                                  |
+| CLI upgrade       | versions in every cell fingerprint; a pair across one is labelled in the verdict, not in the key             |
 
 **Judge calibration runs before every scoring pass.** Forty frozen
 `(claim, defect, verdict)` pairs replay through the current judge. Agreement

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -382,10 +382,11 @@ scoring. `--check-fixtures` covers the inputs once, before the matrix starts;
 under `--skill-ref` the spec worktree is the live checkout for the two hours in
 between, and the contract digest alone would not notice.
 
-`--report` refuses to compute McNemar across rows with different
-`comparability_key` unless the row is a bridge run, and `--score --against`
-stores `vs_baseline.mcnemar: null` for such a pair rather than numbers nobody
-may read. Rows with different keys are different series and plot separately.
+`--score --against` requires the baseline to carry the plan's
+`comparability_key`. It refuses a cross-key pair before model work. `--report`
+also refuses to compute McNemar across different keys unless the row is a
+hand-assembled bridge run. Rows with different keys are different series and
+plot separately.
 
 `--report` reads rows of the current `contract_digest` only. The ledger keeps
 the rows a retired contract scored, and reporting one under today's contract
@@ -445,9 +446,9 @@ re-audits the calibration set before the new judge's labels are trusted.
 
 No CLI mode plans a bridge run: `--kind` accepts `full` and `canary`, and
 `buildPlan` refuses anything else. What the harness contributes is the row's
-standing — `bridge` is a valid ledger kind, and both `--report` and
-`--score --against` pair a bridge row across two comparability keys where every
-other row is refused.
+standing — `bridge` is a valid ledger kind, `--validate --against` re-derives
+its cross-key pairing, and `--report` renders it. Ordinary scoring refuses a
+cross-key baseline.
 
 ## Establish the baseline
 

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -247,12 +247,13 @@ second ledger delta left for a PR of its own.
 
 `--against` takes a row file path or an `executed_at` prefix and reaches the
 plan, `--score`, `--validate` and `--report` alike. The plan and row therefore
-record `selection: "explicit"`, and all steps read the same baseline. Without
-it the plan and row record automatic selection, and the candidate resolves the
+record `baseline_selection: "explicit"` and
+`vs_baseline.selection: "explicit"`. The plan also records the resolved row's
+identity and digest. Scoring rejects a different row. Without `--against`, the
+plan and row record automatic selection, and the candidate resolves the
 ledger's stored anchor. A candidate also stamps `skill_ref` and `dirty: true`
 into the ledger row. Never compare a candidate against a ledger row from three
-months ago: that comparison silently includes an unknown amount of model
-drift.
+months ago: that comparison silently includes an unknown amount of model drift.
 
 The run ends by printing the branch, commit and `gh pr create` commands for the
 ledger PR. Pass `--pr` to execute them instead. There is no auto-merge; a human

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -160,12 +160,13 @@ launchd job runs the same code path. Only one run at a time may hold the shared
 state: every cell resets, cleans and stages `.skill` into the shared per-PR
 checkout, and every run appends to the ledger, so a scheduled run starting
 under a manual one would rewrite the tree the other is reviewing. The script
-takes a `run.lock` directory under both the checkout's git directory and the
+takes a `run.lock` owner record under both the checkout's git directory and the
 fixture cache — they move independently, under `--repo` and `--cache-dir` — and
-refuses to start while another live run holds either. A process atomically
-claims a stale lock before it removes the lock, so two starters cannot both
-reclaim one killed run. The skill under test is snapshotted once, before the first
-cell, and every cell stages from that snapshot: the plan records one skill
+refuses to start while another live run holds either. A hard link publishes the
+complete owner record atomically. A process also claims a stale lock before it
+removes the lock, so two starters cannot both reclaim one killed run. The skill
+under test is snapshotted once, before the first cell, and every cell stages
+from that snapshot: the plan records one skill
 digest for the whole matrix, and two hours is long enough to edit the installed
 skill under a running evaluation. A snapshot that no longer matches the planned
 digest refuses the run instead of mixing two treatments into one row. Every

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -124,9 +124,12 @@ dirty `--skill-ref`
 candidate row can name an installed baseline that is not committed on the same
 branch. CI recomputes that candidate against its own evidence and counts it in
 `unpaired_baselines`. An installed row cannot use this waiver.
-For each installed row, CI also resolves the automatic baseline from ledger
-append order and requires the row to name that exact anchor. A row cannot name
-a later row on the same branch as its baseline.
+Each paired row records whether `--against` selected its baseline or append
+order selected it automatically. `plan.json` records the same choice before
+the run spends model quota. CI requires both records to match. For every
+automatic row, including a dirty candidate, CI resolves the baseline from
+ledger append order and requires the row to name that exact anchor. An
+automatic row cannot name a later row on the same branch as its baseline.
 
 Both the ledger check and `--validate --append` hold the frozen denominator. A
 condition that scored a PR at all carries every defect that PR froze, and a
@@ -242,12 +245,14 @@ publish stages that whole file next to its own detail directory alone. The
 installed run's detail directory is then never committed, and there is no
 second ledger delta left for a PR of its own.
 
-`--against` takes a row file path or an `executed_at` prefix and reaches
-`--score`, `--validate` and `--report` alike, so all three read the same
-baseline. Without it the candidate resolves the ledger's stored anchor. That
-stamps `skill_ref` and `dirty: true` into the ledger row. Never compare a
-candidate against a ledger row from three months ago: that comparison silently
-includes an unknown amount of model drift.
+`--against` takes a row file path or an `executed_at` prefix and reaches the
+plan, `--score`, `--validate` and `--report` alike. The plan and row therefore
+record `selection: "explicit"`, and all steps read the same baseline. Without
+it the plan and row record automatic selection, and the candidate resolves the
+ledger's stored anchor. A candidate also stamps `skill_ref` and `dirty: true`
+into the ledger row. Never compare a candidate against a ledger row from three
+months ago: that comparison silently includes an unknown amount of model
+drift.
 
 The run ends by printing the branch, commit and `gh pr create` commands for the
 ledger PR. Pass `--pr` to execute them instead. There is no auto-merge; a human
@@ -424,8 +429,8 @@ the contract, so each of those is an ordinary full run against its own
 
 The bridge row is assembled by hand from the newer of the two runs: copy its
 `row.json`, set `kind` to `"bridge"`, and record the retiring run's
-`executed_at`, its `comparability_key`, and the McNemar delta between the two
-in `vs_baseline`. `--validate ROW --detail-dir RUNDIR --append --against
+`executed_at`, its `comparability_key`, `selection: "explicit"`, and the
+McNemar delta between the two in `vs_baseline`. `--validate ROW --detail-dir RUNDIR --append --against
 RETIRING_ROW` re-derives every recorded number from the run detail before
 appending, `vs_baseline` included: the McNemar counts are recomputed from the
 two rows' `per_defect` vectors and a stated `baseline_executed_at`,

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -117,10 +117,13 @@ of passing. It calls no model — the recompute reads the committed
 model credentials. Every scored full or canary row must commit `plan.json`, its
 `result-*.json` files, and `calibration.json`. A complete row must carry one
 result file for every planned cell. A partial row must carry evidence for every
-condition it records. CI also checks each condition's model, effort, and finder
-against the planned cells. It regenerates the exact cell list from the frozen
-contract and row kind. Editing `plan.json` cannot remove a required cell. A
-dirty `--skill-ref`
+condition it records. `calibration.json` records the exact cell IDs that existed
+when scoring began. CI requires that list to match the committed result files
+and the row status. Deleting a completed result cannot turn a complete run into
+a partial run. CI also checks each condition's model, effort, and finder against
+the planned cells. It regenerates the exact cell list from the frozen contract
+and row kind. Editing `plan.json` cannot remove a required cell. A dirty
+`--skill-ref`
 candidate row can name an installed baseline that is not committed on the same
 branch. CI recomputes that candidate against its own evidence and counts it in
 `unpaired_baselines`. An installed row cannot use this waiver.
@@ -178,8 +181,11 @@ cached — a finder that exits non-zero fails its cell even when it wrote a
 partial report, because a truncated review cached is a permanent zero-recall
 score. A cached cell is reused only when its stored
 fingerprint — skill digest, kind, contract digest, the two CLI versions, the
-finder argv digest and the orchestrator digest — matches the current run,
-and the run directory carries the kind and the skill digest in its name, so an
+finder argv digest, the orchestrator digest, and the installed-or-candidate
+selection — matches the current run. The scorer preserves that fingerprint in
+every result and in `calibration.json`, and CI checks it against the row and
+plan. Editing both metadata copies cannot relabel a candidate as an installed
+run. The run directory carries the kind and the skill digest in its name, so an
 aborted run followed by a skill edit re-runs instead of scoring the old skill
 under the new digest. A run that ends before it scores keeps its cells on disk
 for that retry — publishing strips them from the commit with an exclude

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -104,18 +104,29 @@ falls back to the `origin/main` tip when no merge base resolves. CI and the
 gate add `--require-base`, which fails the check when the base ref does not
 resolve at all, so the guard can never turn itself into a silent no-op.
 
-CI also adds `--revalidate-appended`, which recomputes every row the branch
-adds from the detail the same branch commits. Schema, id coverage and
+Required CI, the advisory freshness workflow, and the local quality gate add
+`--revalidate-appended`.
+It recomputes every row the branch adds from the detail the same branch commits.
+Schema, id coverage and
 append-only history all stay satisfied when a ledger PR edits its own row's
 verdict, counters or `per_defect` bits after the local `--validate --append`,
 and this is the only PR workflow there is. Like `--require-base` it refuses to
 no-op: with no base it cannot tell which rows are new, and it says so instead
 of passing. It calls no model — the recompute reads the committed
 `result-*.json` and `calibration.json` files — so the workflow stays free of
-model credentials. A row whose recorded baseline is not committed on the same
-branch, which is the candidate row of a sitting whose installed ledger PR has
-not merged yet, is recomputed against its own bits and detail and counted in
-`unpaired_baselines` rather than failed.
+model credentials. Every scored full or canary row must commit `plan.json`, its
+`result-*.json` files, and `calibration.json`. A complete row must carry one
+result file for every planned cell. A partial row must carry evidence for every
+condition it records. CI also checks each condition's model, effort, and finder
+against the planned cells. It regenerates the exact cell list from the frozen
+contract and row kind. Editing `plan.json` cannot remove a required cell. A
+dirty `--skill-ref`
+candidate row can name an installed baseline that is not committed on the same
+branch. CI recomputes that candidate against its own evidence and counts it in
+`unpaired_baselines`. An installed row cannot use this waiver.
+For each installed row, CI also resolves the automatic baseline from ledger
+append order and requires the row to name that exact anchor. A row cannot name
+a later row on the same branch as its baseline.
 
 Both the ledger check and `--validate --append` hold the frozen denominator. A
 condition that scored a PR at all carries every defect that PR froze, and a
@@ -151,8 +162,9 @@ checkout, and every run appends to the ledger, so a scheduled run starting
 under a manual one would rewrite the tree the other is reviewing. The script
 takes a `run.lock` directory under both the checkout's git directory and the
 fixture cache — they move independently, under `--repo` and `--cache-dir` — and
-refuses to start while another live run holds either; a lock left behind by a
-killed run is reclaimed. The skill under test is snapshotted once, before the first
+refuses to start while another live run holds either. A process atomically
+claims a stale lock before it removes the lock, so two starters cannot both
+reclaim one killed run. The skill under test is snapshotted once, before the first
 cell, and every cell stages from that snapshot: the plan records one skill
 digest for the whole matrix, and two hours is long enough to edit the installed
 skill under a running evaluation. A snapshot that no longer matches the planned
@@ -176,12 +188,15 @@ results, row and report the earlier row still claims and reuse its publication
 branch. Seeded cells are fingerprint-checked one by one like any other. The
 skill directory itself may hold no symlink: `cp -R` would stage the link, so the
 contestant would read bytes `skill_digest` never covered and an edit to that
-target mid-run would change the treatment. The six-hour deadline bounds the whole run: three quarters
+target mid-run would change the treatment. The digest length-frames every path
+and file body, so a path/content boundary cannot alias another skill. The
+six-hour deadline bounds the whole run: three quarters
 of it start cells and bound each finder and contestant process, the rest bounds
 the judge pass, and a run that reaches either bound reports a partial matrix
 rather than a table with quietly missing cells. A stalled process is killed
 rather than waited on, because a deadline checked only between cells is no
-deadline at all. A PR whose
+deadline at all. After TERM, the watchdog completes its group-wide KILL before
+the run returns, even when the direct child exits first. A PR whose
 draw-2 cell never ran is scored on draw 1 alone: the defect's bit vector is as
 long as the draws its own PR completed, so a missing cell shrinks the
 denominator instead of recording misses that were never possible.
@@ -208,11 +223,17 @@ the checkout, where no branch switch reaches it, and logs the exact `--against`
 argument. A row carries every bit the comparison reads, so no detail directory
 is needed for the baseline.
 
+Claude auto-review skips that branch only when the diff contains the ledger and
+files under `docs/evals/review-skill-runs/`. Any other changed path keeps normal
+auto-review enabled. The branch prefix alone grants no review exemption.
+
 Naming the `executed_at` is correct once the installed PR is merged and main is
 pulled, because the row is then in the checkout's ledger. It is never a date
 typed from memory: `--against` resolves against rows the ledger already holds,
 so a value no row carries fails the pre-flight before the candidate spends
-anything.
+anything. The pre-flight also validates the full baseline row, its frozen
+matrix, its comparability key, and that its `executed_at` precedes the plan's
+fixed `planned_at` timestamp. These checks finish before the first model call.
 
 Publish first, or both rows land in one working tree and only one of them
 reaches a PR: each run appends to the same ledger file, and the candidate's
@@ -332,8 +353,9 @@ controls; a runtime change large enough to move the score shows up as a flip
 against the anchor with the version drift named beside it.
 
 `scorer_digest` covers every file that can move a recorded number or a recorded
-verdict — the scorer, the per-condition fold, the recompute and the verdict
-rules — not the extraction alone. It also covers the two fixture helpers:
+verdict — the CLI scoring orchestration, the scorer, the per-condition fold,
+the recompute, and the verdict rules — not the extraction alone. It also covers
+the two fixture helpers:
 `review-eval-fixtures.mjs` picks the matrix, the truth file and the recall
 denominator, and `build-fixture.sh` materializes the checkout the contestant
 reviews and carries the checks that verify it, so an edit to either moves what
@@ -347,9 +369,11 @@ a silently paired one is not.
 
 `--score` rechecks the bytes the contract pins by `sha256` — both prompts, every
 truth file, every frozen finder report — before it calls the judge, and refuses
-the pass when one of them moved. `--check-fixtures` covers them once, before the
-matrix starts; under `--skill-ref` the spec worktree is the live checkout for
-the two hours in between, and the contract digest alone would not notice.
+the pass when one of them moved. It snapshots every parsed truth file before
+the first calibration call, so a later checkout edit cannot change one cell's
+scoring. `--check-fixtures` covers the inputs once, before the matrix starts;
+under `--skill-ref` the spec worktree is the live checkout for the two hours in
+between, and the contract digest alone would not notice.
 
 `--report` refuses to compute McNemar across rows with different
 `comparability_key` unless the row is a bridge run, and `--score --against`
@@ -428,7 +452,9 @@ Every later run pairs against that anchor, never against the run before it: a
 five-point slide repeated four times never trips the per-run flip threshold,
 but it does show against the anchor. The anchor moves only for a `PROMOTE`
 row, which is where the runbook already requires a reviewed PR; from then on
-that promoted row is the baseline of record.
+that promoted row is the baseline of record. Baseline selection uses immutable
+ledger append order. A backdated row cannot move ahead of the established
+anchor because its machine clock was slow.
 
 1. Merge the harness. The contract must be on `main` before anything is scored
    against it, so the spec worktree can find it.

--- a/scripts/gate/routing-table/arms-workflows.mjs
+++ b/scripts/gate/routing-table/arms-workflows.mjs
@@ -128,7 +128,8 @@ export const WORKFLOW_ARMS = [
                 reason: "review skill evaluation freshness workflow changed",
               },
               {
-                command: "pnpm review:eval -- --check-ledger --require-base",
+                command:
+                  "pnpm review:eval -- --check-ledger --require-base --revalidate-appended",
                 reason: "review skill evaluation freshness workflow changed",
               },
             ],

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -158,7 +158,8 @@ export const HEAD_GROUPS = [
             reason: "review skill evaluation contract changed",
           },
           {
-            command: "pnpm review:eval -- --check-ledger --require-base",
+            command:
+              "pnpm review:eval -- --check-ledger --require-base --revalidate-appended",
             reason: "review skill evaluation contract changed",
           },
         ],
@@ -176,7 +177,8 @@ export const HEAD_GROUPS = [
             reason: "review skill evaluation harness changed",
           },
           {
-            command: "pnpm review:eval -- --check-ledger --require-base",
+            command:
+              "pnpm review:eval -- --check-ledger --require-base --revalidate-appended",
             reason: "review skill evaluation harness changed",
           },
         ],

--- a/scripts/review/review-eval-fixtures.mjs
+++ b/scripts/review/review-eval-fixtures.mjs
@@ -184,15 +184,21 @@ export function scorableTotals(contract) {
  * the first head and the base; the frozen truth names the last head, which is
  * the commit that carries the fixes and is therefore the answer key.
  */
-export function forbiddenShasForFixture({ fixture, repoRoot = process.cwd() }) {
+export function forbiddenShasForFixture({
+  fixture,
+  repoRoot = process.cwd(),
+  truth: suppliedTruth = null,
+}) {
   const forbidden = new Set();
-  let truth;
-  try {
-    truth = JSON.parse(
-      readBytes(repoRoot, fixture.truth_file).toString("utf8"),
-    );
-  } catch {
-    return [];
+  let truth = suppliedTruth;
+  if (!truth) {
+    try {
+      truth = JSON.parse(
+        readBytes(repoRoot, fixture.truth_file).toString("utf8"),
+      );
+    } catch {
+      return [];
+    }
   }
   for (const sha of [truth.last_head]) {
     if (

--- a/scripts/review/review-eval-ledger.mjs
+++ b/scripts/review/review-eval-ledger.mjs
@@ -837,10 +837,17 @@ export function freshness({
     return Boolean(instant) && instant > evaluatedAt;
   }).length;
 
-  const lastAny = newestInstant(eligible, () => true, evaluatedAt);
+  // A bridge records a reviewed transition between two existing full runs. It
+  // does not execute the harness or complete a new matrix, so it moves neither
+  // of these clocks even when its hand-assembled row is current and complete.
+  const lastAny = newestInstant(
+    eligible,
+    (row) => row.kind !== "bridge",
+    evaluatedAt,
+  );
   const lastComplete = newestInstant(
     eligible,
-    (row) => row.status === "complete",
+    (row) => row.kind !== "bridge" && row.status === "complete",
     evaluatedAt,
   );
   // A failed or partial full run verified nothing: it is a trace that the

--- a/scripts/review/review-eval-ledger.mjs
+++ b/scripts/review/review-eval-ledger.mjs
@@ -133,10 +133,10 @@ export const INSTANT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
  * Parse a canonical UTC date-time; return null when it is not one.
  *
  * `new Date(value)` accepts far more than the schema promises — "0", "2026-9-8"
- * and RFC-style dates all parse — and `resolveBaseline` orders rows by
- * comparing `executed_at` as strings. A row carrying any of those would pass
- * validation and then sort or filter against every canonical row incorrectly,
- * so the format is required, not merely parseable. The round-trip check is what
+ * and RFC-style dates all parse — and baseline resolution orders rows by
+ * `executed_at`. A row carrying any of those would pass validation and then
+ * sort or filter against every canonical row incorrectly, so the format is
+ * required, not merely parseable. The round-trip check is what
  * refuses a well-shaped impossible date such as `2026-02-31T00:00:00Z`, which
  * `Date` silently rolls forward into March.
  */

--- a/scripts/review/review-eval-ledger.mjs
+++ b/scripts/review/review-eval-ledger.mjs
@@ -462,6 +462,58 @@ export function validateLedgerRow(row, label = "row") {
   return problems;
 }
 
+/** Validate one row against the current frozen contract and matrix. */
+export function validateLedgerRowAgainstContract({
+  row,
+  contract,
+  contractDigest,
+  label = "baseline row",
+}) {
+  const problems = validateLedgerRow(row, label);
+  if (problems.length > 0) return problems;
+  if (contractDigest && row.contract_digest !== contractDigest) {
+    problems.push(
+      `${label}.contract_digest does not match the current contract`,
+    );
+    return problems;
+  }
+  problems.push(...frozenDefectProblems({ contract, row, label }));
+  // The other half of the frozen denominator: which conditions, which PRs and
+  // how many draws a complete run must have scored at all.
+  problems.push(...completeMatrixProblems({ contract, row, label }));
+  return problems;
+}
+
+/** Validate an external baseline before a generated plan starts paid work. */
+export function baselinePreflightProblems({
+  row,
+  contract,
+  contractDigest,
+  planComparabilityKey,
+  candidateExecutedAt,
+}) {
+  const problems = validateLedgerRowAgainstContract({
+    row,
+    contract,
+    contractDigest,
+  });
+  if (row?.comparability_key !== planComparabilityKey) {
+    problems.push(
+      "baseline comparability_key does not match the generated plan",
+    );
+  }
+  if (
+    typeof candidateExecutedAt === "string" &&
+    typeof row?.executed_at === "string" &&
+    !(row.executed_at < candidateExecutedAt)
+  ) {
+    problems.push(
+      "baseline executed_at must precede the generated plan's candidate timestamp",
+    );
+  }
+  return problems;
+}
+
 /**
  * Read the JSONL ledger. A zero-byte file is a valid empty ledger; a malformed
  * line is a hard error that names its line number.
@@ -691,15 +743,18 @@ export function checkLedger({ path, contract, contractDigest, baseRows }) {
 
   rows.forEach((row, index) => {
     const label = `ledger row ${index + 1}`;
-    const rowProblems = validateLedgerRow(row, label);
+    const rowProblems =
+      contractDigest && row.contract_digest !== contractDigest
+        ? validateLedgerRow(row, label)
+        : validateLedgerRowAgainstContract({
+            row,
+            contract,
+            contractDigest,
+            label,
+          });
     problems.push(...rowProblems);
     if (rowProblems.length) return;
     if (contractDigest && row.contract_digest !== contractDigest) return;
-    problems.push(...frozenDefectProblems({ contract, row, label }));
-    // The other half of the frozen denominator: which conditions, which PRs and
-    // how many draws a complete run must have scored at all. Reported after the
-    // per-id checks above, which name the narrower fault when a row breaks both.
-    problems.push(...completeMatrixProblems({ contract, row, label }));
   });
 
   if (baseRows) {

--- a/scripts/review/review-eval-ledger.mjs
+++ b/scripts/review/review-eval-ledger.mjs
@@ -425,7 +425,7 @@ export function validateLedgerRow(row, label = "row") {
         row.vs_baseline,
         `${label}.vs_baseline`,
         ["baseline_executed_at", "mcnemar"],
-        ["baseline_comparability_key", "control_mcnemar"],
+        ["baseline_comparability_key", "control_mcnemar", "selection"],
         problems,
       )
     ) {
@@ -455,6 +455,14 @@ export function validateLedgerRow(row, label = "row") {
           row.vs_baseline.baseline_comparability_key,
           `${label}.vs_baseline.baseline_comparability_key`,
           problems,
+        );
+      }
+      if (
+        Object.hasOwn(row.vs_baseline, "selection") &&
+        !["automatic", "explicit"].includes(row.vs_baseline.selection)
+      ) {
+        problems.push(
+          `${label}.vs_baseline.selection must be automatic or explicit`,
         );
       }
     }

--- a/scripts/review/review-eval-ledger.test.mjs
+++ b/scripts/review/review-eval-ledger.test.mjs
@@ -916,6 +916,28 @@ test("a candidate run never restarts the installed-skill clock", () => {
   );
 });
 
+test("a bridge transition never advances a run freshness clock", () => {
+  const result = freshness({
+    rows: [
+      row({ executed_at: daysAgo(200) }),
+      row({
+        executed_at: daysAgo(2),
+        kind: "bridge",
+        status: "complete",
+      }),
+    ],
+    contract,
+    now: NOW,
+    contractDigest: DIGEST_A,
+  });
+  assert.equal(result.daysSinceAny, 200);
+  assert.equal(result.daysSinceComplete, 200);
+  assert.equal(result.daysSinceFull, 200);
+  assert.equal(result.lastAnyAt, daysAgo(200));
+  assert.equal(result.lastCompleteAt, daysAgo(200));
+  assert.equal(result.lastFullAt, daysAgo(200));
+});
+
 test("a future-dated row runs no freshness clock", () => {
   // A complete full row dated a year out would hold every clock below zero
   // until that date arrives. A skewed machine clock or a hand-edited

--- a/scripts/review/review-eval-report.mjs
+++ b/scripts/review/review-eval-report.mjs
@@ -205,8 +205,8 @@ function runtimeDrift(row, baselineRow) {
     .join(", ")}; a flip may come from the runtime rather than the skill`;
 }
 
-function comparable(row, baselineRow) {
-  if (!baselineRow) return { usable: false, reason: null };
+/** Whether one row has the intrinsic standing required of a baseline. */
+export function baselineEligibility(row) {
   // The same standing `resolveBaseline` requires of an anchor. A canary is a
   // floor test on a two-cell subset and a partial or failed run is a matrix
   // with cells that never ran, so neither carries the per-defect bits a flip
@@ -214,10 +214,17 @@ function comparable(row, baselineRow) {
   // the chance to find as gains, and produce a RED or PROMOTE verdict from
   // non-ranking evidence. `resolveBaseline` never selects such a row; this
   // refuses one named explicitly with `--against`.
-  if (baselineRow.kind !== "full" || baselineRow.status !== "complete") {
+  if (row?.kind !== "full" || row?.status !== "complete") {
     return {
       usable: false,
-      reason: `baseline is a ${baselineRow.kind} row with status ${baselineRow.status}; comparison refused (a baseline must be a complete full run)`,
+      reason: `baseline is a ${row?.kind} row with status ${row?.status}; comparison refused (a baseline must be a complete full run)`,
+    };
+  }
+  if (!installedSkillRun(row)) {
+    return {
+      usable: false,
+      reason:
+        "baseline is not an installed-skill run; comparison refused (a candidate cannot become the denominator)",
     };
   }
   // The baseline supplies `baseHeadline`, every flip count derived from it and
@@ -225,10 +232,10 @@ function comparable(row, baselineRow) {
   // would rank a calibrated candidate on numbers the runbook calls unusable, so
   // it is refused as a baseline exactly the way `resolveBaseline` refuses to
   // anchor on one.
-  if (!judgeCalibrationPasses(baselineRow)) {
+  if (!judgeCalibrationPasses(row)) {
     return {
       usable: false,
-      reason: `baseline ${calibrationReason(baselineRow)}; comparison refused`,
+      reason: `baseline ${calibrationReason(row)}; comparison refused`,
     };
   }
   // A leaked baseline is refused for the same reason, and here it matters more
@@ -236,21 +243,40 @@ function comparable(row, baselineRow) {
   // flip count, so answer-key-contaminated bits would silently score every
   // clean run after them as a regression. `resolveBaseline` never selects such
   // a row; this refuses one named explicitly with `--against`.
-  if (leakSuspected(baselineRow)) {
+  if (leakSuspected(row)) {
     return {
       usable: false,
       reason:
         "baseline notes record a suspected leak; comparison refused (its bits are not trusted)",
     };
   }
-  // `resolveBaseline` only ever anchors on a row that precedes the candidate.
-  // A later row named with `--against` reverses the pairing: its bits become
+  const { condition } = headlineCondition(row);
+  if (
+    !isObject(condition) ||
+    !isObject(condition.per_defect) ||
+    Object.keys(condition.per_defect).length === 0
+  ) {
+    return {
+      usable: false,
+      reason:
+        "baseline carries no scored condition; comparison refused (there are no defect bits to pair)",
+    };
+  }
+  return { usable: true, reason: null };
+}
+
+function comparable(row, baselineRow, { baselineIsExplicit = true } = {}) {
+  if (!baselineRow) return { usable: false, reason: null };
+  const eligibility = baselineEligibility(baselineRow);
+  if (!eligibility.usable) return eligibility;
+  // `resolveBaseline` establishes precedence from append order. A baseline
+  // named outside that ledger context still needs a timestamp guard. A later
+  // row named with `--against` reverses the pairing: its bits become
   // the base, so the defects the candidate found and the later row did not are
   // counted as lost and the ones it gained as gains. The delta then reads
-  // backwards, and a regression can print PROMOTE. Instants are ISO-8601 UTC —
-  // `checkInstant` refuses any other form — so a string compare orders them,
-  // the same compare `resolveBaseline` uses.
-  if (!(baselineRow.executed_at < row.executed_at)) {
+  // backwards, and a regression can print PROMOTE. Instants are ISO-8601 UTC,
+  // so a string compare orders explicit rows without overriding append order.
+  if (baselineIsExplicit && !(baselineRow.executed_at < row.executed_at)) {
     return {
       usable: false,
       reason: `baseline executed_at ${baselineRow.executed_at} does not precede this row's ${row.executed_at}; comparison refused (a baseline must be the earlier run)`,
@@ -331,7 +357,12 @@ function canaryVerdict({ contract, row }) {
  * run whose numbers are untrusted or incomplete may not be escalated on them
  * either.
  */
-export function verdict({ contract, row, baselineRow = null }) {
+export function verdict({
+  contract,
+  row,
+  baselineRow = null,
+  baselineIsExplicit = true,
+}) {
   if (!isObject(contract?.verdict_rules)) {
     throw new Error("contract is missing verdict_rules");
   }
@@ -354,7 +385,7 @@ export function verdict({ contract, row, baselineRow = null }) {
     return { verdict: "INCOMPLETE", reasons: ["row carries no condition"] };
   }
 
-  const pairing = comparable(row, baselineRow);
+  const pairing = comparable(row, baselineRow, { baselineIsExplicit });
   const baseline = pairing.usable ? baselineRow : null;
   if (pairing.reason) reasons.push(pairing.reason);
   if (!baselineRow) reasons.push("no baseline row; comparison skipped");
@@ -585,6 +616,7 @@ export function renderReport({
   contract,
   row,
   baselineRow = null,
+  baselineIsExplicit = true,
   truth = null,
   repoRoot = null,
 }) {
@@ -593,7 +625,12 @@ export function renderReport({
     : repoRoot
       ? loadTruthIndex({ contract, repoRoot })
       : new Map();
-  const decision = verdict({ contract, row, baselineRow });
+  const decision = verdict({
+    contract,
+    row,
+    baselineRow,
+    baselineIsExplicit,
+  });
   // The row is the artifact of record, so the report states the verdict the
   // row carries. Recomputing it is a check, never a silent substitution: a
   // disagreement is printed instead of hidden.
@@ -603,7 +640,7 @@ export function renderReport({
       ? null
       : `stored verdict ${stored} disagrees with the verdict recomputed here (${decision.verdict}); revalidate the row before ranking on it`;
   const { name, condition } = headlineCondition(row);
-  const pairing = comparable(row, baselineRow);
+  const pairing = comparable(row, baselineRow, { baselineIsExplicit });
   const baseHeadline =
     pairing.usable && baselineRow ? baselineRow.conditions?.[name] : null;
   const flips = baseHeadline

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -342,8 +342,8 @@ function checkClose(stated, found, tolerance, label, digits, problems) {
  * `--validate` had to take it on the row's own say-so. Each cell record now
  * carries the dollars its own judge calls cost and `calibration.json` carries
  * the replay's, which makes the run total a sum of evidence like every other
- * number on the row. Returns null when the detail predates that, so a row
- * written before the field existed is not failed for it.
+ * number on the row. Returns null only when the directory has no scored cell
+ * detail. Missing or invalid cost evidence produces NaN so validation fails.
  */
 function recomputeScoringUsd(dir) {
   let files;
@@ -354,23 +354,32 @@ function recomputeScoringUsd(dir) {
   } catch {
     return null;
   }
+  if (files.length === 0) return null;
   let total = 0;
-  let seen = false;
   for (const file of files) {
     const record = readJson(path.join(dir, file));
-    if (!Object.hasOwn(record ?? {}, "scoring_usd")) continue;
-    seen = true;
-    total += Number(record.scoring_usd ?? 0);
+    if (
+      !Object.hasOwn(record ?? {}, "scoring_usd") ||
+      typeof record.scoring_usd !== "number" ||
+      !Number.isFinite(record.scoring_usd) ||
+      record.scoring_usd < 0
+    ) {
+      return Number.NaN;
+    }
+    total += record.scoring_usd;
   }
   const calibrationFile = path.join(dir, "calibration.json");
-  if (existsSync(calibrationFile)) {
-    const record = readJson(calibrationFile);
-    if (Object.hasOwn(record ?? {}, "scoring_usd")) {
-      seen = true;
-      total += Number(record.scoring_usd ?? 0);
-    }
+  if (!existsSync(calibrationFile)) return Number.NaN;
+  const calibration = readJson(calibrationFile);
+  if (
+    !Object.hasOwn(calibration ?? {}, "scoring_usd") ||
+    typeof calibration.scoring_usd !== "number" ||
+    !Number.isFinite(calibration.scoring_usd) ||
+    calibration.scoring_usd < 0
+  ) {
+    return Number.NaN;
   }
-  return seen ? total : null;
+  return total + calibration.scoring_usd;
 }
 
 /**
@@ -709,9 +718,13 @@ export function revalidateRow({
       problems,
     );
   }
-  if (dir && Object.hasOwn(row, "scoring_usd")) {
+  if (dir && hasCellResults(dir)) {
     const spent = recomputeScoringUsd(dir);
-    if (spent !== null) {
+    if (!Object.hasOwn(row, "scoring_usd")) {
+      problems.push(
+        "row.scoring_usd is missing; scored run detail requires a recorded judge cost total",
+      );
+    } else if (spent !== null) {
       checkClose(row.scoring_usd, spent, 0.005, "row.scoring_usd", 2, problems);
     }
   }

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -11,6 +11,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { fixtureForPr } from "./review-eval-fixtures.mjs";
+import { parseInstant } from "./review-eval-ledger.mjs";
 import {
   baselineEligibility,
   compareConditions,
@@ -120,6 +121,10 @@ export function failedRow({
  * "First" and "newest" use ledger append order. A slow machine clock cannot
  * place a later row before the established anchor.
  *
+ * An external row has no ledger position. For that row, its execution time
+ * bounds the eligible ledger prefix. This prevents a later ledger row from
+ * becoming the automatic baseline of an earlier external result.
+ *
  * A row whose judge calibration failed is never eligible, as anchor or as
  * re-anchor: the runbook excludes such a row from baseline comparison, and an
  * anchor is the comparison every later run is paired against.
@@ -149,8 +154,18 @@ export function resolveBaseline({ rows, row }) {
             candidate.contract_digest === row?.contract_digest &&
             candidate.detail_dir === row?.detail_dir,
         );
+  const rowInstant = rowIndex === -1 ? parseInstant(row?.executed_at) : null;
   const priorRows =
-    rowIndex === -1 ? ledgerRows : ledgerRows.slice(0, rowIndex);
+    rowIndex === -1
+      ? ledgerRows.filter((candidate) => {
+          const candidateInstant = parseInstant(candidate.executed_at);
+          return (
+            rowInstant !== null &&
+            candidateInstant !== null &&
+            candidateInstant < rowInstant
+          );
+        })
+      : ledgerRows.slice(0, rowIndex);
   const eligible = priorRows.filter(
     (candidate) =>
       baselineEligibility(candidate).usable &&

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -173,14 +173,16 @@ export function resolveBaseline({ rows, row }) {
  * re-derives is a claim, and `--validate` re-derives it from the same two
  * `per_defect` vectors the scorer read.
  */
-export function buildVsBaseline({ row, baselineRow }) {
+export function buildVsBaseline({ row, baselineRow, selection = null }) {
   if (!baselineRow) return null;
+  const selectionField = selection === null ? {} : { selection };
   const paired =
     row.comparability_key === baselineRow.comparability_key ||
     row.kind === "bridge";
   if (!paired) {
     return {
       baseline_executed_at: baselineRow.executed_at,
+      ...selectionField,
       baseline_comparability_key: baselineRow.comparability_key,
       mcnemar: null,
     };
@@ -192,6 +194,7 @@ export function buildVsBaseline({ row, baselineRow }) {
     : { b: 0, c: 0 };
   const vs = {
     baseline_executed_at: baselineRow.executed_at,
+    ...selectionField,
     baseline_comparability_key: baselineRow.comparability_key,
     mcnemar: { b: flips.b, c: flips.c, delta: flips.b - flips.c },
   };
@@ -477,12 +480,21 @@ function checkMcnemar(stated, expected, label, problems) {
  * A row that records no pairing at all is not a problem here: it under-claims,
  * and the verdict is derived from the baseline directly either way.
  */
-function checkVsBaseline({ row, baseline, problems }) {
+function checkVsBaseline({ row, baseline, baselineIsExplicit, problems }) {
   const stated = row.vs_baseline ?? null;
   if (!baseline || stated === null) return;
   if (!isShape(stated)) {
     problems.push("row.vs_baseline is neither null nor an object");
     return;
+  }
+  const expectedSelection = baselineIsExplicit ? "explicit" : "automatic";
+  if (
+    Object.hasOwn(stated, "selection") &&
+    stated.selection !== expectedSelection
+  ) {
+    problems.push(
+      `row.vs_baseline.selection is ${stated.selection}; this validation uses ${expectedSelection} baseline selection`,
+    );
   }
   const expected = buildVsBaseline({ row, baselineRow: baseline });
   if (stated.baseline_executed_at !== expected.baseline_executed_at) {
@@ -696,7 +708,7 @@ export function revalidateRow({
   }
   const baseline =
     baselineRow ?? resolveBaseline({ rows: ledgerRows ?? [], row });
-  checkVsBaseline({ row, baseline, problems });
+  checkVsBaseline({ row, baseline, baselineIsExplicit, problems });
   // The verdict is a function of the row and its baseline together: a net loss
   // of flips is RED and a net gain is PROMOTE, both read against the anchor.
   // `baselineMissing` says the caller knows the row was scored against a

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -284,8 +284,18 @@ function recomputeFromDetail({ dir, condition, ids, prForId }) {
     byDraw.set(draw, entry);
     wrongClaims += Number(record.novel?.novelWrong ?? 0);
     novelReal += Number(record.novel?.novelReal ?? 0);
-    usd += Number(record.usd ?? 0);
-    seconds += Number(record.seconds ?? 0);
+    const cellUsd = record.usd;
+    const cellSeconds = record.seconds;
+    usd =
+      typeof cellUsd === "number" && Number.isFinite(cellUsd) && cellUsd >= 0
+        ? usd + cellUsd
+        : Number.NaN;
+    seconds =
+      typeof cellSeconds === "number" &&
+      Number.isFinite(cellSeconds) &&
+      cellSeconds >= 0
+        ? seconds + cellSeconds
+        : Number.NaN;
     claimsByPr.set(
       String(record.pr),
       (claimsByPr.get(String(record.pr)) ?? 0) + (record.claims ?? []).length,

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -12,11 +12,9 @@ import path from "node:path";
 
 import { fixtureForPr } from "./review-eval-fixtures.mjs";
 import {
+  baselineEligibility,
   compareConditions,
   headlineCondition,
-  installedSkillRun,
-  judgeCalibrationPasses,
-  leakSuspected,
   verdict,
 } from "./review-eval-report.mjs";
 
@@ -93,6 +91,7 @@ export function failedRow({
       [name]: {
         model: plan.cells[0]?.model ?? contract.sut.verifier.model,
         effort: plan.cells[0]?.effort ?? contract.sut.verifier.effort,
+        ...(plan.cells[0]?.finder ? { finder: plan.cells[0].finder } : {}),
         draws: 1,
         recall: zero(scope.scorableIds),
         p1: zero(scope.p1Ids),
@@ -118,6 +117,8 @@ export function failedRow({
  * threshold still shows against the score the baseline PR established. The
  * anchor moves only where the runbook says it may — a reviewed PROMOTE row —
  * and the newest such row then becomes the anchor for everything after it.
+ * "First" and "newest" use ledger append order. A slow machine clock cannot
+ * place a later row before the established anchor.
  *
  * A row whose judge calibration failed is never eligible, as anchor or as
  * re-anchor: the runbook excludes such a row from baseline comparison, and an
@@ -137,18 +138,24 @@ export function failedRow({
  * explicitly, which is how a candidate is compared on purpose.
  */
 export function resolveBaseline({ rows, row }) {
-  const eligible = (rows ?? [])
-    .filter(
-      (candidate) =>
-        candidate.kind === "full" &&
-        candidate.status === "complete" &&
-        installedSkillRun(candidate) &&
-        judgeCalibrationPasses(candidate) &&
-        !leakSuspected(candidate) &&
-        candidate.comparability_key === row.comparability_key &&
-        candidate.executed_at < row.executed_at,
-    )
-    .sort((left, right) => (left.executed_at < right.executed_at ? -1 : 1));
+  const ledgerRows = rows ?? [];
+  const objectIndex = ledgerRows.indexOf(row);
+  const rowIndex =
+    objectIndex !== -1
+      ? objectIndex
+      : ledgerRows.findIndex(
+          (candidate) =>
+            candidate.executed_at === row?.executed_at &&
+            candidate.contract_digest === row?.contract_digest &&
+            candidate.detail_dir === row?.detail_dir,
+        );
+  const priorRows =
+    rowIndex === -1 ? ledgerRows : ledgerRows.slice(0, rowIndex);
+  const eligible = priorRows.filter(
+    (candidate) =>
+      baselineEligibility(candidate).usable &&
+      candidate.comparability_key === row.comparability_key,
+  );
   if (eligible.length === 0) return null;
   const reAnchored = eligible.findLast(
     (candidate) => candidate.verdict === "PROMOTE",
@@ -530,6 +537,7 @@ export function revalidateRow({
   detailDir = null,
   ledgerRows = [],
   baselineRow = null,
+  baselineIsExplicit = baselineRow !== null,
   baselineMissing = false,
   calibrationSet = null,
 }) {
@@ -710,7 +718,12 @@ export function revalidateRow({
   }
   let recomputed = null;
   try {
-    recomputed = verdict({ contract, row, baselineRow: baseline }).verdict;
+    recomputed = verdict({
+      contract,
+      row,
+      baselineRow: baseline,
+      baselineIsExplicit,
+    }).verdict;
   } catch (error) {
     problems.push(
       `the verdict could not be recomputed: ${error instanceof Error ? error.message : String(error)}`,

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -135,9 +135,16 @@ function walkFiles(dir, base = dir, found = []) {
 export function skillDigest(dir) {
   const root = expandHome(dir);
   const hash = createHash("sha256");
+  const updateFramed = (bytes) => {
+    const value = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+    const length = Buffer.alloc(8);
+    length.writeBigUInt64BE(BigInt(value.length));
+    hash.update(length);
+    hash.update(value);
+  };
   for (const relative of walkFiles(root).sort()) {
-    hash.update(relative);
-    hash.update(readFileSync(path.join(root, relative)));
+    updateFramed(relative);
+    updateFramed(readFileSync(path.join(root, relative)));
   }
   return hash.digest("hex");
 }
@@ -911,6 +918,7 @@ async function scoreOneCell({
   cellResult,
   contract,
   repoRoot,
+  truth,
   exec: baseExec,
   runGit = defaultRunGit,
 }) {
@@ -921,7 +929,6 @@ async function scoreOneCell({
   const cellCost = { usd: 0 };
   const exec = meterExec(baseExec, cellCost);
   const fixture = fixtureForPr(contract, cell.pr);
-  const truth = readJson(path.join(repoRoot, fixture.truth_file));
   const transcript = cellResult.output;
   // The judge model is the one the comparability key records. Reading a
   // default here would let a judge retirement move the key while scoring kept
@@ -970,7 +977,7 @@ async function scoreOneCell({
     truth,
     pr: cell.pr,
     excludeLogins,
-    forbiddenShas: forbiddenShasForFixture({ fixture, repoRoot }),
+    forbiddenShas: forbiddenShasForFixture({ fixture, repoRoot, truth }),
   });
   return {
     cell_id: cell.cell_id,
@@ -1109,6 +1116,15 @@ export async function scorePlan({
   now = new Date(),
   write = true,
 }) {
+  // Freeze every truth object before the first model call. A candidate run uses
+  // the operator's live checkout, and calibration can take long enough for an
+  // edit after the CLI's digest check to otherwise change later cell scoring.
+  const truthByPr = new Map(
+    [...new Set(plan.cells.map((cell) => cell.pr))].map((pr) => {
+      const fixture = fixtureForPr(contract, pr);
+      return [pr, readJson(path.join(repoRoot, fixture.truth_file))];
+    }),
+  );
   const scoringCost = { usd: 0 };
   const metered = meterExec(exec, scoringCost);
   const calibrationCost = { usd: 0 };
@@ -1153,6 +1169,7 @@ export async function scorePlan({
       cellResult,
       contract,
       repoRoot,
+      truth: truthByPr.get(cell.pr),
       exec: metered,
       runGit,
     });
@@ -1215,9 +1232,15 @@ export async function scorePlan({
     detail_dir: plan.detail_dir,
     notes: notes.join(" | "),
   };
+  const baselineIsExplicit = baselineRow !== null;
   const baseline = baselineRow ?? resolveBaseline({ rows: ledgerRows, row });
   row.vs_baseline = buildVsBaseline({ row, baselineRow: baseline });
-  const decision = verdict({ contract, row, baselineRow: baseline });
+  const decision = verdict({
+    contract,
+    row,
+    baselineRow: baseline,
+    baselineIsExplicit,
+  });
   row.verdict = decision.verdict;
   if (leaked.length && ["GREEN", "PROMOTE"].includes(row.verdict)) {
     row.verdict = "AMBER";

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -1146,6 +1146,20 @@ export async function scorePlan({
   now = new Date(),
   write = true,
 }) {
+  // Refuse edits to the branch-owned plan before calibration or judge calls
+  // spend quota. Later evidence validation applies the same frozen matrix.
+  if (!Array.isArray(plan.cells)) {
+    throw new Error("plan carries no cells array");
+  }
+  if (!["full", "canary"].includes(plan.kind)) {
+    throw new Error(
+      `plan has no frozen ${String(plan.kind ?? "unknown")} matrix to score`,
+    );
+  }
+  const expectedCells = planCells({ contract, kind: plan.kind });
+  if (JSON.stringify(plan.cells) !== JSON.stringify(expectedCells)) {
+    throw new Error(`plan cells do not match the frozen ${plan.kind} matrix`);
+  }
   const baselineIsExplicit = baselineRow !== null;
   const baselineSelection = baselineIsExplicit ? "explicit" : "automatic";
   if (plan.baseline_selection !== baselineSelection) {

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -1151,6 +1151,9 @@ export async function scorePlan({
   if (!Array.isArray(plan.cells)) {
     throw new Error("plan carries no cells array");
   }
+  if (plan.contract_digest !== contractDigest) {
+    throw new Error("plan contract digest does not match the scoring contract");
+  }
   if (!["full", "canary"].includes(plan.kind)) {
     throw new Error(
       `plan has no frozen ${String(plan.kind ?? "unknown")} matrix to score`,

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -95,6 +95,18 @@ function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+/** The exact explicit baseline a plan authorizes scoring against. */
+export function baselinePlanIdentity(row) {
+  if (!row) return null;
+  return {
+    executed_at: row.executed_at,
+    contract_digest: row.contract_digest,
+    comparability_key: row.comparability_key,
+    detail_dir: row.detail_dir,
+    row_digest: sha256(JSON.stringify(row)),
+  };
+}
+
 function readJson(file) {
   try {
     return JSON.parse(readFileSync(file, "utf8"));
@@ -377,7 +389,7 @@ export function buildPlan({
   skillRef = null,
   runsDir = DEFAULT_RUNS_DIR,
   ledgerRows = [],
-  baselineIsExplicit = false,
+  baselineRow = null,
   now = new Date(),
   env = process.env,
   write = true,
@@ -432,7 +444,8 @@ export function buildPlan({
     comparability_key: key,
     judge: { ...contract.judge },
     detail_dir: detailDir,
-    baseline_selection: baselineIsExplicit ? "explicit" : "automatic",
+    baseline_selection: baselineRow === null ? "automatic" : "explicit",
+    baseline: baselinePlanIdentity(baselineRow),
     // The directory of the previous execution under this name, whose cells this
     // one may seed from, or null when this is the first. Never the directory
     // this run writes to: a recorded row's evidence is not overwritten.
@@ -1123,6 +1136,13 @@ export async function scorePlan({
   if (plan.baseline_selection !== baselineSelection) {
     throw new Error(
       `plan baseline_selection is ${String(plan.baseline_selection)}; this score command is ${baselineSelection}`,
+    );
+  }
+  const plannedBaseline = plan.baseline ?? null;
+  const scoreBaseline = baselinePlanIdentity(baselineRow);
+  if (JSON.stringify(plannedBaseline) !== JSON.stringify(scoreBaseline)) {
+    throw new Error(
+      `plan baseline ${String(plannedBaseline?.executed_at ?? "none")} does not match score baseline ${String(scoreBaseline?.executed_at ?? "none")}`,
     );
   }
   // Freeze every truth object before the first model call. A candidate run uses

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -1277,7 +1277,11 @@ export async function scorePlan({
     detail_dir: plan.detail_dir,
     notes: notes.join(" | "),
   };
-  const baseline = baselineRow ?? resolveBaseline({ rows: ledgerRows, row });
+  // Automatic scoring creates the row before it appends it. Resolve it as the
+  // next ledger entry so clock skew cannot replace append-order semantics with
+  // the timestamp fallback reserved for external report files.
+  const baseline =
+    baselineRow ?? resolveBaseline({ rows: [...ledgerRows, row], row });
   row.vs_baseline = buildVsBaseline({
     row,
     baselineRow: baseline,

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -377,6 +377,7 @@ export function buildPlan({
   skillRef = null,
   runsDir = DEFAULT_RUNS_DIR,
   ledgerRows = [],
+  baselineIsExplicit = false,
   now = new Date(),
   env = process.env,
   write = true,
@@ -431,6 +432,7 @@ export function buildPlan({
     comparability_key: key,
     judge: { ...contract.judge },
     detail_dir: detailDir,
+    baseline_selection: baselineIsExplicit ? "explicit" : "automatic",
     // The directory of the previous execution under this name, whose cells this
     // one may seed from, or null when this is the first. Never the directory
     // this run writes to: a recorded row's evidence is not overwritten.
@@ -1116,6 +1118,13 @@ export async function scorePlan({
   now = new Date(),
   write = true,
 }) {
+  const baselineIsExplicit = baselineRow !== null;
+  const baselineSelection = baselineIsExplicit ? "explicit" : "automatic";
+  if (plan.baseline_selection !== baselineSelection) {
+    throw new Error(
+      `plan baseline_selection is ${String(plan.baseline_selection)}; this score command is ${baselineSelection}`,
+    );
+  }
   // Freeze every truth object before the first model call. A candidate run uses
   // the operator's live checkout, and calibration can take long enough for an
   // edit after the CLI's digest check to otherwise change later cell scoring.
@@ -1232,9 +1241,12 @@ export async function scorePlan({
     detail_dir: plan.detail_dir,
     notes: notes.join(" | "),
   };
-  const baselineIsExplicit = baselineRow !== null;
   const baseline = baselineRow ?? resolveBaseline({ rows: ledgerRows, row });
-  row.vs_baseline = buildVsBaseline({ row, baselineRow: baseline });
+  row.vs_baseline = buildVsBaseline({
+    row,
+    baselineRow: baseline,
+    selection: baselineSelection,
+  });
   const decision = verdict({
     contract,
     row,

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -30,13 +30,13 @@ import {
   PIPELINE_DRAWS,
   scorableTotals,
 } from "./review-eval-fixtures.mjs";
-import { freshness } from "./review-eval-ledger.mjs";
+import { baselinePreflightProblems, freshness } from "./review-eval-ledger.mjs";
 import {
   buildVsBaseline,
   conditionScope,
   resolveBaseline,
 } from "./review-eval-result-shape.mjs";
-import { verdict } from "./review-eval-report.mjs";
+import { baselineEligibility, verdict } from "./review-eval-report.mjs";
 import {
   aggregateDraws,
   classifyNovel,
@@ -1144,6 +1144,22 @@ export async function scorePlan({
     throw new Error(
       `plan baseline ${String(plannedBaseline?.executed_at ?? "none")} does not match score baseline ${String(scoreBaseline?.executed_at ?? "none")}`,
     );
+  }
+  if (baselineIsExplicit) {
+    const eligibility = baselineEligibility(baselineRow);
+    const baselineProblems = baselinePreflightProblems({
+      row: baselineRow,
+      contract,
+      contractDigest,
+      planComparabilityKey: plan.comparability_key,
+      candidateExecutedAt: plan.planned_at,
+    });
+    if (!eligibility.usable) baselineProblems.unshift(eligibility.reason);
+    if (baselineProblems.length > 0) {
+      throw new Error(
+        `explicit baseline is not eligible for this plan:\n${baselineProblems.join("\n")}`,
+      );
+    }
   }
   // Freeze every truth object before the first model call. A candidate run uses
   // the operator's live checkout, and calibration can take long enough for an

--- a/scripts/review/review-eval-run.mjs
+++ b/scripts/review/review-eval-run.mjs
@@ -573,11 +573,15 @@ export function leakSignals({
  * under one provenance. `finder_argv_digest` is the command the pipeline
  * condition spawns, and `orchestrator_digest` is the script that spawns it with
  * its tools, turn limit and skill staging, so both move a recorded number the
- * same way.
+ * same way. `skill_ref` and `dirty` preserve whether the execution measured the
+ * installed skill or an explicit candidate. That status controls freshness and
+ * automatic baseline eligibility, so the scored evidence must retain it.
  */
 export function cellFingerprint({ plan }) {
   return {
     skill_digest: plan?.inputs?.skill_digest ?? null,
+    skill_ref: plan?.inputs?.skill_ref ?? null,
+    dirty: plan?.inputs?.dirty === true,
     kind: plan?.kind ?? null,
     contract_digest: plan?.contract_digest ?? null,
     claude_cli: plan?.inputs?.claude_cli ?? null,
@@ -608,6 +612,15 @@ export function cellReuseDecision({ plan, resultPath, result = null }) {
   const found = stored?.fingerprint;
   if (!found || typeof found !== "object") {
     return { reuse: false, reason: "the cached cell carries no fingerprint" };
+  }
+  const unexpected = Object.keys(found).filter(
+    (field) => !Object.hasOwn(expected, field),
+  );
+  if (unexpected.length > 0) {
+    return {
+      reuse: false,
+      reason: `the cached cell fingerprint carries unexpected ${unexpected.join(", ")}`,
+    };
   }
   const differing = Object.keys(expected).filter(
     (field) => found[field] !== expected[field],
@@ -931,6 +944,7 @@ export function resetFixture({
 async function scoreOneCell({
   cell,
   cellResult,
+  fingerprint,
   contract,
   repoRoot,
   truth,
@@ -996,6 +1010,7 @@ async function scoreOneCell({
   });
   return {
     cell_id: cell.cell_id,
+    fingerprint,
     pr: cell.pr,
     condition: cell.condition,
     draw: cell.draw,
@@ -1161,6 +1176,30 @@ export async function scorePlan({
       );
     }
   }
+  const completedCellResults = new Map();
+  const fingerprint = cellFingerprint({ plan });
+  const missing = [];
+  for (const cell of plan.cells) {
+    const cellResult = readCellResult(planDir, cell);
+    if (!cellResult) {
+      missing.push(cell.cell_id);
+      continue;
+    }
+    const reuse = cellReuseDecision({
+      plan,
+      resultPath: cellResultPath(planDir, cell),
+      result: cellResult,
+    });
+    if (!reuse.reuse) {
+      throw new Error(`cell ${cell.cell_id} cannot be scored: ${reuse.reason}`);
+    }
+    completedCellResults.set(cell.cell_id, cellResult);
+  }
+  if (completedCellResults.size === 0) {
+    throw new Error(
+      `no completed cell results under ${planDir}; run the orchestrator first`,
+    );
+  }
   // Freeze every truth object before the first model call. A candidate run uses
   // the operator's live checkout, and calibration can take long enough for an
   // edit after the CLI's digest check to otherwise change later cell scoring.
@@ -1190,6 +1229,8 @@ export async function scorePlan({
           model: contract.judge.model,
           agreement: calibration.agreement,
           total: calibration.total,
+          fingerprint,
+          completed_cell_ids: [...completedCellResults.keys()],
           // The replay's share of `scoring_usd`. With the per-cell shares it
           // makes the row's scoring cost re-derivable from the detail.
           scoring_usd: calibrationCost.usd,
@@ -1201,17 +1242,14 @@ export async function scorePlan({
     );
   }
   const scored = new Map();
-  const missing = [];
   const leaked = [];
   for (const cell of plan.cells) {
-    const cellResult = readCellResult(planDir, cell);
-    if (!cellResult) {
-      missing.push(cell.cell_id);
-      continue;
-    }
+    const cellResult = completedCellResults.get(cell.cell_id);
+    if (!cellResult) continue;
     const record = await scoreOneCell({
       cell,
       cellResult,
+      fingerprint,
       contract,
       repoRoot,
       truth: truthByPr.get(cell.pr),
@@ -1230,12 +1268,6 @@ export async function scorePlan({
       );
     }
   }
-  if (scored.size === 0) {
-    throw new Error(
-      `no completed cell results under ${planDir}; run the orchestrator first`,
-    );
-  }
-
   const conditions = {};
   for (const name of ["pipeline", "replay", "control"]) {
     const folded = foldCondition({

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -61,8 +61,9 @@ const PLACEHOLDER_PATTERN = /\{\{([A-Z_]+)\}\}/g;
 const promptDir = fileURLToPath(new URL("./prompts", import.meta.url));
 const scriptPath = fileURLToPath(import.meta.url);
 // Every file that can change a recorded number or a recorded verdict. The
-// extraction and the matcher live here, the per-condition fold and the leak
-// signal live in `review-eval-run.mjs`, the recompute lives in
+// extraction and the matcher live here, CLI scoring orchestration lives in
+// `review-eval.mjs`, the per-condition fold and the leak signal live in
+// `review-eval-run.mjs`, the recompute lives in
 // `review-eval-result-shape.mjs`, and the verdict rules live in
 // `review-eval-report.mjs`.
 //
@@ -78,6 +79,7 @@ const scriptPath = fileURLToPath(import.meta.url);
 // Editing any of them changes what a row means, so all of them are hashed into
 // `matcher_digest` and comparison is refused across the change.
 export const SCORING_MODULES = [
+  "review-eval.mjs",
   "review-eval-run.mjs",
   "review-eval-result-shape.mjs",
   "review-eval-report.mjs",

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -64,7 +64,8 @@ const scriptPath = fileURLToPath(import.meta.url);
 // extraction and the matcher live here, CLI scoring orchestration lives in
 // `review-eval.mjs`, the per-condition fold and the leak signal live in
 // `review-eval-run.mjs`, the recompute lives in
-// `review-eval-result-shape.mjs`, and the verdict rules live in
+// `review-eval-result-shape.mjs`, timestamp validation lives in
+// `review-eval-ledger.mjs`, and the verdict rules live in
 // `review-eval-report.mjs`.
 //
 // The two fixture helpers are hashed for the same reason. `gridFixtures()`
@@ -82,6 +83,7 @@ export const SCORING_MODULES = [
   "review-eval.mjs",
   "review-eval-run.mjs",
   "review-eval-result-shape.mjs",
+  "review-eval-ledger.mjs",
   "review-eval-report.mjs",
   "review-eval-fixtures.mjs",
   "build-fixture.sh",

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -758,6 +758,7 @@ test("scorerDigest covers every module that can move a recorded number", () => {
   // truth file and the recall denominator, and `build-fixture.sh` materializes
   // the checkout the contestant reviews and carries the checks that verify it.
   for (const name of [
+    "review-eval.mjs",
     "review-eval-run.mjs",
     "review-eval-result-shape.mjs",
     "review-eval-report.mjs",

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -752,15 +752,17 @@ test("scorerDigest is a stable sha256 over the scorer and its prompts", () => {
 });
 
 test("scorerDigest covers every module that can move a recorded number", () => {
-  // The per-condition fold, the recompute and the verdict rules live outside
-  // this module, so an edit to one of them must break the pairing too. So do
-  // the fixture helpers: `review-eval-fixtures.mjs` chooses the matrix, the
-  // truth file and the recall denominator, and `build-fixture.sh` materializes
-  // the checkout the contestant reviews and carries the checks that verify it.
+  // The per-condition fold, the recompute, timestamp validation and the
+  // verdict rules live outside this module, so an edit to one of them must
+  // break the pairing too. So do the fixture helpers:
+  // `review-eval-fixtures.mjs` chooses the matrix, the truth file and the recall
+  // denominator, and `build-fixture.sh` materializes the checkout the
+  // contestant reviews and carries the checks that verify it.
   for (const name of [
     "review-eval.mjs",
     "review-eval-run.mjs",
     "review-eval-result-shape.mjs",
+    "review-eval-ledger.mjs",
     "review-eval-report.mjs",
     "review-eval-fixtures.mjs",
     "build-fixture.sh",

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -6,7 +6,13 @@
 // (`run-eval.sh`) invokes it.
 
 import { spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { parseArgs as parseNodeArgs } from "node:util";
@@ -841,6 +847,38 @@ function revalidateAppendedRows({ options, context, result, base }) {
   const calibrationSet = existsSync(calibrationFile)
     ? readJson(calibrationFile)
     : null;
+  const repoRoot = realpathSync(context.repoRoot);
+  const detailDirectoryIdentity = (detailDir, label) => {
+    const resolved = path.resolve(repoRoot, detailDir);
+    const insideRepo = (target) => {
+      const relative = path.relative(repoRoot, target);
+      return (
+        relative === "" ||
+        (relative !== ".." &&
+          !relative.startsWith(`..${path.sep}`) &&
+          !path.isAbsolute(relative))
+      );
+    };
+    if (!insideRepo(resolved)) {
+      problems.push(`${label} names detail_dir ${detailDir} outside the repo`);
+      return null;
+    }
+    const canonical = existsSync(resolved) ? realpathSync(resolved) : resolved;
+    if (!insideRepo(canonical)) {
+      problems.push(`${label} names detail_dir ${detailDir} outside the repo`);
+      return null;
+    }
+    return canonical;
+  };
+  const usedDetailDirs = new Set();
+  for (const row of base.rows ?? []) {
+    if (typeof row.detail_dir !== "string") continue;
+    const identity = detailDirectoryIdentity(
+      row.detail_dir,
+      `base row ${row.executed_at}`,
+    );
+    if (identity !== null) usedDetailDirs.add(identity);
+  }
   let unpaired = 0;
   for (const row of appended) {
     const label = `appended row ${row.executed_at}`;
@@ -848,7 +886,15 @@ function revalidateAppendedRows({ options, context, result, base }) {
       problems.push(`${label} carries no detail_dir to recompute from`);
       continue;
     }
-    const dir = path.resolve(context.repoRoot, row.detail_dir);
+    const dir = detailDirectoryIdentity(row.detail_dir, label);
+    if (dir === null) continue;
+    if (row.kind !== "bridge" && usedDetailDirs.has(dir)) {
+      problems.push(
+        `${label} reuses detail_dir ${row.detail_dir} from an earlier ledger row`,
+      );
+      continue;
+    }
+    usedDetailDirs.add(dir);
     if (!existsSync(dir)) {
       problems.push(
         `${label} names detail_dir ${row.detail_dir}, which this branch does not commit`,

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -1056,20 +1056,33 @@ function runEvidenceProblems({ dir, row, contract }) {
             rowConditions.has(cell.condition),
           );
           for (const condition of rowConditions) {
-            const hasConditionResult = cells
-              .filter((cell) => cell.condition === condition)
-              .some((cell) =>
-                existsSync(
-                  path.join(
-                    dir,
-                    `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
-                  ),
+            const resultCells = cells.filter(
+              (cell) =>
+                cell.condition === condition &&
+                resultFiles.includes(
+                  `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
                 ),
-              );
-            if (!hasConditionResult) {
+            );
+            if (resultCells.length === 0) {
               problems.push(
                 `${dir} carries no scored result for row condition ${condition}`,
               );
+              continue;
+            }
+            const representedPrs = new Set(resultCells.map((cell) => cell.pr));
+            const perDefect = row.conditions?.[condition]?.per_defect ?? {};
+            for (const pr of representedPrs) {
+              const fixture = contract.fixtures.find(
+                (candidate) => candidate.pr === pr,
+              );
+              const missingIds = (fixture?.scorable_ids ?? [])
+                .map(String)
+                .filter((id) => !Object.hasOwn(perDefect, id));
+              if (missingIds.length > 0) {
+                problems.push(
+                  `${dir} row condition ${condition} omits frozen defect ${missingIds.join(", ")} for scored result PR ${pr}`,
+                );
+              }
             }
           }
         }

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -528,6 +528,7 @@ function nonRegularEvidenceProblems(dir) {
   for (const file of readdirSync(dir).filter(
     (name) =>
       name === "calibration.json" ||
+      name === "plan.json" ||
       (name.startsWith("result-") && name.endsWith(".json")),
   )) {
     try {
@@ -736,26 +737,84 @@ export function planProvenanceProblems({
   return problems;
 }
 
-/** Preserve a scorer's hard leak flag on every row that reuses its results. */
-function resultLeakProblems({ dir, row }) {
+/** Validate required fields that every scored result must retain. */
+function resultEvidenceProblems({ dir, row }) {
   if (row.status === "failed" || !existsSync(dir)) return [];
   const regularityProblems = nonRegularEvidenceProblems(dir);
   if (regularityProblems.length > 0) return regularityProblems;
   const problems = [];
+  if (holdsCellResults(dir)) {
+    const scoringUsd = row?.scoring_usd;
+    if (
+      !Object.hasOwn(row ?? {}, "scoring_usd") ||
+      typeof scoringUsd !== "number" ||
+      !Number.isFinite(scoringUsd) ||
+      scoringUsd < 0
+    ) {
+      problems.push(
+        "row.scoring_usd must be a nonnegative finite number for scored evidence",
+      );
+    }
+  }
   let resultRecordsLeak = false;
   for (const resultFile of readdirSync(dir).filter(
     (name) => name.startsWith("result-") && name.endsWith(".json"),
   )) {
     try {
-      const leak = readJson(path.join(dir, resultFile))?.leak;
+      const record = readJson(path.join(dir, resultFile));
+      const scoringUsd = record?.scoring_usd;
       if (
-        leak?.suspected === true ||
-        (Array.isArray(leak?.hard) && leak.hard.length > 0)
+        !Object.hasOwn(record ?? {}, "scoring_usd") ||
+        typeof scoringUsd !== "number" ||
+        !Number.isFinite(scoringUsd) ||
+        scoringUsd < 0
       ) {
+        problems.push(
+          `${dir}/${resultFile} scoring_usd must be a nonnegative finite number`,
+        );
+      }
+      const leak = record?.leak;
+      const hard = leak?.hard;
+      const suspected = leak?.suspected;
+      if (
+        leak === null ||
+        typeof leak !== "object" ||
+        Array.isArray(leak) ||
+        !Array.isArray(hard) ||
+        typeof suspected !== "boolean"
+      ) {
+        problems.push(
+          `${dir}/${resultFile} leak must carry a hard array and suspected boolean`,
+        );
+      } else if (suspected !== hard.length > 0) {
+        problems.push(
+          `${dir}/${resultFile} leak.suspected must equal whether leak.hard is non-empty`,
+        );
+      }
+      if (suspected === true || (Array.isArray(hard) && hard.length > 0)) {
         resultRecordsLeak = true;
       }
     } catch {
       // The normal evidence checks report unreadable result records.
+    }
+  }
+  const calibrationFile = path.join(dir, "calibration.json");
+  if (existsSync(calibrationFile)) {
+    try {
+      const calibration = readJson(calibrationFile);
+      const scoringUsd = calibration?.scoring_usd;
+      if (
+        !Object.hasOwn(calibration ?? {}, "scoring_usd") ||
+        typeof scoringUsd !== "number" ||
+        !Number.isFinite(scoringUsd) ||
+        scoringUsd < 0
+      ) {
+        problems.push(
+          `${dir}/calibration.json scoring_usd must be a nonnegative finite number`,
+        );
+      }
+    } catch {
+      // The calibration evidence checks report an unreadable record.
     }
   }
   if (resultRecordsLeak && !leakSuspected(row)) {
@@ -776,7 +835,7 @@ function runEvidenceProblems({ dir, row, contract }) {
   if (row.status === "failed") return [];
   const regularityProblems = nonRegularEvidenceProblems(dir);
   if (regularityProblems.length > 0) return regularityProblems;
-  const problems = resultLeakProblems({ dir, row });
+  const problems = resultEvidenceProblems({ dir, row });
   // A bridge intentionally reuses the source full run's plan and scored
   // records. It owes no new evidence, but it must retain any leak flag those
   // records carry because that flag makes the reused score unusable.
@@ -956,27 +1015,6 @@ function runEvidenceProblems({ dir, row, contract }) {
             if (!Number.isFinite(value) || value < 0) {
               problems.push(
                 `${dir}/${resultFile} ${field} must be a nonnegative finite number`,
-              );
-            }
-          }
-          if (Object.hasOwn(record ?? {}, "scoring_usd")) {
-            const value = Number(record.scoring_usd);
-            if (!Number.isFinite(value) || value < 0) {
-              problems.push(
-                `${dir}/${resultFile} scoring_usd must be a nonnegative finite number`,
-              );
-            }
-          }
-          if (record?.leak !== undefined) {
-            const hard = record.leak?.hard;
-            const suspected = record.leak?.suspected;
-            if (!Array.isArray(hard) || typeof suspected !== "boolean") {
-              problems.push(
-                `${dir}/${resultFile} leak must carry a hard array and suspected boolean`,
-              );
-            } else if (suspected !== hard.length > 0) {
-              problems.push(
-                `${dir}/${resultFile} leak.suspected must equal whether leak.hard is non-empty`,
               );
             }
           }

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -55,6 +55,7 @@ import {
   assertAuthorizedFreshnessWorkflow,
   buildPlan,
   baselinePlanIdentity,
+  cellFingerprint,
   claudeExec,
   comparabilityKey,
   DEFAULT_CALIBRATION_PATH,
@@ -764,6 +765,14 @@ function resultEvidenceProblems({ dir, row }) {
   const regularityProblems = nonRegularEvidenceProblems(dir);
   if (regularityProblems.length > 0) return regularityProblems;
   const problems = [];
+  let expectedFingerprint = null;
+  try {
+    expectedFingerprint = cellFingerprint({
+      plan: readJson(path.join(dir, "plan.json")),
+    });
+  } catch {
+    // planProvenanceProblems reports a missing or unreadable plan.
+  }
   if (holdsCellResults(dir)) {
     const scoringUsd = row?.scoring_usd;
     if (
@@ -783,6 +792,15 @@ function resultEvidenceProblems({ dir, row }) {
   )) {
     try {
       const record = readJson(path.join(dir, resultFile));
+      if (
+        expectedFingerprint !== null &&
+        JSON.stringify(record?.fingerprint) !==
+          JSON.stringify(expectedFingerprint)
+      ) {
+        problems.push(
+          `${dir}/${resultFile} fingerprint does not match the plan execution inputs`,
+        );
+      }
       const scoringUsd = record?.scoring_usd;
       if (
         !Object.hasOwn(record ?? {}, "scoring_usd") ||
@@ -823,6 +841,15 @@ function resultEvidenceProblems({ dir, row }) {
   if (existsSync(calibrationFile)) {
     try {
       const calibration = readJson(calibrationFile);
+      if (
+        expectedFingerprint !== null &&
+        JSON.stringify(calibration?.fingerprint) !==
+          JSON.stringify(expectedFingerprint)
+      ) {
+        problems.push(
+          `${dir}/calibration.json fingerprint does not match the plan execution inputs`,
+        );
+      }
       const scoringUsd = calibration?.scoring_usd;
       if (
         !Object.hasOwn(calibration ?? {}, "scoring_usd") ||
@@ -893,15 +920,60 @@ function runEvidenceProblems({ dir, row, contract }) {
         const resultFiles = readdirSync(dir).filter(
           (name) => name.startsWith("result-") && name.endsWith(".json"),
         );
-        if (
-          row.status === "partial" &&
-          [...plannedResults.keys()].every((resultFile) =>
-            resultFiles.includes(resultFile),
-          )
-        ) {
-          problems.push(
-            `${dir} records partial status but carries every planned result cell`,
-          );
+        try {
+          const completedCellIds = readJson(
+            path.join(dir, "calibration.json"),
+          )?.completed_cell_ids;
+          if (
+            !Array.isArray(completedCellIds) ||
+            completedCellIds.some(
+              (cellId) => typeof cellId !== "string" || cellId.length === 0,
+            )
+          ) {
+            problems.push(
+              `${dir}/calibration.json completed_cell_ids must be an array of non-empty strings`,
+            );
+          } else {
+            const plannedCellIds = new Set(
+              plan.cells.map((cell) => cell.cell_id),
+            );
+            const completedSet = new Set(completedCellIds);
+            if (completedSet.size !== completedCellIds.length) {
+              problems.push(
+                `${dir}/calibration.json completed_cell_ids must not contain duplicates`,
+              );
+            }
+            for (const cellId of completedSet) {
+              if (!plannedCellIds.has(cellId)) {
+                problems.push(
+                  `${dir}/calibration.json records unplanned completed cell ${cellId}`,
+                );
+              }
+            }
+            const resultCellIds = resultFiles
+              .map((resultFile) => plannedResults.get(resultFile)?.cell_id)
+              .filter(Boolean);
+            const sorted = (values) => [...values].sort();
+            if (
+              JSON.stringify(sorted(completedSet)) !==
+              JSON.stringify(sorted(new Set(resultCellIds)))
+            ) {
+              problems.push(
+                `${dir} result files do not match calibration.json completed_cell_ids`,
+              );
+            }
+            const expectedStatus =
+              completedSet.size === plannedCellIds.size
+                ? "complete"
+                : "partial";
+            if (row.status !== expectedStatus) {
+              problems.push(
+                `${dir} records ${row.status} status but calibration.json proves a ${expectedStatus} matrix`,
+              );
+            }
+          }
+        } catch {
+          // The calibration evidence checks report an unreadable record.
         }
         for (const resultFile of resultFiles) {
           const cell = plannedResults.get(resultFile);

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -1011,8 +1011,12 @@ function runEvidenceProblems({ dir, row, contract }) {
             }
           }
           for (const field of ["usd", "seconds"]) {
-            const value = Number(record?.[field]);
-            if (!Number.isFinite(value) || value < 0) {
+            const value = record?.[field];
+            if (
+              typeof value !== "number" ||
+              !Number.isFinite(value) ||
+              value < 0
+            ) {
               problems.push(
                 `${dir}/${resultFile} ${field} must be a nonnegative finite number`,
               );

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -6,6 +6,7 @@
 // (`run-eval.sh`) invokes it.
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -42,6 +43,7 @@ import {
 } from "./review-eval-ledger.mjs";
 import {
   parseLeadingReviewEvalMarkers,
+  leakSuspected,
   renderReport,
   REVIEW_EVAL_OWNERSHIP_LABEL,
   scheduleIssuePayload,
@@ -704,10 +706,43 @@ export function planProvenanceProblems({
   return problems;
 }
 
+/** Preserve a scorer's hard leak flag on every row that reuses its results. */
+function resultLeakProblems({ dir, row }) {
+  if (row.status === "failed" || !existsSync(dir)) return [];
+  const problems = [];
+  let resultRecordsLeak = false;
+  for (const resultFile of readdirSync(dir).filter(
+    (name) => name.startsWith("result-") && name.endsWith(".json"),
+  )) {
+    try {
+      if (readJson(path.join(dir, resultFile))?.leak?.suspected === true) {
+        resultRecordsLeak = true;
+      }
+    } catch {
+      // The normal evidence checks report unreadable result records.
+    }
+  }
+  if (resultRecordsLeak && !leakSuspected(row)) {
+    problems.push(
+      `${dir} carries a result with leak.suspected true, but the row notes omit leak suspected`,
+    );
+  }
+  if (resultRecordsLeak && row.verdict !== "AMBER") {
+    problems.push(
+      `${dir} carries a result with leak.suspected true, but the row verdict is ${row.verdict} instead of AMBER`,
+    );
+  }
+  return problems;
+}
+
 /** Evidence files required for every row that claims scored results. */
 function runEvidenceProblems({ dir, row, contract }) {
-  if (row.kind === "bridge" || row.status === "failed") return [];
-  const problems = [];
+  if (row.status === "failed") return [];
+  const problems = resultLeakProblems({ dir, row });
+  // A bridge intentionally reuses the source full run's plan and scored
+  // records. It owes no new evidence, but it must retain any leak flag those
+  // records carry because that flag makes the reused score unusable.
+  if (row.kind === "bridge") return problems;
   if (!holdsCellResults(dir)) {
     problems.push(`${dir} carries no scored result-*.json files`);
   }
@@ -837,6 +872,50 @@ function runEvidenceProblems({ dir, row, contract }) {
   return problems;
 }
 
+/** Canonical JSON text for evidence fingerprints. */
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Digest the scored result and calibration records, independent of layout. */
+function runEvidenceDigest(dir) {
+  if (!existsSync(dir)) return null;
+  const files = readdirSync(dir)
+    .filter(
+      (name) =>
+        name === "calibration.json" ||
+        (name.startsWith("result-") && name.endsWith(".json")),
+    )
+    .sort();
+  if (files.length === 0) return null;
+  const hash = createHash("sha256");
+  const update = (value) => {
+    const bytes = Buffer.from(value);
+    const length = Buffer.alloc(8);
+    length.writeBigUInt64BE(BigInt(bytes.length));
+    hash.update(length);
+    hash.update(bytes);
+  };
+  try {
+    for (const file of files) {
+      update(file);
+      update(canonicalJson(readJson(path.join(dir, file))));
+    }
+  } catch {
+    return null;
+  }
+  return hash.digest("hex");
+}
+
 /**
  * Recompute every row this branch appends, from the detail the same branch
  * commits. `checkLedger` proves a ledger PR is schema-valid, covers the frozen
@@ -895,13 +974,22 @@ function revalidateAppendedRows({ options, context, result, base }) {
     return canonical;
   };
   const usedDetailDirs = new Set();
+  const usedEvidence = new Map();
   for (const row of base.rows ?? []) {
     if (typeof row.detail_dir !== "string") continue;
     const identity = detailDirectoryIdentity(
       row.detail_dir,
       `base row ${row.executed_at}`,
     );
-    if (identity !== null) usedDetailDirs.add(identity);
+    if (identity !== null) {
+      usedDetailDirs.add(identity);
+      if (row.kind !== "bridge" && row.status !== "failed") {
+        const digest = runEvidenceDigest(identity);
+        if (digest !== null) {
+          usedEvidence.set(digest, `base row ${row.executed_at}`);
+        }
+      }
+    }
   }
   let unpaired = 0;
   for (const row of appended) {
@@ -925,6 +1013,17 @@ function revalidateAppendedRows({ options, context, result, base }) {
       );
       continue;
     }
+    if (row.kind !== "bridge" && row.status !== "failed") {
+      const digest = runEvidenceDigest(dir);
+      const previous = digest === null ? null : usedEvidence.get(digest);
+      if (previous) {
+        problems.push(
+          `${label} reuses scored result and calibration evidence from ${previous}`,
+        );
+      } else if (digest !== null) {
+        usedEvidence.set(digest, label);
+      }
+    }
     // The recorded pairing is rechecked against the row it actually names, not
     // against whatever anchor this ledger would resolve on its own — those are
     // two different pairs of runs, and comparing the wrong one reports
@@ -933,6 +1032,7 @@ function revalidateAppendedRows({ options, context, result, base }) {
     // branch does not carry; that pairing cannot be rechecked here, so the row
     // is recomputed against its own bits and detail alone and counted as
     // unpaired rather than failed.
+    const skipsBaselinePairing = row.status === "failed";
     const recordedAt = row.vs_baseline?.baseline_executed_at ?? null;
     const baselineRow =
       recordedAt === null
@@ -946,21 +1046,29 @@ function revalidateAppendedRows({ options, context, result, base }) {
       row.inputs?.dirty === true &&
       row.inputs?.skill_ref !== "installed" &&
       baselineSelection === "explicit";
-    if (missingRecordedBaseline && !candidateMissingBaseline) {
+    if (
+      !skipsBaselinePairing &&
+      missingRecordedBaseline &&
+      !candidateMissingBaseline
+    ) {
       problems.push(
         `${label}: baseline ${recordedAt} is not in the ledger; only a dirty --skill-ref candidate row with explicit selection may waive a missing baseline`,
       );
     }
     const baselineMissing = candidateMissingBaseline;
     if (baselineMissing) unpaired += 1;
-    if (recordedAt !== null && baselineSelection === null) {
+    if (
+      !skipsBaselinePairing &&
+      recordedAt !== null &&
+      baselineSelection === null
+    ) {
       problems.push(
         `${label}: vs_baseline.selection must record automatic or explicit baseline selection`,
       );
     }
     const baselineIsExplicit =
       row.kind === "bridge" || baselineSelection === "explicit";
-    if (!baselineMissing && !baselineIsExplicit) {
+    if (!skipsBaselinePairing && !baselineMissing && !baselineIsExplicit) {
       const resolvedBaseline = resolveBaseline({ rows, row });
       const sameBaseline =
         resolvedBaseline === baselineRow ||
@@ -983,8 +1091,8 @@ function revalidateAppendedRows({ options, context, result, base }) {
       row,
       repoRoot: context.repoRoot,
       detailDir: dir,
-      ledgerRows: baselineMissing ? [] : rows,
-      baselineRow,
+      ledgerRows: baselineMissing || skipsBaselinePairing ? [] : rows,
+      baselineRow: skipsBaselinePairing ? null : baselineRow,
       baselineIsExplicit,
       // Half the verdict is the pairing: a regression and a promotion are both
       // read out of the flip counts against the anchor. Recomputing an unpaired

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -550,6 +550,7 @@ export function planProvenanceProblems({
     return [error instanceof Error ? error.message : String(error)];
   }
   const problems = [];
+  /** True when the plan carries the complete explicit-baseline fingerprint. */
   const validBaselineIdentity = (value) =>
     value !== null &&
     typeof value === "object" &&

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -705,7 +705,7 @@ export function planProvenanceProblems({
 }
 
 /** Evidence files required for every row that claims scored results. */
-function runEvidenceProblems({ dir, row }) {
+function runEvidenceProblems({ dir, row, contract }) {
   if (row.kind === "bridge" || row.status === "failed") return [];
   const problems = [];
   if (!holdsCellResults(dir)) {
@@ -749,6 +749,30 @@ function runEvidenceProblems({ dir, row }) {
               problems.push(
                 `${dir}/${resultFile} ${field} is ${JSON.stringify(record?.[field])}; plan.json recorded ${JSON.stringify(cell[field])}`,
               );
+            }
+          }
+          const fixture = contract.fixtures.find(
+            (candidate) => candidate.pr === cell.pr,
+          );
+          if (!Array.isArray(record?.matched_ids)) {
+            problems.push(`${dir}/${resultFile} matched_ids must be an array`);
+          } else if (fixture) {
+            const allowedIds = new Set(fixture.scorable_ids.map(String));
+            for (const id of record.matched_ids) {
+              if (
+                !(
+                  typeof id === "string" ||
+                  (typeof id === "number" && Number.isSafeInteger(id))
+                )
+              ) {
+                problems.push(
+                  `${dir}/${resultFile} matched_ids contains non-scalar ${JSON.stringify(id)}`,
+                );
+              } else if (!allowedIds.has(String(id))) {
+                problems.push(
+                  `${dir}/${resultFile} matched_ids contains ${JSON.stringify(id)}, which fixture PR ${cell.pr} does not score`,
+                );
+              }
             }
           }
           if (!rowConditions.has(cell.condition)) {
@@ -981,7 +1005,7 @@ function revalidateAppendedRows({ options, context, result, base }) {
       }).map((problem) => `${label}: ${problem}`),
     );
     problems.push(
-      ...runEvidenceProblems({ dir, row }).map(
+      ...runEvidenceProblems({ dir, row, contract: context.contract }).map(
         (problem) => `${label}: ${problem}`,
       ),
     );

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -43,6 +43,7 @@ import {
   validateLedgerRow,
 } from "./review-eval-ledger.mjs";
 import {
+  baselineEligibility,
   parseLeadingReviewEvalMarkers,
   leakSuspected,
   renderReport,
@@ -567,20 +568,37 @@ export function planProvenanceProblems({
   baselineRow = null,
   expectedComparabilityKey = null,
 }) {
+  const problems = [];
+  const checkBaselineStanding = () => {
+    if (baselineRow === null) return;
+    const eligibility = baselineEligibility(baselineRow);
+    if (!eligibility.usable) {
+      problems.push(
+        `explicit baseline ${baselineRow.executed_at} is not eligible: ${eligibility.reason}`,
+      );
+    }
+    if (!(baselineRow.executed_at < row.executed_at)) {
+      problems.push(
+        `explicit baseline ${baselineRow.executed_at} must precede candidate ${row.executed_at}`,
+      );
+    }
+  };
+  if (row.kind === "bridge") checkBaselineStanding();
   const file = path.join(dir, "plan.json");
   if (!existsSync(file)) {
-    if (row.kind === "bridge" && !holdsCellResults(dir)) return [];
-    return [
+    if (row.kind === "bridge" && !holdsCellResults(dir)) return problems;
+    problems.push(
       `${dir} carries no plan.json; the row's provenance cannot be checked against the run that produced it`,
-    ];
+    );
+    return problems;
   }
   let plan;
   try {
     plan = readJson(file);
   } catch (error) {
-    return [error instanceof Error ? error.message : String(error)];
+    problems.push(error instanceof Error ? error.message : String(error));
+    return problems;
   }
-  const problems = [];
   /** True when the plan carries the complete explicit-baseline fingerprint. */
   const validBaselineIdentity = (value) =>
     value !== null &&
@@ -696,6 +714,9 @@ export function planProvenanceProblems({
     problems.push(
       `resolved baseline does not match the explicit baseline identity plan.json in ${row.detail_dir} recorded`,
     );
+  }
+  if (plan.baseline_selection === "explicit" && row.kind !== "bridge") {
+    checkBaselineStanding();
   }
   if (!Array.isArray(plan.cells)) {
     problems.push(`plan.json in ${row.detail_dir} carries no cells array`);
@@ -861,6 +882,16 @@ function runEvidenceProblems({ dir, row, contract }) {
         const resultFiles = readdirSync(dir).filter(
           (name) => name.startsWith("result-") && name.endsWith(".json"),
         );
+        if (
+          row.status === "partial" &&
+          [...plannedResults.keys()].every((resultFile) =>
+            resultFiles.includes(resultFile),
+          )
+        ) {
+          problems.push(
+            `${dir} records partial status but carries every planned result cell`,
+          );
+        }
         for (const resultFile of resultFiles) {
           const cell = plannedResults.get(resultFile);
           if (!cell) {

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -907,8 +907,45 @@ function runEvidenceDigest(dir) {
   };
   try {
     for (const file of files) {
+      const record = readJson(path.join(dir, file));
+      const scoreEvidence =
+        file === "calibration.json"
+          ? {
+              outcomes: [...(record?.outcomes ?? [])]
+                .map((outcome) => ({
+                  record_id: String(outcome?.record_id),
+                  expected: outcome?.expected,
+                  actual: outcome?.actual,
+                }))
+                .sort((left, right) =>
+                  canonicalJson(left).localeCompare(canonicalJson(right)),
+                ),
+              scoring_usd: {
+                present: Object.hasOwn(record ?? {}, "scoring_usd"),
+                value: Number(record?.scoring_usd ?? 0),
+              },
+            }
+          : {
+              cell_id: record?.cell_id,
+              pr: record?.pr,
+              condition: record?.condition,
+              draw: record?.draw,
+              matched_ids: [
+                ...new Set((record?.matched_ids ?? []).map((id) => String(id))),
+              ].sort(),
+              claim_count: (record?.claims ?? []).length,
+              novel_wrong: Number(record?.novel?.novelWrong ?? 0),
+              novel_real: Number(record?.novel?.novelReal ?? 0),
+              usd: Number(record?.usd ?? 0),
+              seconds: Number(record?.seconds ?? 0),
+              scoring_usd: {
+                present: Object.hasOwn(record ?? {}, "scoring_usd"),
+                value: Number(record?.scoring_usd ?? 0),
+              },
+              leak_suspected: record?.leak?.suspected === true,
+            };
       update(file);
-      update(canonicalJson(readJson(path.join(dir, file))));
+      update(canonicalJson(scoreEvidence));
     }
   } catch {
     return null;

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -714,6 +714,43 @@ function runEvidenceProblems({ dir, row }) {
         const planConditions = new Set(
           plan.cells.map((cell) => cell.condition),
         );
+        const plannedResults = new Map(
+          plan.cells.map((cell) => [
+            `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
+            cell,
+          ]),
+        );
+        const resultFiles = readdirSync(dir).filter(
+          (name) => name.startsWith("result-") && name.endsWith(".json"),
+        );
+        for (const resultFile of resultFiles) {
+          const cell = plannedResults.get(resultFile);
+          if (!cell) {
+            problems.push(`${dir} carries unplanned result file ${resultFile}`);
+            continue;
+          }
+          let record;
+          try {
+            record = readJson(path.join(dir, resultFile));
+          } catch (error) {
+            problems.push(
+              error instanceof Error ? error.message : String(error),
+            );
+            continue;
+          }
+          for (const field of ["cell_id", "pr", "condition", "draw"]) {
+            if (record?.[field] !== cell[field]) {
+              problems.push(
+                `${dir}/${resultFile} ${field} is ${JSON.stringify(record?.[field])}; plan.json recorded ${JSON.stringify(cell[field])}`,
+              );
+            }
+          }
+          if (!rowConditions.has(cell.condition)) {
+            problems.push(
+              `${dir}/${resultFile} records condition ${cell.condition}, but the row omits it`,
+            );
+          }
+        }
         if (row.status === "complete") {
           for (const condition of planConditions) {
             if (!rowConditions.has(condition)) {
@@ -731,7 +768,7 @@ function runEvidenceProblems({ dir, row }) {
           }
           for (const cell of plan.cells) {
             const resultFile = `result-${cell.pr}-${cell.condition}-${cell.draw}.json`;
-            if (!existsSync(path.join(dir, resultFile))) {
+            if (!resultFiles.includes(resultFile)) {
               problems.push(
                 `${dir} carries no ${resultFile} for planned cell ${cell.cell_id ?? "unknown"}`,
               );

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -1523,6 +1523,13 @@ async function modeValidate(options, context) {
     context.repoRoot,
     options.calibrationPath,
   );
+  // An automatic row is scored at the next ledger position. Before append it
+  // is still an external object, so timestamp fallback can wrongly exclude an
+  // established anchor whose clock is later. Give validation the same pending
+  // append position that scorePlan used.
+  const validationLedgerRows = options.append
+    ? [...ledgerRows, row]
+    : ledgerRows;
   const revalidated = revalidateRow({
     contract: context.contract,
     row,
@@ -1530,7 +1537,7 @@ async function modeValidate(options, context) {
     // The run detail may sit outside `--root`: the orchestrator reads the
     // contract from a spec worktree while the cells live in the real checkout.
     detailDir: options.detailDir ? path.resolve(options.detailDir) : null,
-    ledgerRows,
+    ledgerRows: validationLedgerRows,
     // Name the same baseline `--score --against` used, or the row's own
     // verdict is rechecked against a baseline it was never scored on.
     baselineRow: resolveRowReference({

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -715,7 +715,11 @@ function resultLeakProblems({ dir, row }) {
     (name) => name.startsWith("result-") && name.endsWith(".json"),
   )) {
     try {
-      if (readJson(path.join(dir, resultFile))?.leak?.suspected === true) {
+      const leak = readJson(path.join(dir, resultFile))?.leak;
+      if (
+        leak?.suspected === true ||
+        (Array.isArray(leak?.hard) && leak.hard.length > 0)
+      ) {
         resultRecordsLeak = true;
       }
     } catch {
@@ -810,6 +814,46 @@ function runEvidenceProblems({ dir, row, contract }) {
               }
             }
           }
+          if (!Array.isArray(record?.claims)) {
+            problems.push(`${dir}/${resultFile} claims must be an array`);
+          }
+          for (const field of ["novelWrong", "novelReal"]) {
+            const value = Number(record?.novel?.[field]);
+            if (!Number.isSafeInteger(value) || value < 0) {
+              problems.push(
+                `${dir}/${resultFile} novel.${field} must be a nonnegative safe integer`,
+              );
+            }
+          }
+          for (const field of ["usd", "seconds"]) {
+            const value = Number(record?.[field]);
+            if (!Number.isFinite(value) || value < 0) {
+              problems.push(
+                `${dir}/${resultFile} ${field} must be a nonnegative finite number`,
+              );
+            }
+          }
+          if (Object.hasOwn(record ?? {}, "scoring_usd")) {
+            const value = Number(record.scoring_usd);
+            if (!Number.isFinite(value) || value < 0) {
+              problems.push(
+                `${dir}/${resultFile} scoring_usd must be a nonnegative finite number`,
+              );
+            }
+          }
+          if (record?.leak !== undefined) {
+            const hard = record.leak?.hard;
+            const suspected = record.leak?.suspected;
+            if (!Array.isArray(hard) || typeof suspected !== "boolean") {
+              problems.push(
+                `${dir}/${resultFile} leak must carry a hard array and suspected boolean`,
+              );
+            } else if (suspected !== hard.length > 0) {
+              problems.push(
+                `${dir}/${resultFile} leak.suspected must equal whether leak.hard is non-empty`,
+              );
+            }
+          }
           if (!rowConditions.has(cell.condition)) {
             problems.push(
               `${dir}/${resultFile} records condition ${cell.condition}, but the row omits it`,
@@ -886,7 +930,7 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
-/** Digest the scored result and calibration records, independent of layout. */
+/** Digest one run's exact canonical scored evidence, independent of layout. */
 function runEvidenceDigest(dir) {
   if (!existsSync(dir)) return null;
   const files = readdirSync(dir)
@@ -907,45 +951,8 @@ function runEvidenceDigest(dir) {
   };
   try {
     for (const file of files) {
-      const record = readJson(path.join(dir, file));
-      const scoreEvidence =
-        file === "calibration.json"
-          ? {
-              outcomes: [...(record?.outcomes ?? [])]
-                .map((outcome) => ({
-                  record_id: String(outcome?.record_id),
-                  expected: outcome?.expected,
-                  actual: outcome?.actual,
-                }))
-                .sort((left, right) =>
-                  canonicalJson(left).localeCompare(canonicalJson(right)),
-                ),
-              scoring_usd: {
-                present: Object.hasOwn(record ?? {}, "scoring_usd"),
-                value: Number(record?.scoring_usd ?? 0),
-              },
-            }
-          : {
-              cell_id: record?.cell_id,
-              pr: record?.pr,
-              condition: record?.condition,
-              draw: record?.draw,
-              matched_ids: [
-                ...new Set((record?.matched_ids ?? []).map((id) => String(id))),
-              ].sort(),
-              claim_count: (record?.claims ?? []).length,
-              novel_wrong: Number(record?.novel?.novelWrong ?? 0),
-              novel_real: Number(record?.novel?.novelReal ?? 0),
-              usd: Number(record?.usd ?? 0),
-              seconds: Number(record?.seconds ?? 0),
-              scoring_usd: {
-                present: Object.hasOwn(record ?? {}, "scoring_usd"),
-                value: Number(record?.scoring_usd ?? 0),
-              },
-              leak_suspected: record?.leak?.suspected === true,
-            };
       update(file);
-      update(canonicalJson(scoreEvidence));
+      update(canonicalJson(readJson(path.join(dir, file))));
     }
   } catch {
     return null;

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -10,6 +10,7 @@ import { createHash } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -520,6 +521,26 @@ function holdsCellResults(dir) {
   }
 }
 
+/** Reject evidence links and special files before any JSON reader follows them. */
+function nonRegularEvidenceProblems(dir) {
+  if (!existsSync(dir)) return [];
+  const problems = [];
+  for (const file of readdirSync(dir).filter(
+    (name) =>
+      name === "calibration.json" ||
+      (name.startsWith("result-") && name.endsWith(".json")),
+  )) {
+    try {
+      if (!lstatSync(path.join(dir, file)).isFile()) {
+        problems.push(`${dir}/${file} must be a regular evidence file`);
+      }
+    } catch {
+      problems.push(`${dir}/${file} cannot be inspected as an evidence file`);
+    }
+  }
+  return problems;
+}
+
 /**
  * The row's provenance, checked against the plan that produced it.
  *
@@ -543,6 +564,7 @@ export function planProvenanceProblems({
   row,
   contract,
   baselineRow = null,
+  expectedComparabilityKey = null,
 }) {
   const file = path.join(dir, "plan.json");
   if (!existsSync(file)) {
@@ -604,6 +626,14 @@ export function planProvenanceProblems({
         `row ${field} is ${JSON.stringify(row[field])}; plan.json in ${row.detail_dir} planned ${JSON.stringify(plan[field])}`,
       );
     }
+  }
+  if (
+    expectedComparabilityKey !== null &&
+    plan.comparability_key !== expectedComparabilityKey
+  ) {
+    problems.push(
+      `plan.json in ${row.detail_dir} carries comparability_key ${JSON.stringify(plan.comparability_key)}; current frozen inputs derive ${expectedComparabilityKey}`,
+    );
   }
   // The inputs are the skill, argv, orchestrator and CLI provenance the scorer
   // copies out of the plan verbatim, so any difference is an edit.
@@ -709,6 +739,8 @@ export function planProvenanceProblems({
 /** Preserve a scorer's hard leak flag on every row that reuses its results. */
 function resultLeakProblems({ dir, row }) {
   if (row.status === "failed" || !existsSync(dir)) return [];
+  const regularityProblems = nonRegularEvidenceProblems(dir);
+  if (regularityProblems.length > 0) return regularityProblems;
   const problems = [];
   let resultRecordsLeak = false;
   for (const resultFile of readdirSync(dir).filter(
@@ -742,6 +774,8 @@ function resultLeakProblems({ dir, row }) {
 /** Evidence files required for every row that claims scored results. */
 function runEvidenceProblems({ dir, row, contract }) {
   if (row.status === "failed") return [];
+  const regularityProblems = nonRegularEvidenceProblems(dir);
+  if (regularityProblems.length > 0) return regularityProblems;
   const problems = resultLeakProblems({ dir, row });
   // A bridge intentionally reuses the source full run's plan and scored
   // records. It owes no new evidence, but it must retain any leak flag those
@@ -814,15 +848,107 @@ function runEvidenceProblems({ dir, row, contract }) {
               }
             }
           }
-          if (!Array.isArray(record?.claims)) {
+          const claims = record?.claims;
+          if (!Array.isArray(claims)) {
             problems.push(`${dir}/${resultFile} claims must be an array`);
+          } else {
+            for (const claim of claims) {
+              if (typeof claim !== "string" || claim.trim().length === 0) {
+                problems.push(
+                  `${dir}/${resultFile} claims must contain only non-empty strings`,
+                );
+                break;
+              }
+            }
           }
-          for (const field of ["novelWrong", "novelReal"]) {
+          for (const field of [
+            "claims",
+            "novelWrong",
+            "novelReal",
+            "novelVague",
+            "restatedKnown",
+            "alreadyMatched",
+          ]) {
             const value = Number(record?.novel?.[field]);
             if (!Number.isSafeInteger(value) || value < 0) {
               problems.push(
                 `${dir}/${resultFile} novel.${field} must be a nonnegative safe integer`,
               );
+            }
+          }
+          if (
+            Array.isArray(claims) &&
+            record?.novel?.claims !== claims.length
+          ) {
+            problems.push(
+              `${dir}/${resultFile} novel.claims must equal the claims array length`,
+            );
+          }
+          if (
+            Array.isArray(record?.matched_ids) &&
+            record?.novel?.alreadyMatched !== record.matched_ids.length
+          ) {
+            problems.push(
+              `${dir}/${resultFile} novel.alreadyMatched must equal the matched_ids array length`,
+            );
+          }
+          const verdicts = record?.novel?.verdicts;
+          if (
+            verdicts === null ||
+            typeof verdicts !== "object" ||
+            Array.isArray(verdicts)
+          ) {
+            problems.push(
+              `${dir}/${resultFile} novel.verdicts must be an object`,
+            );
+          } else if (Array.isArray(claims)) {
+            const expectedKeys = claims.map((_claim, index) =>
+              String(index + 1),
+            );
+            const actualKeys = Object.keys(verdicts).sort(
+              (left, right) => Number(left) - Number(right),
+            );
+            if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+              problems.push(
+                `${dir}/${resultFile} novel.verdicts must carry one numbered verdict per claim`,
+              );
+            }
+            const counts = {
+              real: 0,
+              wrong: 0,
+              vague: 0,
+              known: 0,
+            };
+            let validVerdicts = true;
+            for (const verdict of Object.values(verdicts)) {
+              if (
+                verdict === null ||
+                typeof verdict !== "object" ||
+                Array.isArray(verdict) ||
+                !Object.hasOwn(counts, verdict.class)
+              ) {
+                validVerdicts = false;
+                break;
+              }
+              counts[verdict.class] += 1;
+            }
+            if (!validVerdicts) {
+              problems.push(
+                `${dir}/${resultFile} novel.verdicts carries an invalid class`,
+              );
+            } else {
+              for (const [field, count] of [
+                ["novelReal", counts.real],
+                ["novelWrong", counts.wrong],
+                ["novelVague", counts.vague],
+                ["restatedKnown", counts.known],
+              ]) {
+                if (record?.novel?.[field] !== count) {
+                  problems.push(
+                    `${dir}/${resultFile} novel.${field} does not match novel.verdicts`,
+                  );
+                }
+              }
             }
           }
           for (const field of ["usd", "seconds"]) {
@@ -933,6 +1059,7 @@ function canonicalJson(value) {
 /** Digest one run's exact canonical scored evidence, independent of layout. */
 function runEvidenceDigest(dir) {
   if (!existsSync(dir)) return null;
+  if (nonRegularEvidenceProblems(dir).length > 0) return null;
   const files = readdirSync(dir)
     .filter(
       (name) =>
@@ -994,6 +1121,11 @@ function revalidateAppendedRows({ options, context, result, base }) {
   const calibrationSet = existsSync(calibrationFile)
     ? readJson(calibrationFile)
     : null;
+  const expectedComparabilityKey = comparabilityKey({
+    contract: context.contract,
+    contractDigest: context.contractDigest,
+    calibrationDigest: fileDigest(calibrationFile),
+  });
   const repoRoot = realpathSync(context.repoRoot);
   const detailDirectoryIdentity = (detailDir, label) => {
     const resolved = path.resolve(repoRoot, detailDir);
@@ -1015,10 +1147,15 @@ function revalidateAppendedRows({ options, context, result, base }) {
       problems.push(`${label} names detail_dir ${detailDir} outside the repo`);
       return null;
     }
+    if (canonical === repoRoot) {
+      problems.push(`${label} names the repository root as detail_dir`);
+      return null;
+    }
     return canonical;
   };
   const usedDetailDirs = new Set();
   const usedEvidence = new Map();
+  const baseDetailPaths = new Map();
   for (const row of base.rows ?? []) {
     if (typeof row.detail_dir !== "string") continue;
     const identity = detailDirectoryIdentity(
@@ -1027,10 +1164,55 @@ function revalidateAppendedRows({ options, context, result, base }) {
     );
     if (identity !== null) {
       usedDetailDirs.add(identity);
+      baseDetailPaths.set(
+        path
+          .relative(repoRoot, path.resolve(repoRoot, row.detail_dir))
+          .split(path.sep)
+          .join("/"),
+        row.executed_at,
+      );
+      baseDetailPaths.set(
+        path.relative(repoRoot, identity).split(path.sep).join("/"),
+        row.executed_at,
+      );
+      problems.push(
+        ...nonRegularEvidenceProblems(identity).map(
+          (problem) => `base row ${row.executed_at}: ${problem}`,
+        ),
+      );
       if (row.kind !== "bridge" && row.status !== "failed") {
         const digest = runEvidenceDigest(identity);
         if (digest !== null) {
           usedEvidence.set(digest, `base row ${row.executed_at}`);
+        }
+      }
+    }
+  }
+  if (base.rows && base.base) {
+    const changed = spawnSync(
+      "git",
+      ["diff", "--name-only", "-z", "--no-renames", base.base, "--"],
+      { cwd: repoRoot },
+    );
+    if (changed.status !== 0) {
+      problems.push(
+        `could not compare base evidence directories with ${base.base}`,
+      );
+    } else {
+      for (const changedPath of String(changed.stdout)
+        .split("\0")
+        .filter(Boolean)) {
+        for (const [detailPath, executedAt] of baseDetailPaths) {
+          if (
+            changedPath === detailPath ||
+            changedPath.startsWith(`${detailPath}/`) ||
+            detailPath.startsWith(`${changedPath}/`)
+          ) {
+            problems.push(
+              `base row ${executedAt} evidence changed at ${changedPath}`,
+            );
+            break;
+          }
         }
       }
     }
@@ -1057,6 +1239,11 @@ function revalidateAppendedRows({ options, context, result, base }) {
       );
       continue;
     }
+    problems.push(
+      ...nonRegularEvidenceProblems(dir).map(
+        (problem) => `${label}: ${problem}`,
+      ),
+    );
     if (row.kind !== "bridge" && row.status !== "failed") {
       const digest = runEvidenceDigest(dir);
       const previous = digest === null ? null : usedEvidence.get(digest);
@@ -1154,6 +1341,7 @@ function revalidateAppendedRows({ options, context, result, base }) {
         row,
         contract: context.contract,
         baselineRow,
+        expectedComparabilityKey,
       }).map((problem) => `${label}: ${problem}`),
     );
     problems.push(

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -49,6 +49,7 @@ import {
   DEFAULT_LEDGER_PATH,
   DEFAULT_RUNS_DIR,
   fileDigest,
+  planCells,
   planStalenessIssueSync,
   resolveKind,
   scorePlan,
@@ -524,17 +525,16 @@ function holdsCellResults(dir) {
  * written before the matrix spends anything, so it is the run's own statement
  * of what it was. A directory that holds cell results must hold it: deleting
  * the file cannot buy back the check, exactly as with `calibration.json`. A
- * detail directory with no cell results — the hand-assembled bridge row — is
- * left to the reviewer of the ledger PR, as it already is elsewhere.
+ * Only an evidence-free hand-assembled bridge row may omit the plan. It cannot
+ * become an automatic anchor or refresh the full-run clock.
  */
-export function planProvenanceProblems({ dir, row }) {
+export function planProvenanceProblems({ dir, row, contract }) {
   const file = path.join(dir, "plan.json");
   if (!existsSync(file)) {
-    return holdsCellResults(dir)
-      ? [
-          `${dir} carries cell results but no plan.json; the row's provenance cannot be checked against the run that produced it`,
-        ]
-      : [];
+    if (row.kind === "bridge" && !holdsCellResults(dir)) return [];
+    return [
+      `${dir} carries no plan.json; the row's provenance cannot be checked against the run that produced it`,
+    ];
   }
   let plan;
   try {
@@ -575,6 +575,115 @@ export function planProvenanceProblems({ dir, row }) {
     problems.push(
       `row inputs do not match the inputs plan.json in ${row.detail_dir} recorded`,
     );
+  }
+  if (!Array.isArray(plan.cells)) {
+    problems.push(`plan.json in ${row.detail_dir} carries no cells array`);
+    return problems;
+  }
+  if (!contract || !["full", "canary"].includes(plan.kind)) {
+    problems.push(
+      `plan.json in ${row.detail_dir} has no frozen ${plan.kind ?? "unknown"} matrix to validate`,
+    );
+  } else {
+    const expectedCells = planCells({ contract, kind: plan.kind });
+    if (JSON.stringify(plan.cells) !== JSON.stringify(expectedCells)) {
+      problems.push(
+        `plan.json in ${row.detail_dir} cells do not match the frozen ${plan.kind} matrix`,
+      );
+    }
+  }
+  for (const [name, condition] of Object.entries(row.conditions ?? {})) {
+    const cells = plan.cells.filter((cell) => cell.condition === name);
+    if (cells.length === 0) {
+      problems.push(
+        `row condition ${name} has no matching cell in plan.json in ${row.detail_dir}`,
+      );
+      continue;
+    }
+    for (const field of ["model", "effort", "finder"]) {
+      const planned = [...new Set(cells.map((cell) => cell[field]))];
+      if (planned.length !== 1) {
+        problems.push(
+          `plan.json in ${row.detail_dir} records ${planned.length} ${field} values for condition ${name}`,
+        );
+      } else if (condition?.[field] !== planned[0]) {
+        problems.push(
+          `row condition ${name}.${field} is ${JSON.stringify(condition?.[field])}; plan.json recorded ${JSON.stringify(planned[0])}`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+/** Evidence files required for every row that claims scored results. */
+function runEvidenceProblems({ dir, row }) {
+  if (row.kind === "bridge" || row.status === "failed") return [];
+  const problems = [];
+  if (!holdsCellResults(dir)) {
+    problems.push(`${dir} carries no scored result-*.json files`);
+  }
+  const planFile = path.join(dir, "plan.json");
+  if (existsSync(planFile)) {
+    try {
+      const plan = readJson(planFile);
+      if (Array.isArray(plan.cells)) {
+        const rowConditions = new Set(Object.keys(row.conditions ?? {}));
+        const planConditions = new Set(
+          plan.cells.map((cell) => cell.condition),
+        );
+        if (row.status === "complete") {
+          for (const condition of planConditions) {
+            if (!rowConditions.has(condition)) {
+              problems.push(
+                `${dir} planned condition ${condition}, but the complete row omits it`,
+              );
+            }
+          }
+          for (const condition of rowConditions) {
+            if (!planConditions.has(condition)) {
+              problems.push(
+                `${dir} complete row condition ${condition} has no planned cells`,
+              );
+            }
+          }
+          for (const cell of plan.cells) {
+            const resultFile = `result-${cell.pr}-${cell.condition}-${cell.draw}.json`;
+            if (!existsSync(path.join(dir, resultFile))) {
+              problems.push(
+                `${dir} carries no ${resultFile} for planned cell ${cell.cell_id ?? "unknown"}`,
+              );
+            }
+          }
+        } else {
+          const cells = plan.cells.filter((cell) =>
+            rowConditions.has(cell.condition),
+          );
+          for (const condition of rowConditions) {
+            const hasConditionResult = cells
+              .filter((cell) => cell.condition === condition)
+              .some((cell) =>
+                existsSync(
+                  path.join(
+                    dir,
+                    `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
+                  ),
+                ),
+              );
+            if (!hasConditionResult) {
+              problems.push(
+                `${dir} carries no scored result for row condition ${condition}`,
+              );
+            }
+          }
+        }
+      }
+    } catch {
+      // planProvenanceProblems reports the unreadable plan with its full error.
+    }
+  }
+  if (!existsSync(path.join(dir, "calibration.json"))) {
+    problems.push(`${dir} carries no calibration.json`);
   }
   return problems;
 }
@@ -641,8 +750,39 @@ function revalidateAppendedRows({ options, context, result, base }) {
         ? null
         : (rows.find((candidate) => candidate.executed_at === recordedAt) ??
           null);
-    const baselineMissing = recordedAt !== null && baselineRow === null;
+    const missingRecordedBaseline = recordedAt !== null && baselineRow === null;
+    const candidateMissingBaseline =
+      missingRecordedBaseline &&
+      row.inputs?.dirty === true &&
+      row.inputs?.skill_ref !== "installed";
+    if (missingRecordedBaseline && !candidateMissingBaseline) {
+      problems.push(
+        `${label}: baseline ${recordedAt} is not in the ledger; only a dirty --skill-ref candidate row may waive a missing baseline`,
+      );
+    }
+    const baselineMissing = candidateMissingBaseline;
     if (baselineMissing) unpaired += 1;
+    const baselineIsExplicit =
+      row.kind === "bridge" ||
+      (row.inputs?.dirty === true && row.inputs?.skill_ref !== "installed");
+    if (!baselineMissing && !baselineIsExplicit) {
+      const resolvedBaseline = resolveBaseline({ rows, row });
+      const sameBaseline =
+        resolvedBaseline === baselineRow ||
+        (resolvedBaseline !== null &&
+          baselineRow !== null &&
+          resolvedBaseline.executed_at === baselineRow.executed_at &&
+          resolvedBaseline.contract_digest === baselineRow.contract_digest &&
+          resolvedBaseline.detail_dir === baselineRow.detail_dir);
+      if (
+        !sameBaseline &&
+        !(resolvedBaseline === null && baselineRow === null)
+      ) {
+        problems.push(
+          `${label}: recorded baseline ${recordedAt ?? "none"} does not match the append-order baseline ${resolvedBaseline?.executed_at ?? "none"}`,
+        );
+      }
+    }
     const check = revalidateRow({
       contract: context.contract,
       row,
@@ -650,6 +790,7 @@ function revalidateAppendedRows({ options, context, result, base }) {
       detailDir: dir,
       ledgerRows: baselineMissing ? [] : rows,
       baselineRow,
+      baselineIsExplicit,
       // Half the verdict is the pairing: a regression and a promotion are both
       // read out of the flip counts against the anchor. Recomputing an unpaired
       // row without one turns a recorded RED or PROMOTE into GREEN and fails
@@ -661,7 +802,12 @@ function revalidateAppendedRows({ options, context, result, base }) {
     });
     problems.push(...check.problems.map((problem) => `${label}: ${problem}`));
     problems.push(
-      ...planProvenanceProblems({ dir, row }).map(
+      ...planProvenanceProblems({ dir, row, contract: context.contract }).map(
+        (problem) => `${label}: ${problem}`,
+      ),
+    );
+    problems.push(
+      ...runEvidenceProblems({ dir, row }).map(
         (problem) => `${label}: ${problem}`,
       ),
     );
@@ -897,19 +1043,26 @@ async function modeReport(options, context) {
       `the ledger has no row for contract ${context.contractDigest.slice(0, 8)} to report`,
     );
   }
-  const baselineRow =
-    resolveRowReference({
-      reference: options.against,
-      rows,
-      repoRoot: context.repoRoot,
-    }) ?? resolveBaseline({ rows, row });
+  const explicitBaseline = resolveRowReference({
+    reference: options.against,
+    rows,
+    repoRoot: context.repoRoot,
+  });
+  const baselineRow = explicitBaseline ?? resolveBaseline({ rows, row });
+  const baselineIsExplicit = explicitBaseline !== null;
   const markdown = renderReport({
     contract: context.contract,
     row,
     baselineRow,
+    baselineIsExplicit,
     repoRoot: context.repoRoot,
   });
-  const decision = verdict({ contract: context.contract, row, baselineRow });
+  const decision = verdict({
+    contract: context.contract,
+    row,
+    baselineRow,
+    baselineIsExplicit,
+  });
   if (options.json) {
     printObject(
       {

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -853,9 +853,20 @@ function resultEvidenceProblems({ dir, row }) {
 
 /** Evidence files required for every row that claims scored results. */
 function runEvidenceProblems({ dir, row, contract }) {
-  if (row.status === "failed") return [];
   const regularityProblems = nonRegularEvidenceProblems(dir);
   if (regularityProblems.length > 0) return regularityProblems;
+  if (row.status === "failed") {
+    return readdirSync(dir)
+      .filter(
+        (name) =>
+          name === "calibration.json" ||
+          (name.startsWith("result-") && name.endsWith(".json")),
+      )
+      .map(
+        (name) =>
+          `${dir} failed row retains scoring artifact ${name}; failed traces must clear scored evidence`,
+      );
+  }
   const problems = resultEvidenceProblems({ dir, row });
   // A bridge intentionally reuses the source full run's plan and scored
   // records. It owes no new evidence, but it must retain any leak flag those

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -66,7 +66,7 @@ export const DEFAULT_REVIEW_EVAL_REPO = "mento-protocol/monitoring-monorepo";
 const MODE_OPTIONS = {
   "check-fixtures": ["offline", "src-repo"],
   "check-ledger": ["base-ref", "require-base", "revalidate-appended"],
-  plan: ["kind", "skill-ref", "out", "runs-dir"],
+  plan: ["kind", "skill-ref", "out", "runs-dir", "against"],
   score: ["against", "calibration"],
   validate: ["append", "against", "calibration", "detail-dir"],
   report: ["against", "row"],
@@ -228,7 +228,7 @@ Options:
   --out DIR              Plan directory (default: the run's detail directory)
   --runs-dir PATH        Detail root (default: ${DEFAULT_RUNS_DIR})
   --against REF          Baseline row: a file path or an executed_at prefix
-                         (--score, --report, and --validate)
+                         (--plan, --score, --report, and --validate)
   --detail-dir DIR       Run detail to recompute from (--validate); default is
                          the row's own detail_dir under --root
   --row REF              Row to report (default: the newest ledger row)
@@ -576,6 +576,26 @@ export function planProvenanceProblems({ dir, row, contract }) {
       `row inputs do not match the inputs plan.json in ${row.detail_dir} recorded`,
     );
   }
+  if (!["automatic", "explicit"].includes(plan.baseline_selection)) {
+    problems.push(
+      `plan.json in ${row.detail_dir} carries invalid baseline_selection ${JSON.stringify(plan.baseline_selection)}`,
+    );
+  } else if (
+    plan.baseline_selection === "explicit" &&
+    row.vs_baseline === null &&
+    row.kind !== "bridge" &&
+    row.status !== "failed"
+  ) {
+    problems.push(
+      `row has no vs_baseline; plan.json in ${row.detail_dir} planned an explicit baseline`,
+    );
+  } else if (row.vs_baseline !== null && row.kind !== "bridge") {
+    if (row.vs_baseline?.selection !== plan.baseline_selection) {
+      problems.push(
+        `row baseline selection is ${JSON.stringify(row.vs_baseline?.selection)}; plan.json in ${row.detail_dir} planned ${JSON.stringify(plan.baseline_selection)}`,
+      );
+    }
+  }
   if (!Array.isArray(plan.cells)) {
     problems.push(`plan.json in ${row.detail_dir} carries no cells array`);
     return problems;
@@ -751,20 +771,26 @@ function revalidateAppendedRows({ options, context, result, base }) {
         : (rows.find((candidate) => candidate.executed_at === recordedAt) ??
           null);
     const missingRecordedBaseline = recordedAt !== null && baselineRow === null;
+    const baselineSelection = row.vs_baseline?.selection ?? null;
     const candidateMissingBaseline =
       missingRecordedBaseline &&
       row.inputs?.dirty === true &&
-      row.inputs?.skill_ref !== "installed";
+      row.inputs?.skill_ref !== "installed" &&
+      baselineSelection === "explicit";
     if (missingRecordedBaseline && !candidateMissingBaseline) {
       problems.push(
-        `${label}: baseline ${recordedAt} is not in the ledger; only a dirty --skill-ref candidate row may waive a missing baseline`,
+        `${label}: baseline ${recordedAt} is not in the ledger; only a dirty --skill-ref candidate row with explicit selection may waive a missing baseline`,
       );
     }
     const baselineMissing = candidateMissingBaseline;
     if (baselineMissing) unpaired += 1;
+    if (recordedAt !== null && baselineSelection === null) {
+      problems.push(
+        `${label}: vs_baseline.selection must record automatic or explicit baseline selection`,
+      );
+    }
     const baselineIsExplicit =
-      row.kind === "bridge" ||
-      (row.inputs?.dirty === true && row.inputs?.skill_ref !== "installed");
+      row.kind === "bridge" || baselineSelection === "explicit";
     if (!baselineMissing && !baselineIsExplicit) {
       const resolvedBaseline = resolveBaseline({ rows, row });
       const sameBaseline =
@@ -836,6 +862,7 @@ async function modePlan(options, context) {
     // The rows decide which detail directory this execution may own: one a row
     // already points at holds that row's evidence and is never written again.
     ledgerRows: rows,
+    baselineIsExplicit: options.against !== null,
   });
   printObject(plan, options.json);
 }

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -30,6 +30,7 @@ import {
   completeMatrixProblems,
   freshness,
   frozenDefectProblems,
+  parseInstant,
   readLedger,
   validateLedgerRow,
 } from "./review-eval-ledger.mjs";
@@ -43,6 +44,7 @@ import {
 import {
   assertAuthorizedFreshnessWorkflow,
   buildPlan,
+  baselinePlanIdentity,
   claudeExec,
   comparabilityKey,
   DEFAULT_CALIBRATION_PATH,
@@ -528,7 +530,12 @@ function holdsCellResults(dir) {
  * Only an evidence-free hand-assembled bridge row may omit the plan. It cannot
  * become an automatic anchor or refresh the full-run clock.
  */
-export function planProvenanceProblems({ dir, row, contract }) {
+export function planProvenanceProblems({
+  dir,
+  row,
+  contract,
+  baselineRow = null,
+}) {
   const file = path.join(dir, "plan.json");
   if (!existsSync(file)) {
     if (row.kind === "bridge" && !holdsCellResults(dir)) return [];
@@ -543,6 +550,26 @@ export function planProvenanceProblems({ dir, row, contract }) {
     return [error instanceof Error ? error.message : String(error)];
   }
   const problems = [];
+  const validBaselineIdentity = (value) =>
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value).sort()) ===
+      JSON.stringify(
+        [
+          "comparability_key",
+          "contract_digest",
+          "detail_dir",
+          "executed_at",
+          "row_digest",
+        ].sort(),
+      ) &&
+    parseInstant(value.executed_at) !== null &&
+    /^[0-9a-f]{64}$/.test(value.contract_digest) &&
+    /^[0-9a-f]{64}$/.test(value.comparability_key) &&
+    typeof value.detail_dir === "string" &&
+    value.detail_dir.length > 0 &&
+    /^[0-9a-f]{64}$/.test(value.row_digest);
   for (const field of [
     "contract_digest",
     "comparability_key",
@@ -581,6 +608,20 @@ export function planProvenanceProblems({ dir, row, contract }) {
       `plan.json in ${row.detail_dir} carries invalid baseline_selection ${JSON.stringify(plan.baseline_selection)}`,
     );
   } else if (
+    plan.baseline_selection === "automatic" &&
+    plan.baseline !== null
+  ) {
+    problems.push(
+      `plan.json in ${row.detail_dir} planned automatic baseline selection but carries an explicit baseline identity`,
+    );
+  } else if (
+    plan.baseline_selection === "explicit" &&
+    !validBaselineIdentity(plan.baseline)
+  ) {
+    problems.push(
+      `plan.json in ${row.detail_dir} planned an explicit baseline but carries no valid baseline identity`,
+    );
+  } else if (
     plan.baseline_selection === "explicit" &&
     row.vs_baseline === null &&
     row.kind !== "bridge" &&
@@ -595,6 +636,26 @@ export function planProvenanceProblems({ dir, row, contract }) {
         `row baseline selection is ${JSON.stringify(row.vs_baseline?.selection)}; plan.json in ${row.detail_dir} planned ${JSON.stringify(plan.baseline_selection)}`,
       );
     }
+    if (
+      plan.baseline_selection === "explicit" &&
+      (plan.baseline.executed_at !== row.vs_baseline?.baseline_executed_at ||
+        plan.baseline.comparability_key !==
+          row.vs_baseline?.baseline_comparability_key)
+    ) {
+      problems.push(
+        `row baseline identity does not match the explicit baseline plan.json in ${row.detail_dir} recorded`,
+      );
+    }
+  }
+  if (
+    plan.baseline_selection === "explicit" &&
+    baselineRow !== null &&
+    JSON.stringify(plan.baseline) !==
+      JSON.stringify(baselinePlanIdentity(baselineRow))
+  ) {
+    problems.push(
+      `resolved baseline does not match the explicit baseline identity plan.json in ${row.detail_dir} recorded`,
+    );
   }
   if (!Array.isArray(plan.cells)) {
     problems.push(`plan.json in ${row.detail_dir} carries no cells array`);
@@ -828,9 +889,12 @@ function revalidateAppendedRows({ options, context, result, base }) {
     });
     problems.push(...check.problems.map((problem) => `${label}: ${problem}`));
     problems.push(
-      ...planProvenanceProblems({ dir, row, contract: context.contract }).map(
-        (problem) => `${label}: ${problem}`,
-      ),
+      ...planProvenanceProblems({
+        dir,
+        row,
+        contract: context.contract,
+        baselineRow,
+      }).map((problem) => `${label}: ${problem}`),
     );
     problems.push(
       ...runEvidenceProblems({ dir, row }).map(
@@ -844,6 +908,11 @@ function revalidateAppendedRows({ options, context, result, base }) {
 
 async function modePlan(options, context) {
   const rows = readLedger(path.resolve(context.repoRoot, options.ledgerPath));
+  const baselineRow = resolveRowReference({
+    reference: options.against,
+    rows,
+    repoRoot: context.repoRoot,
+  });
   const kind = resolveKind({
     kind: options.kind,
     rows,
@@ -862,7 +931,7 @@ async function modePlan(options, context) {
     // The rows decide which detail directory this execution may own: one a row
     // already points at holds that row's evidence and is never written again.
     ledgerRows: rows,
-    baselineIsExplicit: options.against !== null,
+    baselineRow,
   });
   printObject(plan, options.json);
 }

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3284,6 +3284,60 @@ test("scorePlan rejects an ineligible explicit baseline before model work", asyn
   }
 });
 
+test("scorePlan rejects an altered cell matrix before model work", async () => {
+  const root = makeRoot();
+  try {
+    const plan = buildPlan({
+      contract,
+      contractDigest,
+      kind: "canary",
+      repoRoot: root,
+      outDir: path.join(root, "run"),
+      env: planEnv,
+    });
+    for (const cell of plan.cells) {
+      const dir = path.join(plan.plan_dir, "cells", cell.cell_id);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        path.join(dir, "result.json"),
+        JSON.stringify({
+          ok: true,
+          fingerprint: cellFingerprint({ plan }),
+          output: "nothing looks wrong here",
+          seconds: 10,
+          cost_usd: 0.5,
+          fixture_path: root,
+        }),
+      );
+    }
+    plan.cells[0].model = `${plan.cells[0].model}-altered`;
+    let modelCalls = 0;
+    await assert.rejects(
+      scorePlan({
+        plan,
+        contract,
+        contractDigest,
+        repoRoot: root,
+        planDir: plan.plan_dir,
+        exec: async () => {
+          modelCalls += 1;
+          throw new Error("model must not run");
+        },
+        calibrationSet: JSON.parse(
+          readFileSync(
+            path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+            "utf8",
+          ),
+        ),
+      }),
+      /plan cells do not match the frozen canary matrix/,
+    );
+    assert.equal(modelCalls, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("scorePlan resolves an automatic baseline by ledger append order", async () => {
   const root = makeRoot();
   try {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3284,7 +3284,7 @@ test("scorePlan rejects an ineligible explicit baseline before model work", asyn
   }
 });
 
-test("scorePlan rejects an altered cell matrix before model work", async () => {
+test("scorePlan rejects altered plan inputs before model work", async () => {
   const root = makeRoot();
   try {
     const plan = buildPlan({
@@ -3310,13 +3310,12 @@ test("scorePlan rejects an altered cell matrix before model work", async () => {
         }),
       );
     }
-    plan.cells[0].model = `${plan.cells[0].model}-altered`;
     let modelCalls = 0;
-    await assert.rejects(
+    const score = (digest = contractDigest) =>
       scorePlan({
         plan,
         contract,
-        contractDigest,
+        contractDigest: digest,
         repoRoot: root,
         planDir: plan.plan_dir,
         exec: async () => {
@@ -3329,7 +3328,16 @@ test("scorePlan rejects an altered cell matrix before model work", async () => {
             "utf8",
           ),
         ),
-      }),
+      });
+    await assert.rejects(
+      score("f".repeat(64)),
+      /plan contract digest does not match the scoring contract/,
+    );
+    assert.equal(modelCalls, 0);
+
+    plan.cells[0].model = `${plan.cells[0].model}-altered`;
+    await assert.rejects(
+      score(),
       /plan cells do not match the frozen canary matrix/,
     );
     assert.equal(modelCalls, 0);

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5567,16 +5567,35 @@ test("--revalidate-appended accepts a failed trace after an eligible baseline", 
       `${JSON.stringify(baseline)}\n${JSON.stringify(failed)}\n`,
     );
 
-    const checked = cli(
-      [
-        "--check-ledger",
-        "--revalidate-appended",
-        "--base-ref",
-        "HEAD",
-        "--json",
-      ],
-      { root },
+    const flags = [
+      "--check-ledger",
+      "--revalidate-appended",
+      "--base-ref",
+      "HEAD",
+      "--json",
+    ];
+    const concealedScore = cli(flags, { root });
+    assert.equal(concealedScore.status, 1);
+    const concealedProblems = JSON.parse(concealedScore.stdout).problems.join(
+      " | ",
     );
+    assert.match(
+      concealedProblems,
+      /failed row retains scoring artifact calibration\.json/,
+    );
+    assert.match(
+      concealedProblems,
+      /failed row retains scoring artifact result-1990-pipeline-1\.json/,
+    );
+
+    const failedDetail = path.join(root, failed.detail_dir);
+    unlinkSync(path.join(failedDetail, "calibration.json"));
+    for (const name of readdirSync(failedDetail)) {
+      if (name.startsWith("result-") && name.endsWith(".json")) {
+        unlinkSync(path.join(failedDetail, name));
+      }
+    }
+    const checked = cli([...flags], { root });
     assert.equal(checked.status, 0, checked.stdout + checked.stderr);
     assert.equal(JSON.parse(checked.stdout).revalidated_rows, 1);
   } finally {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4917,78 +4917,6 @@ test("--revalidate-appended rejects copied evidence in a new directory", () => {
       JSON.parse(checked.stdout).problems.join(" | "),
       /reuses scored result and calibration evidence from base row/,
     );
-
-    const copiedResult = readdirSync(copiedDetail).find((file) => {
-      if (!file.startsWith("result-")) return false;
-      const record = JSON.parse(
-        readFileSync(path.join(copiedDetail, file), "utf8"),
-      );
-      return (record.matched_ids ?? []).length > 1;
-    });
-    assert.ok(copiedResult);
-    const copiedResultPath = path.join(copiedDetail, copiedResult);
-    const copiedRecord = JSON.parse(readFileSync(copiedResultPath, "utf8"));
-    copiedRecord.judge_reasoning = "changed text that does not affect scoring";
-    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
-
-    const metadataChanged = cli(
-      [
-        "--check-ledger",
-        "--revalidate-appended",
-        "--base-ref",
-        "HEAD",
-        "--json",
-      ],
-      { root },
-    );
-    assert.equal(metadataChanged.status, 1);
-    assert.match(
-      JSON.parse(metadataChanged.stdout).problems.join(" | "),
-      /reuses scored result and calibration evidence from base row/,
-    );
-
-    const reorderedMatches = [...copiedRecord.matched_ids].reverse();
-    copiedRecord.matched_ids = [
-      Number(reorderedMatches[0]),
-      ...reorderedMatches,
-    ];
-    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
-    const equivalentMatches = cli(
-      [
-        "--check-ledger",
-        "--revalidate-appended",
-        "--base-ref",
-        "HEAD",
-        "--json",
-      ],
-      { root },
-    );
-    assert.equal(equivalentMatches.status, 1);
-    assert.match(
-      JSON.parse(equivalentMatches.stdout).problems.join(" | "),
-      /reuses scored result and calibration evidence from base row/,
-    );
-
-    copiedRecord.usd = String(copiedRecord.usd);
-    copiedRecord.seconds = String(copiedRecord.seconds);
-    copiedRecord.novel.novelWrong = String(copiedRecord.novel.novelWrong);
-    copiedRecord.novel.novelReal = String(copiedRecord.novel.novelReal);
-    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
-    const equivalentNumbers = cli(
-      [
-        "--check-ledger",
-        "--revalidate-appended",
-        "--base-ref",
-        "HEAD",
-        "--json",
-      ],
-      { root },
-    );
-    assert.equal(equivalentNumbers.status, 1);
-    assert.match(
-      JSON.parse(equivalentNumbers.stdout).problems.join(" | "),
-      /reuses scored result and calibration evidence from base row/,
-    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -5533,15 +5461,33 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     );
     writeRowEvidence(root, row);
 
+    const negativeCounter = JSON.parse(readFileSync(plannedResult, "utf8"));
+    negativeCounter.novel.novelWrong = -1;
+    writeFileSync(plannedResult, JSON.stringify(negativeCounter));
+    const negativeResult = cli(flags, { root });
+    assert.equal(negativeResult.status, 1);
+    assert.match(
+      JSON.parse(negativeResult.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json novel\.novelWrong must be a nonnegative safe integer/,
+    );
+    writeRowEvidence(root, row);
+
     const leakedResult = JSON.parse(readFileSync(plannedResult, "utf8"));
-    leakedResult.leak = { suspected: true, hard: ["answer key path"] };
+    leakedResult.leak = { suspected: false, hard: ["answer key path"] };
     writeFileSync(plannedResult, JSON.stringify(leakedResult));
     const hiddenLeak = cli(flags, { root });
     assert.equal(hiddenLeak.status, 1);
+    const leakProblems = JSON.parse(hiddenLeak.stdout).problems.join(" | ");
     assert.match(
-      JSON.parse(hiddenLeak.stdout).problems.join(" | "),
+      leakProblems,
+      /leak\.suspected must equal whether leak\.hard is non-empty/,
+    );
+    assert.match(
+      leakProblems,
       /row notes omit leak suspected.*row verdict is .* instead of AMBER/,
     );
+    leakedResult.leak.suspected = true;
+    writeFileSync(plannedResult, JSON.stringify(leakedResult));
     row.notes = "leak suspected: answer key path";
     row.verdict = "AMBER";
     writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -2158,6 +2158,40 @@ test("resolveBaseline finds a deserialized ledger row by stable identity", () =>
   );
 });
 
+test("resolveBaseline excludes future ledger anchors from an external row", () => {
+  const anchor = makeRow({ executedAt: "2026-09-08T10:00:00Z" });
+  const external = makeRow({ executedAt: "2026-10-08T10:00:00Z" });
+  const futurePromotion = makeRow({
+    executedAt: "2026-11-08T10:00:00Z",
+    verdict: "PROMOTE",
+  });
+  assert.equal(
+    resolveBaseline({ rows: [anchor, futurePromotion], row: external })
+      .executed_at,
+    anchor.executed_at,
+  );
+});
+
+test("resolveBaseline rejects a malformed instant on an external row", () => {
+  const anchor = makeRow({ executedAt: "2026-02-28T10:00:00Z" });
+  const external = makeRow({ executedAt: "2026-02-31T10:00:00Z" });
+  assert.equal(resolveBaseline({ rows: [anchor], row: external }), null);
+});
+
+test("resolveBaseline excludes a malformed external baseline candidate", () => {
+  const anchor = makeRow({ executedAt: "2026-02-01T10:00:00Z" });
+  const malformedPromotion = makeRow({
+    executedAt: "2026-02-31T10:00:00Z",
+    verdict: "PROMOTE",
+  });
+  const external = makeRow({ executedAt: "2026-04-01T10:00:00Z" });
+  assert.equal(
+    resolveBaseline({ rows: [anchor, malformedPromotion], row: external })
+      .executed_at,
+    anchor.executed_at,
+  );
+});
+
 test("an automatic baseline ranks a later-appended backdated row", () => {
   const ids = scorableIdsFor(contract.fixtures.map((fixture) => fixture.pr));
   const p1 = new Set(p1IdsFor(contract.fixtures.map((fixture) => fixture.pr)));

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5743,6 +5743,94 @@ test("--revalidate-appended refuses a later appended automatic baseline", () => 
   }
 });
 
+test("--revalidate-appended binds partial rows to every scored PR", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const scoredFixtures = contract.fixtures.filter(
+      (fixture) => fixture.scorable_ids.length > 0,
+    );
+    assert.ok(scoredFixtures.length > 1);
+    const [retainedFixture, omittedFixture] = scoredFixtures;
+    const row = makeRow({
+      matchedIds: scorableIdsFor([retainedFixture.pr]),
+      status: "partial",
+    });
+    writeRowEvidence(root, row);
+    const condition = row.conditions.pipeline;
+    for (const id of omittedFixture.scorable_ids.map(String)) {
+      delete condition.per_defect[id];
+    }
+    const omittedP1 = p1IdsFor([omittedFixture.pr]).length;
+    condition.recall.opportunities -=
+      omittedFixture.scorable_ids.length * condition.draws;
+    condition.recall.rate = Number(
+      (condition.recall.matched / condition.recall.opportunities).toFixed(3),
+    );
+    condition.p1.opportunities -= omittedP1 * condition.draws;
+    condition.p1.rate =
+      condition.p1.opportunities === 0
+        ? null
+        : Number(
+            (condition.p1.matched / condition.p1.opportunities).toFixed(3),
+          );
+    row.verdict = verdict({ contract, row }).verdict;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      new RegExp(
+        `row condition pipeline omits frozen defect .* for scored result PR ${omittedFixture.pr}`,
+      ),
+    );
+
+    for (let draw = 1; draw <= condition.draws; draw += 1) {
+      rmSync(
+        path.join(
+          root,
+          row.detail_dir,
+          `result-${omittedFixture.pr}-pipeline-${draw}.json`,
+        ),
+      );
+    }
+    const legitimatePartial = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(
+      legitimatePartial.status,
+      0,
+      legitimatePartial.stdout + legitimatePartial.stderr,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended checks a row against its committed plan", () => {
   const root = makeRoot();
   try {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5299,6 +5299,54 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     );
     writeRowEvidence(root, row);
 
+    const foreignFixture = contract.fixtures.find(
+      (fixture) => fixture.pr !== 1990 && fixture.scorable_ids.length > 0,
+    );
+    assert.ok(foreignFixture);
+    const foreignMatch = JSON.parse(readFileSync(plannedResult, "utf8"));
+    foreignMatch.matched_ids.push(foreignFixture.scorable_ids[0]);
+    writeFileSync(plannedResult, JSON.stringify(foreignMatch));
+    const crossFixtureMatch = cli(flags, { root });
+    assert.equal(crossFixtureMatch.status, 1);
+    assert.match(
+      JSON.parse(crossFixtureMatch.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json matched_ids contains .*fixture PR 1990 does not score/,
+    );
+    writeRowEvidence(root, row);
+
+    for (const malformed of [undefined, null, ""]) {
+      const malformedMatches = JSON.parse(readFileSync(plannedResult, "utf8"));
+      if (malformed === undefined) {
+        delete malformedMatches.matched_ids;
+      } else {
+        malformedMatches.matched_ids = malformed;
+      }
+      writeFileSync(plannedResult, JSON.stringify(malformedMatches));
+      const malformedResult = cli(flags, { root });
+      assert.equal(malformedResult.status, 1);
+      assert.match(
+        JSON.parse(malformedResult.stdout).problems.join(" | "),
+        /result-1990-pipeline-1\.json matched_ids must be an array/,
+      );
+      writeRowEvidence(root, row);
+    }
+
+    const nestedMatch = JSON.parse(readFileSync(plannedResult, "utf8"));
+    nestedMatch.matched_ids = [
+      [
+        contract.fixtures.find((fixture) => fixture.pr === 1990)
+          .scorable_ids[0],
+      ],
+    ];
+    writeFileSync(plannedResult, JSON.stringify(nestedMatch));
+    const nestedResult = cli(flags, { root });
+    assert.equal(nestedResult.status, 1);
+    assert.match(
+      JSON.parse(nestedResult.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json matched_ids contains non-scalar/,
+    );
+    writeRowEvidence(root, row);
+
     // A scored explicit plan must retain its pairing. Removing vs_baseline and
     // changing the verdict to the unpaired result cannot erase that evidence.
     const planFile = path.join(detail, "plan.json");

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4858,6 +4858,66 @@ test("--revalidate-appended rejects reused and aliased detail directories", () =
   }
 });
 
+test("--revalidate-appended rejects copied evidence in a new directory", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const original = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const originalDetail = writeRowEvidence(root, original);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(original)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record original run");
+
+    const copied = structuredClone(original);
+    copied.executed_at = "2026-10-08T10:41:07Z";
+    copied.detail_dir =
+      "docs/evals/review-skill-runs/2026-10-08-copied-evidence";
+    const copiedDetail = path.join(root, copied.detail_dir);
+    cpSync(originalDetail, copiedDetail, { recursive: true });
+    const copiedPlan = JSON.parse(
+      readFileSync(path.join(copiedDetail, "plan.json"), "utf8"),
+    );
+    copiedPlan.detail_dir = copied.detail_dir;
+    writeFileSync(
+      path.join(copiedDetail, "plan.json"),
+      JSON.stringify(copiedPlan),
+    );
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(original)}\n${JSON.stringify(copied)}\n`,
+    );
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /reuses scored result and calibration evidence from base row/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended requires every planned cell of a complete row", () => {
   const root = makeRoot();
   try {
@@ -5078,6 +5138,54 @@ test("--revalidate-appended leaves an unpaired row's verdict alone", () => {
   }
 });
 
+test("--revalidate-appended accepts a failed trace after an eligible baseline", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseline = makeRow({ fullMatrix: true });
+    writeRowEvidence(root, baseline);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseline)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record baseline");
+
+    const failed = makeRow({
+      executedAt: "2026-10-08T10:41:07Z",
+      status: "failed",
+      verdict: "INCOMPLETE",
+    });
+    failed.detail_dir = "docs/evals/review-skill-runs/2026-10-08-failed";
+    failed.notes = "run failed: model process exited 1";
+    writeRowEvidence(root, failed);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseline)}\n${JSON.stringify(failed)}\n`,
+    );
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 0, checked.stdout + checked.stderr);
+    assert.equal(JSON.parse(checked.stdout).revalidated_rows, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended refuses a missing baseline on an installed row", () => {
   const root = makeRoot();
   try {
@@ -5136,6 +5244,7 @@ test("--revalidate-appended preserves an automatic candidate baseline", () => {
     });
     const candidate = makeRow({
       executedAt: "2026-09-08T10:00:00Z",
+      matchedIds: scorableIdsFor([1990]),
       fullMatrix: true,
     });
     candidate.detail_dir = "docs/evals/review-skill-runs/2026-09-08-candidate";
@@ -5288,6 +5397,7 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     writeRowEvidence(root, row);
 
     const plannedResult = path.join(detail, "result-1990-pipeline-1.json");
+    const originalVerdict = row.verdict;
     const misidentified = JSON.parse(readFileSync(plannedResult, "utf8"));
     misidentified.cell_id = "pr-1990-pipeline-draw2";
     writeFileSync(plannedResult, JSON.stringify(misidentified));
@@ -5345,6 +5455,29 @@ test("--revalidate-appended checks a row against its committed plan", () => {
       JSON.parse(nestedResult.stdout).problems.join(" | "),
       /result-1990-pipeline-1\.json matched_ids contains non-scalar/,
     );
+    writeRowEvidence(root, row);
+
+    const leakedResult = JSON.parse(readFileSync(plannedResult, "utf8"));
+    leakedResult.leak = { suspected: true, hard: ["answer key path"] };
+    writeFileSync(plannedResult, JSON.stringify(leakedResult));
+    const hiddenLeak = cli(flags, { root });
+    assert.equal(hiddenLeak.status, 1);
+    assert.match(
+      JSON.parse(hiddenLeak.stdout).problems.join(" | "),
+      /row notes omit leak suspected.*row verdict is .* instead of AMBER/,
+    );
+    row.notes = "leak suspected: answer key path";
+    row.verdict = "AMBER";
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    const preservedLeak = cli(flags, { root });
+    assert.equal(
+      preservedLeak.status,
+      0,
+      preservedLeak.stdout + preservedLeak.stderr,
+    );
+    row.notes = "";
+    row.verdict = originalVerdict;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
     writeRowEvidence(root, row);
 
     // A scored explicit plan must retain its pairing. Removing vs_baseline and
@@ -5572,6 +5705,37 @@ test("--revalidate-appended accepts an explicit bridge pairing", () => {
     ];
     const checked = cli(flags, { root });
     assert.equal(checked.status, 0, checked.stdout + checked.stderr);
+
+    const bridgeVerdict = bridge.verdict;
+    const bridgeResult = path.join(
+      root,
+      newer.detail_dir,
+      "result-1990-pipeline-1.json",
+    );
+    const leakedResult = JSON.parse(readFileSync(bridgeResult, "utf8"));
+    leakedResult.leak = { suspected: true, hard: ["answer key path"] };
+    writeFileSync(bridgeResult, JSON.stringify(leakedResult));
+    const hiddenBridgeLeak = cli(flags, { root });
+    assert.equal(hiddenBridgeLeak.status, 1);
+    assert.match(
+      JSON.parse(hiddenBridgeLeak.stdout).problems.join(" | "),
+      /row notes omit leak suspected.*row verdict is .* instead of AMBER/,
+    );
+    bridge.notes = "leak suspected: answer key path";
+    bridge.verdict = "AMBER";
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(retiring)}\n${JSON.stringify(bridge)}\n`,
+    );
+    const preservedBridgeLeak = cli(flags, { root });
+    assert.equal(
+      preservedBridgeLeak.status,
+      0,
+      preservedBridgeLeak.stdout + preservedBridgeLeak.stderr,
+    );
+    bridge.notes = "";
+    bridge.verdict = bridgeVerdict;
+    writeRowEvidence(root, newer);
 
     delete bridge.vs_baseline.selection;
     writeFileSync(

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -1761,6 +1761,43 @@ test("--validate --append refuses a row that overstates its own verdict", () => 
   }
 });
 
+test("--validate --append rejects coerced cell cost and duration", () => {
+  const root = makeRoot();
+  try {
+    const row = makeRow({
+      matchedIds: scorableIdsFor([1990, 1999]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, row);
+    const rowPath = path.join(root, "row.json");
+    const resultPath = path.join(detail, "result-1990-pipeline-1.json");
+    const resultRecord = JSON.parse(readFileSync(resultPath, "utf8"));
+    resultRecord.usd = null;
+    resultRecord.seconds = "600";
+    writeFileSync(resultPath, JSON.stringify(resultRecord));
+    writeFileSync(rowPath, JSON.stringify(row, null, 2));
+
+    const result = cli(
+      ["--validate", rowPath, "--append", "--detail-dir", detail, "--json"],
+      { root },
+    );
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.appended, false);
+    assert.match(
+      output.problems.join(" | "),
+      /conditions\.pipeline\.usd cannot be checked; the run detail sums to NaN/,
+    );
+    assert.match(
+      output.problems.join(" | "),
+      /conditions\.pipeline\.seconds cannot be checked; the run detail sums to NaN/,
+    );
+    assert.equal(readLedger(path.join(root, ledgerRelative)).length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--validate applies the schema check without --append", () => {
   const root = makeRoot();
   try {
@@ -5921,6 +5958,25 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     assert.match(
       invalidCostProblems,
       /calibration\.json scoring_usd must be a nonnegative finite number/,
+    );
+    writeRowEvidence(root, row);
+
+    const invalidCellCost = JSON.parse(readFileSync(plannedResult, "utf8"));
+    invalidCellCost.usd = null;
+    invalidCellCost.seconds = "600";
+    writeFileSync(plannedResult, JSON.stringify(invalidCellCost));
+    const invalidCellCostResult = cli(flags, { root });
+    assert.equal(invalidCellCostResult.status, 1);
+    const invalidCellCostProblems = JSON.parse(
+      invalidCellCostResult.stdout,
+    ).problems.join(" | ");
+    assert.match(
+      invalidCellCostProblems,
+      /result-1990-pipeline-1\.json usd must be a nonnegative finite number/,
+    );
+    assert.match(
+      invalidCellCostProblems,
+      /result-1990-pipeline-1\.json seconds must be a nonnegative finite number/,
     );
     writeRowEvidence(root, row);
 

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4360,6 +4360,16 @@ test("the orchestrator rejects an ineligible baseline before paid work", () => {
     script.indexOf("baselinePlanIdentity(row)") <
       script.indexOf("# --- the run deadline"),
   );
+  assert.match(
+    script,
+    /writeFileSync\(snapshot, `\$\{JSON\.stringify\(row\)\}\\n`\)/,
+  );
+  assert.match(script, /AGAINST="\$BASELINE_SNAPSHOT"/);
+  assert.ok(
+    script.indexOf('AGAINST="$BASELINE_SNAPSHOT"') <
+      script.indexOf("# --- the run deadline"),
+  );
+  assert.match(script, /rm -f "\$BASELINE_SNAPSHOT"/);
   assert.match(script, /eligible complete full baseline row/);
   assert.match(script, /malformed or incompatible with the generated plan/);
 });

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3093,17 +3093,20 @@ test("a PR that ran fewer draws loses opportunities, not recall", async () => {
   }
 });
 
-test("scorePlan stores no McNemar against an incomparable baseline", async () => {
+test("scorePlan binds an eligible explicit baseline before model work", async () => {
   const root = makeRoot();
   try {
-    const foreignBaseline = makeRow({ key: "c".repeat(64) });
+    const baseline = makeRow({
+      executedAt: "2026-08-01T10:00:00Z",
+      fullMatrix: true,
+    });
     const plan = buildPlan({
       contract,
       contractDigest,
       kind: "canary",
       repoRoot: root,
       outDir: path.join(root, "run"),
-      baselineRow: foreignBaseline,
+      baselineRow: baseline,
       env: planEnv,
     });
     for (const cell of plan.cells) {
@@ -3139,16 +3142,10 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
         baselineRow,
       });
 
-    // `--against` may name any row, including one that measures something
-    // else. That pair is recorded, never counted.
-    const foreign = await score(foreignBaseline);
-    assert.deepEqual(validateLedgerRow(foreign.row), []);
-    assert.equal(foreign.row.vs_baseline.selection, "explicit");
-    assert.equal(foreign.row.vs_baseline.mcnemar, null);
-    assert.equal(
-      foreign.row.vs_baseline.baseline_comparability_key,
-      "c".repeat(64),
-    );
+    const paired = await score(baseline);
+    assert.deepEqual(validateLedgerRow(paired.row), []);
+    assert.equal(paired.row.vs_baseline.selection, "explicit");
+    assert.equal(typeof paired.row.vs_baseline.mcnemar.delta, "number");
 
     await assert.rejects(
       score(makeRow()),
@@ -3158,6 +3155,50 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
       score(null),
       /plan baseline_selection is explicit; this score command is automatic/,
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scorePlan rejects an ineligible explicit baseline before model work", async () => {
+  const root = makeRoot();
+  try {
+    const baseline = makeRow({
+      executedAt: "2026-08-01T10:00:00Z",
+      status: "partial",
+    });
+    const plan = buildPlan({
+      contract,
+      contractDigest,
+      kind: "canary",
+      repoRoot: root,
+      outDir: path.join(root, "run"),
+      baselineRow: baseline,
+      env: planEnv,
+    });
+    let modelCalls = 0;
+    await assert.rejects(
+      scorePlan({
+        plan,
+        contract,
+        contractDigest,
+        repoRoot: root,
+        planDir: plan.plan_dir,
+        exec: async () => {
+          modelCalls += 1;
+          throw new Error("model must not run");
+        },
+        calibrationSet: JSON.parse(
+          readFileSync(
+            path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+            "utf8",
+          ),
+        ),
+        baselineRow: baseline,
+      }),
+      /explicit baseline is not eligible.*complete full run/s,
+    );
+    assert.equal(modelCalls, 0);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4344,8 +4344,17 @@ test("the orchestrator rejects an ineligible baseline before paid work", () => {
   );
   assert.match(script, /baselinePreflightProblems\(\{/);
   assert.match(script, /planComparabilityKey: plan\.comparability_key/);
+  assert.match(script, /baselinePlanIdentity\(row\)/);
+  assert.match(
+    script,
+    /JSON\.stringify\(plannedBaseline\) !== JSON\.stringify\(currentBaseline\)/,
+  );
   assert.ok(
     script.indexOf("baselinePreflightProblems({") <
+      script.indexOf("# --- the run deadline"),
+  );
+  assert.ok(
+    script.indexOf("baselinePlanIdentity(row)") <
       script.indexOf("# --- the run deadline"),
   );
   assert.match(script, /eligible complete full baseline row/);

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -42,6 +42,7 @@ import {
 import { baselineEligibility, verdict } from "./review-eval-report.mjs";
 import {
   assertAuthorizedFreshnessWorkflow,
+  baselinePlanIdentity,
   buildPlan,
   cellFingerprint,
   cellReuseDecision,
@@ -280,6 +281,16 @@ function writeRowEvidence(root, row) {
       kind: row.kind,
       detail_dir: row.detail_dir,
       baseline_selection: row.vs_baseline?.selection ?? "automatic",
+      baseline:
+        row.vs_baseline?.selection === "explicit"
+          ? {
+              executed_at: row.vs_baseline.baseline_executed_at,
+              contract_digest: row.contract_digest,
+              comparability_key: row.vs_baseline.baseline_comparability_key,
+              detail_dir: "external-baseline",
+              row_digest: "0".repeat(64),
+            }
+          : null,
       inputs: row.inputs,
       cells,
     }),
@@ -544,13 +555,16 @@ test("--plan --skill-ref stamps a dirty candidate run", () => {
     assert.equal(plan.inputs.dirty, true);
     assert.match(plan.inputs.skill_ref, /prompts$/);
 
+    const baseline = makeRow({ executedAt: "2026-07-08T10:00:00Z" });
+    const baselinePath = path.join(root, "baseline-row.json");
+    writeFileSync(baselinePath, JSON.stringify(baseline));
     const explicit = cli(
       [
         "--plan",
         "--kind",
         "canary",
         "--against",
-        "/tmp/baseline-row.json",
+        baselinePath,
         "--out",
         path.join(root, "explicit-plan"),
         "--json",
@@ -558,7 +572,9 @@ test("--plan --skill-ref stamps a dirty candidate run", () => {
       { root, env: planEnv },
     );
     assert.equal(explicit.status, 0, explicit.stderr);
-    assert.equal(JSON.parse(explicit.stdout).baseline_selection, "explicit");
+    const explicitPlan = JSON.parse(explicit.stdout);
+    assert.equal(explicitPlan.baseline_selection, "explicit");
+    assert.deepEqual(explicitPlan.baseline, baselinePlanIdentity(baseline));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3080,13 +3096,14 @@ test("a PR that ran fewer draws loses opportunities, not recall", async () => {
 test("scorePlan stores no McNemar against an incomparable baseline", async () => {
   const root = makeRoot();
   try {
+    const foreignBaseline = makeRow({ key: "c".repeat(64) });
     const plan = buildPlan({
       contract,
       contractDigest,
       kind: "canary",
       repoRoot: root,
       outDir: path.join(root, "run"),
-      baselineIsExplicit: true,
+      baselineRow: foreignBaseline,
       env: planEnv,
     });
     for (const cell of plan.cells) {
@@ -3124,7 +3141,7 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
 
     // `--against` may name any row, including one that measures something
     // else. That pair is recorded, never counted.
-    const foreign = await score(makeRow({ key: "c".repeat(64) }));
+    const foreign = await score(foreignBaseline);
     assert.deepEqual(validateLedgerRow(foreign.row), []);
     assert.equal(foreign.row.vs_baseline.selection, "explicit");
     assert.equal(foreign.row.vs_baseline.mcnemar, null);
@@ -3133,8 +3150,10 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
       "c".repeat(64),
     );
 
-    const paired = await score(makeRow());
-    assert.equal(typeof paired.row.vs_baseline.mcnemar.delta, "number");
+    await assert.rejects(
+      score(makeRow()),
+      /plan baseline .* does not match score baseline/,
+    );
     await assert.rejects(
       score(null),
       /plan baseline_selection is explicit; this score command is automatic/,
@@ -4201,7 +4220,7 @@ test("the orchestrator carries one baseline through plan, score, validate and re
   // so the plan, row, revalidation and PR body cannot disagree about what it
   // was ranked on.
   assert.equal(
-    script.match(/PLAN_ARGS\+\=\(--against "\$AGAINST"\)/g)?.length,
+    script.match(/PLAN_ARGS\+=\(--against "\$AGAINST"\)/g)?.length,
     2,
   );
   assert.match(script, /AGAINST_ARGS=\(--against "\$AGAINST"\)/);
@@ -5067,6 +5086,13 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     const planFile = path.join(detail, "plan.json");
     const explicitPlan = JSON.parse(readFileSync(planFile, "utf8"));
     explicitPlan.baseline_selection = "explicit";
+    explicitPlan.baseline = {
+      executed_at: "2026-08-08T10:00:00Z",
+      contract_digest: row.contract_digest,
+      comparability_key: row.comparability_key,
+      detail_dir: "docs/evals/review-skill-runs/baseline",
+      row_digest: "0".repeat(64),
+    };
     writeFileSync(planFile, JSON.stringify(explicitPlan));
     const lostPairing = cli(flags, { root });
     assert.equal(lostPairing.status, 1);
@@ -5177,6 +5203,7 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
       kind: "full",
       detail_dir: row.detail_dir,
       baseline_selection: "automatic",
+      baseline: null,
       inputs: row.inputs,
       cells: planCells({ contract, kind: "full" }),
     };

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -279,6 +279,7 @@ function writeRowEvidence(root, row) {
       comparability_key: row.comparability_key,
       kind: row.kind,
       detail_dir: row.detail_dir,
+      baseline_selection: row.vs_baseline?.selection ?? "automatic",
       inputs: row.inputs,
       cells,
     }),
@@ -505,6 +506,7 @@ test("--plan writes plan.json and pins the comparability key", () => {
     assert.equal(result.status, 0, result.stderr);
     const plan = JSON.parse(result.stdout);
     assert.equal(plan.kind, "canary");
+    assert.equal(plan.baseline_selection, "automatic");
     assert.equal(plan.cells.length, 3);
     assert.equal(
       plan.comparability_key,
@@ -541,6 +543,22 @@ test("--plan --skill-ref stamps a dirty candidate run", () => {
     const plan = JSON.parse(result.stdout);
     assert.equal(plan.inputs.dirty, true);
     assert.match(plan.inputs.skill_ref, /prompts$/);
+
+    const explicit = cli(
+      [
+        "--plan",
+        "--kind",
+        "canary",
+        "--against",
+        "/tmp/baseline-row.json",
+        "--out",
+        path.join(root, "explicit-plan"),
+        "--json",
+      ],
+      { root, env: planEnv },
+    );
+    assert.equal(explicit.status, 0, explicit.stderr);
+    assert.equal(JSON.parse(explicit.stdout).baseline_selection, "explicit");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1052,12 +1070,26 @@ test("revalidateRow recomputes vs_baseline instead of trusting it", () => {
     executedAt: "2026-12-08T10:00:00Z",
     matchedIds: scorableIdsFor([1990]),
   });
-  row.vs_baseline = buildVsBaseline({ row, baselineRow });
+  row.vs_baseline = buildVsBaseline({
+    row,
+    baselineRow,
+    selection: "explicit",
+  });
   row.verdict = verdict({ contract, row, baselineRow }).verdict;
   assert.ok(row.vs_baseline.mcnemar.b > 0, "the fixture pair must flip");
   assert.deepEqual(
     revalidateRow({ contract, row, repoRoot, baselineRow }).problems,
     [],
+  );
+  assert.match(
+    revalidateRow({
+      contract,
+      row,
+      repoRoot,
+      baselineRow,
+      baselineIsExplicit: false,
+    }).problems.join(" | "),
+    /row\.vs_baseline\.selection is explicit; this validation uses automatic/,
   );
 
   const flattened = {
@@ -3020,6 +3052,7 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
       kind: "canary",
       repoRoot: root,
       outDir: path.join(root, "run"),
+      baselineIsExplicit: true,
       env: planEnv,
     });
     for (const cell of plan.cells) {
@@ -3059,6 +3092,7 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
     // else. That pair is recorded, never counted.
     const foreign = await score(makeRow({ key: "c".repeat(64) }));
     assert.deepEqual(validateLedgerRow(foreign.row), []);
+    assert.equal(foreign.row.vs_baseline.selection, "explicit");
     assert.equal(foreign.row.vs_baseline.mcnemar, null);
     assert.equal(
       foreign.row.vs_baseline.baseline_comparability_key,
@@ -3067,6 +3101,10 @@ test("scorePlan stores no McNemar against an incomparable baseline", async () =>
 
     const paired = await score(makeRow());
     assert.equal(typeof paired.row.vs_baseline.mcnemar.delta, "number");
+    await assert.rejects(
+      score(null),
+      /plan baseline_selection is explicit; this score command is automatic/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -4117,7 +4155,7 @@ test("the orchestrator rejects a cell whose finder or report failed", () => {
   assert.match(script, /frozen finder report \$finder_report is unreadable/);
 });
 
-test("the orchestrator carries one baseline through score, validate and report", () => {
+test("the orchestrator carries one baseline through plan, score, validate and report", () => {
   const script = readFileSync(
     path.join(repoRoot, "scripts/review/run-eval.sh"),
     "utf8",
@@ -4125,8 +4163,13 @@ test("the orchestrator carries one baseline through score, validate and report",
   // The candidate procedure runs the installed skill and the candidate in one
   // sitting. Without a baseline argument the candidate resolves the ledger's
   // stored anchor instead, which is the model drift the procedure exists to
-  // exclude. The same argument reaches all three commands so the row, its
-  // revalidation and the PR body cannot disagree about what it was ranked on.
+  // exclude. The same argument reaches both plans and all three later commands
+  // so the plan, row, revalidation and PR body cannot disagree about what it
+  // was ranked on.
+  assert.equal(
+    script.match(/PLAN_ARGS\+\=\(--against "\$AGAINST"\)/g)?.length,
+    2,
+  );
   assert.match(script, /AGAINST_ARGS=\(--against "\$AGAINST"\)/);
   const expansion = /"\$\{AGAINST_ARGS\[@\]\+"\$\{AGAINST_ARGS\[@\]\}"\}"/g;
   assert.equal(script.match(expansion)?.length, 3);
@@ -4750,6 +4793,7 @@ test("--revalidate-appended leaves an unpaired row's verdict alone", () => {
     };
     row.vs_baseline = {
       baseline_executed_at: "2026-08-01T09:00:00Z",
+      selection: "explicit",
       baseline_comparability_key: row.comparability_key,
       mcnemar: { b: 0, c: 6, delta: -6 },
     };
@@ -4761,6 +4805,18 @@ test("--revalidate-appended leaves an unpaired row's verdict alone", () => {
     const report = JSON.parse(unpaired.stdout);
     assert.equal(report.unpaired_baselines, 1);
     assert.equal(report.revalidated_rows, 1);
+
+    // Automatic selection cannot waive a missing row. An automatic baseline
+    // must resolve from this ledger's append order.
+    row.vs_baseline.selection = "automatic";
+    writeRowEvidence(root, row);
+    writeFileSync(ledgerPath, `${JSON.stringify(row)}\n`);
+    const missingAutomatic = cli(flags, { root });
+    assert.equal(missingAutomatic.status, 1);
+    assert.match(
+      JSON.parse(missingAutomatic.stdout).problems.join(" | "),
+      /only a dirty --skill-ref candidate row with explicit selection/,
+    );
 
     // The suppression is only for the row whose recorded baseline is missing.
     // A row that records no pairing at all is still recomputed, so a forged
@@ -4795,6 +4851,7 @@ test("--revalidate-appended refuses a missing baseline on an installed row", () 
     const row = makeRow({ fullMatrix: true });
     row.vs_baseline = {
       baseline_executed_at: "2026-08-01T09:00:00Z",
+      selection: "automatic",
       baseline_comparability_key: row.comparability_key,
       mcnemar: { b: 0, c: 0, delta: 0 },
     };
@@ -4819,6 +4876,69 @@ test("--revalidate-appended refuses a missing baseline on an installed row", () 
   }
 });
 
+test("--revalidate-appended preserves an automatic candidate baseline", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    // Append order makes this the anchor even though its wall-clock timestamp
+    // is later. Automatic selection must keep append-order semantics for a
+    // candidate in the same way it does for an installed run.
+    const anchor = makeRow({
+      executedAt: "2026-10-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    const candidate = makeRow({
+      executedAt: "2026-09-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    candidate.detail_dir = "docs/evals/review-skill-runs/2026-09-08-candidate";
+    candidate.inputs = {
+      ...candidate.inputs,
+      skill_ref: "/tmp/review-candidate",
+      dirty: true,
+    };
+    candidate.vs_baseline = buildVsBaseline({
+      row: candidate,
+      baselineRow: anchor,
+      selection: "automatic",
+    });
+    candidate.verdict = verdict({
+      contract,
+      row: candidate,
+      baselineRow: anchor,
+      baselineIsExplicit: false,
+    }).verdict;
+    writeRowEvidence(root, anchor);
+    writeRowEvidence(root, candidate);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(anchor)}\n${JSON.stringify(candidate)}\n`,
+    );
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 0, checked.stdout + checked.stderr);
+    assert.equal(JSON.parse(checked.stdout).revalidated_rows, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended refuses a later appended automatic baseline", () => {
   const root = makeRoot();
   try {
@@ -4834,12 +4954,21 @@ test("--revalidate-appended refuses a later appended automatic baseline", () => 
       executedAt: "2026-09-08T10:00:00Z",
       fullMatrix: true,
     });
+    first.inputs = {
+      ...first.inputs,
+      skill_ref: "/tmp/review-candidate",
+      dirty: true,
+    };
     const later = makeRow({
       executedAt: "2026-10-08T10:00:00Z",
       fullMatrix: true,
     });
     later.detail_dir = "docs/evals/review-skill-runs/2026-10-08-deadbeef";
-    first.vs_baseline = buildVsBaseline({ row: first, baselineRow: later });
+    first.vs_baseline = buildVsBaseline({
+      row: first,
+      baselineRow: later,
+      selection: "automatic",
+    });
     writeRowEvidence(root, first);
     writeRowEvidence(root, later);
     writeFileSync(
@@ -4899,9 +5028,22 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     const clean = cli(flags, { root });
     assert.equal(clean.status, 0, clean.stdout + clean.stderr);
 
+    // A scored explicit plan must retain its pairing. Removing vs_baseline and
+    // changing the verdict to the unpaired result cannot erase that evidence.
+    const planFile = path.join(detail, "plan.json");
+    const explicitPlan = JSON.parse(readFileSync(planFile, "utf8"));
+    explicitPlan.baseline_selection = "explicit";
+    writeFileSync(planFile, JSON.stringify(explicitPlan));
+    const lostPairing = cli(flags, { root });
+    assert.equal(lostPairing.status, 1);
+    assert.match(
+      JSON.parse(lostPairing.stdout).problems.join(" | "),
+      /row has no vs_baseline; plan\.json in .* planned an explicit baseline/,
+    );
+    writeRowEvidence(root, row);
+
     // plan.json is branch-editable evidence. Removing one planned cell and its
     // result cannot make that cell disappear from the frozen contract matrix.
-    const planFile = path.join(detail, "plan.json");
     const thinnedPlan = JSON.parse(readFileSync(planFile, "utf8"));
     const removedCell = thinnedPlan.cells.pop();
     writeFileSync(planFile, JSON.stringify(thinnedPlan));
@@ -5000,6 +5142,7 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
       comparability_key: row.comparability_key,
       kind: "full",
       detail_dir: row.detail_dir,
+      baseline_selection: "automatic",
       inputs: row.inputs,
       cells: planCells({ contract, kind: "full" }),
     };
@@ -5050,6 +5193,72 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended accepts an explicit bridge pairing", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const retiring = makeRow({
+      executedAt: "2026-08-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    const newer = makeRow({
+      executedAt: "2026-09-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    newer.detail_dir = "docs/evals/review-skill-runs/2026-09-08-new-model";
+    const bridge = JSON.parse(JSON.stringify(newer));
+    bridge.kind = "bridge";
+    bridge.vs_baseline = buildVsBaseline({
+      row: bridge,
+      baselineRow: retiring,
+      selection: "explicit",
+    });
+    bridge.verdict = verdict({
+      contract,
+      row: bridge,
+      baselineRow: retiring,
+      baselineIsExplicit: true,
+    }).verdict;
+    writeRowEvidence(root, retiring);
+    writeRowEvidence(root, newer);
+    const ledgerPath = path.join(root, ledgerRelative);
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(retiring)}\n${JSON.stringify(bridge)}\n`,
+    );
+    const flags = [
+      "--check-ledger",
+      "--revalidate-appended",
+      "--base-ref",
+      "HEAD",
+      "--json",
+    ];
+    const checked = cli(flags, { root });
+    assert.equal(checked.status, 0, checked.stdout + checked.stderr);
+
+    delete bridge.vs_baseline.selection;
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(retiring)}\n${JSON.stringify(bridge)}\n`,
+    );
+    const missingSelection = cli(flags, { root });
+    assert.equal(missingSelection.status, 1);
+    assert.match(
+      JSON.parse(missingSelection.stdout).problems.join(" | "),
+      /vs_baseline\.selection must record automatic or explicit/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4340,10 +4340,14 @@ test("the orchestrator rejects an ineligible baseline before paid work", () => {
     path.join(repoRoot, "scripts/review/run-eval.sh"),
     "utf8",
   );
-  assert.match(script, /baselineEligibility\(row\)/);
+  assert.equal(script.match(/baselineEligibility\(row\)/g)?.length, 2);
   assert.ok(
     script.indexOf("baselineEligibility(row)") <
       script.indexOf("# --- the run deadline"),
+  );
+  assert.ok(
+    script.lastIndexOf("baselineEligibility(row)") <
+      script.indexOf("writeFileSync(snapshot"),
   );
   assert.match(script, /baselinePreflightProblems\(\{/);
   assert.match(script, /planComparabilityKey: plan\.comparability_key/);
@@ -4911,6 +4915,78 @@ test("--revalidate-appended rejects copied evidence in a new directory", () => {
     assert.equal(checked.status, 1);
     assert.match(
       JSON.parse(checked.stdout).problems.join(" | "),
+      /reuses scored result and calibration evidence from base row/,
+    );
+
+    const copiedResult = readdirSync(copiedDetail).find((file) => {
+      if (!file.startsWith("result-")) return false;
+      const record = JSON.parse(
+        readFileSync(path.join(copiedDetail, file), "utf8"),
+      );
+      return (record.matched_ids ?? []).length > 1;
+    });
+    assert.ok(copiedResult);
+    const copiedResultPath = path.join(copiedDetail, copiedResult);
+    const copiedRecord = JSON.parse(readFileSync(copiedResultPath, "utf8"));
+    copiedRecord.judge_reasoning = "changed text that does not affect scoring";
+    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
+
+    const metadataChanged = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(metadataChanged.status, 1);
+    assert.match(
+      JSON.parse(metadataChanged.stdout).problems.join(" | "),
+      /reuses scored result and calibration evidence from base row/,
+    );
+
+    const reorderedMatches = [...copiedRecord.matched_ids].reverse();
+    copiedRecord.matched_ids = [
+      Number(reorderedMatches[0]),
+      ...reorderedMatches,
+    ];
+    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
+    const equivalentMatches = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(equivalentMatches.status, 1);
+    assert.match(
+      JSON.parse(equivalentMatches.stdout).problems.join(" | "),
+      /reuses scored result and calibration evidence from base row/,
+    );
+
+    copiedRecord.usd = String(copiedRecord.usd);
+    copiedRecord.seconds = String(copiedRecord.seconds);
+    copiedRecord.novel.novelWrong = String(copiedRecord.novel.novelWrong);
+    copiedRecord.novel.novelReal = String(copiedRecord.novel.novelReal);
+    writeFileSync(copiedResultPath, JSON.stringify(copiedRecord));
+    const equivalentNumbers = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(equivalentNumbers.status, 1);
+    assert.match(
+      JSON.parse(equivalentNumbers.stdout).problems.join(" | "),
       /reuses scored result and calibration evidence from base row/,
     );
   } finally {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4223,6 +4223,7 @@ test("one review eval at a time may hold the shared run state", async () => {
     });
     assert.equal(staleReclaimer.status, 0, staleReclaimer.stderr);
     assert.match(staleReclaimer.stdout, /reclaiming a run lock/);
+    assert.equal(existsSync(`${lock}.reclaim`), false);
 
     // Two contenders that observe the same dead reclaimer cannot both take
     // the next generation. Keep the winner alive long enough for the loser to
@@ -4253,6 +4254,8 @@ test("one review eval at a time may hold the shared run state", async () => {
       [0, 1],
       JSON.stringify(contenders),
     );
+    assert.equal(existsSync(`${lock}.reclaim`), false);
+    assert.equal(existsSync(`${cacheLock}.reclaim`), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -4773,6 +4776,73 @@ test("--check-ledger --revalidate-appended catches an edited appended row", () =
       JSON.parse(noBase.stdout).problems.join(" | "),
       /--revalidate-appended cannot tell which rows are new/,
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects reused and aliased detail directories", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const original = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    writeRowEvidence(root, original);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(original)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record original run");
+
+    const alias = path.join(
+      path.dirname(original.detail_dir),
+      "original-evidence-alias",
+    );
+    symlinkSync(path.basename(original.detail_dir), path.join(root, alias));
+    for (const detailDir of [
+      original.detail_dir,
+      path.join(
+        path.dirname(original.detail_dir),
+        "..",
+        "review-skill-runs",
+        path.basename(original.detail_dir),
+      ),
+      alias,
+    ]) {
+      const copied = {
+        ...structuredClone(original),
+        executed_at: "2026-10-08T10:41:07Z",
+        detail_dir: detailDir,
+      };
+      writeFileSync(
+        path.join(root, ledgerRelative),
+        `${JSON.stringify(original)}\n${JSON.stringify(copied)}\n`,
+      );
+      const checked = cli(
+        [
+          "--check-ledger",
+          "--revalidate-appended",
+          "--base-ref",
+          "HEAD",
+          "--json",
+        ],
+        { root },
+      );
+      assert.equal(checked.status, 1, detailDir);
+      assert.match(
+        JSON.parse(checked.stdout).problems.join(" | "),
+        /appended row .* reuses detail_dir .* from an earlier ledger row/,
+        detailDir,
+      );
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5743,6 +5743,148 @@ test("--revalidate-appended refuses a later appended automatic baseline", () => 
   }
 });
 
+test("--revalidate-appended rejects a self-selected explicit baseline", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const row = makeRow({ fullMatrix: true });
+    const detail = writeRowEvidence(root, row);
+    row.vs_baseline = buildVsBaseline({
+      row,
+      baselineRow: row,
+      selection: "explicit",
+    });
+    const planFile = path.join(detail, "plan.json");
+    const plan = JSON.parse(readFileSync(planFile, "utf8"));
+    plan.baseline_selection = "explicit";
+    plan.baseline = baselinePlanIdentity(row);
+    writeFileSync(planFile, JSON.stringify(plan));
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      new RegExp(
+        `explicit baseline ${row.executed_at} must precede candidate ${row.executed_at}`,
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects an ineligible explicit baseline", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const baseline = makeRow({
+      executedAt: "2026-08-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    baseline.notes = "leak suspected: test fixture";
+    baseline.verdict = verdict({ contract, row: baseline }).verdict;
+    const candidate = makeRow({
+      executedAt: "2026-09-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    candidate.detail_dir = "docs/evals/review-skill-runs/2026-09-08-candidate";
+    candidate.vs_baseline = buildVsBaseline({
+      row: candidate,
+      baselineRow: baseline,
+      selection: "explicit",
+    });
+    writeRowEvidence(root, baseline);
+    const candidateDetail = writeRowEvidence(root, candidate);
+    const planFile = path.join(candidateDetail, "plan.json");
+    const plan = JSON.parse(readFileSync(planFile, "utf8"));
+    plan.baseline = baselinePlanIdentity(baseline);
+    writeFileSync(planFile, JSON.stringify(plan));
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseline)}\n${JSON.stringify(candidate)}\n`,
+    );
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /explicit baseline .* is not eligible: baseline notes record a suspected leak/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects complete evidence relabelled partial", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const row = makeRow({ fullMatrix: true });
+    writeRowEvidence(root, row);
+    row.status = "partial";
+    row.verdict = verdict({ contract, row }).verdict;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /records partial status but carries every planned result cell/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended binds partial rows to every scored PR", () => {
   const root = makeRoot();
   try {
@@ -6334,6 +6476,32 @@ test("--revalidate-appended accepts an explicit bridge pairing", () => {
     ];
     const checked = cli(flags, { root });
     assert.equal(checked.status, 0, checked.stdout + checked.stderr);
+
+    rmSync(path.join(root, newer.detail_dir), {
+      recursive: true,
+      force: true,
+    });
+    mkdirSync(path.join(root, newer.detail_dir), { recursive: true });
+    const retiringVerdict = retiring.verdict;
+    retiring.notes = "leak suspected: test fixture";
+    retiring.verdict = verdict({ contract, row: retiring }).verdict;
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(retiring)}\n${JSON.stringify(bridge)}\n`,
+    );
+    const ineligibleBridgeBaseline = cli(flags, { root });
+    assert.equal(ineligibleBridgeBaseline.status, 1);
+    assert.match(
+      JSON.parse(ineligibleBridgeBaseline.stdout).problems.join(" | "),
+      /explicit baseline .* is not eligible: baseline notes record a suspected leak/,
+    );
+    retiring.notes = "";
+    retiring.verdict = retiringVerdict;
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify(retiring)}\n${JSON.stringify(bridge)}\n`,
+    );
+    writeRowEvidence(root, newer);
 
     const bridgeVerdict = bridge.verdict;
     const bridgeResult = path.join(

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -254,6 +254,7 @@ function writeRowEvidence(root, row) {
         writeFileSync(
           path.join(detail, `result-${pr}-${name}-${draw}.json`),
           JSON.stringify({
+            cell_id: `pr-${pr}-${name}-draw${draw}`,
             pr,
             condition: name,
             draw,
@@ -3204,6 +3205,62 @@ test("scorePlan rejects an ineligible explicit baseline before model work", asyn
   }
 });
 
+test("scorePlan resolves an automatic baseline by ledger append order", async () => {
+  const root = makeRoot();
+  try {
+    const plan = buildPlan({
+      contract,
+      contractDigest,
+      kind: "canary",
+      repoRoot: root,
+      outDir: path.join(root, "run"),
+      env: planEnv,
+    });
+    for (const cell of plan.cells) {
+      const dir = path.join(plan.plan_dir, "cells", cell.cell_id);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        path.join(dir, "result.json"),
+        JSON.stringify({
+          ok: true,
+          output: "scripts/pr/pr-ready-state-core.mjs:750 is too long.",
+          seconds: 300,
+          cost_usd: 3.5,
+          fixture_path: root,
+        }),
+      );
+    }
+    const anchor = makeRow({
+      executedAt: "2026-10-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    const scored = await scorePlan({
+      plan,
+      contract,
+      contractDigest,
+      repoRoot: root,
+      planDir: plan.plan_dir,
+      exec: stubExec().exec,
+      runGit: stubGit().runGit,
+      calibrationSet: JSON.parse(
+        readFileSync(
+          path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+          "utf8",
+        ),
+      ),
+      ledgerRows: [anchor],
+      now: new Date("2026-09-08T10:00:00Z"),
+    });
+    assert.equal(
+      scored.row.vs_baseline.baseline_executed_at,
+      anchor.executed_at,
+    );
+    assert.equal(scored.row.vs_baseline.selection, "automatic");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("scorePlan reports a partial matrix and refuses an empty one", async () => {
   const root = makeRoot();
   try {
@@ -5121,6 +5178,37 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     );
     const clean = cli(flags, { root });
     assert.equal(clean.status, 0, clean.stdout + clean.stderr);
+
+    writeFileSync(
+      path.join(detail, "result-9999-pipeline-1.json"),
+      JSON.stringify({
+        cell_id: "pr-9999-pipeline-draw1",
+        pr: 9999,
+        condition: "pipeline",
+        draw: 1,
+        matched_ids: [],
+      }),
+    );
+    const unplanned = cli(flags, { root });
+    assert.equal(unplanned.status, 1);
+    assert.match(
+      JSON.parse(unplanned.stdout).problems.join(" | "),
+      /carries unplanned result file result-9999-pipeline-1\.json/,
+    );
+    unlinkSync(path.join(detail, "result-9999-pipeline-1.json"));
+    writeRowEvidence(root, row);
+
+    const plannedResult = path.join(detail, "result-1990-pipeline-1.json");
+    const misidentified = JSON.parse(readFileSync(plannedResult, "utf8"));
+    misidentified.cell_id = "pr-1990-pipeline-draw2";
+    writeFileSync(plannedResult, JSON.stringify(misidentified));
+    const wrongIdentity = cli(flags, { root });
+    assert.equal(wrongIdentity.status, 1);
+    assert.match(
+      JSON.parse(wrongIdentity.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json cell_id is .*plan\.json recorded "pr-1990-pipeline-draw1"/,
+    );
+    writeRowEvidence(root, row);
 
     // A scored explicit plan must retain its pairing. Removing vs_baseline and
     // changing the verdict to the unpaired result cannot erase that evidence.

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3933,7 +3933,7 @@ test("one review eval at a time may hold the shared run state", async () => {
     const cacheLock = path.join(cache, "run.lock");
     const lockFunction = shellFunction("acquire_one_lock");
     assert.ok(
-      lockFunction.indexOf('ln "$claim_ticket" "$claim_file"') <
+      lockFunction.indexOf('"$claim_ticket" "$claim_file"') <
         lockFunction.indexOf('rm -rf "$lock"'),
       "a stale lock is deleted before this process claims it",
     );
@@ -3944,13 +3944,24 @@ test("one review eval at a time may hold the shared run state", async () => {
     assert.equal(free.status, 0, free.stderr);
     assert.match(free.stdout, new RegExp(`held ${lock}`));
     assert.match(free.stdout, new RegExp(`held ${cacheLock}`));
-    assert.equal(
-      readFileSync(path.join(lock, "pid"), "utf8").trim().length > 0,
-      true,
+    assert.equal(readFileSync(lock, "utf8").trim().length > 0, true);
+
+    // The owner record is complete before its hard link makes the lock path
+    // visible. A suspended owner therefore exposes no pid-less lock that a
+    // contender can mistake for stale state.
+    assert.ok(
+      lockFunction.indexOf(`printf '%s\\n' "$$" >"$owner_ticket"`) <
+        lockFunction.indexOf('"$owner_ticket" "$lock" 2>/dev/null'),
+      "the lock is published before its owner record is complete",
+    );
+    assert.match(
+      lockFunction,
+      /linkSync\(process\.argv\[1\], process\.argv\[2\]\)/,
+      "lock publication must name the exact destination path",
     );
 
     // A live holder is a real conflict, and the run refuses before it spends.
-    writeFileSync(path.join(lock, "pid"), `${process.pid}\n`);
+    writeFileSync(lock, `${process.pid}\n`);
     const busy = spawnSync("bash", ["-c", harness(cache)], {
       encoding: "utf8",
     });
@@ -3967,10 +3978,45 @@ test("one review eval at a time may hold the shared run state", async () => {
     assert.equal(elsewhere.status, 1);
     assert.match(elsewhere.stderr, new RegExp(`holds ${lock}`));
 
-    // A lock left behind by a SIGKILL is reclaimed rather than wedging the job.
+    // A live directory-form lock from an older checkout remains a conflict.
+    // Exact link publication must not create an owner ticket inside it.
+    rmSync(lock, { force: true });
+    mkdirSync(lock);
+    writeFileSync(path.join(lock, "pid"), `${process.pid}\n`);
+    const legacyBusy = spawnSync("bash", ["-c", harness(cache)], {
+      encoding: "utf8",
+    });
+    assert.equal(legacyBusy.status, 1);
+    assert.match(legacyBusy.stderr, /another review eval \(pid \d+\) holds/);
+
+    // An old owner can be suspended between mkdir and writing pid. Treat that
+    // directory as occupied because its liveness cannot be proved safely.
+    unlinkSync(path.join(lock, "pid"));
+    const legacyUnidentified = spawnSync("bash", ["-c", harness(cache)], {
+      encoding: "utf8",
+    });
+    assert.equal(legacyUnidentified.status, 1);
+    assert.match(
+      legacyUnidentified.stderr,
+      /cannot identify the run lock owner/,
+    );
+    assert.equal(existsSync(lock), true);
+
+    // A dead directory-form lock is reclaimed and replaced by the atomic
+    // owner-record file, so upgrades do not wedge scheduled runs.
     const dead = spawnSync("bash", ["-c", "exit 0"]);
     writeFileSync(path.join(lock, "pid"), `${dead.pid}\n`);
-    writeFileSync(path.join(cacheLock, "pid"), `${dead.pid}\n`);
+    writeFileSync(cacheLock, `${dead.pid}\n`);
+    const legacyReclaimed = spawnSync("bash", ["-c", harness(cache)], {
+      encoding: "utf8",
+    });
+    assert.equal(legacyReclaimed.status, 0, legacyReclaimed.stderr);
+    assert.match(legacyReclaimed.stdout, /reclaiming a run lock/);
+    assert.equal(readFileSync(lock, "utf8").trim().length > 0, true);
+
+    // A lock left behind by a SIGKILL is reclaimed rather than wedging the job.
+    writeFileSync(lock, `${dead.pid}\n`);
+    writeFileSync(cacheLock, `${dead.pid}\n`);
     const reclaimed = spawnSync("bash", ["-c", harness(cache)], {
       encoding: "utf8",
     });
@@ -3979,10 +4025,10 @@ test("one review eval at a time may hold the shared run state", async () => {
 
     // A killed stale-lock reclaimer leaves its own marker. Its dead pid makes
     // that marker recoverable, so it cannot wedge every later scheduled run.
-    writeFileSync(path.join(lock, "pid"), `${dead.pid}\n`);
+    writeFileSync(lock, `${dead.pid}\n`);
     mkdirSync(`${lock}.reclaim`, { recursive: true });
     writeFileSync(path.join(`${lock}.reclaim`, "0"), `${dead.pid}\n`);
-    writeFileSync(path.join(cacheLock, "pid"), `${dead.pid}\n`);
+    writeFileSync(cacheLock, `${dead.pid}\n`);
     const staleReclaimer = spawnSync("bash", ["-c", harness(cache)], {
       encoding: "utf8",
     });
@@ -3993,7 +4039,7 @@ test("one review eval at a time may hold the shared run state", async () => {
     // the next generation. Keep the winner alive long enough for the loser to
     // see its pid rather than treating the new run lock as stale again.
     for (const target of [lock, cacheLock]) {
-      writeFileSync(path.join(target, "pid"), `${dead.pid}\n`);
+      writeFileSync(target, `${dead.pid}\n`);
       mkdirSync(`${target}.reclaim`, { recursive: true });
       writeFileSync(path.join(`${target}.reclaim`, "0"), `${dead.pid}\n`);
     }

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3283,6 +3283,29 @@ test("scorePlan resolves an automatic baseline by ledger append order", async ()
       anchor.executed_at,
     );
     assert.equal(scored.row.vs_baseline.selection, "automatic");
+
+    // The local append validates the row at its pending ledger position. The
+    // anchor's clock is later than this row, so treating the row as external
+    // would exclude the established anchor and recompute the wrong verdict.
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(anchor)}\n`,
+    );
+    const rowPath = path.join(plan.plan_dir, "row.json");
+    writeFileSync(rowPath, JSON.stringify(scored.row));
+    const appended = cli(
+      [
+        "--validate",
+        rowPath,
+        "--append",
+        "--detail-dir",
+        plan.plan_dir,
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(appended.status, 0, appended.stdout + appended.stderr);
+    assert.equal(readLedger(path.join(root, ledgerRelative)).length, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -4407,6 +4430,16 @@ test("the orchestrator rejects an ineligible baseline before paid work", () => {
   assert.match(
     script,
     /writeFileSync\(snapshot, `\$\{JSON\.stringify\(row\)\}\\n`\)/,
+  );
+  assert.match(
+    script,
+    /BASELINE_SNAPSHOT="\$\(mktemp "\$LOCK_ROOT\/review-eval-baseline/,
+  );
+  assert.equal(
+    /BASELINE_SNAPSHOT="\$\(mktemp "\$TMPROOT\/review-eval-baseline/.test(
+      script,
+    ),
+    false,
   );
   assert.match(script, /AGAINST="\$BASELINE_SNAPSHOT"/);
   assert.ok(

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -240,6 +240,27 @@ function writeRowEvidence(root, row) {
   const detail = path.join(root, row.detail_dir);
   mkdirSync(detail, { recursive: true });
   const cells = planCells({ contract, kind: row.kind });
+  const plan = {
+    contract_digest: row.contract_digest,
+    comparability_key: row.comparability_key,
+    kind: row.kind,
+    detail_dir: row.detail_dir,
+    baseline_selection: row.vs_baseline?.selection ?? "automatic",
+    baseline:
+      row.vs_baseline?.selection === "explicit"
+        ? {
+            executed_at: row.vs_baseline.baseline_executed_at,
+            contract_digest: row.contract_digest,
+            comparability_key: row.vs_baseline.baseline_comparability_key,
+            detail_dir: "external-baseline",
+            row_digest: "0".repeat(64),
+          }
+        : null,
+    inputs: row.inputs,
+    cells,
+  };
+  const fingerprint = cellFingerprint({ plan });
+  const completedCellIds = [];
   for (const [name, condition] of Object.entries(row.conditions)) {
     const idsByPr = new Map();
     for (const id of Object.keys(condition.per_defect)) {
@@ -271,6 +292,7 @@ function writeRowEvidence(root, row) {
           path.join(detail, `result-${pr}-${name}-${draw}.json`),
           JSON.stringify({
             cell_id: `pr-${pr}-${name}-draw${draw}`,
+            fingerprint,
             pr,
             condition: name,
             draw,
@@ -296,32 +318,12 @@ function writeRowEvidence(root, row) {
             leak: { suspected: false, hard: [] },
           }),
         );
+        completedCellIds.push(`pr-${pr}-${name}-draw${draw}`);
         first = false;
       }
     }
   }
-  writeFileSync(
-    path.join(detail, "plan.json"),
-    JSON.stringify({
-      contract_digest: row.contract_digest,
-      comparability_key: row.comparability_key,
-      kind: row.kind,
-      detail_dir: row.detail_dir,
-      baseline_selection: row.vs_baseline?.selection ?? "automatic",
-      baseline:
-        row.vs_baseline?.selection === "explicit"
-          ? {
-              executed_at: row.vs_baseline.baseline_executed_at,
-              contract_digest: row.contract_digest,
-              comparability_key: row.vs_baseline.baseline_comparability_key,
-              detail_dir: "external-baseline",
-              row_digest: "0".repeat(64),
-            }
-          : null,
-      inputs: row.inputs,
-      cells,
-    }),
-  );
+  writeFileSync(path.join(detail, "plan.json"), JSON.stringify(plan));
   const calibration = JSON.parse(
     readFileSync(
       path.join(root, "docs/evals/review-skill-judge-calibration.json"),
@@ -331,6 +333,8 @@ function writeRowEvidence(root, row) {
   writeFileSync(
     path.join(detail, "calibration.json"),
     JSON.stringify({
+      fingerprint,
+      completed_cell_ids: completedCellIds,
       outcomes: calibration.records.map((record) => ({
         record_id: record.record_id,
         expected: record.expected_verdict,
@@ -798,10 +802,12 @@ test("a cached cell from another skill or contract is never reused", () => {
     "claude_cli",
     "codex_cli",
     "contract_digest",
+    "dirty",
     "finder_argv_digest",
     "kind",
     "orchestrator_digest",
     "skill_digest",
+    "skill_ref",
   ]);
 
   const decide = (result) =>
@@ -812,6 +818,10 @@ test("a cached cell from another skill or contract is never reused", () => {
     decide({ ok: true, fingerprint: { ...fingerprint, skill_digest: "0" } })
       .reason,
     /different skill_digest/,
+  );
+  assert.match(
+    decide({ ok: true, fingerprint: { ...fingerprint, legacy: true } }).reason,
+    /unexpected legacy/,
   );
   assert.match(
     decide({ ok: true, fingerprint: { ...fingerprint, kind: "full" } }).reason,
@@ -833,8 +843,10 @@ test("a cached cell from another skill or contract is never reused", () => {
   for (const field of [
     "claude_cli",
     "codex_cli",
+    "dirty",
     "finder_argv_digest",
     "orchestrator_digest",
+    "skill_ref",
   ]) {
     assert.match(
       decide({ ok: true, fingerprint: { ...fingerprint, [field]: "moved" } })
@@ -2889,6 +2901,7 @@ test("scorePlan folds stubbed cells into a schema-valid ledger row", async () =>
         path.join(dir, "result.json"),
         JSON.stringify({
           ok: true,
+          fingerprint: cellFingerprint({ plan }),
           output: `scripts/pr/pr-ready-state-core.mjs:750 is too long.`,
           seconds: 300,
           cost_usd: 3.5,
@@ -3106,6 +3119,7 @@ test("a PR that ran fewer draws loses opportunities, not recall", async () => {
         path.join(dir, "result.json"),
         JSON.stringify({
           ok: true,
+          fingerprint: cellFingerprint({ plan }),
           output: `${finding.path}:${finding.line} is wrong.`,
           seconds: 300,
           cost_usd: 3.5,
@@ -3181,6 +3195,7 @@ test("scorePlan binds an eligible explicit baseline before model work", async ()
         path.join(dir, "result.json"),
         JSON.stringify({
           ok: true,
+          fingerprint: cellFingerprint({ plan }),
           output: "scripts/pr/pr-ready-state-core.mjs:750 is too long.",
           seconds: 300,
           cost_usd: 3.5,
@@ -3287,6 +3302,7 @@ test("scorePlan resolves an automatic baseline by ledger append order", async ()
         path.join(dir, "result.json"),
         JSON.stringify({
           ok: true,
+          fingerprint: cellFingerprint({ plan }),
           output: "scripts/pr/pr-ready-state-core.mjs:750 is too long.",
           seconds: 300,
           cost_usd: 3.5,
@@ -3383,10 +3399,45 @@ test("scorePlan reports a partial matrix and refuses an empty one", async () => 
     const cell = plan.cells[0];
     const dir = path.join(plan.plan_dir, "cells", cell.cell_id);
     mkdirSync(dir, { recursive: true });
+    const canonicalFingerprint = cellFingerprint({ plan });
     writeFileSync(
       path.join(dir, "result.json"),
       JSON.stringify({
         ok: true,
+        fingerprint: { ...canonicalFingerprint, legacy: true },
+        output: "nothing looks wrong here",
+        seconds: 10,
+        cost_usd: 0.5,
+        fixture_path: root,
+      }),
+    );
+    let invalidFingerprintCalls = 0;
+    await assert.rejects(
+      scorePlan({
+        plan,
+        contract,
+        contractDigest,
+        repoRoot: root,
+        planDir: plan.plan_dir,
+        exec: async () => {
+          invalidFingerprintCalls += 1;
+          throw new Error("model must not run");
+        },
+        runGit: stubGit().runGit,
+        calibrationSet,
+      }),
+      /fingerprint carries unexpected legacy/,
+    );
+    assert.equal(invalidFingerprintCalls, 0);
+
+    const reorderedFingerprint = Object.fromEntries(
+      Object.entries(canonicalFingerprint).reverse(),
+    );
+    writeFileSync(
+      path.join(dir, "result.json"),
+      JSON.stringify({
+        ok: true,
+        fingerprint: reorderedFingerprint,
         output: "nothing looks wrong here",
         seconds: 10,
         cost_usd: 0.5,
@@ -3406,6 +3457,16 @@ test("scorePlan reports a partial matrix and refuses an empty one", async () => 
     assert.equal(scored.row.status, "partial");
     assert.equal(scored.missing.length, 2);
     assert.match(scored.row.notes, /2 cell\(s\) missing/);
+    const scoredResult = JSON.parse(
+      readFileSync(
+        path.join(
+          plan.plan_dir,
+          `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
+        ),
+        "utf8",
+      ),
+    );
+    assert.deepEqual(scoredResult.fingerprint, canonicalFingerprint);
     // A canary that did not finish never ranks, not even as a pass.
     assert.equal(scored.row.verdict, "INCOMPLETE");
   } finally {
@@ -3421,6 +3482,7 @@ function writeCell(plan, cell, { output, root, usd = 3.5 }) {
     path.join(dir, "result.json"),
     JSON.stringify({
       ok: true,
+      fingerprint: cellFingerprint({ plan }),
       output,
       seconds: 300,
       cost_usd: usd,
@@ -5897,7 +5959,7 @@ test("--revalidate-appended rejects complete evidence relabelled partial", () =>
     assert.equal(checked.status, 1);
     assert.match(
       JSON.parse(checked.stdout).problems.join(" | "),
-      /records partial status but carries every planned result cell/,
+      /records partial status but calibration\.json proves a complete matrix/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -5972,6 +6034,28 @@ test("--revalidate-appended binds partial rows to every scored PR", () => {
         ),
       );
     }
+    const concealedCompletion = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(concealedCompletion.status, 1);
+    assert.match(
+      JSON.parse(concealedCompletion.stdout).problems.join(" | "),
+      /result files do not match calibration\.json completed_cell_ids/,
+    );
+
+    const calibrationFile = path.join(root, row.detail_dir, "calibration.json");
+    const calibration = JSON.parse(readFileSync(calibrationFile, "utf8"));
+    calibration.completed_cell_ids = calibration.completed_cell_ids.filter(
+      (cellId) => !cellId.startsWith(`pr-${omittedFixture.pr}-pipeline-`),
+    );
+    writeFileSync(calibrationFile, JSON.stringify(calibration));
     const legitimatePartial = cli(
       [
         "--check-ledger",
@@ -6368,6 +6452,58 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     assert.match(
       JSON.parse(deleted.stdout).problems.join(" | "),
       /carries no plan\.json/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended binds candidate status to execution evidence", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const row = makeRow({ fullMatrix: true });
+    row.inputs = {
+      ...row.inputs,
+      skill_ref: "/tmp/review-candidate",
+      dirty: true,
+    };
+    const detail = writeRowEvidence(root, row);
+
+    row.inputs = { ...row.inputs, skill_ref: "installed" };
+    delete row.inputs.dirty;
+    const planFile = path.join(detail, "plan.json");
+    const plan = JSON.parse(readFileSync(planFile, "utf8"));
+    plan.inputs = row.inputs;
+    writeFileSync(planFile, JSON.stringify(plan));
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    const problems = JSON.parse(checked.stdout).problems.join(" | ");
+    assert.match(
+      problems,
+      /result-.* fingerprint does not match the plan execution inputs/,
+    );
+    assert.match(
+      problems,
+      /calibration\.json fingerprint does not match the plan execution inputs/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -2068,7 +2068,7 @@ test("baselineEligibility refuses rows that cannot be paired", () => {
   for (const row of [
     { ...usable, kind: "canary" },
     { ...usable, status: "partial" },
-    { ...usable, judge_calibration: { agreement: 37, total: 40 } },
+    { ...usable, judge_calibration: { agreement: 33, total: 40 } },
     { ...usable, notes: "leak suspected: reviewer login" },
     {
       ...usable,

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -222,6 +222,7 @@ function makeRow({
       },
     },
     judge_calibration: { agreement: 40, total: 40 },
+    scoring_usd: 0,
     vs_baseline: null,
     detail_dir: "docs/evals/review-skill-runs/2026-09-08-deadbeef",
     notes: "",
@@ -291,6 +292,8 @@ function writeRowEvidence(root, row) {
             },
             usd: first ? condition.usd : 0,
             seconds: first ? condition.seconds : 0,
+            scoring_usd: 0,
+            leak: { suspected: false, hard: [] },
           }),
         );
         first = false;
@@ -333,6 +336,7 @@ function writeRowEvidence(root, row) {
         expected: record.expected_verdict,
         actual: record.expected_verdict,
       })),
+      scoring_usd: 0,
     }),
   );
   return detail;
@@ -4172,6 +4176,19 @@ test("one review eval at a time may hold the shared run state", async () => {
       "lock publication must name the exact destination path",
     );
 
+    // A reclaimer can die after it removes the old lock but before it publishes
+    // a replacement. The next direct lock owner must retire that abandoned
+    // claim, even when its ticket pid now belongs to a live process.
+    rmSync(lock, { force: true });
+    rmSync(cacheLock, { force: true });
+    mkdirSync(`${lock}.reclaim`, { recursive: true });
+    writeFileSync(path.join(`${lock}.reclaim`, "0"), `${process.pid}\n`);
+    const abandonedClaim = spawnSync("bash", ["-c", harness(cache)], {
+      encoding: "utf8",
+    });
+    assert.equal(abandonedClaim.status, 0, abandonedClaim.stderr);
+    assert.equal(existsSync(`${lock}.reclaim`), false);
+
     // A live holder is a real conflict, and the run refuses before it spends.
     writeFileSync(lock, `${process.pid}\n`);
     const busy = spawnSync("bash", ["-c", harness(cache)], {
@@ -5183,6 +5200,52 @@ test("--revalidate-appended rejects a symlinked base evidence file", () => {
   }
 });
 
+test("--revalidate-appended rejects a symlinked base plan", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, baseRow);
+    const planFile = path.join(detail, "plan.json");
+    const target = path.join(root, "docs/evals/base-plan-target.json");
+    writeFileSync(target, readFileSync(planFile));
+    unlinkSync(planFile);
+    symlinkSync(path.relative(detail, target), planFile);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record linked base plan");
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .*plan\.json must be a regular evidence file/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended requires every planned cell of a complete row", () => {
   const root = makeRoot();
   try {
@@ -5752,6 +5815,79 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     assert.match(
       JSON.parse(falseNovelResult.stdout).problems.join(" | "),
       /result-1990-pipeline-1\.json novel\.novelVague does not match novel\.verdicts/,
+    );
+    writeRowEvidence(root, row);
+
+    const missingRequiredEvidence = JSON.parse(
+      readFileSync(plannedResult, "utf8"),
+    );
+    delete missingRequiredEvidence.scoring_usd;
+    delete missingRequiredEvidence.leak;
+    writeFileSync(plannedResult, JSON.stringify(missingRequiredEvidence));
+    delete row.scoring_usd;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    writeFileSync(rowPath, JSON.stringify(row, null, 2));
+    const calibrationFile = path.join(detail, "calibration.json");
+    const missingCalibrationCost = JSON.parse(
+      readFileSync(calibrationFile, "utf8"),
+    );
+    delete missingCalibrationCost.scoring_usd;
+    writeFileSync(calibrationFile, JSON.stringify(missingCalibrationCost));
+    const missingRequiredResult = cli(flags, { root });
+    assert.equal(missingRequiredResult.status, 1);
+    const missingRequiredProblems = JSON.parse(
+      missingRequiredResult.stdout,
+    ).problems.join(" | ");
+    assert.match(
+      missingRequiredProblems,
+      /result-1990-pipeline-1\.json scoring_usd must be a nonnegative finite number/,
+    );
+    assert.match(
+      missingRequiredProblems,
+      /result-1990-pipeline-1\.json leak must carry a hard array and suspected boolean/,
+    );
+    assert.match(
+      missingRequiredProblems,
+      /calibration\.json scoring_usd must be a nonnegative finite number/,
+    );
+    assert.match(
+      missingRequiredProblems,
+      /row\.scoring_usd must be a nonnegative finite number for scored evidence/,
+    );
+    const localMissingTotal = cli(
+      ["--validate", rowPath, "--append", "--detail-dir", detail, "--json"],
+      { root },
+    );
+    assert.equal(localMissingTotal.status, 1);
+    assert.match(
+      JSON.parse(localMissingTotal.stdout).problems.join(" | "),
+      /row\.scoring_usd is missing; scored run detail requires a recorded judge cost total/,
+    );
+    row.scoring_usd = 0;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    writeFileSync(rowPath, JSON.stringify(row, null, 2));
+    writeRowEvidence(root, row);
+
+    const invalidResultCost = JSON.parse(readFileSync(plannedResult, "utf8"));
+    invalidResultCost.scoring_usd = null;
+    writeFileSync(plannedResult, JSON.stringify(invalidResultCost));
+    const invalidCalibrationCost = JSON.parse(
+      readFileSync(calibrationFile, "utf8"),
+    );
+    invalidCalibrationCost.scoring_usd = "1.25";
+    writeFileSync(calibrationFile, JSON.stringify(invalidCalibrationCost));
+    const invalidCostResult = cli(flags, { root });
+    assert.equal(invalidCostResult.status, 1);
+    const invalidCostProblems = JSON.parse(
+      invalidCostResult.stdout,
+    ).problems.join(" | ");
+    assert.match(
+      invalidCostProblems,
+      /result-1990-pipeline-1\.json scoring_usd must be a nonnegative finite number/,
+    );
+    assert.match(
+      invalidCostProblems,
+      /calibration\.json scoring_usd must be a nonnegative finite number/,
     );
     writeRowEvidence(root, row);
 

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5,7 +5,7 @@
 // so the judge path is covered without spending a cent.
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   cpSync,
@@ -28,14 +28,18 @@ import {
   forbiddenShasForFixture,
   loadContract,
 } from "./review-eval-fixtures.mjs";
-import { readLedger, validateLedgerRow } from "./review-eval-ledger.mjs";
+import {
+  baselinePreflightProblems,
+  readLedger,
+  validateLedgerRow,
+} from "./review-eval-ledger.mjs";
 import {
   baseLedgerRows,
   parseArgs,
   planProvenanceProblems,
   runScheduleIssue,
 } from "./review-eval.mjs";
-import { verdict } from "./review-eval-report.mjs";
+import { baselineEligibility, verdict } from "./review-eval-report.mjs";
 import {
   assertAuthorizedFreshnessWorkflow,
   buildPlan,
@@ -166,10 +170,10 @@ function makeRow({
         opportunities === 0 ? null : Number((hit / opportunities).toFixed(3)),
     };
   };
-  const conditionOver = (subset, draws) => ({
+  const conditionOver = (subset, draws, withFinder = true) => ({
     model: "claude-opus-5",
     effort: "high",
-    finder: "gpt-5.6-sol@high",
+    ...(withFinder ? { finder: "gpt-5.6-sol@high" } : {}),
     draws,
     recall: count(subset, draws),
     p1: count(
@@ -223,10 +227,79 @@ function makeRow({
   };
   if (fullMatrix) {
     built.conditions.replay = conditionOver(scorableIdsFor(gridPrs), 2);
-    built.conditions.control = conditionOver(ids, 1);
+    built.conditions.control = conditionOver(ids, 1, false);
   }
   built.verdict = statedVerdict ?? verdict({ contract, row: built }).verdict;
   return built;
+}
+
+/** Write the plan, scored cells, and calibration evidence for one test row. */
+function writeRowEvidence(root, row) {
+  const detail = path.join(root, row.detail_dir);
+  mkdirSync(detail, { recursive: true });
+  const cells = planCells({ contract, kind: row.kind });
+  for (const [name, condition] of Object.entries(row.conditions)) {
+    const idsByPr = new Map();
+    for (const id of Object.keys(condition.per_defect)) {
+      const fixture = contract.fixtures.find((candidate) =>
+        candidate.scorable_ids.map(String).includes(id),
+      );
+      if (!fixture) continue;
+      idsByPr.set(fixture.pr, [...(idsByPr.get(fixture.pr) ?? []), id]);
+    }
+    let first = true;
+    for (let draw = 1; draw <= condition.draws; draw += 1) {
+      for (const [pr, ids] of idsByPr) {
+        writeFileSync(
+          path.join(detail, `result-${pr}-${name}-${draw}.json`),
+          JSON.stringify({
+            pr,
+            condition: name,
+            draw,
+            matched_ids: ids.filter(
+              (id) => condition.per_defect[id][draw - 1] === 1,
+            ),
+            claims: ["claim"],
+            novel: {
+              novelWrong: first ? condition.wrong_claims : 0,
+              novelReal: first ? condition.novel_real : 0,
+            },
+            usd: first ? condition.usd : 0,
+            seconds: first ? condition.seconds : 0,
+          }),
+        );
+        first = false;
+      }
+    }
+  }
+  writeFileSync(
+    path.join(detail, "plan.json"),
+    JSON.stringify({
+      contract_digest: row.contract_digest,
+      comparability_key: row.comparability_key,
+      kind: row.kind,
+      detail_dir: row.detail_dir,
+      inputs: row.inputs,
+      cells,
+    }),
+  );
+  const calibration = JSON.parse(
+    readFileSync(
+      path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+      "utf8",
+    ),
+  );
+  writeFileSync(
+    path.join(detail, "calibration.json"),
+    JSON.stringify({
+      outcomes: calibration.records.map((record) => ({
+        record_id: record.record_id,
+        expected: record.expected_verdict,
+        actual: record.expected_verdict,
+      })),
+    }),
+  );
+  return detail;
 }
 
 test("parseArgs selects exactly one mode and rejects the rest", () => {
@@ -819,6 +892,23 @@ test("a symlink in the skill directory refuses the digest", () => {
   }
 });
 
+test("skillDigest frames file paths and contents", () => {
+  const first = mkdtempSync(path.join(tmpdir(), "review-eval-skill-first-"));
+  const second = mkdtempSync(path.join(tmpdir(), "review-eval-skill-second-"));
+  try {
+    for (const dir of [first, second]) {
+      writeFileSync(path.join(dir, "SKILL.md"), "# review\n");
+    }
+    // Without framing, both streams end in the same bytes: `abc`.
+    writeFileSync(path.join(first, "a"), "bc");
+    writeFileSync(path.join(second, "ab"), "c");
+    assert.notEqual(skillDigest(first), skillDigest(second));
+  } finally {
+    rmSync(first, { recursive: true, force: true });
+    rmSync(second, { recursive: true, force: true });
+  }
+});
+
 test("a baseline from another CLI version is paired and labelled", () => {
   // The comparability key deliberately omits the CLI versions: they ship far
   // more often than this suite runs, so keying on them would end the lineage at
@@ -877,7 +967,15 @@ test("failedRow is schema-valid and never ranks", () => {
   assert.deepEqual(validateLedgerRow(row), []);
   assert.equal(row.status, "failed");
   assert.equal(row.verdict, "INCOMPLETE");
+  assert.equal(row.conditions.replay.finder, plan.cells[0].finder);
   assert.match(row.notes, /unauthenticated/);
+  const dir = mkdtempSync(path.join(tmpdir(), "review-eval-failed-row-"));
+  try {
+    writeFileSync(path.join(dir, "plan.json"), JSON.stringify(plan));
+    assert.deepEqual(planProvenanceProblems({ dir, row, contract }), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("revalidateRow recomputes the numbers and catches a tampered count", () => {
@@ -1870,7 +1968,7 @@ test("--report renders the newest row and pairs it with its baseline", () => {
   }
 });
 
-test("resolveBaseline ignores incomparable, incomplete, and later rows", () => {
+test("resolveBaseline ignores incomparable, incomplete, and later-appended rows", () => {
   const row = makeRow({ executedAt: "2026-12-08T10:00:00Z" });
   const rows = [
     makeRow({ executedAt: "2026-09-08T10:00:00Z", status: "partial" }),
@@ -1878,11 +1976,103 @@ test("resolveBaseline ignores incomparable, incomplete, and later rows", () => {
     makeRow({ executedAt: "2026-11-08T10:00:00Z", kind: "canary" }),
     makeRow({ executedAt: "2027-01-08T10:00:00Z" }),
   ];
-  assert.equal(resolveBaseline({ rows, row }), null);
+  const laterAppended = rows.at(-1);
+  const prior = rows.slice(0, -1);
+  assert.equal(
+    resolveBaseline({ rows: [...prior, row, laterAppended], row }),
+    null,
+  );
   const usable = makeRow({ executedAt: "2026-11-30T10:00:00Z" });
   assert.equal(
-    resolveBaseline({ rows: [...rows, usable], row }).executed_at,
+    resolveBaseline({ rows: [...prior, usable, row, laterAppended], row })
+      .executed_at,
     usable.executed_at,
+  );
+});
+
+test("baselineEligibility refuses rows that cannot be paired", () => {
+  const usable = makeRow({ fullMatrix: true });
+  assert.equal(baselineEligibility(usable).usable, true);
+  for (const row of [
+    { ...usable, kind: "canary" },
+    { ...usable, status: "partial" },
+    { ...usable, judge_calibration: { agreement: 37, total: 40 } },
+    { ...usable, notes: "leak suspected: reviewer login" },
+    {
+      ...usable,
+      inputs: { ...usable.inputs, skill_ref: "/tmp/candidate", dirty: true },
+    },
+    { ...usable, conditions: {} },
+  ]) {
+    assert.equal(baselineEligibility(row).usable, false);
+  }
+});
+
+test("baseline preflight rejects a wrong key and malformed frozen bits", () => {
+  const row = makeRow({ fullMatrix: true });
+  assert.deepEqual(
+    baselinePreflightProblems({
+      row,
+      contract,
+      contractDigest,
+      planComparabilityKey: row.comparability_key,
+      candidateExecutedAt: "2026-10-08T10:00:00Z",
+    }),
+    [],
+  );
+  assert.match(
+    baselinePreflightProblems({
+      row,
+      contract,
+      contractDigest,
+      planComparabilityKey: "f".repeat(64),
+      candidateExecutedAt: "2026-10-08T10:00:00Z",
+    }).join(" | "),
+    /comparability_key does not match the generated plan/,
+  );
+  const malformed = JSON.parse(JSON.stringify(row));
+  const [id] = Object.keys(malformed.conditions.pipeline.per_defect);
+  malformed.conditions.pipeline.per_defect[id] = "found";
+  assert.match(
+    baselinePreflightProblems({
+      row: malformed,
+      contract,
+      contractDigest,
+      planComparabilityKey: malformed.comparability_key,
+      candidateExecutedAt: "2026-10-08T10:00:00Z",
+    }).join(" | "),
+    /must be a non-empty array/,
+  );
+  assert.match(
+    baselinePreflightProblems({
+      row,
+      contract,
+      contractDigest,
+      planComparabilityKey: row.comparability_key,
+      candidateExecutedAt: row.executed_at,
+    }).join(" | "),
+    /must precede the generated plan's candidate timestamp/,
+  );
+});
+
+test("resolveBaseline uses the same eligibility rule as an explicit baseline", () => {
+  const empty = {
+    ...makeRow({ executedAt: "2026-09-08T10:00:00Z" }),
+    conditions: {},
+  };
+  const clean = makeRow({ executedAt: "2026-10-08T10:00:00Z" });
+  const emptyPromotion = {
+    ...makeRow({
+      executedAt: "2026-11-08T10:00:00Z",
+      verdict: "PROMOTE",
+    }),
+    conditions: {},
+  };
+  const row = makeRow({ executedAt: "2026-12-08T10:00:00Z" });
+  assert.equal(resolveBaseline({ rows: [empty], row }), null);
+  assert.equal(
+    resolveBaseline({ rows: [empty, clean, emptyPromotion], row }).executed_at,
+    clean.executed_at,
   );
 });
 
@@ -1910,6 +2100,52 @@ test("resolveBaseline anchors on the first full row until a PROMOTE re-anchors",
       .executed_at,
     promoted.executed_at,
   );
+});
+
+test("resolveBaseline keeps append order when a later row is backdated", () => {
+  const anchor = makeRow({ executedAt: "2026-09-08T10:00:00Z" });
+  const backdated = makeRow({ executedAt: "2026-08-08T10:00:00Z" });
+  const row = makeRow({ executedAt: "2026-12-08T10:00:00Z" });
+  assert.equal(
+    resolveBaseline({ rows: [anchor, backdated, row], row }).executed_at,
+    anchor.executed_at,
+  );
+});
+
+test("resolveBaseline finds a deserialized ledger row by stable identity", () => {
+  const anchor = makeRow({ executedAt: "2026-09-08T10:00:00Z" });
+  const row = makeRow({ executedAt: "2026-10-08T10:00:00Z" });
+  const promoted = makeRow({
+    executedAt: "2026-11-08T10:00:00Z",
+    verdict: "PROMOTE",
+  });
+  const clone = JSON.parse(JSON.stringify(row));
+  assert.equal(
+    resolveBaseline({ rows: [anchor, row, promoted], row: clone }).executed_at,
+    anchor.executed_at,
+  );
+});
+
+test("an automatic baseline ranks a later-appended backdated row", () => {
+  const ids = scorableIdsFor(contract.fixtures.map((fixture) => fixture.pr));
+  const p1 = new Set(p1IdsFor(contract.fixtures.map((fixture) => fixture.pr)));
+  const lost = ids.filter((id) => !p1.has(id)).slice(0, 6);
+  const anchor = makeRow({
+    executedAt: "2026-09-08T10:00:00Z",
+    matchedIds: ids,
+  });
+  const row = makeRow({
+    executedAt: "2026-08-08T10:00:00Z",
+    matchedIds: ids.filter((id) => !lost.includes(id)),
+  });
+  const decision = verdict({
+    contract,
+    row,
+    baselineRow: anchor,
+    baselineIsExplicit: false,
+  });
+  assert.equal(decision.verdict, "RED");
+  assert.match(decision.reasons.join(" | "), /lost a net 6 defects/);
 });
 
 test("resolveBaseline refuses a row whose judge calibration failed", () => {
@@ -2545,6 +2781,62 @@ test("scorePlan folds stubbed cells into a schema-valid ledger row", async () =>
       0,
       "scoring never writes the ledger",
     );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scorePlan freezes truth before the calibration pass", async () => {
+  const root = makeRoot();
+  try {
+    const plan = buildPlan({
+      contract,
+      contractDigest,
+      kind: "canary",
+      repoRoot: root,
+      outDir: path.join(root, "run"),
+      env: planEnv,
+    });
+    const fixture = contract.fixtures.find(
+      (candidate) => candidate.pr === plan.cells[0].pr,
+    );
+    const truthFile = path.join(root, fixture.truth_file);
+    const originalTruth = JSON.parse(readFileSync(truthFile, "utf8"));
+    for (const cell of plan.cells) {
+      writeCell(plan, cell, {
+        output: `scripts/pr/pr-ready-state-core.mjs:750 is too long. ${originalTruth.last_head}`,
+        root,
+      });
+    }
+    const inner = stubExec().exec;
+    let changed = false;
+    const exec = async (request) => {
+      if (!changed) {
+        changed = true;
+        writeFileSync(truthFile, JSON.stringify({ findings: [] }));
+      }
+      return inner(request);
+    };
+    const scored = await scorePlan({
+      plan,
+      contract,
+      contractDigest,
+      repoRoot: root,
+      planDir: plan.plan_dir,
+      exec,
+      runGit: stubGit().runGit,
+      calibrationSet: JSON.parse(
+        readFileSync(
+          path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+          "utf8",
+        ),
+      ),
+    });
+    const frozenBits = fixture.scorable_ids.flatMap(
+      (id) => scored.row.conditions.replay.per_defect[String(id)] ?? [],
+    );
+    assert.ok(frozenBits.some((bit) => bit === 1));
+    assert.match(scored.row.notes, /withheld commit/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3613,7 +3905,7 @@ test("the ledger commit leaves the operator's other staged work alone", () => {
   }
 });
 
-test("one review eval at a time may hold the shared run state", () => {
+test("one review eval at a time may hold the shared run state", async () => {
   // Every cell resets and cleans the shared per-PR checkout and stages `.skill`
   // in it, and every run appends to the checkout's ledger. Two overlapping
   // runs — the launchd job starting under a manual run, or two manual runs —
@@ -3623,7 +3915,7 @@ test("one review eval at a time may hold the shared run state", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "review-eval-lock-"));
   try {
     const lockRoot = path.join(dir, "git");
-    const harness = (cacheDir) =>
+    const harness = (cacheDir, tail = "") =>
       [
         "set -uo pipefail",
         `LOCK_ROOT=${JSON.stringify(lockRoot)}`,
@@ -3634,10 +3926,17 @@ test("one review eval at a time may hold the shared run state", () => {
         shellFunction("acquire_one_lock"),
         shellFunction("acquire_run_lock"),
         'acquire_run_lock; printf "held %s\\n" "${LOCK_DIRS[@]}"',
+        tail,
       ].join("\n");
     const cache = path.join(dir, "cache");
     const lock = path.join(lockRoot, "run.lock");
     const cacheLock = path.join(cache, "run.lock");
+    const lockFunction = shellFunction("acquire_one_lock");
+    assert.ok(
+      lockFunction.indexOf('ln "$claim_ticket" "$claim_file"') <
+        lockFunction.indexOf('rm -rf "$lock"'),
+      "a stale lock is deleted before this process claims it",
+    );
 
     const free = spawnSync("bash", ["-c", harness(cache)], {
       encoding: "utf8",
@@ -3677,6 +3976,48 @@ test("one review eval at a time may hold the shared run state", () => {
     });
     assert.equal(reclaimed.status, 0, reclaimed.stderr);
     assert.match(reclaimed.stdout, /reclaiming a run lock/);
+
+    // A killed stale-lock reclaimer leaves its own marker. Its dead pid makes
+    // that marker recoverable, so it cannot wedge every later scheduled run.
+    writeFileSync(path.join(lock, "pid"), `${dead.pid}\n`);
+    mkdirSync(`${lock}.reclaim`, { recursive: true });
+    writeFileSync(path.join(`${lock}.reclaim`, "0"), `${dead.pid}\n`);
+    writeFileSync(path.join(cacheLock, "pid"), `${dead.pid}\n`);
+    const staleReclaimer = spawnSync("bash", ["-c", harness(cache)], {
+      encoding: "utf8",
+    });
+    assert.equal(staleReclaimer.status, 0, staleReclaimer.stderr);
+    assert.match(staleReclaimer.stdout, /reclaiming a run lock/);
+
+    // Two contenders that observe the same dead reclaimer cannot both take
+    // the next generation. Keep the winner alive long enough for the loser to
+    // see its pid rather than treating the new run lock as stale again.
+    for (const target of [lock, cacheLock]) {
+      writeFileSync(path.join(target, "pid"), `${dead.pid}\n`);
+      mkdirSync(`${target}.reclaim`, { recursive: true });
+      writeFileSync(path.join(`${target}.reclaim`, "0"), `${dead.pid}\n`);
+    }
+    const runContender = () =>
+      new Promise((resolve) => {
+        const child = spawn("bash", ["-c", harness(cache, "sleep 0.5")], {
+          encoding: "utf8",
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (chunk) => {
+          stdout += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk;
+        });
+        child.on("close", (status) => resolve({ status, stdout, stderr }));
+      });
+    const contenders = await Promise.all([runContender(), runContender()]);
+    assert.deepEqual(
+      contenders.map(({ status }) => status).sort(),
+      [0, 1],
+      JSON.stringify(contenders),
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -3749,6 +4090,26 @@ test("the orchestrator carries one baseline through score, validate and report",
       `${mode} does not receive the baseline`,
     );
   }
+});
+
+test("the orchestrator rejects an ineligible baseline before paid work", () => {
+  const script = readFileSync(
+    path.join(repoRoot, "scripts/review/run-eval.sh"),
+    "utf8",
+  );
+  assert.match(script, /baselineEligibility\(row\)/);
+  assert.ok(
+    script.indexOf("baselineEligibility(row)") <
+      script.indexOf("# --- the run deadline"),
+  );
+  assert.match(script, /baselinePreflightProblems\(\{/);
+  assert.match(script, /planComparabilityKey: plan\.comparability_key/);
+  assert.ok(
+    script.indexOf("baselinePreflightProblems({") <
+      script.indexOf("# --- the run deadline"),
+  );
+  assert.match(script, /eligible complete full baseline row/);
+  assert.match(script, /malformed or incompatible with the generated plan/);
 });
 
 test("the installed baseline survives the checkout the candidate needs", () => {
@@ -3884,23 +4245,30 @@ test("the deadline terminates the whole subprocess tree, not only its parent", (
   );
   const definition = script.match(/^run_bounded\(\) \{\n[\s\S]*?^\}$/m);
   assert.ok(definition, "run_bounded is not defined at column zero");
+  const fastDefinition = definition[0].replace("sleep 10", "sleep 1");
   const dir = mkdtempSync(path.join(tmpdir(), "review-eval-bounded-"));
   let grandchild = null;
   try {
     const harness = path.join(dir, "harness.sh");
     const outFile = path.join(dir, "out");
+    const heartbeat = path.join(dir, "heartbeat");
+    const child = [
+      'trap "exit 0" TERM',
+      `(trap "" TERM; while :; do printf . >> ${JSON.stringify(heartbeat)}; sleep 0.2; done) &`,
+      'echo "$!"',
+      "while :; do sleep 120; done",
+    ].join("\n");
+    const childArg = `'${child.replaceAll("'", `'"'"'`)}'`;
     writeFileSync(
       harness,
       [
         "#!/usr/bin/env bash",
         "set -uo pipefail",
-        definition[0],
+        fastDefinition,
         "status=0",
-        // The direct child leaves a background process behind and then stalls
-        // past the bound, exactly like a judge pass that hangs on a session
-        // limit. It `exec`s so that it dies on the group's TERM rather than on
-        // the KILL ten seconds later, which keeps the case under five seconds.
-        `run_bounded ${JSON.stringify(outFile)} 3 bash -c 'sleep 120 & echo "$!"; exec sleep 120' || status=$?`,
+        // The direct child exits when TERM reaches it. Its descendant ignores
+        // TERM, so only the watchdog's later group-wide KILL can stop it.
+        `run_bounded ${JSON.stringify(outFile)} 3 bash -c ${childArg} || status=$?`,
         'echo "status=$status"',
       ].join("\n"),
     );
@@ -3912,10 +4280,12 @@ test("the deadline terminates the whole subprocess tree, not only its parent", (
     // The group signal is delivered with the parent's; give the kernel a beat
     // before asking whether the grandchild is gone.
     spawnSync("sleep", ["1"]);
-    assert.throws(
-      () => process.kill(grandchild, 0),
-      /ESRCH/,
-      `grandchild ${grandchild} outlived the deadline`,
+    const stoppedAt = readFileSync(heartbeat, "utf8").length;
+    spawnSync("sleep", ["1"]);
+    assert.equal(
+      readFileSync(heartbeat, "utf8").length,
+      stoppedAt,
+      `grandchild ${grandchild} kept running after the deadline`,
     );
     grandchild = null;
   } finally {
@@ -4041,8 +4411,12 @@ test("required CI routes the nested frozen inputs to the scripts job", () => {
 });
 
 test("the ledger PR workflow recomputes the rows it appends", () => {
-  const workflow = readFileSync(
+  const advisory = readFileSync(
     path.join(repoRoot, ".github/workflows/review-eval-freshness.yml"),
+    "utf8",
+  );
+  const required = readFileSync(
+    path.join(repoRoot, ".github/workflows/ci.yml"),
     "utf8",
   );
   // Schema, id coverage and append-only history all stay satisfied when a
@@ -4050,9 +4424,31 @@ test("the ledger PR workflow recomputes the rows it appends", () => {
   // the local `--validate --append`. The only PR workflow there is has to
   // recompute the row from the detail the same branch commits, or the committed
   // report is backed by nothing a reader can check.
-  assert.match(workflow, /--check-ledger --require-base --revalidate-appended/);
+  for (const workflow of [advisory, required]) {
+    assert.match(
+      workflow,
+      /--check-ledger --require-base --revalidate-appended/,
+    );
+  }
   // The recompute reads committed JSON. This job must stay credential-free.
-  assert.doesNotMatch(workflow, /ANTHROPIC|OPENAI|api[_-]?key/i);
+  assert.doesNotMatch(advisory, /ANTHROPIC|OPENAI|api[_-]?key/i);
+});
+
+test("the Claude review exemption verifies scorecard-only paths", () => {
+  const workflow = readFileSync(
+    path.join(repoRoot, ".github/workflows/claude.yml"),
+    "utf8",
+  );
+  assert.doesNotMatch(
+    workflow,
+    /!startsWith\(github\.event\.pull_request\.head\.ref, 'eval\/review-skill-'\)/,
+  );
+  assert.match(workflow, /Verify review-eval scorecard-only scope/);
+  assert.match(workflow, /git merge-base "\$BASE_SHA" "\$HEAD_SHA"/);
+  assert.match(workflow, /git diff --quiet "\$merge_base" "\$HEAD_SHA"/);
+  assert.match(workflow, /docs\/evals\/review-skill-ledger\.jsonl/);
+  assert.match(workflow, /docs\/evals\/review-skill-runs\/\*\*/);
+  assert.match(workflow, /if: steps\.review-scope\.outputs\.skip != 'true'/);
 });
 
 test("--check-ledger --revalidate-appended catches an edited appended row", () => {
@@ -4076,7 +4472,7 @@ test("--check-ledger --revalidate-appended catches an edited appended row", () =
       matchedIds: scorableIdsFor([1990]),
       fullMatrix: true,
     });
-    mkdirSync(path.join(root, row.detail_dir), { recursive: true });
+    writeRowEvidence(root, row);
     writeFileSync(rowPath, JSON.stringify(row, null, 2));
     assert.equal(
       cli(["--validate", rowPath, "--append", "--json"], { root }).status,
@@ -4133,6 +4529,65 @@ test("--check-ledger --revalidate-appended catches an edited appended row", () =
   }
 });
 
+test("--revalidate-appended requires every planned cell of a complete row", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const row = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, row);
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    for (const file of readdirSync(detail)) {
+      if (file.includes("-control-")) rmSync(path.join(detail, file));
+    }
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /carries no result-.*-control-1\.json for planned cell/,
+    );
+
+    delete row.conditions.control;
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    const omitted = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(omitted.status, 1);
+    assert.match(
+      JSON.parse(omitted.stdout).problems.join(" | "),
+      /planned condition control, but the complete row omits it/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended treats a base without a ledger as all-appended", () => {
   const root = makeRoot();
   try {
@@ -4159,7 +4614,7 @@ test("--revalidate-appended treats a base without a ledger as all-appended", () 
       matchedIds: scorableIdsFor([1990]),
       fullMatrix: true,
     });
-    mkdirSync(path.join(root, row.detail_dir), { recursive: true });
+    writeRowEvidence(root, row);
     const rowPath = path.join(root, "row.json");
     writeFileSync(rowPath, JSON.stringify(row, null, 2));
     assert.equal(
@@ -4242,12 +4697,17 @@ test("--revalidate-appended leaves an unpaired row's verdict alone", () => {
       fullMatrix: true,
       verdict: "PROMOTE",
     });
+    row.inputs = {
+      ...row.inputs,
+      skill_ref: "/tmp/review-candidate",
+      dirty: true,
+    };
     row.vs_baseline = {
       baseline_executed_at: "2026-08-01T09:00:00Z",
       baseline_comparability_key: row.comparability_key,
       mcnemar: { b: 0, c: 6, delta: -6 },
     };
-    mkdirSync(path.join(root, row.detail_dir), { recursive: true });
+    writeRowEvidence(root, row);
     const ledgerPath = path.join(root, ledgerRelative);
     writeFileSync(ledgerPath, `${JSON.stringify(row)}\n`);
     const unpaired = cli(flags, { root });
@@ -4276,6 +4736,91 @@ test("--revalidate-appended leaves an unpaired row's verdict alone", () => {
   }
 });
 
+test("--revalidate-appended refuses a missing baseline on an installed row", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+    const row = makeRow({ fullMatrix: true });
+    row.vs_baseline = {
+      baseline_executed_at: "2026-08-01T09:00:00Z",
+      baseline_comparability_key: row.comparability_key,
+      mcnemar: { b: 0, c: 0, delta: 0 },
+    };
+    writeRowEvidence(root, row);
+    writeFileSync(path.join(root, ledgerRelative), `${JSON.stringify(row)}\n`);
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    const output = JSON.parse(checked.stdout);
+    assert.equal(output.unpaired_baselines, 0);
+    assert.match(output.problems.join(" | "), /only a dirty --skill-ref/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended refuses a later appended automatic baseline", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "base");
+
+    const first = makeRow({
+      executedAt: "2026-09-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    const later = makeRow({
+      executedAt: "2026-10-08T10:00:00Z",
+      fullMatrix: true,
+    });
+    later.detail_dir = "docs/evals/review-skill-runs/2026-10-08-deadbeef";
+    first.vs_baseline = buildVsBaseline({ row: first, baselineRow: later });
+    writeRowEvidence(root, first);
+    writeRowEvidence(root, later);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(first)}\n${JSON.stringify(later)}\n`,
+    );
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /recorded baseline .* does not match the append-order baseline none/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended checks a row against its committed plan", () => {
   const root = makeRoot();
   try {
@@ -4298,18 +4843,7 @@ test("--revalidate-appended checks a row against its committed plan", () => {
       matchedIds: scorableIdsFor([1990]),
       fullMatrix: true,
     });
-    const detail = path.join(root, row.detail_dir);
-    mkdirSync(detail, { recursive: true });
-    writeFileSync(
-      path.join(detail, "plan.json"),
-      JSON.stringify({
-        contract_digest: row.contract_digest,
-        comparability_key: row.comparability_key,
-        kind: row.kind,
-        detail_dir: row.detail_dir,
-        inputs: row.inputs,
-      }),
-    );
+    const detail = writeRowEvidence(root, row);
     const rowPath = path.join(root, "row.json");
     writeFileSync(rowPath, JSON.stringify(row, null, 2));
     assert.equal(
@@ -4318,6 +4852,26 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     );
     const clean = cli(flags, { root });
     assert.equal(clean.status, 0, clean.stdout + clean.stderr);
+
+    // plan.json is branch-editable evidence. Removing one planned cell and its
+    // result cannot make that cell disappear from the frozen contract matrix.
+    const planFile = path.join(detail, "plan.json");
+    const thinnedPlan = JSON.parse(readFileSync(planFile, "utf8"));
+    const removedCell = thinnedPlan.cells.pop();
+    writeFileSync(planFile, JSON.stringify(thinnedPlan));
+    rmSync(
+      path.join(
+        detail,
+        `result-${removedCell.pr}-${removedCell.condition}-${removedCell.draw}.json`,
+      ),
+    );
+    const thinned = cli(flags, { root });
+    assert.equal(thinned.status, 1);
+    assert.match(
+      JSON.parse(thinned.stdout).problems.join(" | "),
+      /plan\.json in .* cells do not match the frozen full matrix/,
+    );
+    writeRowEvidence(root, row);
 
     // Re-keying a first full row after the local append leaves its no-baseline
     // GREEN verdict, its bits and its counters all intact, and opens a lineage
@@ -4333,6 +4887,37 @@ test("--revalidate-appended checks a row against its committed plan", () => {
       /row comparability_key is "9+"; plan\.json in .* planned/,
     );
 
+    writeFileSync(
+      ledgerPath,
+      `${JSON.stringify({
+        ...row,
+        conditions: {
+          ...row.conditions,
+          pipeline: { ...row.conditions.pipeline, model: "forged-model" },
+        },
+      })}\n`,
+    );
+    const reprovenanced = cli(flags, { root });
+    assert.equal(reprovenanced.status, 1);
+    assert.match(
+      JSON.parse(reprovenanced.stdout).problems.join(" | "),
+      /row condition pipeline\.model is "forged-model"/,
+    );
+
+    writeFileSync(ledgerPath, `${JSON.stringify(row)}\n`);
+    for (const file of readdirSync(detail)) {
+      if (file === "calibration.json" || file.startsWith("result-")) {
+        rmSync(path.join(detail, file));
+      }
+    }
+    const evidenceFree = cli(flags, { root });
+    assert.equal(evidenceFree.status, 1);
+    assert.match(
+      JSON.parse(evidenceFree.stdout).problems.join(" | "),
+      /carries no scored result-\*\.json files.*carries no calibration\.json/,
+    );
+    writeRowEvidence(root, row);
+
     // Deleting the plan does not buy the check back: a directory that holds
     // cell results must hold the plan that produced them.
     writeFileSync(ledgerPath, `${JSON.stringify(row)}\n`);
@@ -4345,7 +4930,7 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     assert.equal(deleted.status, 1);
     assert.match(
       JSON.parse(deleted.stdout).problems.join(" | "),
-      /carries cell results but no plan\.json/,
+      /carries no plan\.json/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -4370,11 +4955,16 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
       kind: "full",
       detail_dir: row.detail_dir,
       inputs: row.inputs,
+      cells: planCells({ contract, kind: "full" }),
     };
     writeFileSync(path.join(dir, "plan.json"), JSON.stringify(plan));
-    assert.deepEqual(planProvenanceProblems({ dir, row }), []);
+    assert.deepEqual(planProvenanceProblems({ dir, row, contract }), []);
     assert.deepEqual(
-      planProvenanceProblems({ dir, row: { ...row, kind: "bridge" } }),
+      planProvenanceProblems({
+        dir,
+        row: { ...row, kind: "bridge" },
+        contract,
+      }),
       [],
     );
 
@@ -4384,6 +4974,7 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
       planProvenanceProblems({
         dir,
         row: { ...row, kind: "bridge", comparability_key: "9".repeat(64) },
+        contract,
       }).join(" | "),
       /row comparability_key is "9+"; plan\.json in .* planned/,
     );
@@ -4398,14 +4989,17 @@ test("a hand-assembled bridge row keeps the full run's plan", () => {
       planProvenanceProblems({
         dir,
         row: { ...row, kind: "bridge" },
+        contract,
       }).join(" | "),
       /row kind is "bridge"; plan\.json in .* planned "canary"/,
     );
     writeFileSync(path.join(dir, "plan.json"), JSON.stringify(plan));
     assert.match(
-      planProvenanceProblems({ dir, row: { ...row, kind: "canary" } }).join(
-        " | ",
-      ),
+      planProvenanceProblems({
+        dir,
+        row: { ...row, kind: "canary" },
+        contract,
+      }).join(" | "),
       /row kind is "canary"; plan\.json in .* planned "full"/,
     );
   } finally {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -251,6 +251,21 @@ function writeRowEvidence(root, row) {
     let first = true;
     for (let draw = 1; draw <= condition.draws; draw += 1) {
       for (const [pr, ids] of idsByPr) {
+        const matchedIds = ids.filter(
+          (id) => condition.per_defect[id][draw - 1] === 1,
+        );
+        const novelWrong = first ? condition.wrong_claims : 0;
+        const novelReal = first ? condition.novel_real : 0;
+        const claimCount = Math.max(1, novelWrong + novelReal);
+        const claims = Array.from(
+          { length: claimCount },
+          (_unused, index) => `claim ${index + 1}`,
+        );
+        const classes = [
+          ...Array(novelWrong).fill("wrong"),
+          ...Array(novelReal).fill("real"),
+          ...Array(claimCount - novelWrong - novelReal).fill("vague"),
+        ];
         writeFileSync(
           path.join(detail, `result-${pr}-${name}-${draw}.json`),
           JSON.stringify({
@@ -258,13 +273,21 @@ function writeRowEvidence(root, row) {
             pr,
             condition: name,
             draw,
-            matched_ids: ids.filter(
-              (id) => condition.per_defect[id][draw - 1] === 1,
-            ),
-            claims: ["claim"],
+            matched_ids: matchedIds,
+            claims,
             novel: {
-              novelWrong: first ? condition.wrong_claims : 0,
-              novelReal: first ? condition.novel_real : 0,
+              claims: claimCount,
+              novelWrong,
+              novelReal,
+              novelVague: claimCount - novelWrong - novelReal,
+              restatedKnown: 0,
+              alreadyMatched: matchedIds.length,
+              verdicts: Object.fromEntries(
+                classes.map((className, index) => [
+                  String(index + 1),
+                  { class: className },
+                ]),
+              ),
             },
             usd: first ? condition.usd : 0,
             seconds: first ? condition.seconds : 0,
@@ -4922,6 +4945,244 @@ test("--revalidate-appended rejects copied evidence in a new directory", () => {
   }
 });
 
+test("--revalidate-appended rejects edits to base-row evidence", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, baseRow);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record base run");
+
+    const resultFile = path.join(detail, "result-1990-pipeline-1.json");
+    const edited = JSON.parse(readFileSync(resultFile, "utf8"));
+    edited.claims = ["replacement claim"];
+    writeFileSync(resultFile, JSON.stringify(edited));
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.equal(JSON.parse(checked.stdout).revalidated_rows, 0);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .* evidence changed at .*result-1990-pipeline-1\.json/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects edits through a base-row detail symlink", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, baseRow);
+    const alias = path.join(
+      path.dirname(baseRow.detail_dir),
+      "base-evidence-alias",
+    );
+    symlinkSync(path.basename(baseRow.detail_dir), path.join(root, alias));
+    baseRow.detail_dir = alias;
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record symlinked base run");
+
+    const resultFile = path.join(detail, "result-1990-pipeline-1.json");
+    const edited = JSON.parse(readFileSync(resultFile, "utf8"));
+    edited.claims = ["replacement claim"];
+    writeFileSync(resultFile, JSON.stringify(edited));
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .* evidence changed at .*result-1990-pipeline-1\.json/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects a detail directory normalized to the repo root", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({ fullMatrix: true });
+    baseRow.detail_dir = "docs/..";
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record root detail path");
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .* names the repository root as detail_dir/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects a retargeted parent detail symlink", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const runs = path.dirname(baseRow.detail_dir);
+    baseRow.detail_dir = path.join(runs, "target-one", "run");
+    const firstDetail = writeRowEvidence(root, baseRow);
+    const secondDetail = path.join(root, runs, "target-two", "run");
+    cpSync(firstDetail, secondDetail, { recursive: true });
+    const alias = path.join(root, runs, "alias");
+    symlinkSync("target-one", alias);
+    baseRow.detail_dir = path.join(runs, "alias", "run");
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record parent detail symlink");
+
+    unlinkSync(alias);
+    symlinkSync("target-two", alias);
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .* evidence changed at .*\/alias/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("--revalidate-appended rejects a symlinked base evidence file", () => {
+  const root = makeRoot();
+  try {
+    const git = (...args) =>
+      spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+    git("init", "--quiet");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "eval");
+
+    const baseRow = makeRow({
+      matchedIds: scorableIdsFor([1990]),
+      fullMatrix: true,
+    });
+    const detail = writeRowEvidence(root, baseRow);
+    const resultFile = path.join(detail, "result-1990-pipeline-1.json");
+    const target = path.join(root, "docs/evals/base-result-target.json");
+    writeFileSync(target, readFileSync(resultFile));
+    unlinkSync(resultFile);
+    symlinkSync(path.relative(detail, target), resultFile);
+    writeFileSync(
+      path.join(root, ledgerRelative),
+      `${JSON.stringify(baseRow)}\n`,
+    );
+    git("add", "-A");
+    git("commit", "--quiet", "-m", "record linked base evidence");
+
+    const edited = JSON.parse(readFileSync(target, "utf8"));
+    edited.claims = ["replacement claim"];
+    writeFileSync(target, JSON.stringify(edited));
+
+    const checked = cli(
+      [
+        "--check-ledger",
+        "--revalidate-appended",
+        "--base-ref",
+        "HEAD",
+        "--json",
+      ],
+      { root },
+    );
+    assert.equal(checked.status, 1);
+    assert.match(
+      JSON.parse(checked.stdout).problems.join(" | "),
+      /base row .*result-1990-pipeline-1\.json must be a regular evidence file/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("--revalidate-appended requires every planned cell of a complete row", () => {
   const root = makeRoot();
   try {
@@ -5472,6 +5733,28 @@ test("--revalidate-appended checks a row against its committed plan", () => {
     );
     writeRowEvidence(root, row);
 
+    const invalidClaim = JSON.parse(readFileSync(plannedResult, "utf8"));
+    invalidClaim.claims = [{}];
+    writeFileSync(plannedResult, JSON.stringify(invalidClaim));
+    const invalidClaimResult = cli(flags, { root });
+    assert.equal(invalidClaimResult.status, 1);
+    assert.match(
+      JSON.parse(invalidClaimResult.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json claims must contain only non-empty strings/,
+    );
+    writeRowEvidence(root, row);
+
+    const falseNovelSummary = JSON.parse(readFileSync(plannedResult, "utf8"));
+    falseNovelSummary.novel.novelVague += 1;
+    writeFileSync(plannedResult, JSON.stringify(falseNovelSummary));
+    const falseNovelResult = cli(flags, { root });
+    assert.equal(falseNovelResult.status, 1);
+    assert.match(
+      JSON.parse(falseNovelResult.stdout).problems.join(" | "),
+      /result-1990-pipeline-1\.json novel\.novelVague does not match novel\.verdicts/,
+    );
+    writeRowEvidence(root, row);
+
     const leakedResult = JSON.parse(readFileSync(plannedResult, "utf8"));
     leakedResult.leak = { suspected: false, hard: ["answer key path"] };
     writeFileSync(plannedResult, JSON.stringify(leakedResult));
@@ -5555,6 +5838,17 @@ test("--revalidate-appended checks a row against its committed plan", () => {
       JSON.parse(rekeyed.stdout).problems.join(" | "),
       /row comparability_key is "9+"; plan\.json in .* planned/,
     );
+
+    const rekeyedPlan = JSON.parse(readFileSync(planFile, "utf8"));
+    rekeyedPlan.comparability_key = committed.comparability_key;
+    writeFileSync(planFile, JSON.stringify(rekeyedPlan));
+    const jointlyRekeyed = cli(flags, { root });
+    assert.equal(jointlyRekeyed.status, 1);
+    assert.match(
+      JSON.parse(jointlyRekeyed.stdout).problems.join(" | "),
+      /current frozen inputs derive/,
+    );
+    writeRowEvidence(root, row);
 
     writeFileSync(
       ledgerPath,

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -71,6 +71,7 @@ SPEC=""
 SPEC_TEMP=0
 SHIM=""
 SKILL_SNAPSHOT=""
+BASELINE_SNAPSHOT=""
 LOCK_DIRS=()
 RUN_DIR=""
 PLAN_JSON=""
@@ -189,6 +190,9 @@ cleanup() {
   fi
   if [[ -n $SKILL_SNAPSHOT ]]; then
     rm -rf "$SKILL_SNAPSHOT"
+  fi
+  if [[ -n $BASELINE_SNAPSHOT ]]; then
+    rm -f "$BASELINE_SNAPSHOT"
   fi
   local lock_dir
   for lock_dir in ${LOCK_DIRS[@]+"${LOCK_DIRS[@]}"}; do
@@ -450,10 +454,12 @@ PLAN_JSON="$RUN_DIR/plan.json"
 # row. The generated plan now supplies the remaining checks before paid work:
 # full schema and frozen-matrix validation, plus the exact comparison lineage.
 if [[ -n $AGAINST ]]; then
+  BASELINE_SNAPSHOT="$(mktemp "$TMPROOT/review-eval-baseline.XXXXXX")" ||
+    fail "could not prepare an immutable baseline snapshot under $TMPROOT"
   # shellcheck disable=SC2016  # the single-quoted block is node source
   node --input-type=module -e '
-    const [spec, ledger, contractFile, planFile, reference] = process.argv.slice(1);
-    const { readFileSync } = await import("node:fs");
+    const [spec, ledger, contractFile, planFile, reference, snapshot] = process.argv.slice(1);
+    const { readFileSync, writeFileSync } = await import("node:fs");
     const { loadContract } = await import(`${spec}/scripts/review/review-eval-fixtures.mjs`);
     const { baselinePreflightProblems, readLedger } = await import(`${spec}/scripts/review/review-eval-ledger.mjs`);
     const { resolveRowReference } = await import(`${spec}/scripts/review/review-eval-result-shape.mjs`);
@@ -474,8 +480,10 @@ if [[ -n $AGAINST ]]; then
       candidateExecutedAt: plan.planned_at,
     });
     if (problems.length > 0) throw new Error(problems.join(" | "));
-  ' "$SPEC" "$LEDGER" "$CONTRACT" "$PLAN_JSON" "$AGAINST" >/dev/null 2>&1 ||
+    writeFileSync(snapshot, `${JSON.stringify(row)}\n`);
+  ' "$SPEC" "$LEDGER" "$CONTRACT" "$PLAN_JSON" "$AGAINST" "$BASELINE_SNAPSHOT" >/dev/null 2>&1 ||
     fail "--against $AGAINST is malformed or incompatible with the generated plan"
+  AGAINST="$BASELINE_SNAPSHOT"
 fi
 # shellcheck disable=SC2016  # the single-quoted block is node source
 CELL_COUNT="$(node -e '

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -462,11 +462,14 @@ if [[ -n $AGAINST ]]; then
     const { readFileSync, writeFileSync } = await import("node:fs");
     const { loadContract } = await import(`${spec}/scripts/review/review-eval-fixtures.mjs`);
     const { baselinePreflightProblems, readLedger } = await import(`${spec}/scripts/review/review-eval-ledger.mjs`);
+    const { baselineEligibility } = await import(`${spec}/scripts/review/review-eval-report.mjs`);
     const { resolveRowReference } = await import(`${spec}/scripts/review/review-eval-result-shape.mjs`);
     const { baselinePlanIdentity } = await import(`${spec}/scripts/review/review-eval-run.mjs`);
     const { contract, digest } = loadContract(contractFile);
     const plan = JSON.parse(readFileSync(planFile, "utf8"));
     const row = resolveRowReference({ reference, rows: readLedger(ledger), repoRoot: spec });
+    const eligibility = baselineEligibility(row);
+    if (!eligibility.usable) throw new Error(eligibility.reason);
     const plannedBaseline = plan.baseline ?? null;
     const currentBaseline = baselinePlanIdentity(row);
     if (JSON.stringify(plannedBaseline) !== JSON.stringify(currentBaseline)) {

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -449,9 +449,15 @@ if [[ -n $AGAINST ]]; then
     const { loadContract } = await import(`${spec}/scripts/review/review-eval-fixtures.mjs`);
     const { baselinePreflightProblems, readLedger } = await import(`${spec}/scripts/review/review-eval-ledger.mjs`);
     const { resolveRowReference } = await import(`${spec}/scripts/review/review-eval-result-shape.mjs`);
+    const { baselinePlanIdentity } = await import(`${spec}/scripts/review/review-eval-run.mjs`);
     const { contract, digest } = loadContract(contractFile);
     const plan = JSON.parse(readFileSync(planFile, "utf8"));
     const row = resolveRowReference({ reference, rows: readLedger(ledger), repoRoot: spec });
+    const plannedBaseline = plan.baseline ?? null;
+    const currentBaseline = baselinePlanIdentity(row);
+    if (JSON.stringify(plannedBaseline) !== JSON.stringify(currentBaseline)) {
+      throw new Error("the resolved baseline changed after planning");
+    }
     const problems = baselinePreflightProblems({
       row,
       contract,

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -251,8 +251,8 @@ acquire_one_lock() {
     # Reclaimers elect one owner through immutable, monotonically numbered
     # tickets. `ln` publishes the prepared pid file atomically. A killed owner
     # leaves its generation behind; the next contender creates the next one.
-    # No process deletes or replaces a shared ticket after inspecting its pid,
-    # so a live replacement cannot appear at the same path (the ABA race).
+    # Tickets stay immutable during the election. The winner removes the claim
+    # root only after it publishes the replacement lock owner.
     mkdir "$reclaim_root" 2>/dev/null || true
     [[ -d $reclaim_root ]] ||
       fail "could not create the stale-lock claim root at $reclaim_root"
@@ -293,21 +293,29 @@ acquire_one_lock() {
       confirmed="$(cat "$lock" 2>/dev/null || true)"
     fi
     [[ $confirmed =~ ^[0-9]+$ ]] ||
-      fail "cannot confirm the stale run lock owner at $lock; refusing to reclaim shared run state"
+      {
+        rm -f "$claim_file"
+        fail "cannot confirm the stale run lock owner at $lock; refusing to reclaim shared run state"
+      }
     if [[ $confirmed =~ ^[0-9]+$ ]] && kill -0 "$confirmed" 2>/dev/null; then
+      rm -f "$claim_file"
       fail "another review eval (pid $confirmed) holds $lock; a run rewrites the shared fixtures and appends to the shared ledger, so wait for it to finish"
     fi
     log "reclaiming a run lock left behind by pid ${holder:-unknown}"
     rm -rf "$lock"
-    owner_ticket="$(mktemp "$root/.run.lock.owner.XXXXXX")" ||
+    owner_ticket="$(mktemp "$root/.run.lock.owner.XXXXXX")" || {
+      rm -f "$claim_file"
       fail "could not prepare the run lock owner record under $root"
+    }
     printf '%s\n' "$$" >"$owner_ticket"
     if ! node -e \
       'require("node:fs").linkSync(process.argv[1], process.argv[2])' \
       "$owner_ticket" "$lock" 2>/dev/null; then
       rm -f "$owner_ticket"
+      rm -f "$claim_file"
       fail "another review eval took the run lock at $lock; retry after it finishes"
     fi
+    rm -rf "$reclaim_root"
   fi
   rm -f "$owner_ticket"
   LOCK_DIRS+=("$lock")

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -20,7 +20,8 @@
 # Every cell writes its own output directory and is resumable. A failed cell is
 # never cached: a session-limit error returns in seconds and, cached, would
 # permanently score as a zero-recall review. A cached cell is reused only when
-# its fingerprint — skill digest, kind, contract digest — matches this run.
+# its fingerprint — treatment identity, kind, contract, runtime, finder and
+# orchestrator — matches this run.
 # A run that ends before it scores keeps those cells so the retry reuses them;
 # they never reach the PR.
 #

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -225,6 +225,8 @@ trap cleanup EXIT
 # that fails closed, and the message names the directory to remove.
 acquire_one_lock() {
   local root="$1" what="$2" lock="$1/run.lock" holder="" waited=0
+  local reclaim_root="$1/run.lock.reclaim" claim_file="" claim_holder=""
+  local claim_ticket="" claim_generation=-1 candidate_generation=-1 entry=""
   mkdir -p "$root" || fail "the $what $root is not writable"
   if ! mkdir "$lock" 2>/dev/null; then
     while ((waited < 5)); do
@@ -237,6 +239,47 @@ acquire_one_lock() {
     done
     if [[ $holder =~ ^[0-9]+$ ]] && kill -0 "$holder" 2>/dev/null; then
       fail "another review eval (pid $holder) holds $lock; a run rewrites the shared fixtures and appends to the shared ledger, so wait for it to finish"
+    fi
+    # Reclaimers elect one owner through immutable, monotonically numbered
+    # tickets. `ln` publishes the prepared pid file atomically. A killed owner
+    # leaves its generation behind; the next contender creates the next one.
+    # No process deletes or replaces a shared ticket after inspecting its pid,
+    # so a live replacement cannot appear at the same path (the ABA race).
+    mkdir "$reclaim_root" 2>/dev/null || true
+    [[ -d $reclaim_root ]] ||
+      fail "could not create the stale-lock claim root at $reclaim_root"
+    for entry in "$reclaim_root"/*; do
+      [[ -f $entry ]] || continue
+      candidate_generation="${entry##*/}"
+      [[ $candidate_generation =~ ^[0-9]+$ ]] || continue
+      if ((candidate_generation > claim_generation)); then
+        claim_generation=$candidate_generation
+      fi
+    done
+    if ((claim_generation >= 0)); then
+      claim_file="$reclaim_root/$claim_generation"
+      claim_holder="$(cat "$claim_file" 2>/dev/null || true)"
+      [[ $claim_holder =~ ^[0-9]+$ ]] ||
+        fail "cannot identify the stale-lock reclaimer in $claim_file; refusing to reclaim shared run state"
+      if [[ $claim_holder =~ ^[0-9]+$ ]] &&
+        kill -0 "$claim_holder" 2>/dev/null; then
+        fail "another review eval (pid $claim_holder) is reclaiming the stale lock at $lock; retry after it finishes"
+      fi
+    fi
+    claim_generation=$((claim_generation + 1))
+    claim_file="$reclaim_root/$claim_generation"
+    claim_ticket="$(mktemp "$reclaim_root/.ticket.XXXXXX")" ||
+      fail "could not prepare a stale-lock claim at $reclaim_root"
+    printf '%s\n' "$$" >"$claim_ticket"
+    if ! ln "$claim_ticket" "$claim_file" 2>/dev/null; then
+      rm -f "$claim_ticket"
+      fail "another review eval claimed the stale lock at $lock; retry after it finishes"
+    fi
+    rm -f "$claim_ticket"
+    local confirmed
+    confirmed="$(cat "$lock/pid" 2>/dev/null || true)"
+    if [[ $confirmed =~ ^[0-9]+$ ]] && kill -0 "$confirmed" 2>/dev/null; then
+      fail "another review eval (pid $confirmed) holds $lock; a run rewrites the shared fixtures and appends to the shared ledger, so wait for it to finish"
     fi
     log "reclaiming a run lock left behind by pid ${holder:-unknown}"
     rm -rf "$lock"
@@ -324,9 +367,12 @@ if [[ -n $AGAINST ]]; then
     const [spec, ledger, reference] = process.argv.slice(1);
     const { readLedger } = await import(`${spec}/scripts/review/review-eval-ledger.mjs`);
     const { resolveRowReference } = await import(`${spec}/scripts/review/review-eval-result-shape.mjs`);
-    resolveRowReference({ reference, rows: readLedger(ledger), repoRoot: spec });
+    const { baselineEligibility } = await import(`${spec}/scripts/review/review-eval-report.mjs`);
+    const row = resolveRowReference({ reference, rows: readLedger(ledger), repoRoot: spec });
+    const eligibility = baselineEligibility(row);
+    if (!eligibility.usable) throw new Error(eligibility.reason);
   ' "$SPEC" "$LEDGER" "$AGAINST" >/dev/null 2>&1 ||
-    fail "--against $AGAINST does not resolve to exactly one ledger row or row file"
+    fail "--against $AGAINST does not resolve to one eligible complete full baseline row"
 fi
 
 PLAN_OUT="$(mktemp "$TMPROOT/review-eval-plan.XXXXXX")"
@@ -363,6 +409,31 @@ node "$CLI" "${PLAN_ARGS[@]}" >"$PLAN_OUT" ||
   fail "planning into $RUN_DIR failed"
 RUN_DIR="$(json_field "$PLAN_OUT" plan_dir)"
 PLAN_JSON="$RUN_DIR/plan.json"
+# The first preflight proves that --against resolves to an intrinsically usable
+# row. The generated plan now supplies the remaining checks before paid work:
+# full schema and frozen-matrix validation, plus the exact comparison lineage.
+if [[ -n $AGAINST ]]; then
+  # shellcheck disable=SC2016  # the single-quoted block is node source
+  node --input-type=module -e '
+    const [spec, ledger, contractFile, planFile, reference] = process.argv.slice(1);
+    const { readFileSync } = await import("node:fs");
+    const { loadContract } = await import(`${spec}/scripts/review/review-eval-fixtures.mjs`);
+    const { baselinePreflightProblems, readLedger } = await import(`${spec}/scripts/review/review-eval-ledger.mjs`);
+    const { resolveRowReference } = await import(`${spec}/scripts/review/review-eval-result-shape.mjs`);
+    const { contract, digest } = loadContract(contractFile);
+    const plan = JSON.parse(readFileSync(planFile, "utf8"));
+    const row = resolveRowReference({ reference, rows: readLedger(ledger), repoRoot: spec });
+    const problems = baselinePreflightProblems({
+      row,
+      contract,
+      contractDigest: digest,
+      planComparabilityKey: plan.comparability_key,
+      candidateExecutedAt: plan.planned_at,
+    });
+    if (problems.length > 0) throw new Error(problems.join(" | "));
+  ' "$SPEC" "$LEDGER" "$CONTRACT" "$PLAN_JSON" "$AGAINST" >/dev/null 2>&1 ||
+    fail "--against $AGAINST is malformed or incompatible with the generated plan"
+fi
 # shellcheck disable=SC2016  # the single-quoted block is node source
 CELL_COUNT="$(node -e '
   const plan = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
@@ -404,8 +475,9 @@ remaining_seconds() {
 # running against their own one-hour timeouts, spending quota long after the run
 # reported failure and removed the worktrees they were reading. Monitor mode is
 # what gives the job its own group; it is switched off again immediately, and
-# the group id is read back so a shell that gave the job no group of its own
-# falls back to the bare pid rather than signalling this script's own group.
+# Bash makes the direct child the process-group leader for this simple
+# background job, so its pid is also the group id. This avoids a `ps` lookup
+# that a restricted runner can deny after the child has already started.
 #
 # Standard input comes from /dev/null. In its own process group a child that
 # reads the controlling terminal takes SIGTTIN and stops, which would turn a
@@ -430,12 +502,7 @@ run_bounded() {
   "$@" </dev/null >"$out_file" 2>"${out_file}.err" &
   local pid=$!
   ((monitor_off)) && set +m
-  local own_pgid child_pgid target="$pid"
-  own_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')"
-  child_pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
-  if [[ -n $child_pgid && -n $own_pgid && $child_pgid != "$own_pgid" ]]; then
-    target="-$child_pgid"
-  fi
+  local target="-$pid"
   (
     local waited=0
     while ((waited < limit)); do
@@ -451,7 +518,13 @@ run_bounded() {
   local watcher=$!
   local status=0
   wait "$pid" || status=$?
-  kill -TERM "$watcher" 2>/dev/null || true
+  if [[ -f $marker ]]; then
+    # The direct child can exit on TERM while a model grandchild ignores it.
+    # Let the watchdog finish its group-wide KILL before this function returns.
+    wait "$watcher" 2>/dev/null || true
+  else
+    kill -TERM "$watcher" 2>/dev/null || true
+  fi
   wait "$watcher" 2>/dev/null || true
   if [[ -f $marker ]]; then
     rm -f "$marker"

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -215,28 +215,36 @@ trap cleanup EXIT
 # A fixed order means two runs contending on both cannot each hold one and wait
 # — the loser fails immediately and the EXIT trap frees whatever it took.
 #
-# mkdir is the lock: it is atomic on every filesystem this runs on and needs no
-# flock, which macOS does not ship. The holder's pid goes inside so a lock left
-# behind by a SIGKILL can be told from a live run and reclaimed. The pid is
-# written before the directory is recorded in LOCK_DIRS — the holder must be
-# identifiable the instant the directory exists, or a second run arriving in
-# that window reads no pid and reclaims a live lock. The read side waits for it
-# for the same reason. `kill -0` on a recycled pid can keep a stale lock held;
-# that fails closed, and the message names the directory to remove.
+# A hard link publishes a prepared owner record as the lock. The record already
+# contains the holder's pid when the lock path becomes visible. This gives the
+# acquisition atomicity of mkdir without a window where a suspended owner has
+# created the lock but has not written its pid. The prepared record and lock
+# live under the same root, so the hard link never crosses a filesystem. A lock
+# left behind by SIGKILL can be told from a live run and reclaimed. `kill -0` on
+# a recycled pid can keep a stale lock held; that fails closed, and the message
+# names the file to remove.
 acquire_one_lock() {
-  local root="$1" what="$2" lock="$1/run.lock" holder="" waited=0
+  local root="$1" what="$2" lock="$1/run.lock" holder="" legacy_lock=0
   local reclaim_root="$1/run.lock.reclaim" claim_file="" claim_holder=""
-  local claim_ticket="" claim_generation=-1 candidate_generation=-1 entry=""
+  local claim_ticket="" owner_ticket="" claim_generation=-1
+  local candidate_generation=-1 entry=""
   mkdir -p "$root" || fail "the $what $root is not writable"
-  if ! mkdir "$lock" 2>/dev/null; then
-    while ((waited < 5)); do
-      waited=$((waited + 1))
+  owner_ticket="$(mktemp "$root/.run.lock.owner.XXXXXX")" ||
+    fail "could not prepare the run lock owner record under $root"
+  printf '%s\n' "$$" >"$owner_ticket"
+  if ! node -e \
+    'require("node:fs").linkSync(process.argv[1], process.argv[2])' \
+    "$owner_ticket" "$lock" 2>/dev/null; then
+    rm -f "$owner_ticket"
+    owner_ticket=""
+    if [[ -d $lock ]]; then
+      legacy_lock=1
       holder="$(cat "$lock/pid" 2>/dev/null || true)"
-      if [[ $holder =~ ^[0-9]+$ ]]; then
-        break
-      fi
-      sleep 0.2
-    done
+    else
+      holder="$(cat "$lock" 2>/dev/null || true)"
+    fi
+    [[ $holder =~ ^[0-9]+$ ]] ||
+      fail "cannot identify the run lock owner at $lock; refusing to reclaim shared run state"
     if [[ $holder =~ ^[0-9]+$ ]] && kill -0 "$holder" 2>/dev/null; then
       fail "another review eval (pid $holder) holds $lock; a run rewrites the shared fixtures and appends to the shared ledger, so wait for it to finish"
     fi
@@ -271,22 +279,37 @@ acquire_one_lock() {
     claim_ticket="$(mktemp "$reclaim_root/.ticket.XXXXXX")" ||
       fail "could not prepare a stale-lock claim at $reclaim_root"
     printf '%s\n' "$$" >"$claim_ticket"
-    if ! ln "$claim_ticket" "$claim_file" 2>/dev/null; then
+    if ! node -e \
+      'require("node:fs").linkSync(process.argv[1], process.argv[2])' \
+      "$claim_ticket" "$claim_file" 2>/dev/null; then
       rm -f "$claim_ticket"
       fail "another review eval claimed the stale lock at $lock; retry after it finishes"
     fi
     rm -f "$claim_ticket"
     local confirmed
-    confirmed="$(cat "$lock/pid" 2>/dev/null || true)"
+    if [[ $legacy_lock -eq 1 && -d $lock ]]; then
+      confirmed="$(cat "$lock/pid" 2>/dev/null || true)"
+    else
+      confirmed="$(cat "$lock" 2>/dev/null || true)"
+    fi
+    [[ $confirmed =~ ^[0-9]+$ ]] ||
+      fail "cannot confirm the stale run lock owner at $lock; refusing to reclaim shared run state"
     if [[ $confirmed =~ ^[0-9]+$ ]] && kill -0 "$confirmed" 2>/dev/null; then
       fail "another review eval (pid $confirmed) holds $lock; a run rewrites the shared fixtures and appends to the shared ledger, so wait for it to finish"
     fi
     log "reclaiming a run lock left behind by pid ${holder:-unknown}"
     rm -rf "$lock"
-    mkdir "$lock" 2>/dev/null ||
-      fail "could not take the run lock at $lock; remove it if no eval is running"
+    owner_ticket="$(mktemp "$root/.run.lock.owner.XXXXXX")" ||
+      fail "could not prepare the run lock owner record under $root"
+    printf '%s\n' "$$" >"$owner_ticket"
+    if ! node -e \
+      'require("node:fs").linkSync(process.argv[1], process.argv[2])' \
+      "$owner_ticket" "$lock" 2>/dev/null; then
+      rm -f "$owner_ticket"
+      fail "another review eval took the run lock at $lock; retry after it finishes"
+    fi
   fi
-  printf '%s\n' "$$" >"$lock/pid"
+  rm -f "$owner_ticket"
   LOCK_DIRS+=("$lock")
 }
 

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -320,6 +320,11 @@ acquire_one_lock() {
       fail "another review eval took the run lock at $lock; retry after it finishes"
     fi
     rm -rf "$reclaim_root"
+  else
+    # A prior reclaimer can die after it removes the stale lock and before it
+    # publishes its replacement. Retire that abandoned claim after this owner
+    # wins the now-empty lock so a recycled ticket pid cannot block recovery.
+    rm -rf "$reclaim_root"
   fi
   rm -f "$owner_ticket"
   LOCK_DIRS+=("$lock")

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -41,11 +41,11 @@
 #               [--repo PATH] [--cache-dir DIR] [--deadline SECONDS]
 #               [--against REF]
 #
-# --against names the baseline row this run is scored, validated and reported
-# against: a row file path or an executed_at prefix. The candidate procedure
-# needs it — a --skill-ref run must be compared against the installed run from
-# the same sitting, not against the ledger's stored anchor, or the comparison
-# carries whatever the model did between the anchor and today.
+# --against names the baseline row this run is planned, scored, validated and
+# reported against: a row file path or an executed_at prefix. The candidate
+# procedure needs it — a --skill-ref run must be compared against the installed
+# run from the same sitting, not against the ledger's stored anchor, or the
+# comparison carries whatever the model did between the anchor and today.
 #
 # --deadline bounds the whole run, cells and scoring together. Three quarters of
 # it start cells and bound each finder and contestant process; the rest is
@@ -403,6 +403,9 @@ PLAN_ARGS=(--root "$SPEC" --ledger "$LEDGER" --plan --kind "$KIND" --json)
 if [[ -n $SKILL_REF ]]; then
   PLAN_ARGS+=(--skill-ref "$SKILL_REF")
 fi
+if [[ -n $AGAINST ]]; then
+  PLAN_ARGS+=(--against "$AGAINST")
+fi
 node "$CLI" "${PLAN_ARGS[@]}" >"$PLAN_OUT" || fail "planning failed"
 
 # Read one top-level string field out of a JSON file.
@@ -427,6 +430,9 @@ PLAN_ARGS=(--root "$SPEC" --ledger "$LEDGER" --plan --kind "$KIND" --json
   --out "$RUN_DIR")
 if [[ -n $SKILL_REF ]]; then
   PLAN_ARGS+=(--skill-ref "$SKILL_REF")
+fi
+if [[ -n $AGAINST ]]; then
+  PLAN_ARGS+=(--against "$AGAINST")
 fi
 node "$CLI" "${PLAN_ARGS[@]}" >"$PLAN_OUT" ||
   fail "planning into $RUN_DIR failed"

--- a/scripts/review/run-eval.sh
+++ b/scripts/review/run-eval.sh
@@ -459,8 +459,8 @@ PLAN_JSON="$RUN_DIR/plan.json"
 # row. The generated plan now supplies the remaining checks before paid work:
 # full schema and frozen-matrix validation, plus the exact comparison lineage.
 if [[ -n $AGAINST ]]; then
-  BASELINE_SNAPSHOT="$(mktemp "$TMPROOT/review-eval-baseline.XXXXXX")" ||
-    fail "could not prepare an immutable baseline snapshot under $TMPROOT"
+  BASELINE_SNAPSHOT="$(mktemp "$LOCK_ROOT/review-eval-baseline.XXXXXX")" ||
+    fail "could not prepare an immutable baseline snapshot under $LOCK_ROOT"
   # shellcheck disable=SC2016  # the single-quoted block is node source
   node --input-type=module -e '
     const [spec, ledger, contractFile, planFile, reference, snapshot] = process.argv.slice(1);


### PR DESCRIPTION
## The Problem

- Review-eval ledger rows could pass required checks without complete run evidence, exact condition provenance, or a valid append-order baseline.
- External baselines and stale run locks could fail after model work had started or allow concurrent runs to race shared state.
- Required CI and Claude review routing did not enforce the same evidence and scorecard-only scope rules as the evaluation workflow.

## The Solution

This PR validates the frozen plan, scored results, calibration, baseline lineage, and condition provenance before a row can pass required checks. It validates explicit baselines before paid model calls. It also serializes stale-lock recovery with immutable tickets and limits the Claude review exemption to scorecard-only diffs. These controls protect evaluation evidence and quota. They do not change the evaluation contract, models, scoring thresholds, or production application behavior.

## Details

- Require exact frozen plan cells and result evidence for scored rows.
- Preserve append-order baseline semantics for automatic anchors and timestamp ordering for explicit baselines.
- Validate external baseline schema, frozen matrix, comparability key, eligibility, and time ordering before model work.
- Frame skill digest inputs and include CLI scoring orchestration in the matcher digest.
- Freeze truth before scoring and wait for deadline watchdog escalation to finish.
- Reclaim stale run locks through persistent, immutable generation tickets.
- Add `--revalidate-appended` to required CI, the advisory workflow, and local gate routing.
- Verify Claude's generated-scorecard review exemption against merge-base path scope.

Closes #2101

## Validation

- `CI=true pnpm review:eval:test` passed all 227 tests. This proves the deterministic review-eval behavior covered by the suite; it does not execute paid model cells.
- `node --test scripts/gate/routing-table/routing-table.test.mjs` passed all 35 tests. This proves the mapped command routing assertions; it does not prove GitHub runner policy.
- The full mapped `pnpm agent:quality-gate --run` command set passed every command except `pnpm agent:quality-gate:test`. That self-test's nested autoreview suite passed all mapped commands in 3m1s, but a timing fixture expected `AUTOREVIEW_TEST_PROGRESS family=adapter elapsed=2s` and observed completion timing at 4s. The maintainer approved bypassing only the local pre-push hook with `--no-verify`. GitHub CI remains required.
- `./tools/trunk fmt` and `git diff --check` passed. These checks prove repository formatting and whitespace compliance; they do not prove behavior.
- The final fresh-context source review found no actionable findings. The frozen bundle verified before and after review with manifest `6cef5d40e6410508d30f9fe27e4177fefda449a45629b6c2d31170d8b7afe59a`. This is source review evidence, not runtime or CI proof.
- No browser verification was run because this PR changes workflows, documentation, and evaluation scripts only. It changes no UI files or routes.
- Claude Security scan: skipped (CI review-gate and local orchestration hardening)

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This PR hardens the existing review-eval architecture and records no new long-term subsystem choice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gates, PR auto-review scope, and evaluation baseline semantics—high impact on merge trust and eval comparability, but confined to review-eval tooling and workflows, not production runtime.
> 
> **Overview**
> Tightens the **review-skill evaluation harness** so committed ledger rows cannot pass CI on schema and append-only checks alone while missing or tampering with run evidence, baseline lineage, or frozen plan cells.
> 
> **Ledger revalidation (`--revalidate-appended`)** is now required in CI, the advisory freshness workflow, and local gate routing. Appended rows must carry `plan.json`, every planned `result-*.json`, and `calibration.json`, with plan cells regenerated from the frozen contract so edits cannot drop required matrix cells. Installed rows must record the **append-order** automatic baseline; only dirty `--skill-ref` candidates may waive a missing recorded baseline as `unpaired_baselines`.
> 
> **Baseline and scoring behavior** moves automatic anchor selection to ledger append order (backdated timestamps cannot jump ahead), centralizes baseline eligibility in `baselineEligibility`, and runs `baselinePreflightProblems` in `run-eval.sh` before paid model work. Scoring freezes truth objects before calibration, frames skill-digest inputs to prevent path/content aliasing, and folds CLI orchestration into the matcher digest.
> 
> **Claude auto-review** no longer exempts `eval/review-skill-*` branches by name alone; it uses full history and skips review only when the merge-base diff is limited to the ledger and `docs/evals/review-skill-runs/**`. **Run locking** reclaims stale locks via monotonic generation tickets, and deadline watchdogs wait for group-wide kill after TERM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc6322afe6da907f9e9b98f721927c9c7bcc650. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened evaluation validation for appended entries, baselines, plans, timestamps, evidence, fingerprints, and compatibility.
  * Improved automatic and explicit baseline selection and resolution.
  * Added stricter cost and calibration validation.
  * Improved stale-lock recovery, timed-out process handling, and freshness tracking.
  * Refined review automation to skip only scorecard-only evaluation changes.

* **Documentation**
  * Updated evaluation guidance and result schemas for baseline selection and validation.

* **Tests**
  * Expanded coverage for provenance, input integrity, process handling, freshness, and workflow safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->