### PR TITLE
fix(pr): use synchronous REST merge endpoint

### DIFF
--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -124,9 +124,11 @@ wrapper says so in its own header rather than implying otherwise:
   window begins when the GraphQL child selects its credential and ends when the
   REST child selects its credential. It includes the in-flight final query and
   the consent-ledger write. A `gh auth switch` in that window can make the two
-  children use different keyring or `hosts.yml` credentials. The merge still
-  targets the confirmed repository, pull request, base, and head, but the local
-  ledger can name the wrong GitHub account. This does not apply when `GH_TOKEN`
+  children use different keyring or `hosts.yml` credentials. The REST request
+  still names the confirmed repository and pull request, and `sha` binds the
+  confirmed head. It cannot bind the base, so a retarget after the final read
+  can still land on another branch. The local ledger can name the wrong GitHub
+  account. This does not apply when `GH_TOKEN`
   fixes the credential in the environment. The irreducible window is accepted
   because closing it would require the trust-root wrapper to capture a live
   token and inject it into a child environment, which creates a larger

--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -75,10 +75,11 @@ The ordered gates in `scripts/pr/merge-pr.mjs`:
    it detects queues from rulesets and classic branch protection. The wrapper
    also reads the branch's ruleset rule types as a second signal and a specific
    diagnostic. An unreadable answer from either queue read refuses. The final
-   GraphQL read queries `Repository.mergeQueue` and returns the pull request's
-   current `baseRefName` and `autoMergeRequest` together. A base mismatch
-   refuses, so the queue query must still name the current base. It is the last
-   remote read before consent is recorded and the direct merge starts.
+   GraphQL read queries `Repository.mergeQueue` and returns `viewer.login` plus
+   the pull request's current `baseRefName` and `autoMergeRequest`. A login or
+   base mismatch refuses, so the credential observation and queue query still
+   match the confirmed operator and current base. It is the last remote read
+   before consent is recorded and the direct merge starts.
 
 7. Append the consent record — login, timestamp, pull request, head commit,
    any override reason — to gitignored `.merge-consents.jsonl`, opened
@@ -116,15 +117,17 @@ wrapper says so in its own header rather than implying otherwise:
   pattern list closes that space, and one that read as though it did would be
   worse than a documented gap.
 - **The confirmed login is not bound to the merge subprocess credential.** The
-  wrapper reads the login again after confirmation, then writes the consent
-  record and starts a fresh `gh api` process. A `gh auth switch` during that
-  short interval can make the child use another keyring or `hosts.yml`
+  final combined GraphQL response returns `viewer.login` with every final
+  state. The wrapper compares that login with the operator confirmed before the
+  briefing, then writes consent and starts a fresh `gh api` process. A
+  `gh auth switch` after that response but before the REST child reads its
+  credential can still make the child use another keyring or `hosts.yml`
   credential. The merge still targets the confirmed repository, pull request,
   base, and head, but the local ledger can name the wrong GitHub account. This
   does not apply when `GH_TOKEN` fixes the credential in the environment. The
-  window is accepted because binding it would require the trust-root wrapper to
-  capture a live token and inject it into a child environment, which creates a
-  larger credential-handling surface. Issue 2099 records the decision.
+  irreducible window is accepted because closing it would require the trust-root
+  wrapper to capture a live token and inject it into a child environment, which
+  creates a larger credential-handling surface. Issue 2099 records the decision.
 - **Merge-queue and auto-merge absence are not bound atomically to the merge.**
   The wrapper checks both before the briefing and again in one final GraphQL
   response. A queue or auto-merge request enabled after that read but before
@@ -170,10 +173,10 @@ credentials that cannot merge — and is tracked separately as follow-up.
   was narrowed in the script header, the operating card, and the PR
   description instead of being left standing.
 - **Capture one token and pass it to the merge child.** This would bind the
-  final login read, consent record, and merge to one credential. Rejected
-  because it makes the trust-root wrapper read a live GitHub token and inject
-  it into a child environment. The accepted misattribution window has less
-  impact and does not change what merge the operator approved.
+  final combined viewer read, consent record, and merge to one credential.
+  Rejected because it makes the trust-root wrapper read a live GitHub token and
+  inject it into a child environment. The accepted misattribution window has
+  less impact and does not change what merge the operator approved.
 
 ## Consequences
 

--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -75,9 +75,10 @@ The ordered gates in `scripts/pr/merge-pr.mjs`:
    it detects queues from rulesets and classic branch protection. The wrapper
    also reads the branch's ruleset rule types as a second signal and a specific
    diagnostic. An unreadable answer from either queue read refuses. The final
-   GraphQL read queries `Repository.mergeQueue` and the pull request's
-   `autoMergeRequest` together. It is the last remote read before consent is
-   recorded and the direct merge starts.
+   GraphQL read queries `Repository.mergeQueue` and returns the pull request's
+   current `baseRefName` and `autoMergeRequest` together. A base mismatch
+   refuses, so the queue query must still name the current base. It is the last
+   remote read before consent is recorded and the direct merge starts.
 
 7. Append the consent record — login, timestamp, pull request, head commit,
    any override reason — to gitignored `.merge-consents.jsonl`, opened
@@ -138,12 +139,13 @@ wrapper says so in its own header rather than implying otherwise:
   bound in the confirmation signature and the residual window is accepted
   rather than changing how every merge commit is titled.
 - **The approved base cannot be bound atomically.** The request's `sha` pins the
-  head, and the merge endpoint has no base equivalent. A retarget landing
-  between the final gate read and GitHub processing the merge therefore cannot
-  be prevented here. The
-  wrapper re-reads the base afterwards, says plainly that the merge did not go
-  where the operator approved, and exits non-zero. That is detection, not
-  prevention, and the window is a few hundred milliseconds wide.
+  head, and the merge endpoint has no base equivalent. The final GraphQL read
+  proves that the queue query still names the pull request's current base. A
+  retarget landing after that read but before GitHub processes the merge still
+  cannot be prevented here. The wrapper re-reads the base afterwards, says
+  plainly that the merge did not go where the operator approved, and exits
+  non-zero. That is detection, not prevention, and the window is a few hundred
+  milliseconds wide.
 
 The durable boundary is on GitHub's side of the wire — branch protection, or
 credentials that cannot merge — and is tracked separately as follow-up.

--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -117,17 +117,20 @@ wrapper says so in its own header rather than implying otherwise:
   pattern list closes that space, and one that read as though it did would be
   worse than a documented gap.
 - **The confirmed login is not bound to the merge subprocess credential.** The
-  final combined GraphQL response returns `viewer.login` with every final
-  state. The wrapper compares that login with the operator confirmed before the
-  briefing, then writes consent and starts a fresh `gh api` process. A
-  `gh auth switch` after that response but before the REST child reads its
-  credential can still make the child use another keyring or `hosts.yml`
-  credential. The merge still targets the confirmed repository, pull request,
-  base, and head, but the local ledger can name the wrong GitHub account. This
-  does not apply when `GH_TOKEN` fixes the credential in the environment. The
-  irreducible window is accepted because closing it would require the trust-root
-  wrapper to capture a live token and inject it into a child environment, which
-  creates a larger credential-handling surface. Issue 2099 records the decision.
+  final GraphQL child selects a credential before it sends the combined query;
+  the response returns that credential's `viewer.login` with every final state.
+  The wrapper compares that login with the operator confirmed before the
+  briefing, then writes consent and starts the REST merge child. The residual
+  window begins when the GraphQL child selects its credential and ends when the
+  REST child selects its credential. It includes the in-flight final query and
+  the consent-ledger write. A `gh auth switch` in that window can make the two
+  children use different keyring or `hosts.yml` credentials. The merge still
+  targets the confirmed repository, pull request, base, and head, but the local
+  ledger can name the wrong GitHub account. This does not apply when `GH_TOKEN`
+  fixes the credential in the environment. The irreducible window is accepted
+  because closing it would require the trust-root wrapper to capture a live
+  token and inject it into a child environment, which creates a larger
+  credential-handling surface. Issue 2099 records the decision.
 - **Merge-queue and auto-merge absence are not bound atomically to the merge.**
   The wrapper checks both before the briefing and again in one final GraphQL
   response. A queue or auto-merge request enabled after that read but before

--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -75,7 +75,8 @@ The ordered gates in `scripts/pr/merge-pr.mjs`:
    it detects queues from rulesets and classic branch protection. The wrapper
    also reads the branch's ruleset rule types as a second signal and a specific
    diagnostic. An unreadable answer from either queue read refuses. The final
-   `Repository.mergeQueue` read is the last remote read before consent is
+   GraphQL read queries `Repository.mergeQueue` and the pull request's
+   `autoMergeRequest` together. It is the last remote read before consent is
    recorded and the direct merge starts.
 
 7. Append the consent record — login, timestamp, pull request, head commit,
@@ -123,12 +124,12 @@ wrapper says so in its own header rather than implying otherwise:
   window is accepted because binding it would require the trust-root wrapper to
   capture a live token and inject it into a child environment, which creates a
   larger credential-handling surface. Issue 2099 records the decision.
-- **Merge-queue absence is not bound atomically to the merge.** The wrapper
-  proves that `Repository.mergeQueue(branch:)` is null before the briefing and
-  again as its final remote read. A queue enabled after that read but before
-  GitHub handles the REST request can still be bypassed. The wrapper minimizes
-  this interval, but GitHub's synchronous merge endpoint offers no parameter
-  that binds queue absence to the write.
+- **Merge-queue and auto-merge absence are not bound atomically to the merge.**
+  The wrapper checks both before the briefing and again in one final GraphQL
+  response. A queue or auto-merge request enabled after that read but before
+  GitHub handles the REST request can still be consumed or bypassed. The
+  wrapper minimizes this interval, but GitHub's synchronous merge endpoint
+  offers no parameter that binds either absence to the write.
 - **The squash subject is not pinned.** A title edited in the same window can
   reach the merge commit. Sending `commit_title` would pin it, but this
   repository sets `squash_merge_commit_title=COMMIT_OR_PR_TITLE`: GitHub uses

--- a/docs/adr/0075-pr-merge.md
+++ b/docs/adr/0075-pr-merge.md
@@ -3,7 +3,7 @@ title: One sanctioned human-only merge path
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-26
+last_verified: 2026-08-28
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -21,9 +21,9 @@ garden_lane: adrs-architecture
 "Never merge a pull request without the user's explicit approval" was written
 only in agent instructions. Nothing in the repository could refuse a merge.
 
-`gh pr merge` reaches GitHub's write API directly. No git hook, no CI job, and
-no branch-protection rule observes the decision to press the button, so the
-repository had no place to put a gate even in principle. A merge is
+GitHub's merge API accepts the write directly. No git hook or CI job observes
+the decision to press the button, so the repository had no place to put a gate
+even in principle. A merge is
 irreversible in practice: one agent that reads "ship it" as approval, or one
 operator merging a pull request that went red minutes ago, lands unreviewed
 code on `main` with no record of who approved what.
@@ -62,24 +62,21 @@ The ordered gates in `scripts/pr/merge-pr.mjs`:
    feedback items refuses. The comparison uses identities, not counts, and
    serializes each record on its own so no field can spell another's value.
 6. Refuse a pull request that already has an auto-merge request standing on
-   it, and a ruleset-declared merge-queue base — both before the briefing is
-   printed, and both again after the confirmation.
+   it, or whose base has a merge queue. Read both before the briefing and again
+   after the confirmation.
 
    A standing auto-merge request means GitHub is already holding a merge
-   somebody asked for outside these gates; merging over it and cancelling it
-   are both wrong, and the wrapper cannot tell its own compensation from
-   interference with another operator's state. Refusing also makes the
-   post-merge cleanup provably its own.
+   somebody asked for outside these gates. Merging over it or cancelling it
+   would overwrite another operator's intent.
 
-   A merge-queue base is refused because `gh pr merge` enqueues it and returns
-   success, and nothing the wrapper can call removes a queue entry —
-   `--disable-auto` turns off auto-merge only — so merging first would leave a
-   standing request it cannot take back, which GitHub could complete later
-   outside every gate above. The check reads the branch's **ruleset** rules; a
-   merge queue enabled through a classic branch-protection rule does not
-   surface there, so this narrows the window rather than closing it, and
-   step 8's reconciliation still catches such an enqueue and exits non-zero.
-   An unreadable answer from either read refuses.
+   The synchronous merge endpoint cannot enqueue, but it can bypass a merge
+   queue enabled through classic branch protection and merge directly.
+   `Repository.mergeQueue(branch:)` is therefore the authoritative queue gate;
+   it detects queues from rulesets and classic branch protection. The wrapper
+   also reads the branch's ruleset rule types as a second signal and a specific
+   diagnostic. An unreadable answer from either queue read refuses. The final
+   `Repository.mergeQueue` read is the last remote read before consent is
+   recorded and the direct merge starts.
 
 7. Append the consent record — login, timestamp, pull request, head commit,
    any override reason — to gitignored `.merge-consents.jsonl`, opened
@@ -87,10 +84,13 @@ The ordered gates in `scripts/pr/merge-pr.mjs`:
    check, and a short-write refusal. This is deliberately the **last** step
    before the merge: every refusal above runs first, so no consent record
    exists for a run the gates turned away.
-8. Merge with `--squash --match-head-commit`, then confirm with GitHub that the
-   pull request actually reached `MERGED`, on the approved base and the
-   approved head. Any other outcome — including a failed merge command, which
-   may still have reached GitHub — cancels auto-merge and exits non-zero.
+8. Call the synchronous REST endpoint
+   `PUT /repos/{owner}/{repo}/pulls/{number}/merge` with the approved head in
+   `sha` and `merge_method=squash`. Omit `commit_title` and `commit_message`, so
+   GitHub uses the repository's configured squash defaults. Then confirm that
+   the pull request reached `MERGED` on the approved base and head. Any other
+   outcome exits non-zero. Reconciliation never enables or disables
+   auto-merge, because this request cannot create deferred merge state.
 
 `.claude/settings.json` denies the raw `Bash(gh pr merge:*)` command, removing
 the obvious shortcut past the wrapper for a Claude session.
@@ -108,39 +108,38 @@ wrapper says so in its own header rather than implying otherwise:
   covering `-R` and `--repo`, separated and `=` joined, before and after `pr`. Six of those spellings were run against gh 2.96.0 and
   all six parse; the bare `-R` form was confirmed to bypass the original single
   pattern. It does not cover the same
