### PR TITLE
fix(board): reject ignored sync issue scope

### DIFF
--- a/.agents/skills/doc-garden/SKILL.md
+++ b/.agents/skills/doc-garden/SKILL.md
@@ -38,9 +38,9 @@ list for review.
    repository-wide `issue:board sync` handoff). Run the backfill helper first
    with `--dry-run`.
    It fills empty ownership fields from a trusted claim comment and rejects
-   conflicting Project values. Preview the sync with `--dry-run`. If it
-   includes an unrelated issue, obtain explicit authority for the full
-   projection before you apply it. Do not
+   conflicting Project values. Preview the sync with `--dry-run`. Obtain
+   explicit authority for the repository-wide apply. The apply re-reads live
+   state, so a clean preview does not narrow its scope. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/.agents/skills/doc-garden/SKILL.md
+++ b/.agents/skills/doc-garden/SKILL.md
@@ -35,9 +35,12 @@ list for review.
    fallback in
    [`docs/notes/github-tooling-surfaces.md`](../../../docs/notes/github-tooling-surfaces.md)
    (label transition, claim comment, `issue:board backfill --issue <n>` and
-   `issue:board sync` handoff). Run the backfill helper first with `--dry-run`.
+   repository-wide `issue:board sync` handoff). Run the backfill helper first
+   with `--dry-run`.
    It fills empty ownership fields from a trusted claim comment and rejects
-   conflicting Project values. Do not
+   conflicting Project values. Preview the sync with `--dry-run`. If it
+   includes an unrelated issue, obtain explicit authority for the full
+   projection before you apply it. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/.claude/skills/doc-garden/SKILL.md
+++ b/.claude/skills/doc-garden/SKILL.md
@@ -38,9 +38,9 @@ list for review.
    repository-wide `issue:board sync` handoff). Run the backfill helper first
    with `--dry-run`.
    It fills empty ownership fields from a trusted claim comment and rejects
-   conflicting Project values. Preview the sync with `--dry-run`. If it
-   includes an unrelated issue, obtain explicit authority for the full
-   projection before you apply it. Do not
+   conflicting Project values. Preview the sync with `--dry-run`. Obtain
+   explicit authority for the repository-wide apply. The apply re-reads live
+   state, so a clean preview does not narrow its scope. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/.claude/skills/doc-garden/SKILL.md
+++ b/.claude/skills/doc-garden/SKILL.md
@@ -35,9 +35,12 @@ list for review.
    fallback in
    [`docs/notes/github-tooling-surfaces.md`](../../../docs/notes/github-tooling-surfaces.md)
    (label transition, claim comment, `issue:board backfill --issue <n>` and
-   `issue:board sync` handoff). Run the backfill helper first with `--dry-run`.
+   repository-wide `issue:board sync` handoff). Run the backfill helper first
+   with `--dry-run`.
    It fills empty ownership fields from a trusted claim comment and rejects
-   conflicting Project values. Do not
+   conflicting Project values. Preview the sync with `--dry-run`. If it
+   includes an unrelated issue, obtain explicit authority for the full
+   projection before you apply it. Do not
    overwrite a packet already labeled `needs-grooming`, `agent-active`, or
    `in-pr`; it remains the one live packet until resolved or closed.
 3. Reproduce the packet when needed:

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -69,10 +69,15 @@ Routing labels:
    `agent-active`, adds `in-pr`, and moves the Project item into review when
    the Project has an `In Review` status option. With the default GitHub status
    options, it falls back to `In Progress`.
-6. On merge, GitHub closes issues referenced with closing keywords. Run
-   `pnpm issue:board sync` after merge, or on a schedule, to move closed
-   queue-labeled Project #12 items to `Done` and clear all queue labels. The
-   helper also clears queue labels from closed issues that have no Project item.
+6. On merge, GitHub closes issues referenced with closing keywords. For an ad
+   hoc closeout, run `pnpm issue:board sync --dry-run` after merge. A scheduled
+   job can run the sync under its established authority. The command is
+   repository-wide. It scans every issue with a queue label and does not accept
+   issue-number scope. It moves closed queue-labeled Project #12 items to
+   `Done` and clears all queue labels. Inspect the ad hoc preview. If it includes
+   an issue outside the approved closeout, obtain explicit authority for the
+   full projection before you rerun the command without `--dry-run`. The helper
+   also clears queue labels from closed issues that have no Project item.
    It re-reads and reclassifies each issue before it changes the Project item or
    labels. After each open-state projection, it re-reads the issue and
    reprojects bounded concurrent state changes. After a Done transition, it
