### PR TITLE
fix(gate): recover interrupted drain records

### DIFF
--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -157,7 +157,10 @@ mapping is a Node engine reading a data table — see
 [Where the plan comes from](#where-the-plan-comes-from-adr-0069) below. For a
 routing-sensitive source, the shared classifier adds the offline
 `pnpm docs:navigation-eval -- --check-fixtures` check. It invokes no model or
-scheduled evaluation. Review the output, then run:
+scheduled evaluation. Every tracked Markdown change runs `pnpm docs:index
+--check` and `pnpm docs:navigation-eval:test`. The second command enforces the
+navigation source budgets that the Markdown-only CI job checks. Review the
+output, then run:
 
 ```bash
 pnpm agent:quality-gate --run

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -1976,8 +1976,9 @@ of them.
    otherwise a second condemnation of the same run could swap the entry between
    the read and the unlink, and the unlink would delete an obligation nobody
    had drained. A drainer killed while holding a claimed file leaves it in the
-   directory; the next run reads the token from the file's contents rather than
-   its name, so the suffix costs nothing.
+   directory. The next run reads a non-empty record's token from its contents.
+   For an empty legacy record, it removes every completed claim suffix from the
+   filename before it validates the token.
 
    The scan repeats until a pass finds nothing, because obligations are still
    being published while the drain runs: a waiter condemning some third run's

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3337,6 +3337,15 @@ record_condemned_run() {
 gate_condemned_record_token=""
 gate_condemned_record_lifecycle_contract=""
 
+gate_lock_token_from_claimed_obligation_path() {
+  local token_name
+  token_name="${1##*/}"
+  while [[ "$token_name" =~ ^(.+)\.draining\.[0-9]+$ ]]; do
+    token_name="${BASH_REMATCH[1]}"
+  done
+  printf '%s\n' "$token_name"
+}
+
 # New records bind the token to an explicit recovery lifecycle contract. A
 # command record carries the contract selected before work started. An
 # aggregate request record carries its non-signalling marker-empty contract.
@@ -3344,7 +3353,7 @@ gate_condemned_record_lifecycle_contract=""
 # verified host classifier, never from state-file presence.
 gate_read_condemned_record() {
   local path="$1"
-  local value byte_count expected_bytes version token lifecycle_contract extra
+  local value byte_count expected_bytes version obligation_identity lifecycle_contract extra
   gate_condemned_record_token=""
   gate_condemned_record_lifecycle_contract=""
   [[ -f "$path" && ! -L "$path" && -r "$path" ]] || return 2
@@ -3352,21 +3361,28 @@ gate_read_condemned_record() {
   byte_count="$(LC_ALL=C wc -c < "$path" 2>/dev/null | tr -d '[:space:]')" ||
     return 2
   [[ "$byte_count" =~ ^[0-9]+$ ]] || return 2
-  expected_bytes=$((${#value} + 1))
-  [[ "$byte_count" -eq "$expected_bytes" ]] || return 2
-  case "$value" in
-    agentqg-condemned-v2\|*)
-      IFS='|' read -r version token lifecycle_contract extra <<< "$value"
-      [[ "$version" == "agentqg-condemned-v2" && -z "$extra" ]] || return 2
-      ;;
-    *)
-      token="$value"
-      lifecycle_contract="$(gate_lifecycle_contract_for_host)" || return 2
-      ;;
-  esac
-  gate_lock_token_is_wellformed "$token" || return 2
+  if [[ "$byte_count" -eq 0 ]]; then
+    # A drainer can die after it renames an empty legacy obligation. Later
+    # drainers add more claim suffixes. Recover the token from that claim chain.
+    obligation_identity="$(gate_lock_token_from_claimed_obligation_path "$path")"
+    lifecycle_contract="$(gate_lifecycle_contract_for_host)" || return 2
+  else
+    expected_bytes=$((${#value} + 1))
+    [[ "$byte_count" -eq "$expected_bytes" ]] || return 2
+    case "$value" in
+      agentqg-condemned-v2\|*)
+        IFS='|' read -r version obligation_identity lifecycle_contract extra <<< "$value"
+        [[ "$version" == "agentqg-condemned-v2" && -z "$extra" ]] || return 2
+        ;;
+      *)
+        obligation_identity="$value"
+        lifecycle_contract="$(gate_lifecycle_contract_for_host)" || return 2
+        ;;
+    esac
+  fi
+  gate_lock_token_is_wellformed "$obligation_identity" || return 2
   gate_recovery_lifecycle_contract_is_supported "$lifecycle_contract" || return 2
-  gate_condemned_record_token="$token"
+  gate_condemned_record_token="$obligation_identity"
   gate_condemned_record_lifecycle_contract="$lifecycle_contract"
 }
 

--- a/scripts/agent-quality-gate.sh
+++ b/scripts/agent-quality-gate.sh
@@ -3441,7 +3441,8 @@ gate_drain_obligation_unreadable() {
 # same run publishes a fresh file rather than swapping the one in hand. The
 # claimed copy is removed only once its own processes are confirmed gone, and a
 # drainer killed part way leaves it in the directory for the next run, which
-# reads the token from the file's contents rather than its name.
+# reads a non-empty record's token from its contents. For an empty legacy
+# record, it removes every completed claim suffix from the filename first.
 #
 # The scan repeats until a pass finds nothing, because obligations are still
 # being published while this one drains — a waiter condemning a remnant of some

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -789,6 +789,7 @@ if ! TMPDIR="$unusable_gate_tmpdir" \
 fi
 assert_contains "Mode: dry-run"
 assert_contains "- pnpm docs:index --check (tracked documentation changed)"
+assert_contains "- pnpm docs:navigation-eval:test (tracked documentation can change navigation source budgets)"
 [[ -f "$unusable_gate_tmpdir" ]] ||
   fail "default coordinator dry run changed the unusable inherited TMPDIR path"
 assert_script_occurrences 1 "command -v sha256sum"
@@ -11898,6 +11899,7 @@ scripts/agent-quality-gate.sh \
   --base origin/test \
   > "$output_file"
 assert_contains "- docs"
+assert_contains "- pnpm docs:navigation-eval:test (tracked documentation can change navigation source budgets)"
 assert_contains "- ./tools/trunk check --ci docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci --all"
 
@@ -11905,6 +11907,7 @@ run_gate "docs/deployment.md"
 assert_contains "Detected surfaces:"
 assert_contains "- docs"
 assert_contains "- pnpm docs:index --check (tracked documentation changed)"
+assert_contains "- pnpm docs:navigation-eval:test (tracked documentation can change navigation source budgets)"
 assert_contains "- ./tools/trunk check --ci docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci --all"
 
@@ -24619,6 +24622,26 @@ NODE
     [[ -z "$(awk '/^enter/ { print $2; exit }' "$gate_race_log")" ]] ||
       fail "a run that could not read the ${race_unreadable_case} record executed a mapped command anyway"
   done
+  rm -rf "$gate_race_root/run.lock" "$gate_race_root/condemned.d"
+  rm -f "$gate_race_root"/captured.*
+
+  # An empty obligation can retain a claim suffix when its drainer dies after
+  # the rename. Later drainers add more suffixes. Recover the original token
+  # instead of treating the interrupted claim chain as a malformed token.
+  : > "$gate_race_log"
+  mkdir -p "$gate_race_root/condemned.d"
+  race_interrupted_drain_identity="fixture-interrupted-drain-1-1"
+  race_interrupted_drain_record="${race_interrupted_drain_identity}.draining.66501.draining.77021.draining.58994"
+  gate_test_write_inert_darwin_lineage_state \
+    "$gate_race_root" "$race_interrupted_drain_identity" ||
+    fail "the interrupted empty obligation could not prepare inert Darwin lineage state"
+  : > "$gate_race_root/condemned.d/$race_interrupted_drain_record"
+  race_waiter "interrupted-empty-obligation" 0 0
+  grep -q "All mapped commands passed" \
+    "$gate_race_out/interrupted-empty-obligation.out" ||
+    fail "an empty obligation left by interrupted drainers must not wedge the next run"
+  [[ ! -e "$gate_race_root/condemned.d/$race_interrupted_drain_record" ]] ||
+    fail "the recovered interrupted obligation must be removed after draining"
   rm -rf "$gate_race_root/run.lock" "$gate_race_root/condemned.d"
   rm -f "$gate_race_root"/captured.*
 

--- a/scripts/gate/agent-quality-gate-scheduler-fixture.mjs
+++ b/scripts/gate/agent-quality-gate-scheduler-fixture.mjs
@@ -193,6 +193,7 @@ async function initializeRepository(repository) {
         scripts: {
           "agent:quality-gate": gateScript,
           "docs:index": "node tools/scheduler-capacity-probe.mjs",
+          "docs:navigation-eval:test": 'node -e "process.exit(0)"',
         },
       },
       null,

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -35,6 +35,11 @@ export const HEAD_GROUPS = [
             command: "pnpm docs:index --check",
             reason: "tracked documentation changed",
           },
+          {
+            command: "pnpm docs:navigation-eval:test",
+            reason:
+              "tracked documentation can change navigation source budgets",
+          },
         ],
       },
     ],


### PR DESCRIPTION
## The Problem

- A gate drainer could stop after it renamed an empty legacy obligation record.
- Each later recovery added another `.draining.<pid>` suffix, so the record name no longer matched the run-token grammar.
- Generic Markdown changes did not run the same navigation-source budget tests as the Markdown-only CI job.

## The Solution

The gate now removes every completed drain-claim suffix before it validates an empty legacy record. It still requires a valid run identity and the host lifecycle evidence. Generic Markdown changes now run `pnpm docs:navigation-eval:test` through the routing table. This PR does not relax malformed-record or Darwin lineage checks.

## Details

- Recover the original run identity from a repeated `.draining.<pid>` claim chain.
- Keep v2 condemned-record parsing and lifecycle-contract validation unchanged.
- Add a lock-drain regression for three interrupted claims. The macOS fixture includes inert exact lineage evidence.
- Route tracked Markdown changes to the navigation evaluation test and assert the mapping in dry-run and execution fixtures.
- Update the canonical gate mechanics note with the Markdown mapping.

## Validation

- `GATE_TEST_FOCUS=routing-docs /bin/bash scripts/agent-quality-gate.test.sh` passed. It proves the documentation routes asserted by that focused family; it does not prove unrelated gate families.
- `GATE_TEST_FOCUS=lock-drain /bin/bash scripts/agent-quality-gate.test.sh` passed outside the workspace seatbelt. It proves the legacy lock and interrupted-drain regression family on this macOS host; it does not prove other platforms.
- `pnpm gate:routing-table:test` passed. It proves the routing table contracts; it does not run mapped commands.
- `node --test scripts/gate/agent-quality-gate-scheduler.integration.test.mjs` passed the CI-failing three-worktree Markdown case after the fixture repair. The full focused file passed 22 of 23 tests; a later macOS coordinator-disabled case timed out on a live holder before it reached its expected refusal message. This proves the fixture now supplies the mapped navigation command; it does not establish the unrelated macOS recovery case.
- `/bin/bash -n scripts/agent-quality-gate.sh`, `/bin/bash -n scripts/agent-quality-gate.test.sh`, and `node --check scripts/gate/routing-table/groups-head.mjs` passed. They prove syntax only.
- Prepared-bundle autoreview returned `CLEAN`. Pre-review and post-review verification bound the review to manifest `473fa7db21a729d092679b6ea817316987587082fe7a43c04b01ccf9b845ac5b`. This is source review, not behavior evidence.
- The earlier full local mapped gate completed 11 of 12 commands. Its self-test timed out after 2,100 seconds, and a clean-main focused run reproduced the same detached-drain successor failure. After rebasing onto current `main`, the required sequential autoreview suite also failed only in unchanged Darwin containment paths. The user waived these local blockers for this session. Exact-head CI is the final full gate.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No. This restores the existing ADR 0069, ADR 0072, and ADR 0076 contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation changes now verify both the documentation index and navigation evaluation.
  * Navigation checks validate source limits before quality checks proceed.

* **Bug Fixes**
  * Improved recovery after interrupted processing, including incomplete or legacy records and chained recovery attempts.

* **Tests**
  * Added coverage for navigation reporting in dry-run and documentation-check scenarios.
  * Added coverage confirming interrupted processing can recover and complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->