### PR TITLE
test(docs): lock historical navigation validation semantics

### DIFF
--- a/docs/evals/documentation-navigation.md
+++ b/docs/evals/documentation-navigation.md
@@ -60,6 +60,11 @@ failing committed baseline before treating it as historical comparison
 evidence. They validate it against the frozen baseline fixtures, not the
 current contract.
 
+Historical `--validate` runs skip only the forward-looking total-source
+headroom reserve. They still enforce `max_total_unique_source_bytes` against
+the inventory at `repository_base_commit`. The live `--check-fixtures` run
+enforces both limits against the current documentation inventory.
+
 `sources_requiring_verification` entries are historical qualification traps,
 not live routes. A trap may remain in the immutable fixture after its document
 is retired only when the evaluator explicitly lists that path as a tombstone;

--- a/scripts/docs/docs-navigation-eval.test.mjs
+++ b/scripts/docs/docs-navigation-eval.test.mjs
@@ -721,6 +721,91 @@ test("historical scoring requires a default-branch ancestor and survives deletio
       cwd: temp,
       encoding: "utf8",
     }).trim();
+    const pinnedContext = loadEvaluationContext(
+      {
+        repoRoot: temp,
+        fixturesPath: fixturePath,
+      },
+      { inventoryCommit: commit },
+    );
+    const pinnedFloor = navigationContextFloor(
+      pinnedContext.suite,
+      pinnedContext.inventory,
+    );
+    const reserveAtLimit = structuredClone(context.suite);
+    reserveAtLimit.targets.min_total_unique_source_headroom_bytes =
+      reserveAtLimit.targets.max_total_unique_source_bytes -
+      pinnedFloor.total_unique_route_bytes;
+    writeFileSync(
+      path.join(temp, fixturePath),
+      `${JSON.stringify(reserveAtLimit)}\n`,
+    );
+    assert.doesNotThrow(() =>
+      loadEvaluationContext({
+        repoRoot: temp,
+        fixturesPath: fixturePath,
+      }),
+    );
+    const reserveTooHigh = structuredClone(reserveAtLimit);
+    reserveTooHigh.targets.min_total_unique_source_headroom_bytes += 1;
+    writeFileSync(
+      path.join(temp, fixturePath),
+      `${JSON.stringify(reserveTooHigh)}\n`,
+    );
+    assert.throws(
+      () =>
+        loadEvaluationContext({
+          repoRoot: temp,
+          fixturesPath: fixturePath,
+        }),
+      /cheapest accepted route union leaves .* bytes of headroom/,
+    );
+    assert.doesNotThrow(() =>
+      loadEvaluationContext(
+        {
+          repoRoot: temp,
+          fixturesPath: fixturePath,
+        },
+        { inventoryCommit: commit },
+      ),
+    );
+    const hardCapAtLimit = structuredClone(reserveTooHigh);
+    hardCapAtLimit.targets.max_total_unique_source_bytes =
+      pinnedFloor.total_unique_route_bytes;
+    writeFileSync(
+      path.join(temp, fixturePath),
+      `${JSON.stringify(hardCapAtLimit)}\n`,
+    );
+    assert.doesNotThrow(() =>
+      loadEvaluationContext(
+        {
+          repoRoot: temp,
+          fixturesPath: fixturePath,
+        },
+        { inventoryCommit: commit },
+      ),
+    );
+    const hardCapTooLow = structuredClone(hardCapAtLimit);
+    hardCapTooLow.targets.max_total_unique_source_bytes -= 1;
+    writeFileSync(
+      path.join(temp, fixturePath),
+      `${JSON.stringify(hardCapTooLow)}\n`,
+    );
+    assert.throws(
+      () =>
+        loadEvaluationContext(
+          {
+            repoRoot: temp,
+            fixturesPath: fixturePath,
+          },
+          { inventoryCommit: commit },
+        ),
+      /cheapest accepted route union needs .* bytes; max_total_unique_source_bytes is/,
+    );
+    writeFileSync(
+      path.join(temp, fixturePath),
+      `${JSON.stringify(context.suite)}\n`,
+    );
     const historicalSource = (pathname) => {
       const bytes = execFileSync("git", ["show", `${commit}:${pathname}`], {
         cwd: temp,


### PR DESCRIPTION
## The Problem

- Historical navigation-result validation enforced the forward-looking live headroom reserve against the result's pinned inventory. A branch that restored live headroom could still fail against its merge-base inventory.
- A recorded result could also become invalid after later documentation growth. Existing tests did not prove the reserve and hard-cap boundary behavior through the evaluation loader and CLI.

## The Solution

This PR documents and pins the split validation contract. Live fixture checks enforce the headroom reserve. Historical result checks skip that reserve but still enforce the hard `max_total_unique_source_bytes` cap. The regression test covers exact equality and the adjacent failing value for both limits through `loadEvaluationContext`, then validates the recorded result through the CLI path.

The production predicate already exists on `main` from #2075. This PR adds the missing contract evidence and evaluator documentation. It does not change route scoring, source inventories, or budget values.

## Details

- Build a committed historical inventory in an isolated temporary Git repository.
- Prove that live validation accepts reserve equality and rejects a reserve that is one byte too large.
- Prove that historical validation skips that reserve, accepts hard-cap equality, and rejects a hard cap that is one byte too small.
- State the live and historical rules in the navigation evaluation document.

## Validation

- `pnpm docs:navigation-eval:test` passed all 34 tests.
- `pnpm docs:navigation-eval -- --check-fixtures --json` passed with a 227,210-byte floor, 34,790 bytes of headroom, and a 2,022-byte reserve surplus.
- `pnpm agent:quality-gate --run` passed all 8 mapped commands, including Trunk, documentation index and context checks, script lint, live and historical navigation checks, and Terraform tests.
- These checks prove the deterministic fixture, loader, and CLI contract. They do not prove model answer quality or future documentation size.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This PR documents and tests the existing validation boundary.

Closes #2104

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and test-only changes that document and pin existing loader validation; no production logic or budget values are modified.
> 
> **Overview**
> Documents and regression-tests the **split byte-budget rules** for documentation navigation evaluation: live `--check-fixtures` still enforces both `max_total_unique_source_bytes` and the forward-looking `min_total_unique_source_headroom_bytes` reserve against the **current** inventory, while historical `--validate` **skips only the headroom reserve** but still applies the hard suite cap against the inventory at the result’s pinned `repository_base_commit`.
> 
> The new cases in the isolated-git historical test drive `loadEvaluationContext` through **exact boundary values**—reserve at the limit vs one byte too high on live load, then the same reserve violation allowed when `inventoryCommit` is set, plus hard-cap equality vs one byte under the pinned floor—before restoring the fixture and continuing the existing CLI historical validation path. **No evaluator logic or fixture budgets change** in this diff; it adds contract text and evidence for behavior already on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdde5aca658fb17f6f840af3f70282afb33cafae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified validation behavior for historical and current documentation-navigation evaluations.
  * Documented how headroom and total-source-byte limits are applied.

* **Tests**
  * Added boundary checks for validation limits, including minimum passing values and over-limit failures.
  * Added coverage for loading historical inventory data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->