### PR TITLE
docs(dashboard): document social preview verification

### DIFF
--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -55,6 +55,13 @@ For a narrow verify (specific page or feature), skip the list and go directly to
 
 6. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
 
+7. **Verify dynamic social previews when applicable.** When a change touches
+   dynamic route metadata or an Open Graph image route, run the "Dynamic
+   social-preview verification" section in
+   `docs/notes/dashboard-verification.md` against the final deployed origin.
+   Run this check after the production deployment for post-merge closeout. A
+   localhost or preview result does not prove the production social preview.
+
 ## Auth-state checks
 
 - Logged out: nav shows `Sign in`; authenticated-only nav links are hidden;

--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -53,14 +53,14 @@ For a narrow verify (specific page or feature), skip the list and go directly to
    re-check the affected routes at the relevant breakpoints with `resize_page`.
    A content-and-console pass alone does not cover interaction changes.
 
-6. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
-
-7. **Verify dynamic social previews when applicable.** When a change touches
+6. **Verify dynamic social previews when applicable.** When a change touches
    dynamic route metadata or an Open Graph image route, run the "Dynamic
    social-preview verification" section in
    `docs/notes/dashboard-verification.md` against the final deployed origin.
    Run this check after the production deployment for post-merge closeout. A
    localhost or preview result does not prove the production social preview.
+
+7. **Report** a concise pass/fail summary. If something failed, include what you expected vs what you saw.
 
 ## Auth-state checks
 

--- a/.claude/commands/verify-ui.md
+++ b/.claude/commands/verify-ui.md
@@ -53,8 +53,9 @@ For a narrow verify (specific page or feature), skip the list and go directly to
    re-check the affected routes at the relevant breakpoints with `resize_page`.
    A content-and-console pass alone does not cover interaction changes.
 