@@ -120,7 +125,7 @@ If a follow-up PR fully closes an issue that is already labeled `in-pr` from an
 earlier partial PR, `pnpm issue:review` will refuse because the issue is no
 longer `agent-active`. Do not churn labels just to satisfy the helper. Add a
 fresh issue comment linking the final PR, use a closing keyword in the PR body,
-and run `pnpm issue:board sync` after merge.
+and use the repository-wide sync preview and apply sequence above after merge.
 
 ## Workboard Commands
 
@@ -130,6 +135,7 @@ pnpm issue:claim --issue 901 --agent claude
 pnpm issue:review --pr 123 --issue 901
 pnpm issue:release --issue 901
 pnpm issue:release --issue 901 --needs-grooming
+pnpm issue:board sync --dry-run
 pnpm issue:board sync
 pnpm issue:board backfill --issue 901 --dry-run
 pnpm issue:board:test

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -74,10 +74,12 @@ Routing labels:
    job can run the sync under its established authority. The command is
    repository-wide. It scans every issue with a queue label and does not accept
    issue-number scope. It moves closed queue-labeled Project #12 items to
-   `Done` and clears all queue labels. Inspect the ad hoc preview. If it includes
-   an issue outside the approved closeout, obtain explicit authority for the
-   full projection before you rerun the command without `--dry-run`. The helper
-   also clears queue labels from closed issues that have no Project item.
+   `Done` and clears all queue labels. Inspect the ad hoc preview. Then obtain
+   explicit authority for a repository-wide mutation before you rerun the
+   command without `--dry-run`. The apply re-reads live state, so a clean
+   preview does not narrow its mutation scope. The authority must cover the
+   full projection, including unrelated items. The helper also clears queue
+   labels from closed issues that have no Project item.
    It re-reads and reclassifies each issue before it changes the Project item or
    labels. After each open-state projection, it re-reads the issue and
    reprojects bounded concurrent state changes. After a Done transition, it

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -183,9 +183,11 @@ partial MCP emulation plus an explicit gh-capable handoff:
    read and before the mutation. The helper does not roll back because a
    rollback could erase concurrent state. Run `pnpm issue:board sync --dry-run`
    separately to preview status reconciliation. This command is
-   repository-wide and does not accept issue-number scope. If the preview
-   includes an issue outside the approved closeout, obtain explicit authority
-   for the full projection before you rerun the command without `--dry-run`.
+   repository-wide and does not accept issue-number scope. Obtain explicit
+   authority for a repository-wide mutation before you rerun the command
+   without `--dry-run`. The apply re-reads live state, so a clean preview does
+   not narrow its mutation scope. The authority must cover the full projection,
+   including unrelated items.
 
 ## Known MCP gaps
 

--- a/docs/notes/github-tooling-surfaces.md
+++ b/docs/notes/github-tooling-surfaces.md
@@ -181,8 +181,11 @@ partial MCP emulation plus an explicit gh-capable handoff:
    snapshot, Project field types, and current values. GitHub provides no
    compare-and-swap operation. A concurrent write can still occur after that
    read and before the mutation. The helper does not roll back because a
-   rollback could erase concurrent state. Run `pnpm issue:board sync`
-   separately to reconcile status.
+   rollback could erase concurrent state. Run `pnpm issue:board sync --dry-run`
+   separately to preview status reconciliation. This command is
+   repository-wide and does not accept issue-number scope. If the preview
+   includes an issue outside the approved closeout, obtain explicit authority
+   for the full projection before you rerun the command without `--dry-run`.
 
 ## Known MCP gaps
 

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -428,7 +428,7 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    runtime behavior. Use `Refs #N` instead of `Closes #N` when proof can happen
    only after merge. Close the issue only after the live acceptance criteria
    pass. Then use the repository-wide `pnpm issue:board sync --dry-run` preview
-   and apply contract in
+   and authorized apply contract in
    [`agent-issue-workflow.md`](agent-issue-workflow.md).
 
 ## Non-negotiables

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -426,8 +426,10 @@ review` requests. **Never tag `chatgpt-codex-connector` directly** — it is
    run the owning package's production checks. Report merge, deployment, and
    live proof as separate facts; a successful workflow alone does not prove the
    runtime behavior. Use `Refs #N` instead of `Closes #N` when proof can happen