-  merge issued as `gh api --method PUT repos/{owner}/{repo}/pulls/{n}/merge`,
-  through a `gh alias`, or with other global flags interleaved. No pattern list
-  closes that space, and one that read as though it did would be worse than a
-  documented gap.
-- **A merge queue enabled in the final window still enqueues.** The base's rule
-  types are read before the briefing and again after the confirmation, and a
-  `merge_queue` rule refuses both times. Neither read closes the gap between the
-  last one and GitHub handling the request: `gh pr merge` enqueues rather than
-  merging, and `--disable-auto` cannot remove a queue entry, so the wrapper
-  would be left unable to take back a request it created. Closing this needs a
-  merge operation that cannot enqueue — the REST endpoint with the approved
-  `sha` — which is a change to the wrapper's central call and is tracked in
-  issue 2092. `main` has no `merge_queue` rule today, so the hazard is latent
-  here rather than active.
-- **An interrupt during the merge call skips reconciliation.** SIGINT or
-  SIGTERM reaches this process as well as `gh`, so the wrapper can exit after
-  GitHub accepted a request but before the post-merge reconciliation runs,
-  leaving something standing. The pre-send refusals shrink this to a base with
-  no merge queue, no standing auto-merge request, and `--not-ready-reason` in
-  play. Trapping and forwarding signals around the merge call would narrow it
-  further; issue 2092 removes it outright, because an operation that cannot
-  enqueue or enable auto-merge leaves nothing to reconcile.
+  merge issued as a raw REST call, through a `gh alias`, or with other global
+  flags interleaved. The sanctioned wrapper now uses that REST form after its
+  gates; agents remain forbidden from using the wrapper or the raw form. No
+  pattern list closes that space, and one that read as though it did would be
+  worse than a documented gap.
+- **The confirmed login is not bound to the merge subprocess credential.** The
+  wrapper reads the login again after confirmation, then writes the consent
+  record and starts a fresh `gh api` process. A `gh auth switch` during that
+  short interval can make the child use another keyring or `hosts.yml`
+  credential. The merge still targets the confirmed repository, pull request,
+  base, and head, but the local ledger can name the wrong GitHub account. This
+  does not apply when `GH_TOKEN` fixes the credential in the environment. The
+  window is accepted because binding it would require the trust-root wrapper to
+  capture a live token and inject it into a child environment, which creates a
+  larger credential-handling surface. Issue 2099 records the decision.
+- **Merge-queue absence is not bound atomically to the merge.** The wrapper
+  proves that `Repository.mergeQueue(branch:)` is null before the briefing and
+  again as its final remote read. A queue enabled after that read but before
+  GitHub handles the REST request can still be bypassed. The wrapper minimizes
+  this interval, but GitHub's synchronous merge endpoint offers no parameter
+  that binds queue absence to the write.
 - **The squash subject is not pinned.** A title edited in the same window can
-  reach the merge commit. `gh pr merge --subject` would pin it, but this
+  reach the merge commit. Sending `commit_title` would pin it, but this
   repository sets `squash_merge_commit_title=COMMIT_OR_PR_TITLE`: GitHub uses
   the single commit's subject when a PR has one, and appends `(#N)`. A fixed
-  `--subject` would replace both behaviours on every merge, so the title is
+  title would replace both behaviors on every merge, so the title is
   bound in the confirmation signature and the residual window is accepted
   rather than changing how every merge commit is titled.
-- **The approved base cannot be bound atomically.** `--match-head-commit` pins
-  the head, and the merge endpoint's only matching parameter is `sha`, for the
-  head — there is no base equivalent. A retarget landing between the final gate
-  read and GitHub processing the merge therefore cannot be prevented here. The
+- **The approved base cannot be bound atomically.** The request's `sha` pins the
+  head, and the merge endpoint has no base equivalent. A retarget landing
+  between the final gate read and GitHub processing the merge therefore cannot
+  be prevented here. The
   wrapper re-reads the base afterwards, says plainly that the merge did not go
   where the operator approved, and exits non-zero. That is detection, not
   prevention, and the window is a few hundred milliseconds wide.
@@ -156,7 +155,7 @@ credentials that cannot merge — and is tracked separately as follow-up.
   record who approved which head locally, and cannot refuse before the request
   leaves the machine. Rejected as a replacement, kept as the follow-up.
 - **A pre-push or pre-receive hook.** A merge is not a push. No local hook runs
-  on `gh pr merge`, so there is nothing to hook.
+  on a merge API call, so there is nothing to hook.
 - **Trusting the agent instructions alone.** This was the prior state. The rule
   was correct and unenforced; a rule with no default-refusing mechanism behind
   it fails exactly when an agent misreads intent.
@@ -167,6 +166,11 @@ credentials that cannot merge — and is tracked separately as follow-up.
   expensive. The autoreview pass raised this and it is correct — so the claim
   was narrowed in the script header, the operating card, and the PR
   description instead of being left standing.
+- **Capture one token and pass it to the merge child.** This would bind the
+  final login read, consent record, and merge to one credential. Rejected
+  because it makes the trust-root wrapper read a live GitHub token and inject
+  it into a child environment. The accepted misattribution window has less
+  impact and does not change what merge the operator approved.
 
 ## Consequences
 
@@ -176,10 +180,15 @@ credentials that cannot merge — and is tracked separately as follow-up.
 - Merging now depends on both PR projections. A pull request that is
   check-green but has unresolved review threads no longer merges without a
   recorded reason, which matches the repository's own two-projection all-clear.
-- The merge method is fixed to `--squash`; `allow_merge_commit` and
+- The merge method is fixed to `squash`; `allow_merge_commit` and
   `allow_rebase_merge` are false on this repository. Changing it needs a
   re-check, because a rejected method fails at the API after consent is
   already recorded.
+- The request omits `commit_title` and `commit_message`. The live repository
+  settings verified on 2026-08-28 are
+  `squash_merge_commit_title=COMMIT_OR_PR_TITLE` and
+  `squash_merge_commit_message=COMMIT_MESSAGES`, so GitHub keeps the existing
+  squash subject and message behavior.
 - `.merge-consents.jsonl` is local and gitignored. It is evidence for the
   operator, not an audit log anyone else can read, and an attacker with local
   write can still delete it. It is deliberately not pushed anywhere.
@@ -188,16 +197,19 @@ credentials that cannot merge — and is tracked separately as follow-up.
   `merge-pr-github.mjs` (GitHub calls) so each stays under the 600-line soft
   cap. The suite asserts the cap over all four, which is the only per-PR
   enforcement: `scripts/` has no `max-lines` rule.
-- The `gh api` merge route and CI tokens remain outside this control's reach.
+- Raw merge API calls and CI tokens remain outside this local control's reach.
 
 ## Evidence
 
 - `scripts/pr/merge-pr.mjs`, `scripts/pr/merge-pr-core.mjs`,
   `scripts/pr/merge-pr-io.mjs`, and `.claude/settings.json` enforce the
   decision; `docs/notes/pr-operating-card.md` step 8 routes to it. PR #2072.
-- `scripts/pr/merge-pr.test.mjs` is offline — every GitHub and filesystem
-  boundary is injected — and each refusal case asserts that no consent was
-  recorded and no merge ran.
+- `scripts/pr/merge-pr.test.mjs` is offline. Every GitHub and filesystem
+  boundary is injected. It asserts the exact synchronous REST route, approved
+  `sha`, squash method, omitted title and message fields, and the absence of
+  any auto-merge compensation call on failed or unreadable outcomes. It also
+  asserts queue-object, null-queue, and unreadable-queue responses for
+  `Repository.mergeQueue`.
 - Every gate above was verified by a negative control: removing the
   base-retarget check, the gate-signature check, the feedback gate, the
   hard-link check, the short-write check, the terminal sanitizer, the
@@ -208,6 +220,12 @@ credentials that cannot merge — and is tracked separately as follow-up.
   `contents: read`, and merging a pull request requires `contents: write`, so
   that token cannot merge. The residual is a local session using the operator's
   own `gh` credentials.
-- `gh api repos/mento-protocol/monitoring-monorepo/rulesets` reports no
-  `merge_queue` rule on `main` today; the post-merge verification exists because
-  the wrapper accepts any `--repo`.
+- `gh api repos/mento-protocol/monitoring-monorepo` reports squash-only merge
+  settings with `COMMIT_OR_PR_TITLE` and `COMMIT_MESSAGES`. Post-merge
+  verification remains required because the wrapper accepts any `--repo` and
+  a lost response can hide a completed merge.
+- A read-only GraphQL control on 2026-08-28 returned a queue object and
+  `https://github.com/github/docs/queue/main` for the queue-managed
+  `github/docs` `main` branch. The same `Repository.mergeQueue(branch:)` query
+  returned null for this repository's `main` branch. This verifies the signal
+  without merging either repository.

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -378,13 +378,14 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    the approved head and squash method. The request cannot enqueue or enable
    auto-merge. It can bypass a classic branch-protection merge queue, so the
    wrapper proves `Repository.mergeQueue(branch:)` is null before the briefing
-   and again in a final GraphQL read that also returns the pull request's
-   current `baseRefName` and `autoMergeRequest`. A base mismatch refuses, so the
-   queue query must still name the current target. That query covers ruleset and
-   classic queues while keeping the base and both intent gates in the shortest
-   available race window. The wrapper also reads ruleset rule types as a second
-   signal. Any unreadable intent state refuses. The request omits commit title
-   and message
+   and again in a final GraphQL read that also returns `viewer.login` and the
+   pull request's current `baseRefName` and `autoMergeRequest`. A login or base
+   mismatch refuses, so the credential observation and queue query must still
+   name the confirmed operator and current target. That query covers ruleset
+   and classic queues while keeping the credential, base, and both intent gates
+   in the shortest available race window. The wrapper also reads ruleset rule
+   types as a second signal. Any unreadable intent state refuses. The request
+   omits commit title and message
    fields, so the repository's squash defaults remain in effect. The wrapper
    confirms afterwards that the PR reached `MERGED` on the approved base and
    head. It never disables auto-merge during reconciliation. Any ambiguous
@@ -393,10 +394,11 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    `.claude/settings.json` denies `gh pr merge` and its repository-qualified
    spellings, which removes the obvious shortcuts. Neither layer is an
    unforgeable boundary — a local process running as the operator can
-   synthesize any local signal. A credential switch after the final login read
-   can also misattribute the local consent record; the merge target remains
-   bound. The approval rule above stays the binding control, and the durable
-   boundary belongs on GitHub's side of the wire.
+   synthesize any local signal. A credential switch after the final combined
+   read but before the REST child selects its credential can still misattribute
+   the local consent record; the merge target remains bound. The approval rule
+   above stays the binding control, and the durable boundary belongs on
+   GitHub's side of the wire.
    [ADR 0075](../adr/0075-pr-merge.md) owns the ordered gates,
    the alternatives, and every residual, including what the deny does not
    cover. The Dependabot auto-merge workflow runs in CI, not an agent session,

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -378,9 +378,11 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    the approved head and squash method. The request cannot enqueue or enable
    auto-merge. It can bypass a classic branch-protection merge queue, so the
    wrapper proves `Repository.mergeQueue(branch:)` is null before the briefing
-   and again as its final remote read. That query covers ruleset and classic
-   queues. The wrapper also reads ruleset rule types as a second signal. Any
-   unreadable queue state refuses. The request omits commit title and message
+   and again in a final GraphQL read that also checks the pull request's
+   `autoMergeRequest`. That query covers ruleset and classic queues while
+   keeping both intent gates in the shortest available race window. The wrapper
+   also reads ruleset rule types as a second signal. Any unreadable intent state
+   refuses. The request omits commit title and message
    fields, so the repository's squash defaults remain in effect. The wrapper
    confirms afterwards that the PR reached `MERGED` on the approved base and
    head. It never disables auto-merge during reconciliation. Any ambiguous

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -3,7 +3,7 @@ title: PR Operating Card
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-26
+last_verified: 2026-08-28
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -374,14 +374,25 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    `scripts/pr/merge-pr.mjs` refuses outside an interactive human session, runs
    both step 7 projections, shows a briefing, makes the operator type the
    pull-request number back, re-reads every gate, records consent to gitignored
-   `.merge-consents.jsonl`, and confirms afterwards that the PR reached
-   `MERGED` on the approved base and head. Any ambiguous state refuses; a
-   not-ready PR or unclean feedback ledger needs `--not-ready-reason "<why>"`.
+   `.merge-consents.jsonl`, then calls the synchronous REST merge endpoint with
+   the approved head and squash method. The request cannot enqueue or enable
+   auto-merge. It can bypass a classic branch-protection merge queue, so the
+   wrapper proves `Repository.mergeQueue(branch:)` is null before the briefing
+   and again as its final remote read. That query covers ruleset and classic
+   queues. The wrapper also reads ruleset rule types as a second signal. Any
+   unreadable queue state refuses. The request omits commit title and message
+   fields, so the repository's squash defaults remain in effect. The wrapper
+   confirms afterwards that the PR reached `MERGED` on the approved base and
+   head. It never disables auto-merge during reconciliation. Any ambiguous
+   state refuses; a not-ready PR or unclean feedback ledger needs
+   `--not-ready-reason "<why>"`.
    `.claude/settings.json` denies `gh pr merge` and its repository-qualified
    spellings, which removes the obvious shortcuts. Neither layer is an
    unforgeable boundary — a local process running as the operator can
-   synthesize any local signal — so the approval rule above stays the binding
-   control, and the durable boundary belongs on GitHub's side of the wire.
+   synthesize any local signal. A credential switch after the final login read
+   can also misattribute the local consent record; the merge target remains
+   bound. The approval rule above stays the binding control, and the durable
+   boundary belongs on GitHub's side of the wire.
    [ADR 0075](../adr/0075-pr-merge.md) owns the ordered gates,
    the alternatives, and every residual, including what the deny does not
    cover. The Dependabot auto-merge workflow runs in CI, not an agent session,

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -378,11 +378,13 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    the approved head and squash method. The request cannot enqueue or enable
    auto-merge. It can bypass a classic branch-protection merge queue, so the
    wrapper proves `Repository.mergeQueue(branch:)` is null before the briefing
-   and again in a final GraphQL read that also checks the pull request's
-   `autoMergeRequest`. That query covers ruleset and classic queues while
-   keeping both intent gates in the shortest available race window. The wrapper
-   also reads ruleset rule types as a second signal. Any unreadable intent state
-   refuses. The request omits commit title and message
+   and again in a final GraphQL read that also returns the pull request's
+   current `baseRefName` and `autoMergeRequest`. A base mismatch refuses, so the
+   queue query must still name the current target. That query covers ruleset and
+   classic queues while keeping the base and both intent gates in the shortest
+   available race window. The wrapper also reads ruleset rule types as a second
+   signal. Any unreadable intent state refuses. The request omits commit title
+   and message
    fields, so the repository's squash defaults remain in effect. The wrapper
    confirms afterwards that the PR reached `MERGED` on the approved base and
    head. It never disables auto-merge during reconciliation. Any ambiguous

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -394,11 +394,13 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    `.claude/settings.json` denies `gh pr merge` and its repository-qualified
    spellings, which removes the obvious shortcuts. Neither layer is an
    unforgeable boundary — a local process running as the operator can
-   synthesize any local signal. A credential switch after the final combined
-   read but before the REST child selects its credential can still misattribute
-   the local consent record; the merge target remains bound. The approval rule
-   above stays the binding control, and the durable boundary belongs on
-   GitHub's side of the wire.
+   synthesize any local signal. The credential-attribution window begins when
+   the final GraphQL child selects its credential and ends when the REST child
+   selects its credential. It includes the in-flight final query and the
+   consent-ledger write. A credential switch in this window can still
+   misattribute the local consent record; the merge target remains bound. The
+   approval rule above stays the binding control, and the durable boundary
+   belongs on GitHub's side of the wire.
    [ADR 0075](../adr/0075-pr-merge.md) owns the ordered gates,
    the alternatives, and every residual, including what the deny does not
    cover. The Dependabot auto-merge workflow runs in CI, not an agent session,

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -398,9 +398,11 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    the final GraphQL child selects its credential and ends when the REST child
    selects its credential. It includes the in-flight final query and the
    consent-ledger write. A credential switch in this window can still