-6. **Verify dynamic social previews when applicable.** When a change touches
-   dynamic route metadata or an Open Graph image route, run the "Dynamic
+6. **Verify dynamic social previews when applicable.** When a change can affect
+   dynamic route metadata or an Open Graph image, including through a renderer,
+   data helper, shared font, or other route dependency, run the "Dynamic
    social-preview verification" section in
    `docs/notes/dashboard-verification.md` against the final deployed origin.
    Run this check after the production deployment for post-merge closeout. A

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -428,8 +428,8 @@ autofix branches. See [ADR 0019](adr/0019-vercel-path-aware-deploys.md).
 
 The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](https://monitoring.mento.org).
 
-After a merged change to dynamic route metadata or an Open Graph image route
-deploys, run the
+After a merged change that can affect dynamic route metadata or an Open Graph
+image deploys, including a change to a route dependency, run the
 [dynamic social-preview verification](notes/dashboard-verification.md#dynamic-social-preview-verification)
 against the production origin. A successful Vercel deployment does not prove
 that the production metadata, image, cache policy, or Slack unfurl is correct.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -428,6 +428,12 @@ autofix branches. See [ADR 0019](adr/0019-vercel-path-aware-deploys.md).
 
 The project is named `monitoring-dashboard` and lives at [monitoring.mento.org](https://monitoring.mento.org).
 
+After a merged change to dynamic route metadata or an Open Graph image route
+deploys, run the
+[dynamic social-preview verification](notes/dashboard-verification.md#dynamic-social-preview-verification)
+against the production origin. A successful Vercel deployment does not prove
+that the production metadata, image, cache policy, or Slack unfurl is correct.
+
 ### Infrastructure (Terraform)
 
 Terraform stack ownership is registered in [`terraform.stacks.json`](../terraform.stacks.json) and summarized in [`docs/terraform.md`](./terraform.md). The dashboard/platform stack lives in [`terraform/`](../terraform/). The team-level Vercel Blob store is managed through Vercel Storage and linked to the project outside Terraform. The platform stack covers:

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -310,13 +310,15 @@ final deployed origin in the browser. Do not use a local render as production
 proof.
 
 - Read the exact Open Graph and Twitter title, description, and image values
-  from the raw initial HTML response. Confirm that each value matches the route
-  and its public-data policy.
+  from the raw initial HTML response of an isolated, cookie-free request.
+  Confirm that each value matches the route and its public-data policy.
 - Compare those values with the live DOM when client-side hydration is
   relevant. The hydrated DOM alone does not prove what a crawler receives.
 - Fetch the exact image URL from the deployed document with the browser cache
   disabled. Require HTTP 200, the expected image content type, and the declared
-  pixel dimensions.
+  pixel dimensions. Inspect `Cache-Control` and `Age`, and confirm that they
+  match the route's declared freshness or revalidation policy. Disabling the
+  browser cache does not bypass a CDN cache.
 - Inspect the rendered image. Confirm that it identifies the correct route,
   shows the expected data or fallback state, and has no blank or clipped
   content.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -310,8 +310,10 @@ final deployed origin in the browser. Do not use a local render as production
 proof.
 
 - Read the exact Open Graph and Twitter title, description, and image values
-  from the deployed document. Confirm that each value matches the route and its
-  public-data policy.
+  from the raw initial HTML response. Confirm that each value matches the route
+  and its public-data policy.
+- Compare those values with the live DOM when client-side hydration is
+  relevant. The hydrated DOM alone does not prove what a crawler receives.
 - Fetch the exact image URL from the deployed document with the browser cache
   disabled. Require HTTP 200, the expected image content type, and the declared
   pixel dimensions.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -305,15 +305,27 @@ UI PR shipped or ready. The user may waive visual evidence for a specific PR.
 
 ## Dynamic social-preview verification
 
-For a change to dynamic route metadata or an Open Graph image route, verify the
-final deployed origin in the browser. Do not use a local render as production
-proof.
+For a change that can affect dynamic route metadata or an Open Graph image,
+verify the final deployed origin in the browser. This includes changes to the
+metadata or image route and to a renderer, data helper, shared font, or other
+dependency used by that route. Do not use a local render as production proof.
 
-- Read the exact document title, description, and canonical URL; Open Graph
-  type, URL, title, description, and image values; and Twitter card type,
-  title, description, and image values from the raw initial HTML response of
-  an isolated, cookie-free request. Confirm that each value matches the route
-  and its public-data policy.
+- Send isolated, cookie-free requests with an ordinary browser user agent and
+  each relevant crawler user agent, such as Slackbot or Twitterbot. Check the
+  original document status, redirect chain, and final URL before validating
+  metadata. Require the original status and redirect chain to match the route
+  contract, and require HTTP 200 from the expected final route.
+- Read the exact document title and description; canonical URL; Open Graph
+  type, URL, title, description, image, and image alt values; and Twitter card
+  type, title, description, image, and image alt values from each raw initial
+  HTML response. Confirm that every value the route declares matches its
+  contract and public-data policy. Record expected absence when the route
+  contract does not declare an optional canonical URL, Open Graph URL, or
+  image-alt tag.
+- When metadata has public and private states, verify an explicitly public
+  record and an explicitly private record. Confirm that the private state uses
+  the declared safe fallback and exposes no private label, tag, source, or
+  other restricted data.
 - Inspect the deployed document's `Cache-Control` and `Age` headers. Confirm
   that they match the route's declared freshness or revalidation policy. For
   metadata that can become private, require a policy that prevents stale
@@ -321,11 +333,14 @@ proof.
   public-to-private revocation check.
 - Compare those values with the live DOM when client-side hydration is
   relevant. The hydrated DOM alone does not prove what a crawler receives.
-- Fetch the exact image URL from the deployed document with the browser cache
-  disabled. Require HTTP 200, the expected image content type, and the declared
-  pixel dimensions. Inspect `Cache-Control` and `Age`, and confirm that they
-  match the route's declared freshness or revalidation policy. Disabling the
-  browser cache does not bypass a CDN cache.
+- Fetch the exact image URL from the deployed document in the same isolated,
+  cookie-free context and with the browser cache disabled. Reject any
+  credential-dependent response difference; for an access-controlled route,
+  compare the anonymous response with an authenticated fetch. Require HTTP
+  200, the expected image content type, and the declared pixel dimensions.
+  Inspect `Cache-Control` and `Age`, and confirm that they match the route's
+  declared freshness or revalidation policy. Disabling the browser cache does
+  not bypass a CDN cache.
 - Inspect the rendered image. Confirm that it identifies the correct route,
   shows the expected data or fallback state, and has no blank or clipped
   content.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -309,9 +309,10 @@ For a change to dynamic route metadata or an Open Graph image route, verify the
 final deployed origin in the browser. Do not use a local render as production
 proof.
 
-- Read the exact Open Graph and Twitter title, description, and image values
-  from the raw initial HTML response of an isolated, cookie-free request.
-  Confirm that each value matches the route and its public-data policy.
+- Read the exact Open Graph title, description, and image values and the exact
+  Twitter card type, title, description, and image values from the raw initial
+  HTML response of an isolated, cookie-free request. Confirm that each value
+  matches the route and its public-data policy.
 - Compare those values with the live DOM when client-side hydration is
   relevant. The hydrated DOM alone does not prove what a crawler receives.
 - Fetch the exact image URL from the deployed document with the browser cache

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -302,3 +302,20 @@ A local path, broken Markdown, or an unverified upload is not visual evidence.
 If either revision cannot be rendered, or the authenticated attachment surface
 is unavailable, stop before publication and report the blocker; do not call the
 UI PR shipped or ready. The user may waive visual evidence for a specific PR.
+
+## Dynamic social-preview verification
+
+For a change to dynamic route metadata or an Open Graph image route, verify the
+final deployed origin in the browser. Do not use a local render as production
+proof.
+
+- Read the exact `og:title`, `og:description`, `og:image`, and Twitter image
+  values from the deployed document. Confirm that each value matches the route
+  and its public-data policy.
+- Fetch the exact image URL from the deployed document with the browser cache
+  disabled. Require HTTP 200, the expected image content type, and the declared
+  pixel dimensions.
+- Check browser console errors after the route and image load.
+- Use a URL that Slack has not expanded before when testing the unfurl. Slack
+  can retain the first unfurl for a shared URL, so an existing message does not
+  prove that the current metadata or image is live.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -309,13 +309,17 @@ For a change to dynamic route metadata or an Open Graph image route, verify the
 final deployed origin in the browser. Do not use a local render as production
 proof.
 
-- Read the exact `og:title`, `og:description`, `og:image`, and Twitter image
-  values from the deployed document. Confirm that each value matches the route
-  and its public-data policy.
+- Read the exact Open Graph and Twitter title, description, and image values
+  from the deployed document. Confirm that each value matches the route and its
+  public-data policy.
 - Fetch the exact image URL from the deployed document with the browser cache
   disabled. Require HTTP 200, the expected image content type, and the declared
   pixel dimensions.
+- Inspect the rendered image. Confirm that it identifies the correct route,
+  shows the expected data or fallback state, and has no blank or clipped
+  content.
 - Check browser console errors after the route and image load.
 - Use a URL that Slack has not expanded before when testing the unfurl. Slack
   can retain the first unfurl for a shared URL, so an existing message does not
-  prove that the current metadata or image is live.
+  prove that the current metadata or image is live. Inspect the new unfurl and
+  confirm that its content matches the rendered image.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -306,8 +306,9 @@ UI PR shipped or ready. The user may waive visual evidence for a specific PR.
 ## Dynamic social-preview verification
 
 For any direct or transitive change to dynamic metadata or an Open Graph image,
-verify the final deployed origin. This includes routes, renderers, data helpers,
-and shared fonts. Local and preview results are not production proof.
+verify every affected route and applicable state on the final deployed origin.
+Dependencies include renderers, data helpers, and shared fonts. Local and
+preview results are not production proof.
 
 - Send isolated, cookie-free requests with a normal browser user agent and each
   relevant crawler user agent, such as Slackbot or Twitterbot. Record the
@@ -315,9 +316,9 @@ and shared fonts. Local and preview results are not production proof.
   final HTTP 200.
 - In each raw initial HTML response, verify the exact document title and
   description; canonical URL; Open Graph type, URL, title, description, image,
-  and image alt; and Twitter card, title, description, image, and image alt.
-  Match the route and public-data contract. Record expected absence for an
-  optional canonical URL, Open Graph URL, or image-alt tag.
+  image alt, image width, image height, and image type; and Twitter card,
+  title, description, image, and image alt. Match the route and public-data
+  contract. Record expected absence for optional tags.
 - For public and private metadata states, test an explicit record in each state.
   Require the safe private fallback and no restricted label, tag, or source.
 - Verify document `Cache-Control` and `Age` against its freshness policy. For
@@ -327,9 +328,9 @@ and shared fonts. Local and preview results are not production proof.
   is not crawler proof.
 - Fetch the exact image URL cookie-free with browser caching disabled. For an
   access-controlled route, compare an authenticated fetch and reject any
-  credential dependence. Require HTTP 200, the expected type and dimensions,
-  and `Cache-Control` and `Age` that match policy. Browser cache controls do not
-  bypass a CDN cache.
+  credential dependence. Require HTTP 200. Match the response type and
+  dimensions with the declared image metadata. Require `Cache-Control` and
+  `Age` that match policy. Browser cache controls do not bypass a CDN cache.
 - Inspect the image for the correct route and data or fallback. Require no blank
   or clipped content. Check browser console errors after both loads.
 - Test a URL that Slack has not expanded. An old message is cached evidence.

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -309,10 +309,16 @@ For a change to dynamic route metadata or an Open Graph image route, verify the
 final deployed origin in the browser. Do not use a local render as production
 proof.
 
-- Read the exact Open Graph title, description, and image values and the exact
-  Twitter card type, title, description, and image values from the raw initial
-  HTML response of an isolated, cookie-free request. Confirm that each value
-  matches the route and its public-data policy.
+- Read the exact document title, description, and canonical URL; Open Graph
+  type, URL, title, description, and image values; and Twitter card type,
+  title, description, and image values from the raw initial HTML response of
+  an isolated, cookie-free request. Confirm that each value matches the route
+  and its public-data policy.
+- Inspect the deployed document's `Cache-Control` and `Age` headers. Confirm
+  that they match the route's declared freshness or revalidation policy. For
+  metadata that can become private, require a policy that prevents stale
+  public data from remaining in a shared cache, or perform an equivalent
+  public-to-private revocation check.
 - Compare those values with the live DOM when client-side hydration is
   relevant. The hydrated DOM alone does not prove what a crawler receives.
 - Fetch the exact image URL from the deployed document with the browser cache

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -305,47 +305,32 @@ UI PR shipped or ready. The user may waive visual evidence for a specific PR.
 
 ## Dynamic social-preview verification
 
-For a change that can affect dynamic route metadata or an Open Graph image,
-verify the final deployed origin in the browser. This includes changes to the
-metadata or image route and to a renderer, data helper, shared font, or other
-dependency used by that route. Do not use a local render as production proof.
+For any direct or transitive change to dynamic metadata or an Open Graph image,
+verify the final deployed origin. This includes routes, renderers, data helpers,
+and shared fonts. Local and preview results are not production proof.
 
-- Send isolated, cookie-free requests with an ordinary browser user agent and
-  each relevant crawler user agent, such as Slackbot or Twitterbot. Check the
-  original document status, redirect chain, and final URL before validating
-  metadata. Require the original status and redirect chain to match the route
-  contract, and require HTTP 200 from the expected final route.
-- Read the exact document title and description; canonical URL; Open Graph
-  type, URL, title, description, image, and image alt values; and Twitter card
-  type, title, description, image, and image alt values from each raw initial
-  HTML response. Confirm that every value the route declares matches its
-  contract and public-data policy. Record expected absence when the route
-  contract does not declare an optional canonical URL, Open Graph URL, or
-  image-alt tag.
-- When metadata has public and private states, verify an explicitly public
-  record and an explicitly private record. Confirm that the private state uses
-  the declared safe fallback and exposes no private label, tag, source, or
-  other restricted data.
-- Inspect the deployed document's `Cache-Control` and `Age` headers. Confirm
-  that they match the route's declared freshness or revalidation policy. For
-  metadata that can become private, require a policy that prevents stale
-  public data from remaining in a shared cache, or perform an equivalent
-  public-to-private revocation check.
-- Compare those values with the live DOM when client-side hydration is
-  relevant. The hydrated DOM alone does not prove what a crawler receives.
-- Fetch the exact image URL from the deployed document in the same isolated,
-  cookie-free context and with the browser cache disabled. Reject any
-  credential-dependent response difference; for an access-controlled route,
-  compare the anonymous response with an authenticated fetch. Require HTTP
-  200, the expected image content type, and the declared pixel dimensions.
-  Inspect `Cache-Control` and `Age`, and confirm that they match the route's
-  declared freshness or revalidation policy. Disabling the browser cache does
-  not bypass a CDN cache.
-- Inspect the rendered image. Confirm that it identifies the correct route,
-  shows the expected data or fallback state, and has no blank or clipped
-  content.
-- Check browser console errors after the route and image load.
-- Use a URL that Slack has not expanded before when testing the unfurl. Slack
-  can retain the first unfurl for a shared URL, so an existing message does not
-  prove that the current metadata or image is live. Inspect the new unfurl and
-  confirm that its content matches the rendered image.
+- Send isolated, cookie-free requests with a normal browser user agent and each
+  relevant crawler user agent, such as Slackbot or Twitterbot. Record the
+  initial status, redirects, and final URL. Require the route contract and a
+  final HTTP 200.
+- In each raw initial HTML response, verify the exact document title and
+  description; canonical URL; Open Graph type, URL, title, description, image,
+  and image alt; and Twitter card, title, description, image, and image alt.
+  Match the route and public-data contract. Record expected absence for an
+  optional canonical URL, Open Graph URL, or image-alt tag.
+- For public and private metadata states, test an explicit record in each state.
+  Require the safe private fallback and no restricted label, tag, or source.
+- Verify document `Cache-Control` and `Age` against its freshness policy. For
+  metadata that can become private, prevent stale shared caching or test
+  public-to-private revocation.
+- If hydration affects metadata, compare raw tags with the DOM. The DOM alone
+  is not crawler proof.
+- Fetch the exact image URL cookie-free with browser caching disabled. For an
+  access-controlled route, compare an authenticated fetch and reject any
+  credential dependence. Require HTTP 200, the expected type and dimensions,
+  and `Cache-Control` and `Age` that match policy. Browser cache controls do not
+  bypass a CDN cache.
+- Inspect the image for the correct route and data or fallback. Require no blank
+  or clipped content. Check browser console errors after both loads.
+- Test a URL that Slack has not expanded. An old message is cached evidence.
+  Require the new unfurl to match the inspected image.


### PR DESCRIPTION
## The Problem

- Dynamic social-preview changes had no canonical production verification procedure.
- An existing Slack message can retain an older unfurl after a new preview is deployed.
- Engineers could mistake cached or local evidence for the current production result.

## The Solution

The dashboard verification runbook now defines the production checks for dynamic route metadata and Open Graph images. The UI verification command and deployment runbook now route direct and transitive changes through the same production closeout. The checks cover crawler-specific cookie-free metadata, public and private states, document and image cache policy, redirects, image responses, image dimensions, console errors, and fresh Slack-unfurl evidence. This PR changes documentation only; it does not change dashboard behavior.

## Details

- Verify standard, canonical, Open Graph, Twitter, and image-alt metadata
  through isolated, cookie-free browser and crawler requests.
- Verify the document status, redirect chain, final URL, and expected absence
  of optional URL or image-alt tags.
- Verify both public and private metadata states when the route has both.
- Verify every affected route and state after a shared dependency changes.
- Verify the deployed document cache policy, including revocation behavior for
  metadata that can become private.
- Fetch the exact deployed image URL without credentials and inspect its
  response and CDN cache headers.
- Require HTTP 200, the expected content type, declared dimensions, and the
  expected freshness or revalidation policy.
- Match declared Open Graph image type and dimensions with the image response.
- Use a URL that Slack has not expanded before when checking the unfurl.
- Route `/verify-ui` and the post-merge Vercel closeout to this procedure when
  a direct or transitive change affects dynamic metadata or an Open Graph
  image.

## Validation

- `./tools/trunk fmt docs/notes/dashboard-verification.md .claude/commands/verify-ui.md docs/deployment.md`: passed. This proves the changed documents satisfy the targeted formatter; it does not validate every repository document.
- `pnpm docs:navigation-eval:test`: passed, 34 tests. This proves the canonical
  navigation fixtures and source budgets remain valid; it does not validate
  runtime social previews.
- `git diff --check`: passed. This proves the patch has no whitespace errors; it does not validate links or runtime behavior.
- Local mapped quality gate: skipped under the user's explicit one-time waiver after the shared coordinator failed closed before executing any mapped command because it found a malformed stale-obligation record. Exact-head CI is the validation authority.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the documentation-only limit.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision: not applicable; this PR records verification guidance only.