-   only after merge. Close the issue and run `pnpm issue:board sync` only after
-   the live acceptance criteria pass.
+   only after merge. Close the issue only after the live acceptance criteria
+   pass. Then use the repository-wide `pnpm issue:board sync --dry-run` preview
+   and apply contract in
+   [`agent-issue-workflow.md`](agent-issue-workflow.md).
 
 ## Non-negotiables
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -110,7 +110,7 @@ pnpm issue:claim --count 3 --agent codex       # Claim ready issues and move the
 pnpm issue:review --pr 123 --issue 901         # Move claimed issue to in-pr / review
 pnpm issue:release --issue 901                 # Release a mistaken claim back to agent-ready
 pnpm issue:board sync --dry-run                # Preview the repository-wide queue-label and Project projection
-pnpm issue:board sync                          # Apply the approved repository-wide projection
+pnpm issue:board sync                          # Apply an explicitly authorized repository-wide projection
 pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -109,7 +109,8 @@ pnpm integrations:probe:test   # Unit tests for probe adapters/parsers
 pnpm issue:claim --count 3 --agent codex       # Claim ready issues and move them to In Progress
 pnpm issue:review --pr 123 --issue 901         # Move claimed issue to in-pr / review
 pnpm issue:release --issue 901                 # Release a mistaken claim back to agent-ready
-pnpm issue:board sync                          # Re-project open labels, mark closed items Done, verify closed queue labels clear
+pnpm issue:board sync --dry-run                # Preview the repository-wide queue-label and Project projection
+pnpm issue:board sync                          # Apply the approved repository-wide projection
 pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -25,6 +25,7 @@ import {
   sync,
   validateOpenPr,
 } from "./agent-issue-board.mjs";