-   misattribute the local consent record; the merge target remains bound. The
-   approval rule above stays the binding control, and the durable boundary
-   belongs on GitHub's side of the wire.
+   misattribute the local consent record. The REST request names the confirmed
+   repository and pull request and pins the approved head with `sha`. It cannot
+   pin the base, so a retarget after the final read can still land on another
+   branch. The approval rule above stays the binding control, and the durable
+   boundary belongs on GitHub's side of the wire.
    [ADR 0075](../adr/0075-pr-merge.md) owns the ordered gates,
    the alternatives, and every residual, including what the deny does not
    cover. The Dependabot auto-merge workflow runs in CI, not an agent session,

--- a/scripts/pr/merge-pr-core.mjs
+++ b/scripts/pr/merge-pr-core.mjs
@@ -21,7 +21,7 @@
  * changing this, because a merge method the repository rejects fails at the
  * API rather than here, after consent is already recorded.
  */
-export const MERGE_METHOD_FLAG = "--squash";
+export const MERGE_METHOD = "squash";
 
 export const CONSENT_LOG_BASENAME = ".merge-consents.jsonl";
 
@@ -244,7 +244,7 @@ export function formatBriefing({ summary, feedback, repo, notReadyReason }) {
 
   const lines = [
     "",
-    `About to merge ${sanitizeTerminalText(repo)}#${pr.number} with ${MERGE_METHOD_FLAG.replace("--", "")}.`,
+    `About to merge ${sanitizeTerminalText(repo)}#${pr.number} with ${MERGE_METHOD}.`,
     "",
     `  Title: ${sanitizeTerminalText(pr.title)}`,
     `  Head:  ${sanitizeTerminalText(pr.headRefOid)} (${sanitizeTerminalText(pr.headRefName)})`,
@@ -342,7 +342,7 @@ export function gateSignature({ summary, feedback }) {
 /**
  * The process exit status for one {@link mergePullRequest} result.
  *
- * Only a confirmed merge is a success. A queued pull request and an unreadable
+ * Only a confirmed merge is a success. An open pull request and an unreadable
  * outcome both exit non-zero, so `pnpm pr:merge && <post-merge closeout>` does
  * not run the closeout on a merge the wrapper could not confirm — the shell
  * would otherwise read the wrapper's own refusal to claim success as success.

--- a/scripts/pr/merge-pr-github.mjs
+++ b/scripts/pr/merge-pr-github.mjs
@@ -292,13 +292,15 @@ function parseMergeQueueResponse(parsed) {
 }
 
 /**
- * The final merge-queue and auto-merge state from one GraphQL response.
+ * The final base, merge-queue, and auto-merge state from one GraphQL response.
  *
  * Reading both intent gates together removes the extra remote round trip that
  * would otherwise leave one state older than the other immediately before the
- * direct merge. The response is still not atomic with the later REST write, so
- * callers must keep this as their final remote read and refuse every malformed
- * or partial response.
+ * direct merge. Returning the pull request's current base also proves that the
+ * queue query still names that base. The REST request separately binds the
+ * approved head through `sha`. The response is still not atomic with the later
+ * REST write, so callers must keep this as their final remote read and refuse
+ * every malformed or partial response.
  */
 export async function readFinalMergeIntent({ gh, repo, branch, number }) {
   const { owner, name, host } = splitRepo(repo);
@@ -309,7 +311,7 @@ export async function readFinalMergeIntent({ gh, repo, branch, number }) {
       host ?? "github.com",
       "graphql",
       "-f",
-      `query=query($owner:String!,$name:String!,$branch:String!,$number:Int!){repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url} pullRequest(number:$number){autoMergeRequest{enabledAt}}}}`,
+      `query=query($owner:String!,$name:String!,$branch:String!,$number:Int!){repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url} pullRequest(number:$number){baseRefName autoMergeRequest{enabledAt}}}}`,
       "-f",
       `owner=${owner}`,
       "-f",
@@ -326,17 +328,22 @@ export async function readFinalMergeIntent({ gh, repo, branch, number }) {
   if (
     pullRequest === null ||
     typeof pullRequest !== "object" ||
+    !Object.hasOwn(pullRequest, "baseRefName") ||
     !Object.hasOwn(pullRequest, "autoMergeRequest")
   ) {
     throw new Error(
       "the final merge-intent response did not identify the pull request",
     );
   }
+  const baseRefName = pullRequest.baseRefName;
+  if (typeof baseRefName !== "string" || baseRefName === "") {
+    throw new Error("the final merge-intent response named no base branch");
+  }
   const autoMergeRequest = pullRequest.autoMergeRequest;
   if (autoMergeRequest !== null && typeof autoMergeRequest !== "object") {
     throw new Error("the final auto-merge response was malformed");
   }
-  return { mergeQueue, autoMergeRequest };
+  return { baseRefName, mergeQueue, autoMergeRequest };
 }
 
 /**

--- a/scripts/pr/merge-pr-github.mjs
+++ b/scripts/pr/merge-pr-github.mjs
@@ -269,6 +269,10 @@ export async function readBaseMergeQueue({ gh, repo, branch }) {
     ]),
   );
 
+  return parseMergeQueueResponse(parsed).mergeQueue;
+}
+
+function parseMergeQueueResponse(parsed) {
   if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
     throw new Error("the merge-queue query returned GraphQL errors");
   }
@@ -284,15 +288,64 @@ export async function readBaseMergeQueue({ gh, repo, branch }) {
   if (queue !== null && typeof queue !== "object") {
     throw new Error("the merge-queue response was malformed");
   }
-  return queue;
+  return { repository, mergeQueue: queue };
+}
+
+/**
+ * The final merge-queue and auto-merge state from one GraphQL response.
+ *
+ * Reading both intent gates together removes the extra remote round trip that
+ * would otherwise leave one state older than the other immediately before the
+ * direct merge. The response is still not atomic with the later REST write, so
+ * callers must keep this as their final remote read and refuse every malformed
+ * or partial response.
+ */
+export async function readFinalMergeIntent({ gh, repo, branch, number }) {
+  const { owner, name, host } = splitRepo(repo);
+  const parsed = JSON.parse(
+    await gh([
+      "api",
+      "--hostname",
+      host ?? "github.com",
+      "graphql",
+      "-f",
+      `query=query($owner:String!,$name:String!,$branch:String!,$number:Int!){repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url} pullRequest(number:$number){autoMergeRequest{enabledAt}}}}`,
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-f",
+      `branch=${branch}`,
+      "-F",
+      `number=${number}`,
+    ]),
+  );
+
+  const { repository, mergeQueue } = parseMergeQueueResponse(parsed);
+  const pullRequest = repository.pullRequest;
+  if (
+    pullRequest === null ||
+    typeof pullRequest !== "object" ||
+    !Object.hasOwn(pullRequest, "autoMergeRequest")
+  ) {
+    throw new Error(
+      "the final merge-intent response did not identify the pull request",
+    );
+  }
+  const autoMergeRequest = pullRequest.autoMergeRequest;
+  if (autoMergeRequest !== null && typeof autoMergeRequest !== "object") {
+    throw new Error("the final auto-merge response was malformed");
+  }
+  return { mergeQueue, autoMergeRequest };
 }
 
 /**
  * The rule types GitHub applies to one branch through its rulesets.
  *
- * Ruleset-sourced only. `readBaseMergeQueue` is the authoritative queue gate
- * because it also detects classic branch-protection queues. This read keeps the
- * ruleset-specific diagnosis and provides a second refusal signal.
+ * Ruleset-sourced only. The `Repository.mergeQueue` reads are the authoritative
+ * queue gate because they also detect classic branch-protection queues. This
+ * read keeps the ruleset-specific diagnosis and provides a second refusal
+ * signal.
  *
  * Used to refuse a merge-queue base before the briefing. Queue-managed bases
  * need a deliberate queue workflow, and this read gives the operator that

--- a/scripts/pr/merge-pr-github.mjs
+++ b/scripts/pr/merge-pr-github.mjs
@@ -26,6 +26,7 @@ import { splitRepo } from "./pr-ready-state.mjs";
  * silently, and a hidden second candidate would defeat the ambiguity gate.
  */
 const PR_LIST_LIMIT = 100;
+const LOGIN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$/;
 
 /**
  * Resolve the checkout's own repository and the repository the pull request
@@ -183,7 +184,7 @@ export async function resolveLogin({ gh, host }) {
   // stop every merge on such an account before the briefing. The pattern still
   // has to be narrow — this value is written into the ledger — so it stays
   // ASCII, bounded, and free of whitespace, quotes and shell metacharacters.
-  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$/.test(login)) {
+  if (!LOGIN_PATTERN.test(login)) {
     throw new MergeRefusal("unable to establish the active GitHub login");
   }
   return login;
@@ -292,12 +293,14 @@ function parseMergeQueueResponse(parsed) {
 }
 
 /**
- * The final base, merge-queue, and auto-merge state from one GraphQL response.
+ * The final viewer, base, merge-queue, and auto-merge state from one GraphQL
+ * response.
  *
  * Reading both intent gates together removes the extra remote round trip that
  * would otherwise leave one state older than the other immediately before the
- * direct merge. Returning the pull request's current base also proves that the
- * queue query still names that base. The REST request separately binds the
+ * direct merge. Returning the current viewer binds the credential observation
+ * to those states. Returning the pull request's current base also proves that
+ * the queue query still names that base. The REST request separately binds the
  * approved head through `sha`. The response is still not atomic with the later
  * REST write, so callers must keep this as their final remote read and refuse
  * every malformed or partial response.
@@ -311,7 +314,7 @@ export async function readFinalMergeIntent({ gh, repo, branch, number }) {
       host ?? "github.com",
       "graphql",
       "-f",
-      `query=query($owner:String!,$name:String!,$branch:String!,$number:Int!){repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url} pullRequest(number:$number){baseRefName autoMergeRequest{enabledAt}}}}`,
+      `query=query($owner:String!,$name:String!,$branch:String!,$number:Int!){viewer{login} repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url} pullRequest(number:$number){baseRefName autoMergeRequest{enabledAt}}}}`,
       "-f",
       `owner=${owner}`,
       "-f",
@@ -324,6 +327,12 @@ export async function readFinalMergeIntent({ gh, repo, branch, number }) {
   );
 
   const { repository, mergeQueue } = parseMergeQueueResponse(parsed);
+  const login = parsed?.data?.viewer?.login;
+  if (typeof login !== "string" || !LOGIN_PATTERN.test(login)) {
+    throw new Error(
+      "the final merge-intent response named no usable viewer login",
+    );
+  }
   const pullRequest = repository.pullRequest;
   if (
     pullRequest === null ||
@@ -343,7 +352,7 @@ export async function readFinalMergeIntent({ gh, repo, branch, number }) {
   if (autoMergeRequest !== null && typeof autoMergeRequest !== "object") {
     throw new Error("the final auto-merge response was malformed");
   }
-  return { baseRefName, mergeQueue, autoMergeRequest };
+  return { login, baseRefName, mergeQueue, autoMergeRequest };
 }
 
 /**

--- a/scripts/pr/merge-pr-github.mjs
+++ b/scripts/pr/merge-pr-github.mjs
@@ -11,6 +11,7 @@
  */
 
 import {
+  MERGE_METHOD,
   MergeRefusal,
   PR_NUMBER_PATTERN,
   hostFromRepoUrl,
@@ -189,12 +190,36 @@ export async function resolveLogin({ gh, host }) {
 }
 
 /**
+ * Merge the approved head through GitHub's synchronous REST endpoint.
+ *
+ * This endpoint either completes the merge or fails. It does not enqueue the
+ * pull request and does not enable auto-merge. The request supplies only the
+ * approved head and the repository's fixed merge method. It omits
+ * `commit_title` and `commit_message`, so GitHub applies the repository's
+ * configured squash title and message defaults.
+ */
+export async function mergeApprovedHead({ merge, repo, number, headOid }) {
+  const { owner, name, host } = splitRepo(repo);
+  await merge([
+    "api",
+    "--hostname",
+    host ?? "github.com",
+    "--method",
+    "PUT",
+    `repos/${owner}/${name}/pulls/${number}/merge`,
+    "--raw-field",
+    `sha=${headOid}`,
+    "--raw-field",
+    `merge_method=${MERGE_METHOD}`,
+  ]);
+}
+
+/**
  * Ask GitHub whether the pull request is actually merged.
  *
- * `gh pr merge` exits 0 on a merge-queue base after only ENQUEUEING the pull
- * request, and the queue may rebuild and retest it before any merge happens. A
- * bare success would then leave a consent record bound to the pre-queue head
- * while callers ran post-merge closeout against a pull request still open.
+ * The synchronous merge endpoint returns only after a merge or a failure, but
+ * a transport failure can hide a completed merge. This read binds the outcome
+ * to the approved head and base before callers run post-merge closeout.
  */
 export async function readMergeOutcome({ gh, repo, number }) {
   const parsed = JSON.parse(
@@ -217,18 +242,61 @@ export async function readMergeOutcome({ gh, repo, number }) {
 }
 
 /**
+ * The merge queue configured for one base branch, or null when none exists.
+ *
+ * `Repository.mergeQueue` covers queues enabled through either a ruleset or a
+ * classic branch-protection rule. The synchronous REST merge endpoint can
+ * bypass a classic queue, so callers must prove this value is null before they
+ * send the merge request. A missing or malformed response is not proof and
+ * therefore throws.
+ */
+export async function readBaseMergeQueue({ gh, repo, branch }) {
+  const { owner, name, host } = splitRepo(repo);
+  const parsed = JSON.parse(
+    await gh([
+      "api",
+      "--hostname",
+      host ?? "github.com",
+      "graphql",
+      "-f",
+      `query=query($owner:String!,$name:String!,$branch:String!){repository(owner:$owner,name:$name){mergeQueue(branch:$branch){id url}}}`,
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-f",
+      `branch=${branch}`,
+    ]),
+  );
+
+  if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+    throw new Error("the merge-queue query returned GraphQL errors");
+  }
+  const repository = parsed?.data?.repository;
+  if (
+    repository === null ||
+    typeof repository !== "object" ||
+    !Object.hasOwn(repository, "mergeQueue")
+  ) {
+    throw new Error("the merge-queue response did not identify the branch");
+  }
+  const queue = repository.mergeQueue;
+  if (queue !== null && typeof queue !== "object") {
+    throw new Error("the merge-queue response was malformed");
+  }
+  return queue;
+}
+
+/**
  * The rule types GitHub applies to one branch through its rulesets.
  *
- * Ruleset-sourced only. A merge queue enabled through
- * a CLASSIC branch-protection rule does not surface here, so this narrows the
- * window rather than closing it — `reconcileMergeOutcome` still catches such an
- * enqueue afterwards, reports it and exits non-zero.
+ * Ruleset-sourced only. `readBaseMergeQueue` is the authoritative queue gate
+ * because it also detects classic branch-protection queues. This read keeps the
+ * ruleset-specific diagnosis and provides a second refusal signal.
  *
- * Used to refuse a merge-queue base before the merge request exists. `gh pr
- * merge` enqueues such a base and returns success, and `--disable-auto` does
- * not remove a queue entry — so merging first would create a standing request
- * this wrapper cannot take back, which GitHub could complete later with none
- * of the gates. Checking first is the only fail-closed order.
+ * Used to refuse a merge-queue base before the briefing. Queue-managed bases
+ * need a deliberate queue workflow, and this read gives the operator that
+ * specific reason before consent is recorded.
  */
 export async function readBaseBranchRuleTypes({ gh, repo, branch }) {
   const { owner, name, host } = splitRepo(repo);
@@ -257,19 +325,12 @@ export async function readBaseBranchRuleTypes({ gh, repo, branch }) {
 }
 
 /**
- * Decide what actually happened after the merge command, and leave nothing
- * standing behind.
+ * Decide what actually happened after the synchronous merge request.
  *
- * Any outcome other than a confirmed merge may have left a standing request:
- * `gh pr merge` enqueues when the required checks pass and enables auto-merge
- * when they do not, and `--not-ready-reason` reaches that second path. GitHub
- * can complete such a request minutes or hours later, with none of the gates
- * the wrapper ran — the merge nobody approved, arriving late. So every path
- * here reconciles rather than merely reporting.
- *
- * The caller refuses a pull request that already had auto-merge enabled, so
- * any request cancelled here is one this run created rather than another
- * operator's unrelated state.
+ * The request cannot enqueue or enable auto-merge. A failed or unreadable
+ * outcome therefore needs reporting and verification only. It must never call
+ * `--disable-auto`, because an auto-merge request that appears after the final
+ * gate read belongs to another operator.
  *
  * @param write receives operator-facing lines, normally `stdout.write`.
  */
@@ -283,46 +344,6 @@ export async function reconcileMergeOutcome({
   consentPath,
   write,
 }) {
-  const cancelPendingMerge = async () => {
-    try {
-      await gh([
-        "pr",
-        "merge",
-        String(number),
-        "--repo",
-        repo,
-        "--disable-auto",
-      ]);
-      // `--disable-auto` turns off auto-merge. It does NOT remove a pull
-      // request already sitting in a merge queue, so this is not proof the
-      // request is gone. Report what the command actually does, and name the
-      // case that still needs a hand.
-      return (
-        `Auto-merge has been disabled for this pull request. That does not ` +
-        `remove a merge-queue entry: if the base uses a merge queue, dequeue ` +
-        `it by hand and confirm, because a queued entry can still merge later ` +
-        `without any of the gates above.`
-      );
-    } catch (err) {
-      const message = sanitizeTerminalText(
-        err instanceof Error ? err.message : String(err),
-        "(no message)",
-      );
-      // `gh` fails this call when there is no auto-merge request to turn off,
-      // which is the ordinary case when the merge never reached GitHub. Saying
-      // "this can still merge later" there would be the same over-claiming the
-      // CLOSED branch avoids.
-      if (/auto-merge is not enabled|not enabled for/i.test(message)) {
-        return "There was no auto-merge request to cancel.";
-      }
-      return (
-        `A pending merge request could NOT be cancelled: ${message}. ` +
-        `Cancel it by hand — until you do, this pull request can still merge ` +
-        `later without any of the gates above.`
-      );
-    }
-  };
-
   let outcome = null;
   let outcomeError = null;
   try {
@@ -332,26 +353,22 @@ export async function reconcileMergeOutcome({
   }
 
   if (outcome === null) {
-    // Neither confirmed nor refuted. Cancel first, report second.
-    const cancellation = await cancelPendingMerge();
     write(
       `Could not confirm the merge landed: ${sanitizeTerminalText(outcomeError)}\n` +
         (mergeError
           ? `The merge command also failed: ${sanitizeTerminalText(mergeError)}\n`
           : "") +
-        `${cancellation}\n` +
+        `The synchronous merge endpoint cannot queue this pull request or enable ` +
+        `auto-merge, so this run created no standing merge request.\n` +
         `Check ${repo}#${number} before running any post-merge step.\n`,
     );
     return { merged: false, verified: false, record, consentPath };
   }
 
-  // A closed pull request is not a queued one. Cancelling auto-merge on it
-  // fails, and reporting that failure as "this can still merge later" would be
-  // both false and alarming — GitHub will not merge a closed pull request.
   if (outcome.state === "CLOSED") {
     write(
       `${repo}#${number} is CLOSED, not merged. Nothing was merged and there is ` +
-        `no pending request to cancel: GitHub does not merge a closed pull request. ` +
+        `no request from this run pending: the synchronous endpoint does not queue. ` +
         (mergeError
           ? `The merge command also failed: ${sanitizeTerminalText(mergeError)}. `
           : "") +
@@ -368,20 +385,18 @@ export async function reconcileMergeOutcome({
   }
 
   if (outcome.state !== "MERGED") {
-    const cancellation = await cancelPendingMerge();
     write(
       `${repo}#${number} is ${outcome.state || "in an unreadable state"}, not merged — ` +
-        `a queued or auto-merge target accepts the request without merging it. ` +
+        `the synchronous endpoint did not complete the merge. ` +
         (mergeError
           ? `The merge command also failed: ${sanitizeTerminalText(mergeError)}. `
           : "") +
-        `${cancellation}\n` +
+        `This run created no queued or auto-merge request.\n` +
         `Do not run post-merge steps until it reports MERGED.\n`,
     );
     return {
       merged: false,
       verified: true,
-      queued: true,
       state: outcome.state,
       record,
       consentPath,
@@ -422,9 +437,9 @@ export async function reconcileMergeOutcome({
   }
 
   // MERGED alone does not mean this run's merge landed. If the head moved after
-  // the final gate read and something else merged the new one, our
-  // `--match-head-commit` request fails while this read still says MERGED —
-  // and the consent record would then name a commit GitHub never merged.
+  // the final gate read and something else merged the new one, the REST
+  // request's `sha` check fails while this read still says MERGED — and the
+  // consent record would then name a commit GitHub never merged.
   if (outcome.headRefOid !== approved.headOid.toLowerCase()) {
     write(
       `WARNING: ${repo}#${number} is MERGED at ${outcome.headRefOid}, not the ` +
@@ -453,8 +468,8 @@ export async function reconcileMergeOutcome({
     );
   }
 
-  // `--match-head-commit` pins the head, and the merge API offers nothing that
-  // pins the base: its only matching parameter is `sha`, for the head. So a
+  // The request's `sha` pins the head, and the merge API offers nothing that
+  // pins the base. So a
   // retarget landing between the final gate read and GitHub processing the
   // merge cannot be prevented — only detected, which is what this does.
   const baseMismatch = outcome.baseRefName !== approved.baseRefName;
@@ -483,9 +498,8 @@ export async function reconcileMergeOutcome({
  * The auto-merge request already standing on a pull request, or null.
  *
  * A pull request someone else has already queued for automatic merge is not a
- * state this wrapper can reconcile: its own cleanup would cancel that unrelated
- * request, and it cannot tell compensation from interference. Refusing up front
- * both avoids that and makes the cleanup provably its own.
+ * state this wrapper should merge over. Refusing up front preserves the other
+ * operator's request and makes them resolve that intent explicitly.
  */
 export async function readAutoMergeRequest({ gh, repo, number }) {
   const parsed = JSON.parse(

--- a/scripts/pr/merge-pr.mjs
+++ b/scripts/pr/merge-pr.mjs
@@ -57,9 +57,10 @@
  * no check in this file can be one. What the wrapper does provide is a default
  * that refuses, a briefing the operator must read, a confirmation they must
  * type, and an append-only consent record naming the confirmed GitHub login
- * and approved head. A credential switch after the final combined read but
- * before the REST child selects its credential can still misattribute that
- * record; the accepted residual is below and in ADR 0075.
+ * and approved head. A credential switch after the final GraphQL child selects
+ * its credential but before the REST child selects its credential can still
+ * misattribute that record. This window includes the in-flight query and the
+ * consent-ledger write; the accepted residual is below and in ADR 0075.
  * The approval rule itself remains the binding control, and the only
  * unforgeable boundary would live on GitHub's side of the wire;
  * `docs/adr/0075-pr-merge.md` records that decision and its
@@ -419,10 +420,11 @@ export async function mergePullRequest({
   // final GraphQL response. The base proves the queue query still names the
   // pull request's target, and viewer.login binds the credential observation
   // to the same response. This minimizes the race windows before the direct
-  // REST call. A credential switch after this response can still make the
-  // separate merge child use another account. Capturing and injecting a token
-  // would add a larger credential-handling surface to this trust-root wrapper
-  // (issue 2099; ADR 0075).
+  // REST call. The credential-attribution window starts when this GraphQL child
+  // selects its credential and ends when the REST child selects its credential;
+  // it includes the in-flight query and consent-ledger write. Capturing and
+  // injecting a token would add a larger credential-handling surface to this
+  // trust-root wrapper (issue 2099; ADR 0075).
   let confirmedIntent;
   try {
     confirmedIntent = await readFinalMergeIntent({

--- a/scripts/pr/merge-pr.mjs
+++ b/scripts/pr/merge-pr.mjs
@@ -2,11 +2,9 @@
 /**
  * The sanctioned merge path for this repository.
  *
- * Merging is a human-only action here, and `gh pr merge` reaches GitHub's write
- * API directly: no git hook, no CI job, and no branch protection sees the
- * decision to press the button. A wrapper in front of the real command is
- * therefore the only place the decision can be gated at all, which is why this
- * script runs the ordered gates itself and hands the request to `gh` last.
+ * Merging is a human-only action here. No git hook or CI job sees the decision
+ * to press the button, so this wrapper runs the ordered gates before it calls
+ * GitHub's write API.
  *
  * The order is fixed: refuse outside an interactive human terminal, resolve the
  * repository and the target pull request unambiguously, run the ready-state
@@ -18,33 +16,31 @@
  * an operator who has to re-run one command loses a minute, and a merge nobody
  * approved cannot be taken back.
  *
- * A merge-queue base is refused outright, before any request is sent, and again
- * after the confirmation: `gh pr merge` enqueues such a base and returns
- * success, and nothing this wrapper can call removes a queue entry, so merging
- * first would leave a standing request it cannot take back. An unreadable
- * branch-rules answer refuses too. Those reads narrow the window but cannot
- * close it — a queue enabled between the last read and GitHub handling the
- * request still enqueues. Closing it means merging through an operation that
- * cannot enqueue at all; issue 2092 carries that change.
+ * The final write uses the synchronous REST merge endpoint with the approved
+ * head in `sha` and `merge_method=squash`. That endpoint either completes the
+ * merge or fails. It cannot enqueue the pull request or enable auto-merge, so
+ * an interrupt or a failed response cannot leave a request that GitHub later
+ * completes outside these gates. Reconciliation verifies the outcome but never
+ * disables auto-merge, because any request that appears after the final read
+ * belongs to another operator.
  *
- * An interrupt during the merge call is a third residual: SIGINT or SIGTERM
- * reaches this process too, so it can exit before the reconciliation below
- * runs, leaving a request GitHub might complete later. The pre-send refusals
- * shrink that to a base with no merge queue, no standing auto-merge request,
- * and an override reason in play — and issue 2092 removes it outright, since
- * an operation that cannot enqueue leaves nothing standing to reconcile.
+ * A merge-queue base refuses before the briefing and again after confirmation.
+ * `Repository.mergeQueue` detects queues from rulesets and classic branch
+ * protection. The ruleset read remains as a second diagnostic signal. The REST
+ * endpoint can bypass a classic queue, so an unreadable answer from either read
+ * refuses.
  *
- * Two races are detected rather than prevented. `--match-head-commit` pins the
+ * Two races are detected rather than prevented. The request's `sha` pins the
  * head, and the merge endpoint has no base equivalent, so a retarget between
  * the final gate read and the merge request itself can still land on another
  * branch; the wrapper re-reads the base afterwards and fails loudly when it
  * moved. A title edited in that same window can likewise reach the squash
- * subject. `--subject` would pin it, but this repository sets
+ * subject. Supplying `commit_title` would pin it, but this repository sets
  * `squash_merge_commit_title=COMMIT_OR_PR_TITLE`, so GitHub uses the single
  * commit's subject when there is one and appends `(#N)` — behaviour a fixed
- * `--subject` would replace on every merge. Changing how every merge commit is
- * titled, to close a sub-second window, is the worse trade; the title is bound
- * in the confirmation signature instead.
+ * title would replace on every merge. The REST request omits both title and
+ * message fields, which also preserves `squash_merge_commit_message=COMMIT_MESSAGES`.
+ * The title is bound in the confirmation signature instead.
  *
  * Agents must never invoke this script. Be honest about what makes that true.
  * The interactive-session refusal stops an agent that runs this command the
@@ -54,14 +50,17 @@
  * an unforgeable boundary: a caller on this machine can allocate a
  * pseudo-terminal and clear the markers, and the deny is a command-pattern
  * list, so it covers the spellings someone thought to enumerate and not the
- * same merge issued as `gh api --method PUT repos/{owner}/{repo}/pulls/{n}/merge`,
- * through an alias, or with other global flags interleaved.
+ * REST call this wrapper now uses, an alias, or other global flag orderings.
+ * Using the API inside this sanctioned wrapper does not widen its authority;
+ * agents remain forbidden from invoking the wrapper or the raw API merge.
  * A local process running as the operator can synthesize any local signal, so
  * no check in this file can be one. What the wrapper does provide is a default
  * that refuses, a briefing the operator must read, a confirmation they must
- * type, and an append-only consent record naming who approved which head. The
- * approval rule itself remains the binding control, and the only unforgeable
- * boundary would live on GitHub's side of the wire;
+ * type, and an append-only consent record naming the confirmed GitHub login
+ * and approved head. A credential switch after the final login read can still
+ * misattribute that record; the accepted residual is below and in ADR 0075.
+ * The approval rule itself remains the binding control, and the only
+ * unforgeable boundary would live on GitHub's side of the wire;
  * `docs/adr/0075-pr-merge.md` records that decision and its
  * residual risk.
  *
@@ -77,7 +76,6 @@ import { fileURLToPath } from "node:url";
 
 import {
   COMMIT_OID_PATTERN,
-  MERGE_METHOD_FLAG,
   MergeRefusal,
   buildConsentRecord,
   exitCodeForResult,
@@ -95,7 +93,9 @@ import {
   runGit,
 } from "./merge-pr-io.mjs";
 import {
+  mergeApprovedHead,
   readAutoMergeRequest,
+  readBaseMergeQueue,
   readBaseBranchRuleTypes,
   reconcileMergeOutcome,
   resolveLogin,
@@ -108,7 +108,7 @@ import { fetchReadyState, runGh, splitRepo } from "./pr-ready-state.mjs";
 export {
   AUTOMATION_ENV_MARKERS,
   CONSENT_LOG_BASENAME,
-  MERGE_METHOD_FLAG,
+  MERGE_METHOD,
   MergeRefusal,
   NON_INTERACTIVE_REFUSAL,
   buildConsentRecord,
@@ -277,13 +277,33 @@ export async function mergePullRequest({
 
   const approved = await readGatedReadyState();
 
-  // Refuse a merge-queue base before anything is sent. `gh pr merge` enqueues
-  // such a base and returns success, and nothing this wrapper can call removes
-  // a queue entry — so merging first would leave a standing request GitHub
-  // could complete later with none of the gates above. The base is bound
-  // across the confirmation below, so checking it here is checking the base
-  // that gets merged. An unreadable answer refuses too: this is the last gate
-  // before an irreversible action, and "probably no queue" is not a gate.
+  // Refuse a merge-queue base before anything is sent. Repository.mergeQueue
+  // covers ruleset and classic branch-protection queues. This matters because
+  // the synchronous REST endpoint can bypass a classic queue and merge
+  // directly. The base is bound across the confirmation below.
+  let baseMergeQueue;
+  try {
+    baseMergeQueue = await readBaseMergeQueue({
+      gh,
+      repo: repos.base,
+      branch: approved.baseRefName,
+    });
+  } catch (err) {
+    throw new MergeRefusal(
+      `unable to read the merge-queue state for ${sanitizeTerminalText(approved.baseRefName)} in ${repos.base}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Refusing, because this command must prove the base has no queue before direct merge.`,
+    );
+  }
+  if (baseMergeQueue !== null) {
+    throw new MergeRefusal(
+      `${sanitizeTerminalText(approved.baseRefName)} in ${repos.base} uses a merge queue. ` +
+        `This command uses the synchronous direct-merge endpoint and will not enqueue it. ` +
+        `Merge it through the queue deliberately instead.`,
+    );
+  }
+
+  // Keep the ruleset read as a second queue signal and a specific diagnostic.
   let baseRuleTypes;
   try {
     baseRuleTypes = await readBaseBranchRuleTypes({
@@ -295,7 +315,7 @@ export async function mergePullRequest({
     throw new MergeRefusal(
       `unable to read the branch rules for ${sanitizeTerminalText(approved.baseRefName)} in ${repos.base}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because a merge-queue base would accept a request this command cannot take back.`,
+        `Refusing, because this command does not merge through a queue.`,
     );
   }
   let standingAutoMerge;
@@ -309,7 +329,7 @@ export async function mergePullRequest({
     throw new MergeRefusal(
       `unable to read the auto-merge state of ${repos.base}#${number}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must not cancel a request it did not create.`,
+        `Refusing, because this command must not merge over another operator's request.`,
     );
   }
   if (standingAutoMerge !== null) {
@@ -323,9 +343,8 @@ export async function mergePullRequest({
   if (baseRuleTypes.includes("merge_queue")) {
     throw new MergeRefusal(
       `${sanitizeTerminalText(approved.baseRefName)} in ${repos.base} uses a merge queue. ` +
-        `\`gh pr merge\` would enqueue this pull request and return success, and nothing ` +
-        `this command can call removes a queue entry, so the merge would sit outside ` +
-        `every gate above. Merge it through the queue deliberately instead.`,
+        `This command uses the synchronous direct-merge endpoint and will not enqueue it. ` +
+        `Merge it through the queue deliberately instead.`,
     );
   }
 
@@ -350,8 +369,8 @@ export async function mergePullRequest({
     );
   }
 
-  // The prompt has no time limit, and `--match-head-commit` only notices a new
-  // head commit. A dismissed review, a rerun check, a retargeted base, or new
+  // The prompt has no time limit, and the REST `sha` only notices a new head
+  // commit. A dismissed review, a rerun check, a retargeted base, or new
   // blocking feedback during the wait would otherwise merge on a briefing the
   // operator can no longer see, so every gate runs once more against live
   // state and any difference refuses.
@@ -372,8 +391,7 @@ export async function mergePullRequest({
     );
   }
 
-  // The rules were read before an unbounded prompt, and a merge queue can be
-  // switched on while the operator reads. Re-read them, like every other gate.
+  // Keep the ruleset diagnosis in the repeated gate set too.
   let confirmedRuleTypes;
   try {
     confirmedRuleTypes = await readBaseBranchRuleTypes({
@@ -385,21 +403,19 @@ export async function mergePullRequest({
     throw new MergeRefusal(
       `unable to re-read the branch rules for ${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because a merge-queue base would accept a request this command cannot take back.`,
+        `Refusing, because this command does not merge through a queue.`,
     );
   }
   if (confirmedRuleTypes.includes("merge_queue")) {
     throw new MergeRefusal(
       `${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base} gained a merge queue while you were confirming; ` +
-        `re-run — this command cannot take back a queued request.`,
+        `re-run after choosing the queue workflow deliberately.`,
     );
   }
 
-  // Same reasoning for auto-merge. The pre-briefing read is what licenses the
-  // post-merge cleanup to call anything it cancels its own, and that licence
-  // expires the moment another operator can act — which the unbounded prompt
-  // gives them. Re-read it, or the cleanup could turn off a request enabled
-  // while the operator was reading.
+  // Same reasoning for auto-merge. Re-read after the unbounded prompt so this
+  // command does not merge over a request another operator created while the
+  // briefing was open.
   let confirmedAutoMerge;
   try {
     confirmedAutoMerge = await readAutoMergeRequest({
@@ -411,7 +427,7 @@ export async function mergePullRequest({
     throw new MergeRefusal(
       `unable to re-read the auto-merge state of ${repos.base}#${number}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must not cancel a request it did not create.`,
+        `Refusing, because this command must not merge over another operator's request.`,
     );
   }
   if (confirmedAutoMerge !== null) {
@@ -421,15 +437,42 @@ export async function mergePullRequest({
     );
   }
 
-  // The merge below starts a fresh `gh`, which reads whatever credentials are
-  // active then — not the ones read before the prompt. A `gh auth switch` while
-  // the prompt was open would otherwise record one login in the ledger and
-  // merge as another, which is exactly the attribution the ledger exists to
-  // make true.
+  // The merge below starts a fresh `gh`, which reads the credential active at
+  // child-process start. Re-reading here narrows the unbounded prompt window.
+  // It does not bind the child: `gh auth switch` can still run during the
+  // consent-ledger write and make the merge use another account. That accepted
+  // residual can misattribute the ledger but cannot bypass confirmation or
+  // authorize another target. Capturing and injecting a token would add a
+  // larger credential-handling surface to this trust-root wrapper (issue 2099;
+  // ADR 0075).
   const confirmedLogin = await resolveLogin({ gh, host: repos.host });
   if (confirmedLogin !== login) {
     throw new MergeRefusal(
       `the active GitHub login changed from ${login} to ${confirmedLogin} while you were confirming; re-run so the consent record names who is merging`,
+    );
+  }
+
+  // Make the authoritative queue check the final remote read. This minimizes
+  // the interval in which a classic queue could be enabled before the direct
+  // REST call, which can bypass that queue instead of refusing.
+  let confirmedMergeQueue;
+  try {
+    confirmedMergeQueue = await readBaseMergeQueue({
+      gh,
+      repo: repos.base,
+      branch: confirmed.baseRefName,
+    });
+  } catch (err) {
+    throw new MergeRefusal(
+      `unable to re-read the merge-queue state for ${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Refusing, because this command must prove the base still has no queue before direct merge.`,
+    );
+  }
+  if (confirmedMergeQueue !== null) {
+    throw new MergeRefusal(
+      `${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base} gained a merge queue while you were confirming; ` +
+        `re-run after choosing the queue workflow deliberately.`,
     );
   }
 
@@ -444,24 +487,18 @@ export async function mergePullRequest({
   const consentPath = await appendConsent({ record, git });
   stdout.write(`Recorded consent in ${consentPath}\n`);
 
-  // The merge command itself can fail after the request reached GitHub — a
-  // transport error, a truncated response — so its failure is an ambiguous
-  // outcome, not a clean abort. Hold it and let the reconciliation decide.
+  // The merge command itself can fail after GitHub completed the merge — for
+  // example, when the response is lost. Hold the error and let the outcome
+  // read decide. The synchronous endpoint cannot leave a queued or auto-merge
+  // request behind on any failure path.
   let mergeError = null;
   try {
-    await merge([
-      "pr",
-      "merge",
-      String(number),
-      "--repo",
-      repos.base,
-      MERGE_METHOD_FLAG,
-      // Bind the merge to the head the operator was shown, so a push between
-      // the briefing and the confirmation cannot merge a commit nobody
-      // approved.
-      "--match-head-commit",
-      approved.headOid,
-    ]);
+    await mergeApprovedHead({
+      merge,
+      repo: repos.base,
+      number,
+      headOid: approved.headOid,
+    });
   } catch (err) {
     mergeError = err instanceof Error ? err.message : String(err);
   }

--- a/scripts/pr/merge-pr.mjs
+++ b/scripts/pr/merge-pr.mjs
@@ -429,10 +429,12 @@ export async function mergePullRequest({
     );
   }
 
-  // Read both foreign-intent gates in one final GraphQL response. A separate
-  // queue round trip after the auto-merge read would make that earlier state
-  // stale before the direct REST call. This combined read minimizes both race
-  // windows, although GitHub cannot bind either absence to the later write.
+  // Read the current base and both foreign-intent gates in one final GraphQL
+  // response. The base proves the queue query still names the pull request's
+  // target. A separate queue round trip after the auto-merge read would make
+  // that earlier state stale before the direct REST call. This combined read
+  // minimizes all three race windows, although GitHub cannot bind them to the
+  // later write.
   let confirmedIntent;
   try {
     confirmedIntent = await readFinalMergeIntent({
@@ -446,7 +448,15 @@ export async function mergePullRequest({
       `unable to re-read the final merge intent for ${repos.base}#${number} and ` +
         `${sanitizeTerminalText(confirmed.baseRefName)}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must prove there is no merge queue or auto-merge request before direct merge.`,
+        `Refusing, because this command must prove the base is unchanged and there is no merge queue or auto-merge request before direct merge.`,
+    );
+  }
+  if (confirmedIntent.baseRefName !== confirmed.baseRefName) {
+    throw new MergeRefusal(
+      `${repos.base}#${number} was retargeted from ` +
+        `${sanitizeTerminalText(confirmed.baseRefName)} to ` +
+        `${sanitizeTerminalText(confirmedIntent.baseRefName)} after the final readiness read; ` +
+        `re-run to review the new base and its queue state`,
     );
   }
   if (confirmedIntent.autoMergeRequest !== null) {

--- a/scripts/pr/merge-pr.mjs
+++ b/scripts/pr/merge-pr.mjs
@@ -57,8 +57,9 @@
  * no check in this file can be one. What the wrapper does provide is a default
  * that refuses, a briefing the operator must read, a confirmation they must
  * type, and an append-only consent record naming the confirmed GitHub login
- * and approved head. A credential switch after the final login read can still
- * misattribute that record; the accepted residual is below and in ADR 0075.
+ * and approved head. A credential switch after the final combined read but
+ * before the REST child selects its credential can still misattribute that
+ * record; the accepted residual is below and in ADR 0075.
  * The approval rule itself remains the binding control, and the only
  * unforgeable boundary would live on GitHub's side of the wire;
  * `docs/adr/0075-pr-merge.md` records that decision and its
@@ -414,27 +415,14 @@ export async function mergePullRequest({
     );
   }
 
-  // The merge below starts a fresh `gh`, which reads the credential active at
-  // child-process start. Re-reading here narrows the unbounded prompt window.
-  // It does not bind the child: `gh auth switch` can still run during the
-  // consent-ledger write and make the merge use another account. That accepted
-  // residual can misattribute the ledger but cannot bypass confirmation or
-  // authorize another target. Capturing and injecting a token would add a
-  // larger credential-handling surface to this trust-root wrapper (issue 2099;
-  // ADR 0075).
-  const confirmedLogin = await resolveLogin({ gh, host: repos.host });
-  if (confirmedLogin !== login) {
-    throw new MergeRefusal(
-      `the active GitHub login changed from ${login} to ${confirmedLogin} while you were confirming; re-run so the consent record names who is merging`,
-    );
-  }
-
-  // Read the current base and both foreign-intent gates in one final GraphQL
-  // response. The base proves the queue query still names the pull request's
-  // target. A separate queue round trip after the auto-merge read would make
-  // that earlier state stale before the direct REST call. This combined read
-  // minimizes all three race windows, although GitHub cannot bind them to the
-  // later write.
+  // Read the active login, current base, and both foreign-intent gates in one
+  // final GraphQL response. The base proves the queue query still names the
+  // pull request's target, and viewer.login binds the credential observation
+  // to the same response. This minimizes the race windows before the direct
+  // REST call. A credential switch after this response can still make the
+  // separate merge child use another account. Capturing and injecting a token
+  // would add a larger credential-handling surface to this trust-root wrapper
+  // (issue 2099; ADR 0075).
   let confirmedIntent;
   try {
     confirmedIntent = await readFinalMergeIntent({
@@ -448,7 +436,12 @@ export async function mergePullRequest({
       `unable to re-read the final merge intent for ${repos.base}#${number} and ` +
         `${sanitizeTerminalText(confirmed.baseRefName)}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must prove the base is unchanged and there is no merge queue or auto-merge request before direct merge.`,
+        `Refusing, because this command must prove the login and base are unchanged and there is no merge queue or auto-merge request before direct merge.`,
+    );
+  }
+  if (confirmedIntent.login !== login) {
+    throw new MergeRefusal(
+      `the active GitHub login changed from ${login} to ${confirmedIntent.login} while you were confirming; re-run so the consent record names who is merging`,
     );
   }
   if (confirmedIntent.baseRefName !== confirmed.baseRefName) {

--- a/scripts/pr/merge-pr.mjs
+++ b/scripts/pr/merge-pr.mjs
@@ -97,6 +97,7 @@ import {
   readAutoMergeRequest,
   readBaseMergeQueue,
   readBaseBranchRuleTypes,
+  readFinalMergeIntent,
   reconcileMergeOutcome,
   resolveLogin,
   resolveRepositories,
@@ -413,30 +414,6 @@ export async function mergePullRequest({
     );
   }
 
-  // Same reasoning for auto-merge. Re-read after the unbounded prompt so this
-  // command does not merge over a request another operator created while the
-  // briefing was open.
-  let confirmedAutoMerge;
-  try {
-    confirmedAutoMerge = await readAutoMergeRequest({
-      gh,
-      repo: repos.base,
-      number,
-    });
-  } catch (err) {
-    throw new MergeRefusal(
-      `unable to re-read the auto-merge state of ${repos.base}#${number}: ` +
-        `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must not merge over another operator's request.`,
-    );
-  }
-  if (confirmedAutoMerge !== null) {
-    throw new MergeRefusal(
-      `${repos.base}#${number} gained an auto-merge request while you were confirming; ` +
-        `re-run — this command will not merge over it or cancel it.`,
-    );
-  }
-
   // The merge below starts a fresh `gh`, which reads the credential active at
   // child-process start. Re-reading here narrows the unbounded prompt window.
   // It does not bind the child: `gh auth switch` can still run during the
@@ -452,24 +429,33 @@ export async function mergePullRequest({
     );
   }
 
-  // Make the authoritative queue check the final remote read. This minimizes
-  // the interval in which a classic queue could be enabled before the direct
-  // REST call, which can bypass that queue instead of refusing.
-  let confirmedMergeQueue;
+  // Read both foreign-intent gates in one final GraphQL response. A separate
+  // queue round trip after the auto-merge read would make that earlier state
+  // stale before the direct REST call. This combined read minimizes both race
+  // windows, although GitHub cannot bind either absence to the later write.
+  let confirmedIntent;
   try {
-    confirmedMergeQueue = await readBaseMergeQueue({
+    confirmedIntent = await readFinalMergeIntent({
       gh,
       repo: repos.base,
       branch: confirmed.baseRefName,
+      number,
     });
   } catch (err) {
     throw new MergeRefusal(
-      `unable to re-read the merge-queue state for ${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base}: ` +
+      `unable to re-read the final merge intent for ${repos.base}#${number} and ` +
+        `${sanitizeTerminalText(confirmed.baseRefName)}: ` +
         `${err instanceof Error ? err.message : String(err)}. ` +
-        `Refusing, because this command must prove the base still has no queue before direct merge.`,
+        `Refusing, because this command must prove there is no merge queue or auto-merge request before direct merge.`,
     );
   }
-  if (confirmedMergeQueue !== null) {
+  if (confirmedIntent.autoMergeRequest !== null) {
+    throw new MergeRefusal(
+      `${repos.base}#${number} gained an auto-merge request while you were confirming; ` +
+        `re-run — this command will not merge over it or cancel it.`,
+    );
+  }
+  if (confirmedIntent.mergeQueue !== null) {
     throw new MergeRefusal(
       `${sanitizeTerminalText(confirmed.baseRefName)} in ${repos.base} gained a merge queue while you were confirming; ` +
         `re-run after choosing the queue workflow deliberately.`,

--- a/scripts/pr/merge-pr.test.mjs
+++ b/scripts/pr/merge-pr.test.mjs
@@ -225,12 +225,14 @@ function harness({
   const calls = {
     gh: [],
     git: [],
+    events: [],
     merges: [],
     consents: [],
     prompts: [],
     readyStateReads: 0,
     logins: 0,
     mergeQueues: [],
+    finalIntentReads: [],
     branchRules: [],
     autoMergeReads: 0,
   };
@@ -238,6 +240,7 @@ function harness({
 
   const gh = async (args) => {
     calls.gh.push(args);
+    calls.events.push({ kind: "gh", args });
     if (args[0] === "repo" && args[1] === "view") {
       return JSON.stringify({
         nameWithOwner: "mento-protocol/monitoring-monorepo",
@@ -245,19 +248,41 @@ function harness({
         url: repoUrl,
       });
     }
-    if (args[0] === "api" && args.includes("graphql")) {
-      if (mergeQueueError) throw new Error(mergeQueueError);
+    if (
+      args[0] === "api" &&
+      args.includes("graphql") &&
+      args.some((arg) => String(arg).includes("autoMergeRequest"))
+    ) {
       calls.mergeQueues.push(args);
-      if (calls.mergeQueues.length > 1 && mergeQueueErrorAfterConfirmation) {
+      calls.autoMergeReads += 1;
+      calls.finalIntentReads.push(args);
+      if (mergeQueueErrorAfterConfirmation) {
         throw new Error(mergeQueueErrorAfterConfirmation);
       }
+      if (autoMergeErrorAfterConfirmation) {
+        throw new Error(autoMergeErrorAfterConfirmation);
+      }
       const queue =
-        calls.mergeQueues.length > 1 &&
         baseMergeQueueAfterConfirmation !== undefined
           ? baseMergeQueueAfterConfirmation
           : baseMergeQueue;
+      const request = standingAutoMergeAfterConfirmation
+        ? standingAutoMergeAfterConfirmation
+        : standingAutoMerge;
       return JSON.stringify({
-        data: { repository: { mergeQueue: queue } },
+        data: {
+          repository: {
+            mergeQueue: queue,
+            pullRequest: { autoMergeRequest: request },
+          },
+        },
+      });
+    }
+    if (args[0] === "api" && args.includes("graphql")) {
+      if (mergeQueueError) throw new Error(mergeQueueError);
+      calls.mergeQueues.push(args);
+      return JSON.stringify({
+        data: { repository: { mergeQueue: baseMergeQueue } },
       });
     }
     if (
@@ -291,8 +316,9 @@ function harness({
         })),
       );
     }
-    // The pre-merge auto-merge read and the post-merge outcome read are both
-    // `pr view`; only their fields tell them apart.
+    // The pre-briefing auto-merge read and the post-merge outcome read are both
+    // `pr view`; only their fields tell them apart. The post-confirmation
+    // auto-merge read shares one GraphQL response with the final queue read.
     if (
       args[0] === "pr" &&
       args[1] === "view" &&
@@ -300,14 +326,7 @@ function harness({
     ) {
       if (autoMergeError) throw new Error(autoMergeError);
       calls.autoMergeReads += 1;
-      if (calls.autoMergeReads > 1 && autoMergeErrorAfterConfirmation) {
-        throw new Error(autoMergeErrorAfterConfirmation);
-      }
-      const request =
-        calls.autoMergeReads > 1 && standingAutoMergeAfterConfirmation
-          ? standingAutoMergeAfterConfirmation
-          : standingAutoMerge;
-      return JSON.stringify({ autoMergeRequest: request });
+      return JSON.stringify({ autoMergeRequest: standingAutoMerge });
     }
     if (args[0] === "pr" && args[1] === "view") {
       if (mergeOutcomeError) throw new Error(mergeOutcomeError);
@@ -351,6 +370,7 @@ function harness({
           return summary;
         },
         merge: async (args) => {
+          calls.events.push({ kind: "merge", args });
           calls.merges.push(args);
           if (mergeCommandError) throw new Error(mergeCommandError);
         },
@@ -359,6 +379,7 @@ function harness({
           return answer;
         },
         appendConsent: async ({ record }) => {
+          calls.events.push({ kind: "consent" });
           calls.consents.push(record);
           return "/repo/.merge-consents.jsonl";
         },
@@ -2045,7 +2066,7 @@ await test("an unreadable merge queue after confirmation refuses", async () => {
     mergeQueueErrorAfterConfirmation: "GraphQL: Something went wrong",
   });
 
-  await assertRefuses(h.run(), "unable to re-read the merge-queue state");
+  await assertRefuses(h.run(), "unable to re-read the final merge intent");
   assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
@@ -2093,7 +2114,7 @@ await test("an unreadable auto-merge state after confirming refuses", async () =
   // branch is asserted with no consent and no merge — the suite's contract.
   const h = harness({ autoMergeErrorAfterConfirmation: "500 Server Error" });
 
-  await assertRefuses(h.run(), "unable to re-read the auto-merge state");
+  await assertRefuses(h.run(), "unable to re-read the final merge intent");
   assertEqual(h.calls.merges.length, 0, "nothing should have merged");
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
@@ -2116,6 +2137,46 @@ await test("all post-confirmation intent reads happen on the ordinary path", asy
   );
   assertEqual(h.calls.branchRules.length, 2, "so are the branch rules");
   assertEqual(h.calls.mergeQueues.length, 2, "so is the merge-queue state");
+  assertEqual(
+    h.calls.finalIntentReads.length,
+    1,
+    "the final queue and auto-merge states share one response",
+  );
+});
+
+await test("the final intent read combines both gates immediately before merge", async () => {
+  const h = harness();
+  await h.run();
+
+  const read = h.calls.finalIntentReads[0];
+  assert(read !== undefined, "the final combined intent read must run");
+  assert(
+    read.some((arg) => String(arg).includes("mergeQueue(branch:$branch)")),
+    "the final query must include Repository.mergeQueue",
+  );
+  assert(
+    read.some((arg) => String(arg).includes("autoMergeRequest")),
+    "the final query must include the pull request's auto-merge state",
+  );
+  assert(read.includes("number=2071"), "the query must bind the pull request");
+
+  const readEvent = h.calls.events.findIndex(
+    (event) => event.kind === "gh" && event.args === read,
+  );
+  const mergeEvent = h.calls.events.findIndex(
+    (event) => event.kind === "merge",
+  );
+  assert(
+    readEvent >= 0 && mergeEvent > readEvent,
+    "the read must precede merge",
+  );
+  assertEqual(
+    h.calls.events
+      .slice(readEvent + 1, mergeEvent)
+      .some((event) => event.kind === "gh"),
+    false,
+    "no later remote read may make either final intent state stale",
+  );
 });
 
 await test("a closed pull request is not reported as queued", async () => {

--- a/scripts/pr/merge-pr.test.mjs
+++ b/scripts/pr/merge-pr.test.mjs
@@ -218,8 +218,8 @@ function harness({
   // The base the pull request reports AFTER the merge. A retarget between the
   // final gate read and GitHub processing the merge shows up only here.
   mergedBaseRefName = null,
-  // Logins returned by successive `gh api user` calls; the second models a
-  // `gh auth switch` during the confirmation prompt.
+  // Logins returned by the initial `gh api user` read and the final combined
+  // GraphQL viewer read. The second models `gh auth switch` during the prompt.
   logins = null,
   // The repository URL `gh repo view` reports, which carries the host.
   repoUrl = "https://github.com/mento-protocol/monitoring-monorepo",
@@ -240,6 +240,13 @@ function harness({
     autoMergeReads: 0,
   };
   let output = "";
+  const nextLogin = () => {
+    const login = logins
+      ? (logins[calls.logins] ?? logins[logins.length - 1])
+      : "chapati23";
+    calls.logins += 1;
+    return login;
+  };
 
   const gh = async (args) => {
     calls.gh.push(args);
@@ -274,6 +281,7 @@ function harness({
         : standingAutoMerge;
       return JSON.stringify({
         data: {
+          viewer: { login: nextLogin() },
           repository: {
             mergeQueue: queue,
             pullRequest: {
@@ -311,9 +319,7 @@ function harness({
       return JSON.stringify([types.map((type) => ({ type }))]);
     }
     if (args[0] === "api" && args.includes("user")) {
-      if (logins)
-        return `${logins[calls.logins++] ?? logins[logins.length - 1]}\n`;
-      return "chapati23\n";
+      return `${nextLogin()}\n`;
     }
     if (args[0] === "pr" && args[1] === "list") {
       return JSON.stringify(
@@ -1757,9 +1763,9 @@ await test("an unchanged base reports no mismatch", async () => {
 });
 
 await test("a login switched during confirmation refuses", async () => {
-  // The merge starts a fresh gh, which reads whatever credentials are active
-  // then. Recording one login and merging as another would break exactly the
-  // attribution the ledger exists to provide.
+  // The final combined GraphQL response identifies the credential that read
+  // every final state. Recording one login and observing another would break
+  // exactly the attribution the ledger exists to provide.
   const h = harness({ logins: ["chapati23", "someone-else"] });
 
   await assertRefuses(h.run(), "login changed from chapati23 to someone-else");
@@ -1772,6 +1778,14 @@ await test("an unchanged login still merges", async () => {
   const result = await h.run();
   assertEqual(result.merged, true);
   assertEqual(result.record.login, "chapati23");
+});
+
+await test("an unsafe final viewer login refuses", async () => {
+  const h = harness({ logins: ["chapati23", "not a login"] });
+
+  await assertRefuses(h.run(), "named no usable viewer login");
+  assertEqual(h.calls.merges.length, 0, "nothing should have merged");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
 
 await test("refuses a bare target while GH_HOST is set", async () => {
@@ -2170,7 +2184,7 @@ await test("all post-confirmation intent reads happen on the ordinary path", asy
   );
 });
 
-await test("the final intent read combines both gates immediately before merge", async () => {
+await test("the final read combines every remote gate immediately before merge", async () => {
   const h = harness();
   await h.run();
 
@@ -2187,6 +2201,10 @@ await test("the final intent read combines both gates immediately before merge",
   assert(
     read.some((arg) => String(arg).includes("baseRefName")),
     "the final query must include the pull request's current base",
+  );
+  assert(
+    read.some((arg) => String(arg).includes("viewer{login}")),
+    "the final query must include the active GitHub login",
   );
   assert(read.includes("number=2071"), "the query must bind the pull request");
 

--- a/scripts/pr/merge-pr.test.mjs
+++ b/scripts/pr/merge-pr.test.mjs
@@ -191,13 +191,16 @@ function harness({
   // The second element, when present, is what the post-confirmation re-read
   // returns; without it both reads see the same state.
   summaryAfterConfirmation = null,
-  // What the post-merge confirmation read reports. A merge-queue base leaves
-  // the pull request OPEN even though `gh pr merge` exited 0.
+  // What the post-merge confirmation read reports.
   mergedState = "MERGED",
   mergeOutcomeError = null,
-  disableAutoError = null,
   mergeCommandError = null,
   mergedHeadOid = null,
+  // Repository.mergeQueue covers both ruleset and classic-protection queues.
+  baseMergeQueue = null,
+  mergeQueueError = null,
+  baseMergeQueueAfterConfirmation = undefined,
+  mergeQueueErrorAfterConfirmation = null,
   // Rule types GitHub reports for the base branch, and a read failure knob.
   baseRuleTypes = ["pull_request", "required_status_checks"],
   baseRulesError = null,
@@ -227,6 +230,7 @@ function harness({
     prompts: [],
     readyStateReads: 0,
     logins: 0,
+    mergeQueues: [],
     branchRules: [],
     autoMergeReads: 0,
   };
@@ -239,6 +243,21 @@ function harness({
         nameWithOwner: "mento-protocol/monitoring-monorepo",
         parent,
         url: repoUrl,
+      });
+    }
+    if (args[0] === "api" && args.includes("graphql")) {
+      if (mergeQueueError) throw new Error(mergeQueueError);
+      calls.mergeQueues.push(args);
+      if (calls.mergeQueues.length > 1 && mergeQueueErrorAfterConfirmation) {
+        throw new Error(mergeQueueErrorAfterConfirmation);
+      }
+      const queue =
+        calls.mergeQueues.length > 1 &&
+        baseMergeQueueAfterConfirmation !== undefined
+          ? baseMergeQueueAfterConfirmation
+          : baseMergeQueue;
+      return JSON.stringify({
+        data: { repository: { mergeQueue: queue } },
       });
     }
     if (
@@ -271,14 +290,6 @@ function harness({
           },
         })),
       );
-    }
-    if (
-      args[0] === "pr" &&
-      args[1] === "merge" &&
-      args.includes("--disable-auto")
-    ) {
-      if (disableAutoError) throw new Error(disableAutoError);
-      return "";
     }
     // The pre-merge auto-merge read and the post-merge outcome read are both
     // `pr view`; only their fields tell them apart.
@@ -361,6 +372,17 @@ function harness({
 function assertNothingHappened(calls) {
   assertEqual(calls.consents.length, 0, "consent must not be recorded");
   assertEqual(calls.merges.length, 0, "merge must not run");
+}
+
+function assertNoDeferredMergeMutation(calls) {
+  const mutation = calls.gh.find(
+    (args) => args[0] === "pr" && args[1] === "merge",
+  );
+  assertEqual(
+    mutation,
+    undefined,
+    "reconciliation must not enable or disable auto-merge",
+  );
 }
 
 // --- Refusal: non-TTY ------------------------------------------------------
@@ -697,7 +719,7 @@ await test("an override reason still refuses a head that moved mid-confirmation"
 
 // --- The approved path ------------------------------------------------------
 
-await test("records consent before merging, and binds the merge to the head", async () => {
+await test("records consent before a synchronous squash merge bound to the head", async () => {
   const { run, calls, output } = harness();
   const result = await run();
 
@@ -715,21 +737,38 @@ await test("records consent before merging, and binds the merge to the head", as
   );
 
   const mergeArgs = calls.merges[0];
-  assertEqual(mergeArgs[0], "pr");
-  assertEqual(mergeArgs[1], "merge");
-  assertEqual(mergeArgs[2], "2071");
-  assert(mergeArgs.includes("--squash"), "merge must be a squash");
+  assertEqual(mergeArgs[0], "api");
+  assertEqual(
+    mergeArgs[mergeArgs.indexOf("--hostname") + 1],
+    "github.com",
+    "the write must name its host",
+  );
+  assertEqual(mergeArgs[mergeArgs.indexOf("--method") + 1], "PUT");
   assert(
-    mergeArgs.includes("--match-head-commit"),
-    "merge must be bound to the reviewed head",
+    mergeArgs.includes(
+      "repos/mento-protocol/monitoring-monorepo/pulls/2071/merge",
+    ),
+    "the write must use the synchronous REST merge endpoint",
+  );
+  assert(
+    !mergeArgs.some((arg) => String(arg).includes("merge-async")),
+    "the asynchronous endpoint can enqueue and must never be used",
+  );
+  const fields = mergeArgs.filter(
+    (_arg, index) => mergeArgs[index - 1] === "--raw-field",
   );
   assertEqual(
-    mergeArgs[mergeArgs.indexOf("--match-head-commit") + 1],
-    HEAD_OID,
+    JSON.stringify(fields),
+    JSON.stringify([`sha=${HEAD_OID}`, "merge_method=squash"]),
+    "the body must bind the approved head and squash method only",
   );
   assert(
-    mergeArgs.includes("mento-protocol/monitoring-monorepo"),
-    "merge must name the base repository explicitly",
+    !fields.some(
+      (field) =>
+        field.startsWith("commit_title=") ||
+        field.startsWith("commit_message="),
+    ),
+    "omitting title and message preserves the repository squash defaults",
   );
 
   const briefing = output();
@@ -1034,7 +1073,7 @@ await test("sanitizeTerminalText keeps ordinary text and reports empty values", 
 });
 
 await test("refuses when the base branch is retargeted mid-confirmation", async () => {
-  // `--match-head-commit` binds the head only, so a retarget keeps the same
+  // The REST `sha` binds the head only, so a retarget keeps the same
   // SHA and would merge into a branch the operator was never shown.
   const retargeted = readySummary();
   retargeted.pr = { ...retargeted.pr, baseRefName: "release/v2" };
@@ -1369,18 +1408,17 @@ await test("every record lands on its own line, blank lines and all", async () =
   }
 });
 
-await test("an enqueued pull request is not reported as merged", async () => {
-  // `gh pr merge` exits 0 after enqueueing on a merge-queue base. Reporting
-  // that as merged would let callers run post-merge closeout while the pull
-  // request is still open and the queue is still retesting it.
+await test("an open post-call state is not reported as merged", async () => {
+  // The synchronous endpoint cannot enqueue. An OPEN outcome means the direct
+  // merge did not complete and no standing request came from this run.
   const h = harness({ mergedState: "OPEN" });
 
   const result = await h.run();
-  assertEqual(result.merged, false, "an enqueued request is not merged");
-  assertEqual(result.queued, true, "it should be reported as queued");
+  assertEqual(result.merged, false, "an open pull request is not merged");
+  assertEqual(result.queued, undefined, "the direct call cannot queue it");
   assertEqual(result.verified, true, "the state was read successfully");
   assert(
-    h.output().includes("not merged"),
+    h.output().includes("created no queued or auto-merge request"),
     `the operator should be told, got:\n${h.output()}`,
   );
 });
@@ -1417,9 +1455,15 @@ await test("an Enterprise checkout keeps its host on every call", async () => {
 
   const merged = h.calls.merges[0];
   assertEqual(
-    merged[merged.indexOf("--repo") + 1],
-    "ghe.example.com/mento-protocol/monitoring-monorepo",
+    merged[merged.indexOf("--hostname") + 1],
+    "ghe.example.com",
     "the merge must target the Enterprise host",
+  );
+  assert(
+    merged.includes(
+      "repos/mento-protocol/monitoring-monorepo/pulls/2071/merge",
+    ),
+    "the endpoint must name the Enterprise repository",
   );
 
   const login = h.calls.gh.find(
@@ -1442,10 +1486,7 @@ await test("a github.com checkout still names github.com explicitly", async () =
   );
   assertEqual(login[login.indexOf("--hostname") + 1], "github.com");
   const merged = h.calls.merges[0];
-  assertEqual(
-    merged[merged.indexOf("--repo") + 1],
-    "mento-protocol/monitoring-monorepo",
-  );
+  assertEqual(merged[merged.indexOf("--hostname") + 1], "github.com");
 });
 
 await test("an explicit host-qualified --repo reaches gh verbatim", async () => {
@@ -1455,10 +1496,8 @@ await test("an explicit host-qualified --repo reaches gh verbatim", async () => 
   await h.run();
 
   const merged = h.calls.merges[0];
-  assertEqual(
-    merged[merged.indexOf("--repo") + 1],
-    "ghe.example.com/acme/widgets",
-  );
+  assertEqual(merged[merged.indexOf("--hostname") + 1], "ghe.example.com");
+  assert(merged.includes("repos/acme/widgets/pulls/2071/merge"));
   const login = h.calls.gh.find(
     (args) => args[0] === "api" && args.includes("user"),
   );
@@ -1637,7 +1676,7 @@ await test("the login is always read from a named host", async () => {
 });
 
 await test("a base retargeted during the merge itself is reported", async () => {
-  // `--match-head-commit` pins the head, and GitHub's merge API has no
+  // The REST `sha` pins the head, and GitHub's merge API has no
   // parameter that pins the base — its only matching field is `sha`. So this
   // race cannot be prevented in the wrapper; it must be detected and said
   // plainly rather than reported as a clean merge.
@@ -1757,53 +1796,23 @@ await test("a login with unsafe characters still refuses", async () => {
   assertEqual(h.calls.merges.length, 0, "nothing should have merged");
 });
 
-await test("an enqueued merge has its pending request cancelled", async () => {
-  // gh enqueues when required checks pass and enables auto-merge when they do
-  // not. Either leaves a standing request GitHub can complete later, with none
-  // of the gates — the merge nobody approved.
+await test("an OPEN outcome never mutates auto-merge state", async () => {
   const h = harness({ mergedState: "OPEN" });
   const result = await h.run();
 
   assertEqual(result.merged, false);
-  const cancel = h.calls.gh.find(
-    (args) =>
-      args[0] === "pr" &&
-      args[1] === "merge" &&
-      args.includes("--disable-auto"),
-  );
-  assert(cancel !== undefined, "the pending merge request must be cancelled");
-  assertEqual(
-    cancel[cancel.indexOf("--repo") + 1],
-    "mento-protocol/monitoring-monorepo",
-  );
+  assertNoDeferredMergeMutation(h.calls);
   assert(
-    h.output().includes("Auto-merge has been disabled"),
+    h.output().includes("created no queued or auto-merge request"),
     `the operator should be told, got:\n${h.output()}`,
   );
-  assert(
-    h.output().includes("does not remove a merge-queue entry"),
-    "the report must not overstate what --disable-auto did",
-  );
 });
 
-await test("a failed cancellation is reported, not swallowed", async () => {
-  const h = harness({ mergedState: "OPEN", disableAutoError: "gh refused" });
-  const result = await h.run();
-
-  assertEqual(result.merged, false);
-  assert(
-    h.output().includes("could NOT be cancelled"),
-    `the operator must be warned, got:\n${h.output()}`,
-  );
-  assert(
-    h.output().includes("without any of the gates"),
-    "the warning should say what the risk is",
-  );
-});
-
-await test("a failing merge command still reconciles the pull request", async () => {
-  // The request may have reached GitHub before the command failed, so its
-  // failure is ambiguous rather than a clean abort.
+await test("a foreign auto-merge request after the final read is never cancelled", async () => {
+  // Model the issue #2098 window: another operator acts after the final state
+  // read, while this run's direct merge reports a transport failure and the PR
+  // remains OPEN. The wrapper cannot prove ownership of any later auto-merge
+  // request, so reconciliation must remain read-only.
   const h = harness({
     mergeCommandError: "connection reset",
     mergedState: "OPEN",
@@ -1811,13 +1820,7 @@ await test("a failing merge command still reconciles the pull request", async ()
   const result = await h.run();
 
   assertEqual(result.merged, false);
-  const cancel = h.calls.gh.find(
-    (args) =>
-      args[0] === "pr" &&
-      args[1] === "merge" &&
-      args.includes("--disable-auto"),
-  );
-  assert(cancel !== undefined, "a pending request must still be cancelled");
+  assertNoDeferredMergeMutation(h.calls);
   assert(
     h.output().includes("connection reset"),
     `the command failure must be surfaced, got:\n${h.output()}`,
@@ -1836,25 +1839,22 @@ await test("a failing merge command on an already-merged PR reports the merge", 
   );
 });
 
-await test("an unreadable outcome cancels any pending request", async () => {
-  // Neither confirmed nor refuted: cancel first, report second.
+await test("an unreadable outcome never mutates auto-merge state", async () => {
   const h = harness({ mergeOutcomeError: "gh exploded" });
   const result = await h.run();
 
   assertEqual(result.merged, false);
   assertEqual(result.verified, false);
-  const cancel = h.calls.gh.find(
-    (args) =>
-      args[0] === "pr" &&
-      args[1] === "merge" &&
-      args.includes("--disable-auto"),
+  assertNoDeferredMergeMutation(h.calls);
+  assert(
+    h.output().includes("created no standing merge request"),
+    `the operator should be told, got:\n${h.output()}`,
   );
-  assert(cancel !== undefined, "an unreadable outcome must still cancel");
 });
 
 await test("a merge of a head nobody approved is not a verified merge", async () => {
-  // If the head moved and something else merged the new one, our
-  // --match-head-commit request fails while the PR still reads MERGED. The
+  // If the head moved and something else merged the new one, our REST `sha`
+  // check fails while the PR still reads MERGED. The
   // consent record would then name a commit GitHub never merged.
   const h = harness({ mergedHeadOid: "c".repeat(40) });
   const result = await h.run();
@@ -1883,9 +1883,41 @@ await test("a MERGED state with no head OID is not a verified merge", async () =
   );
 });
 
-await test("a merge-queue base refuses before anything is sent", async () => {
-  // gh enqueues such a base and returns success, and nothing this command can
-  // call removes a queue entry — so the merge must not be attempted at all.
+await test("a classic-protection merge queue refuses before direct merge", async () => {
+  // Repository.mergeQueue exposes a classic queue that the ruleset endpoint
+  // cannot see. The synchronous endpoint could bypass it, so object means stop.
+  const h = harness({
+    baseMergeQueue: {
+      id: "MQ_kwDOExample",
+      url: "https://github.com/mento-protocol/monitoring-monorepo/queue/main",
+    },
+  });
+
+  await assertRefuses(h.run(), "uses a merge queue");
+  assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
+  assertEqual(
+    h.calls.prompts.length,
+    0,
+    "the operator is not asked to confirm",
+  );
+  assertEqual(
+    h.calls.branchRules.length,
+    0,
+    "the authoritative queue object refuses before the diagnostic read",
+  );
+});
+
+await test("an unreadable merge-queue state refuses rather than guessing", async () => {
+  const h = harness({ mergeQueueError: "GraphQL: Resource not accessible" });
+
+  await assertRefuses(h.run(), "unable to read the merge-queue state");
+  assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
+});
+
+await test("a ruleset merge-queue signal also refuses before direct merge", async () => {
+  // Keep the ruleset endpoint as a second signal and specific diagnosis.
   const h = harness({
     baseRuleTypes: ["pull_request", "merge_queue", "required_status_checks"],
   });
@@ -1914,6 +1946,29 @@ await test("an ordinary protected base still merges", async () => {
   const h = harness();
   const result = await h.run();
   assertEqual(result.merged, true);
+  assertEqual(
+    h.calls.mergeQueues.length,
+    2,
+    "a null queue response is proved before and after confirmation",
+  );
+});
+
+await test("the merge-queue read binds the host, repository, and branch", async () => {
+  const h = harness({
+    argv: ["--pr", "2071", "--repo", "ghe.example.com/acme/widgets"],
+  });
+  await h.run();
+
+  const read = h.calls.mergeQueues[0];
+  assert(read !== undefined, "the merge queue must be read");
+  assertEqual(read[read.indexOf("--hostname") + 1], "ghe.example.com");
+  assert(read.includes("owner=acme"), "the query must bind the owner");
+  assert(read.includes("name=widgets"), "the query must bind the repository");
+  assert(read.includes("branch=main"), "the query must bind the base branch");
+  assert(
+    read.some((arg) => String(arg).includes("mergeQueue(branch:$branch)")),
+    "the query must use Repository.mergeQueue for the exact branch",
+  );
 });
 
 await test("the branch-rules read names its host and paginates", async () => {
@@ -1969,10 +2024,35 @@ await test("a merge queue switched on during confirmation refuses", async () => 
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
 
+await test("a classic merge queue switched on during confirmation refuses", async () => {
+  const h = harness({
+    baseMergeQueueAfterConfirmation: {
+      id: "MQ_kwDOExample",
+      url: "https://github.com/mento-protocol/monitoring-monorepo/queue/main",
+    },
+  });
+
+  await assertRefuses(
+    h.run(),
+    "gained a merge queue while you were confirming",
+  );
+  assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
+});
+
+await test("an unreadable merge queue after confirmation refuses", async () => {
+  const h = harness({
+    mergeQueueErrorAfterConfirmation: "GraphQL: Something went wrong",
+  });
+
+  await assertRefuses(h.run(), "unable to re-read the merge-queue state");
+  assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
+});
+
 await test("a pull request that already has auto-merge enabled refuses", async () => {
   // Someone asked GitHub to merge it outside these gates. This command must
-  // neither merge over that nor cancel it — its own cleanup could not tell
-  // compensation from interference.
+  // neither merge over that nor cancel it.
   const h = harness({
     standingAutoMerge: { enabledAt: "2026-08-26T00:00:00Z" },
   });
@@ -1980,49 +2060,21 @@ await test("a pull request that already has auto-merge enabled refuses", async (
   await assertRefuses(h.run(), "already has auto-merge enabled");
   assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
-  const cancel = h.calls.gh.find(
-    (args) => args[0] === "pr" && args.includes("--disable-auto"),
-  );
-  assertEqual(
-    cancel,
-    undefined,
-    "another operator's request must be left alone",
-  );
+  assertNoDeferredMergeMutation(h.calls);
 });
 
 await test("an unreadable auto-merge state refuses", async () => {
-  // Not knowing whether a request already stands is the case where cleanup
-  // could cancel somebody else's.
+  // Not knowing whether another operator already has a request standing is an
+  // ambiguous intent boundary, so the wrapper does not merge over it.
   const h = harness({ autoMergeError: "403 Forbidden" });
 
   await assertRefuses(h.run(), "unable to read the auto-merge state");
   assertEqual(h.calls.merges.length, 0, "no merge request may be sent");
 });
 
-await test("the cleanup only ever cancels a request this run created", async () => {
-  // The refusal above is what makes this true: with no standing request before
-  // the merge, anything --disable-auto turns off was created by this run.
-  const h = harness({ mergedState: "OPEN" });
-  await h.run();
-
-  const autoRead = h.calls.gh.find(
-    (args) => args[0] === "pr" && args.includes("autoMergeRequest"),
-  );
-  assert(
-    autoRead !== undefined,
-    "the pre-merge auto-merge read is what licenses the cleanup",
-  );
-  const cancel = h.calls.gh.find(
-    (args) => args[0] === "pr" && args.includes("--disable-auto"),
-  );
-  assert(cancel !== undefined, "this run's own request is still cancelled");
-});
-
 await test("an auto-merge request enabled during confirmation refuses", async () => {
-  // The pre-briefing read is what licenses the cleanup to call anything it
-  // cancels its own. That licence expires the moment another operator can act,
-  // which the unbounded prompt gives them — so the state is re-read, like every
-  // other gate.
+  // The state is re-read after the unbounded prompt so the wrapper does not
+  // merge over another operator's newly recorded intent.
   const h = harness({
     standingAutoMergeAfterConfirmation: { enabledAt: "2026-08-27T00:00:00Z" },
   });
@@ -2033,14 +2085,7 @@ await test("an auto-merge request enabled during confirmation refuses", async ()
   );
   assertEqual(h.calls.merges.length, 0, "nothing should have merged");
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
-  const cancel = h.calls.gh.find(
-    (args) => args[0] === "pr" && args.includes("--disable-auto"),
-  );
-  assertEqual(
-    cancel,
-    undefined,
-    "the other operator's request must be left alone",
-  );
+  assertNoDeferredMergeMutation(h.calls);
 });
 
 await test("an unreadable auto-merge state after confirming refuses", async () => {
@@ -2061,7 +2106,7 @@ await test("unreadable branch rules after confirming refuse", async () => {
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
 
-await test("both post-confirmation reads happen on the ordinary path", async () => {
+await test("all post-confirmation intent reads happen on the ordinary path", async () => {
   const h = harness();
   await h.run();
   assertEqual(
@@ -2070,12 +2115,10 @@ await test("both post-confirmation reads happen on the ordinary path", async () 
     "auto-merge is read once per gate pass",
   );
   assertEqual(h.calls.branchRules.length, 2, "so are the branch rules");
+  assertEqual(h.calls.mergeQueues.length, 2, "so is the merge-queue state");
 });
 
 await test("a closed pull request is not reported as queued", async () => {
-  // Cancelling auto-merge on a closed PR fails, and reporting that as "this can
-  // still merge later" would be false and alarming — GitHub does not merge a
-  // closed pull request.
   const h = harness({ mergedState: "CLOSED" });
   const result = await h.run();
 
@@ -2083,49 +2126,11 @@ await test("a closed pull request is not reported as queued", async () => {
   assertEqual(result.closed, true);
   assertEqual(result.queued, undefined, "a closed PR is not queued");
   assertEqual(exitCodeForResult(result), 1);
-  const cancel = h.calls.gh.find(
-    (args) => args[0] === "pr" && args.includes("--disable-auto"),
-  );
-  assertEqual(cancel, undefined, "no cancellation is attempted on a closed PR");
+  assertNoDeferredMergeMutation(h.calls);
   assert(
-    h.output().includes("no pending request to cancel"),
+    h.output().includes("no request from this run pending"),
     `the operator should be told plainly, got:\n${h.output()}`,
   );
-  assert(
-    !h.output().includes("can still merge later"),
-    "a closed PR cannot still merge later",
-  );
-});
-
-await test("nothing-to-cancel is not reported as a failed cancellation", async () => {
-  // gh fails --disable-auto when there is no request to turn off, which is the
-  // ordinary case when the merge never reached GitHub. Claiming "this can still
-  // merge later" there is the same over-claiming the CLOSED branch avoids.
-  const h = harness({
-    mergedState: "OPEN",
-    disableAutoError: "X auto-merge is not enabled for this pull request",
-  });
-  await h.run();
-
-  assert(
-    h.output().includes("no auto-merge request to cancel"),
-    `expected the benign wording, got:\n${h.output()}`,
-  );
-  assert(
-    !h.output().includes("can still merge later"),
-    "nothing reached GitHub, so nothing can merge later",
-  );
-});
-
-await test("a genuine cancellation failure still escalates", async () => {
-  const h = harness({ mergedState: "OPEN", disableAutoError: "403 Forbidden" });
-  await h.run();
-
-  assert(
-    h.output().includes("could NOT be cancelled"),
-    `a real failure must still escalate, got:\n${h.output()}`,
-  );
-  assert(h.output().includes("can still merge later"), "and name the risk");
 });
 
 await test("refusal and warning messages sanitize GitHub-sourced text", async () => {
@@ -2199,18 +2204,18 @@ await test("the implicit-target listing asks for more than the gh default", asyn
 
 await test("only a confirmed merge exits zero", async () => {
   // The CLI's exit status is what `pnpm pr:merge && <post-merge closeout>`
-  // branches on. Reporting success for a queued or unverified merge would run
+  // branches on. Reporting success for an open or unverified result would run
   // the closeout on exactly the states this wrapper refused to call a merge.
   assertEqual(exitCodeForResult({ merged: true, verified: true }), 0);
-  assertEqual(exitCodeForResult({ merged: false, queued: true }), 1);
+  assertEqual(exitCodeForResult({ merged: false, state: "OPEN" }), 1);
   assertEqual(exitCodeForResult({ merged: false, verified: false }), 1);
   assertEqual(exitCodeForResult(undefined), 1);
   // `--help` is not a merge and must not read as a failure.
   assertEqual(exitCodeForResult({ merged: false, help: true }), 0);
 
   // Bound to the real results the wrapper returns, so the two cannot drift.
-  const queued = await harness({ mergedState: "OPEN" }).run();
-  assertEqual(exitCodeForResult(queued), 1, "a queued merge must exit nonzero");
+  const open = await harness({ mergedState: "OPEN" }).run();
+  assertEqual(exitCodeForResult(open), 1, "an open PR must exit nonzero");
   const unverified = await harness({ mergeOutcomeError: "gh exploded" }).run();
   assertEqual(
     exitCodeForResult(unverified),

--- a/scripts/pr/merge-pr.test.mjs
+++ b/scripts/pr/merge-pr.test.mjs
@@ -210,6 +210,9 @@ function harness({
   autoMergeError = null,
   standingAutoMergeAfterConfirmation = null,
   autoMergeErrorAfterConfirmation = null,
+  // The base returned beside the final intent state. This can differ from the
+  // last ready-state read when a retarget lands between those two requests.
+  baseRefNameAtFinalIntent = null,
   openPullRequestCount = 1,
   baseRulesErrorAfterConfirmation = null,
   // The base the pull request reports AFTER the merge. A retarget between the
@@ -240,7 +243,7 @@ function harness({
 
   const gh = async (args) => {
     calls.gh.push(args);
-    calls.events.push({ kind: "gh", args });
+    calls.events.push({ kind: "remote-read", source: "gh", args });
     if (args[0] === "repo" && args[1] === "view") {
       return JSON.stringify({
         nameWithOwner: "mento-protocol/monitoring-monorepo",
@@ -273,7 +276,13 @@ function harness({
         data: {
           repository: {
             mergeQueue: queue,
-            pullRequest: { autoMergeRequest: request },
+            pullRequest: {
+              baseRefName:
+                baseRefNameAtFinalIntent ??
+                summaryAfterConfirmation?.pr?.baseRefName ??
+                summary.pr.baseRefName,
+              autoMergeRequest: request,
+            },
           },
         },
       });
@@ -362,6 +371,10 @@ function harness({
         gh,
         git,
         fetchReadyState: async () => {
+          calls.events.push({
+            kind: "remote-read",
+            source: "ready-state",
+          });
           if (readyStateError) throw new Error(readyStateError);
           calls.readyStateReads += 1;
           if (calls.readyStateReads > 1 && summaryAfterConfirmation) {
@@ -2071,6 +2084,19 @@ await test("an unreadable merge queue after confirmation refuses", async () => {
   assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
 });
 
+await test("a retarget before the final intent read refuses", async () => {
+  // The combined query must prove that its queue branch is still the pull
+  // request's current base. The REST `sha` binds the head, but not this base.
+  const h = harness({ baseRefNameAtFinalIntent: "release/v2" });
+
+  await assertRefuses(
+    h.run(),
+    "was retargeted from main to release/v2 after the final readiness read",
+  );
+  assertEqual(h.calls.merges.length, 0, "nothing should have merged");
+  assertEqual(h.calls.consents.length, 0, "no consent should be recorded");
+});
+
 await test("a pull request that already has auto-merge enabled refuses", async () => {
   // Someone asked GitHub to merge it outside these gates. This command must
   // neither merge over that nor cancel it.
@@ -2158,10 +2184,17 @@ await test("the final intent read combines both gates immediately before merge",
     read.some((arg) => String(arg).includes("autoMergeRequest")),
     "the final query must include the pull request's auto-merge state",
   );
+  assert(
+    read.some((arg) => String(arg).includes("baseRefName")),
+    "the final query must include the pull request's current base",
+  );
   assert(read.includes("number=2071"), "the query must bind the pull request");
 
   const readEvent = h.calls.events.findIndex(
-    (event) => event.kind === "gh" && event.args === read,
+    (event) =>
+      event.kind === "remote-read" &&
+      event.source === "gh" &&
+      event.args === read,
   );
   const mergeEvent = h.calls.events.findIndex(
     (event) => event.kind === "merge",
@@ -2173,9 +2206,9 @@ await test("the final intent read combines both gates immediately before merge",
   assertEqual(
     h.calls.events
       .slice(readEvent + 1, mergeEvent)
-      .some((event) => event.kind === "gh"),
+      .some((event) => event.kind === "remote-read"),
     false,
-    "no later remote read may make either final intent state stale",
+    "no later remote read may make the final base or intent state stale",
   );
 });
 


### PR DESCRIPTION
## The Problem

- `pnpm pr:merge` delegated the write to `gh pr merge`, which can enable auto-merge or enqueue instead of completing the approved merge synchronously. A failed run could therefore leave a standing merge request.
- Outcome reconciliation could disable an auto-merge request that another operator created after the wrapper's final state read.
- The ruleset-only queue check did not detect queues configured through classic branch protection. GitHub's synchronous merge endpoint can bypass such a queue and merge directly.

## The Solution

The wrapper now calls GitHub's synchronous pull-request merge REST endpoint with the approved head SHA and the repository's fixed squash method. Before the briefing, it proves `Repository.mergeQueue(branch:)` is null. Its final remote read returns `viewer.login`, the current `baseRefName`, `Repository.mergeQueue`, and `autoMergeRequest` in one GraphQL response. Any changed, missing, or malformed state refuses. Reconciliation only reads the outcome and never enables or disables auto-merge.

The request omits commit title and message fields, so the repository's squash defaults remain in effect. GitHub cannot atomically bind queue absence, the base, the squash subject, or the active keyring credential to this write. ADR 0075 now records those residual windows and their effects.

## Details

- Send `PUT /repos/{owner}/{repo}/pulls/{number}/merge` with only `sha=<approved-head>` and `merge_method=squash`.
- Fail closed when either merge-queue read, the ruleset read, or any field in the combined final state is unavailable.
- Refuse existing or newly created auto-merge requests without cancelling them.
- Refuse a changed login or base before consent, and make the combined state the last remote read before the REST write.
- Bind the post-merge result to the approved head and base before post-merge work can continue.
- Document the accepted credential-attribution residual from #2099 without capturing or injecting a live token.

Closes #2092
Closes #2098
Closes #2099

## Validation

- `./tools/trunk fmt` — passed for all six modified files.
- Immutable fresh-context source review — passed on bundle manifest `c301fa96f30a30593ed03af6cd860ad77d79a723347000aeb3d9a441cd0969ae`, base `d994c6af00e3d29d245f1211d474f8a7f52deb2a`, and head `d35a4111d7ca6a6407f3c99e40fce1b1a7ce8dc3`. The aggregate stable patch ID was `7b35378748d5fd0430fbb5156ab7691df6b072e9`; the binary diff SHA-256 was `16a8adb4b5b287c82be67a5fb23ca64c72082a6c65966113723c89630cd28e33`. The retained-manifest post-review check passed. This proves source-review and patch identity, not live merge behavior.
- `pnpm agent:quality-gate --base d994c6af00e3d29d245f1211d474f8a7f52deb2a --head HEAD --run` — passed all eight mapped commands on `d35a4111`: targeted Trunk, docs index, context check, guardrail prose, script lint, `pr:merge:test`, Terraform contract tests, and documentation navigation fixtures.
- Mandatory pre-push gate — passed the same eight mapped commands and its terminal input-fingerprint check on `d35a4111`. One prior attempt failed closed at terminal fingerprint publication and pushed nothing; the single clean retry passed and published this head.
- `pnpm pr:merge:test` — 110 tests passed. The injected boundaries prove the tested request shape, SHA binding, combined final-state refusals, classic and ruleset queue refusals, remote-read ordering, and non-mutation. The suite does not perform a live merge or prove every future GitHub response shape.
- Live read-only GraphQL probe — GitHub returned `viewer.login`, `baseRefName`, `mergeQueue`, and `autoMergeRequest` in the combined response shape used by the wrapper. This proves current query compatibility, not the later REST merge result.
- Claude Security scan — skipped for the trust-root merge wrapper because that scanner is unavailable in Codex.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the material limits that apply.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision: ADR 0075 is updated in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added synchronous squash merging using the approved pull request revision.
  - Added final verification of login, target branch, merge queue, auto-merge status, and revision before merging.
  - Added verification of the final merged state, including host, branch, and revision details.

- **Bug Fixes**
  - Improved handling of unreadable, ambiguous, failed, or raced merge states.
  - Added detection of credential changes and branch retargeting during merging.
  - Removed unsupported automatic cancellation of queued or auto-merge requests.

- **Documentation**
  - Updated merge procedures, limitations, security considerations, and verification records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->