+import { usage } from "./issue-board-cli.mjs";
 import {
   readBackfillProjectFields,
   writeBackfillProjectFields,
@@ -272,6 +273,16 @@ test("parses claim options for the monitoring workboard", () => {
 });
 
 test("sync is repository-wide and rejects issue scope", () => {
+  const help = usage();
+  assert(
+    help.includes("pnpm issue:board sync --dry-run"),
+    "sync help must name the repository-wide preview",
+  );
+  assert(
+    help.includes("requires explicit repository-wide authority"),
+    "sync help must require repository-wide apply authority",
+  );
+
   const options = parseArgs(["sync", "--dry-run"]);
   assertEqual(options.command, "sync");
   assertEqual(options.dryRun, true);

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -271,6 +271,21 @@ test("parses claim options for the monitoring workboard", () => {
   assertEqual(args.dryRun, true);
 });
 
+test("sync is repository-wide and rejects issue scope", () => {
+  const options = parseArgs(["sync", "--dry-run"]);
+  assertEqual(options.command, "sync");
+  assertEqual(options.dryRun, true);
+  assertEqual(options.issues.length, 0);
+
+  for (const argv of [
+    ["sync", "--issue", "901"],
+    ["sync", "--issues", "901,902"],
+    ["sync", "901"],
+  ]) {
+    assertThrows(() => parseArgs(argv), /sync is repository-wide/);
+  }
+});
+
 test("backfill requires exactly one explicit issue", () => {
   const options = parseArgs(["board", "backfill", "--issue", "901"]);
   assertEqual(options.issues[0], 901);

--- a/scripts/pr/issue-board-cli.mjs
+++ b/scripts/pr/issue-board-cli.mjs
@@ -18,14 +18,14 @@ export function usage() {
   pnpm issue:claim --issue 901 --issue 902 [--agent claude]
   pnpm issue:review --pr 123 --issue 901 [--issue 902]
   pnpm issue:release --issue 901 [--needs-grooming]
-  pnpm issue:board sync [--dry-run]
+  pnpm issue:board sync [--dry-run] (repository-wide)
   pnpm issue:board backfill --issue 901 [--dry-run]
 
 Options:
   --repo <owner/name>              Repository to operate on (default: ${DEFAULT_REPO})
   --project-owner <owner>          Project owner (default: ${DEFAULT_PROJECT_OWNER})
   --project-number <number>        Project number (default: ${DEFAULT_PROJECT_NUMBER})
-  --issue, --issues <numbers>      Issue number(s), comma-separated or repeated
+  --issue, --issues <numbers>      Issue number(s), comma-separated or repeated; not valid for sync
   --count <number>                 Number of ready issues to claim (default: 1)
   --agent <name>                   Agent/session label for comments and project fields
   --branch <name>                  Branch/worktree hint for comments and project fields
@@ -200,6 +200,11 @@ export function parseArgs(argv, env = process.env) {
     options.pr = parsePr(options.prValue, options.repo);
   }
   delete options.prValue;
+  if (options.command === "sync" && options.issueValues.length > 0) {
+    throw new Error(
+      "sync is repository-wide and does not accept --issue, --issues, or positional issue arguments",
+    );
+  }
   options.issues = parseIssueNumbers(options.issueValues, options.repo);
   if (options.command === "backfill") {
     const explicitIssue = options.issueValues[0]?.trim();

--- a/scripts/pr/issue-board-cli.mjs
+++ b/scripts/pr/issue-board-cli.mjs
@@ -18,7 +18,8 @@ export function usage() {
   pnpm issue:claim --issue 901 --issue 902 [--agent claude]
   pnpm issue:review --pr 123 --issue 901 [--issue 902]
   pnpm issue:release --issue 901 [--needs-grooming]
-  pnpm issue:board sync [--dry-run] (repository-wide)
+  pnpm issue:board sync --dry-run       # preview repository-wide changes
+  pnpm issue:board sync                 # apply; requires explicit repository-wide authority
   pnpm issue:board backfill --issue 901 [--dry-run]
 
 Options:


### PR DESCRIPTION
## The Problem

- `pnpm issue:board sync` reconciles every queue-labeled issue in the repository, but the CLI accepted issue-scoped arguments and ignored them.
- An operator could believe that a sync targeted one issue while it changed unrelated queue labels and Project items.

## The Solution

- Reject `--issue`, `--issues`, and positional issue arguments for `sync` before any GitHub request.
- State the repository-wide scope and apply-authorization rule in the CLI help, command reference, operating runbooks, and mirrored skill entry points.
- Require an ad hoc `--dry-run` preview and explicit authority for every repository-wide apply. A clean preview does not narrow the live apply scope. This PR does not add scoped sync behavior.

## Details

- Keep the existing repository-wide reconciliation algorithm unchanged.
- Add parser coverage for the real `pnpm issue:board sync` argument shape.
- Keep the `.agents` and `.claude` `doc-garden` skill copies aligned.
- No architecture decision is required because the command's existing scope does not change.

## Validation

- `pnpm issue:board:test` — 81 tests passed. This proves the covered parser and workboard regression cases; it does not prove live GitHub permissions or mutation behavior.
- `./tools/trunk check <eight changed files>` — passed. This proves the changed files satisfy the configured static checks; it does not prove runtime behavior.
- `git diff --check` — passed. This proves the patch has no whitespace errors; it does not prove command behavior.
- `pnpm issue:board sync --issue 2006 --dry-run` — exited 1 with the repository-wide scope error before transport code ran. This proves the real CLI rejects that scoped call; it does not prove every invalid input shape.
- `pnpm agent:quality-gate --run` — skipped under the user's explicit one-time waiver. Current-head CI is the authoritative gate for publication.
- Prepared-bundle fresh-context review of `86b50fa3c6a8f87d517475d8e966c1f5a855e092` — no findings after two earlier review findings were fixed. Pre-review and post-review verification matched manifest `8df0f8d62ef760bb49296312fd1f8b744cee0467dd733ed1e82929c47cb03af0`. This proves source review of the complete bundle; it does not prove runtime behavior.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the material limit.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] No work is knowingly deferred from this PR.
- [x] Architecture decision is not applicable because the existing command scope does not change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI validation and operator documentation only; repository-wide sync behavior is unchanged and reduces mistaken partial-sync assumptions.
> 
> **Overview**
> **`pnpm issue:board sync` always reconciles every queue-labeled issue**, but the CLI used to accept issue-scoped flags and ignore them—operators could think a sync targeted one issue while unrelated Project items and labels changed.
> 
> This PR **rejects `--issue`, `--issues`, and positional issue numbers for `sync`** in `issue-board-cli.mjs` before any GitHub calls, and updates CLI help to separate **`sync --dry-run`** (preview) from apply (**requires explicit repository-wide authority**). The underlying sync algorithm is unchanged; scoped sync is not added.
> 
> **Runbooks and mirrored doc-garden skills** now describe the same contract: preview with `--dry-run`, obtain authority that covers the full projection (including unrelated items), and note that a clean preview does not narrow live apply scope because apply re-reads state. **`quick-commands.md`** documents the two sync invocations explicitly.
> 
> **Tests** assert help text and parser rejection for common scoped `sync` argv shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b50fa3c6a8f87d517475d8e966c1f5a855e092. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that issue-board synchronization applies repository-wide.
  * Added a required dry-run preview before authorized changes are applied.
  * Documented that applying changes re-reads live state and may affect items beyond the preview.
  * Updated workflow guidance and command examples, including handling closed issues without project items.

* **Bug Fixes**
  * Issue-specific arguments are now rejected for repository-wide synchronization.

* **Tests**
  * Added coverage for dry-run behavior, command help, and invalid sync arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->