### PR TITLE
fix(dashboard): reconcile batch redemptions

### DIFF
--- a/indexer-envio/test/liquityTroveLedger.test.ts
+++ b/indexer-envio/test/liquityTroveLedger.test.ts
@@ -919,7 +919,7 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
     assert.equal(trove?.lastLedgerLogIndex, 2);
   });
 
-  it("batched redemption rows take statusAfter and debtAfter from the replayed entity, not the stale staged classification", async () => {
+  it("reconciles a batch-managed redemption row with Trove cumulatives to the wei and uses replayed status/debt", async () => {
     let mockDb = MockDb.createMockDb();
     seedLoadedCollateral(mockDb);
     const troveId = 13n;
@@ -975,9 +975,15 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
     // Real per-trove redemption order on a batched trove
     // (`_applySingleRedemption`): BatchedTroveUpdated → TroveOperation(6)
     // → BatchUpdated → fee, then the aggregate Redemption after the loop.
-    // 950 of 1_000 debt is redeemed; the replayed share-derived debt (50)
-    // sits under minDebt (100), so the replay classifies the trove zombie
-    // while the staged row was classified from stale pre-replay debt.
+    // Use non-token-aligned values so the proof exercises exact wei, not
+    // rounded whole-token amounts. The replayed share-derived debt remains
+    // under minDebt (100), so the replay classifies the trove zombie while
+    // the staged row was classified from stale pre-replay debt.
+    const redeemedDebt = 950n * D18 + 17n;
+    const redeemedColl = 475n * D18 + 29n;
+    const feeCredited = 1n * D18 + 11n;
+    const debtAfter = 1_000n * D18 - redeemedDebt;
+    const collAfter = 500n * D18 - redeemedColl;
     const redeemTx = {
       blockNumber: 822,
       blockTimestamp: 710_000,
@@ -990,8 +996,8 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
           _troveId: troveId,
           _interestBatchManager: batchManager,
           _batchDebtShares: 1_000n * D18,
-          _coll: 25n * D18,
-          _stake: 25n * D18,
+          _coll: collAfter,
+          _stake: collAfter,
           _snapshotOfTotalCollRedist: 0n,
           _snapshotOfTotalDebtRedist: 0n,
           mockEventData: mockEventData({ ...redeemTx, logIndex: 1 }),
@@ -1000,15 +1006,15 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
           ...redeemTx,
           troveId,
           operation: OP.REDEEM_COLLATERAL,
-          debtChangeFromOperation: -950n * D18,
-          collChangeFromOperation: -475n * D18,
+          debtChangeFromOperation: -redeemedDebt,
+          collChangeFromOperation: -redeemedColl,
           logIndex: 2,
         }),
         LiquityTroveManager.BatchUpdated.createMockEvent({
           _interestBatchManager: batchManager,
           _operation: 0n,
-          _debt: 50n * D18,
-          _coll: 25n * D18,
+          _debt: debtAfter,
+          _coll: collAfter,
           _annualInterestRate: 6n * 10n ** 16n,
           _annualManagementFee: 0n,
           _totalDebtShares: 1_000n * D18,
@@ -1018,13 +1024,13 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
         redemptionFeeEvent({
           ...redeemTx,
           troveId,
-          fee: 1n * D18,
+          fee: feeCredited,
           logIndex: 4,
         }),
         redemptionEvent({
           ...redeemTx,
-          actualBoldAmount: 950n * D18,
-          ethFee: 1n * D18,
+          actualBoldAmount: redeemedDebt,
+          ethFee: feeCredited,
           redemptionPrice: 2_000n * D18,
           logIndex: 5,
         }),
@@ -1042,7 +1048,7 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
     );
     assert.equal(
       row.debtAfter,
-      50n * D18,
+      debtAfter,
       "debtAfter fills from the entity's replayed share-derived debt",
     );
     assert.equal(
@@ -1051,11 +1057,30 @@ describe("TroveLedgerEvent — append-only per-trove ledger", () => {
       "batched debtBefore stays null permanently",
     );
     assert.equal(row.collBefore, 500n * D18);
-    assert.equal(row.collAfter, 25n * D18);
+    assert.equal(row.collAfter, collAfter);
     assert.equal(row.redemptionPrice, 2_000n * D18);
-    assert.equal(row.redemptionFeeCredited, 1n * D18);
+    assert.equal(row.redemptionFeeCredited, feeCredited);
     const trove = mockDb.entities.Trove.get(makeTroveId(collateralId, "0xd"));
     assert.equal(trove?.status, "zombie");
+    assert.equal(trove?.redemptionCount, 1);
+    assert.equal(trove?.redeemedDebt, redeemedDebt);
+    assert.equal(trove?.redeemedColl, redeemedColl);
+    assert.equal(trove?.redemptionFeePaidCum, feeCredited);
+    assert.equal(
+      -row.debtChange,
+      trove?.redeemedDebt,
+      "ledger debt delta and Trove cumulative agree to the wei",
+    );
+    assert.equal(
+      -row.collChange,
+      trove?.redeemedColl,
+      "ledger collateral delta and Trove cumulative agree to the wei",
+    );
+    assert.equal(
+      row.redemptionFeeCredited,
+      trove?.redemptionFeePaidCum,
+      "ledger fee and Trove cumulative agree to the wei",
+    );
     assert.equal(trove?.lastLedgerBlock, 822n, "watermark stamps at finalize");
     assert.equal(trove?.lastLedgerLogIndex, 2);
   });

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-redemption-impact.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-redemption-impact.test.tsx
@@ -412,13 +412,20 @@ describe("TroveRedemptionImpact", () => {
     expect(ledger.refetch).not.toHaveBeenCalled();
   });
 
-  it("switches to the explicit batch notice when a debt snapshot is null", () => {
-    const ledger = ticketLedgerState({ debtSnapshotsComplete: false });
+  it("shows reconciled per-hit figures for batch-managed rows with complete event fields", () => {
+    const rows = ticketRows().map((row) =>
+      row.operation === 6 ? { ...row, debtBefore: null } : row,
+    );
+    const ledger = ticketLedgerState({
+      rows,
+      debtSnapshotsComplete: false,
+    });
     render({ ledger });
 
     const body = text();
-    expect(body).toContain("Batch data unavailable");
-    expect(body).not.toContain("Net equity");
+    expect(body).toContain("Net equity at oracle prices");
+    expect(body).toContain("all rebalancing");
+    expect(body).not.toContain("Batch data unavailable");
     expect(ledger.refetch).not.toHaveBeenCalled();
   });
 

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-redemption-impact.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-redemption-impact.tsx
@@ -230,16 +230,15 @@ function impactDescription(model: TroveRedemptionImpactModel): string {
     case "incomplete":
       return `${base} A redemption row carries no fee record, so per-hit figures cannot be verified.`;
     case "truncated":
-    case "batch":
-      // These carry their own role="status" notice below.
+      // This carries its own role="status" notice below.
       return base;
   }
 }
 
 /** The suppression states that need a live status region, not just muted
- *  prose: they can persist (truncation, batch rows) or demand attention (a
- *  reconciliation mismatch that survived its one refetch — a bug surface,
- *  per the plan's invariant, not a rendering choice). */
+ *  prose: truncation can persist, while a reconciliation mismatch that
+ *  survived its one refetch demands attention as a bug surface, per the
+ *  plan's invariant. */
 function ImpactNotice({ model }: { model: TroveRedemptionImpactModel }) {
   if (model.kind === "mismatch") {
     return (
@@ -257,14 +256,6 @@ function ImpactNotice({ model }: { model: TroveRedemptionImpactModel }) {
       <p role="status" className="mt-3 text-xs text-amber-400">
         Earliest ledger history truncated — per-hit figures are off for an
         incomplete history.
-      </p>
-    );
-  }
-  if (model.reason === "batch") {
-    return (
-      <p role="status" className="mt-3 text-xs text-amber-400">
-        Batch data unavailable — batch-managed rows carry no per-trove debt
-        snapshots, so the reconciliation and per-hit figures are off.
       </p>
     );
   }

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/impact.test.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/impact.test.ts
@@ -99,7 +99,6 @@ function classifyArgs(
     supported: true,
     hasLoadedOnce: true,
     truncated: false,
-    debtSnapshotsComplete: true,
     rows: [hit()],
     watermark,
     cumulatives: watermark,
@@ -267,12 +266,11 @@ describe("classifyTroveRedemptionImpact", () => {
     ).toEqual({ kind: "totals", reason: "truncated" });
   });
 
-  it("switches to the batch notice when any row's debt snapshot is null", () => {
-    expect(
-      classifyTroveRedemptionImpact(
-        classifyArgs({ debtSnapshotsComplete: false }),
-      ),
-    ).toEqual({ kind: "totals", reason: "batch" });
+  it("reconciles a batch-managed redemption row with a null debt snapshot", () => {
+    const result = classifyTroveRedemptionImpact(
+      classifyArgs({ rows: [hit({ debtBefore: null })] }),
+    );
+    expect(result.kind).toBe("reconciled");
   });
 
   it("skips the check — no mismatch claim — when the watermark does not equal the newest row's pair", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/impact.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/impact.ts
@@ -174,8 +174,6 @@ function isZeroCumulatives(cumulatives: TroveRedemptionCumulatives): boolean {
  *  - `pending`: gate open but the ledger has not loaded once.
  *  - `truncated`: capped history counts as partial for every derivation —
  *    a dropped early row would misattribute its deltas.
- *  - `batch`: a null batch debt snapshot switches reconciliation (and the
- *    interest residual) to the explicit batch notice.
  *  - `incomplete`: an op-6 row carries no fee record, so the fee
  *    reconciliation cannot run — passing it with a coerced 0 could confirm
  *    a figure no writer recorded.
@@ -186,7 +184,6 @@ export type TroveRedemptionTotalsReason =
   | "partial"
   | "pending"
   | "truncated"
-  | "batch"
   | "incomplete"
   | "unverified";
 
@@ -204,12 +201,15 @@ export type TroveRedemptionImpactStatus =
  *  check is skipped, except the vacuous case: a `(0, 0)` watermark says "no
  *  ledger row was ever written", and all-zero cumulatives agree with zero
  *  rows exactly, so a fresh trove verifies trivially instead of sitting in
- *  "unverified" forever. */
+ *  "unverified" forever. Debt snapshot completeness is intentionally not a
+ *  gate here: the equality check consumes only event-carried op-6 deltas and
+ *  fees. The user/rebalance split and oracle valuation consume their own
+ *  event-carried fields and degrade independently. The debt chart and
+ *  interest residual keep their separate snapshot gates. */
 export function classifyTroveRedemptionImpact(ledger: {
   supported: boolean;
   hasLoadedOnce: boolean;
   truncated: boolean;
-  debtSnapshotsComplete: boolean;
   rows: readonly CdpTroveLedgerEventRow[];
   watermark: TroveLedgerWatermark | null;
   cumulatives: TroveRedemptionCumulatives | null;
@@ -217,7 +217,6 @@ export function classifyTroveRedemptionImpact(ledger: {
   if (!ledger.supported) return { kind: "totals", reason: "partial" };
   if (!ledger.hasLoadedOnce) return { kind: "totals", reason: "pending" };
   if (ledger.truncated) return { kind: "totals", reason: "truncated" };
-  if (!ledger.debtSnapshotsComplete) return { kind: "totals", reason: "batch" };
   const cumulatives = ledger.cumulatives;
   if (cumulatives == null) return { kind: "totals", reason: "unverified" };
   if (ledger.rows.length === 0) {


### PR DESCRIPTION
## The Problem

- Batch-managed troves have null per-row debt snapshots. The impact classifier used that fact to suppress every per-redemption figure.
- Redemption reconciliation does not read those snapshots. It reads event-carried operation-6 debt, collateral, fee, rebalance, and price fields.
- Production has no interest batches. The indexer writers needed replay proof before the dashboard could trust batch redemption totals.

## The Solution

The dashboard now reconciles batch-managed redemption rows when the reconciliation's own fields are complete. It shows the user-versus-rebalance split and oracle-price impact for those rows.

A hermetic indexer replay follows the real batch redemption handler order. It proves that ledger deltas and `Trove` cumulatives agree to the wei for debt, collateral, and fees.

This change does not infer missing debt snapshots. The debt chart and interest residual keep their existing snapshot gates. Truncation, incomplete fee data, mismatched watermarks, and reconciliation mismatches still suppress per-hit figures.

## Visual verification

Route: `/cdps/chfm/troves/0x754` at 1280 x 720, public and logged out. The base and candidate used the same deterministic production fixture plus batch overlay.

| Base | Candidate |
| --- | --- |
| Three batch notices and no redemption reconciliation | Two snapshot-dependent batch notices, `all rebalancing`, and `+17.50 USDm` net equity |

The candidate still hid the interest estimate. The browser run reported no application console error.

## Details

- Review target: base `ceb73a7305cd5f864a461fbda6d0a6e5c51fe7ec`; candidate `774372b504349395798aa87ff4f0e4bbae48bdaa`.
- Replay `BatchedTroveUpdated -> TroveOperation(6) -> BatchUpdated -> redemption fee -> aggregate Redemption`.
- Use non-token-aligned values to test exact wei accounting.
- Verify that the ledger row keeps `debtBefore` null while its event-carried fields remain usable.
- Verify ledger debt, collateral, and fee values against `Trove.redeemedDebt`, `Trove.redeemedColl`, and `Trove.redemptionFeePaidCum`.
- Remove `debtSnapshotsComplete` from `classifyTroveRedemptionImpact`.
- Remove the impact panel's obsolete batch-only totals reason and notice.
- Keep the batch notices for debt history and interest derivations that still require complete snapshots.

Risk: the classifier now trusts complete batch rows for per-hit figures. Complete-history, watermark, fee-completeness, and exact cumulative-equality gates constrain that risk. Debt charts and interest estimates remain unavailable when debt snapshots are incomplete.

## Validation

- `pnpm --filter @mento-protocol/indexer-envio exec vitest run test/liquityTroveLedger.test.ts` passed 10 tests. The replay proves exact agreement for the modeled batch-managed redemption path. It does not prove a future contract event variant or a live production batch.
- The focused dashboard impact tests passed 35 tests. They prove classifier and panel behavior for the covered states. They do not replace route-level browser verification.
- `pnpm dashboard:react-doctor` scored 100/100, and `pnpm dashboard:react-doctor:diff` passed. These static checks do not prove the rendered batch state.
- Chrome/CDP browser verification proved one schema query, one ledger query, five redemption rows, reconciliation output, two remaining snapshot-dependent notices, and no interest estimate. This deterministic fixture does not prove live-chain batch data.
- `git diff --check` passed at the rebased head. The binary source patch remained unchanged across the final rebase with hash `ba03d553bf53d68e02476d6072d7b53153364dc2fbf45e738467d9ebd5c4ebcb`.
- Autoreview preparation, manifest verification, fresh-context review, and bound post-review verification passed at the exact head with manifest `95902581b5593594ef7af1f17d144c749d442d0ab20d6088a752653386da2209`. The review found no issue with the five changed files. It does not replace runtime tests or human merge approval.
- Local full `agent-quality-gate` was explicitly waived by the operator for this session; GitHub CI is the required full gate. This records the waiver and does not claim a local full-gate result.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, benefit, and material limit.
- [x] The stateful-data UI checklist applies. The change suppresses incomplete derivations instead of approximating them.
- [x] React Doctor remains at 100/100.
- [x] Browser verification covers the UI-visible state.
- [x] No new architecture decision is required. This change applies the existing trove-history design.
- [x] No known work is deferred.

Closes #2116.
Refs #2088, #2089.

Originating review: [PR #2115 batch-redemption thread](https://github.com/mento-protocol/monitoring-monorepo/pull/2115#discussion_r3880103467).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The classifier now surfaces reconciled per-hit figures for batch rows when event fields align with cumulatives; incorrect indexer deltas would show as user-visible totals until mismatch detection fires.
> 
> **Overview**
> **Batch-managed redemption rows with null `debtBefore` no longer force the redemption impact panel into a blanket “batch data unavailable” state.** Reconciliation now runs on op-6 event deltas, fees, and watermark alignment only, so per-hit user/rebalance split and oracle net equity can show when those fields are complete.
> 
> The impact classifier drops the `batch` totals reason and the `debtSnapshotsComplete` input; the panel removes the amber batch notice tied to that path. Truncation, incomplete fees, watermark skew, and mismatch handling are unchanged. Debt charts and interest views still use their own snapshot gates elsewhere.
> 
> The indexer ledger test tightens the batch redemption replay with **non–whole-token wei amounts** and asserts **ledger row deltas match `Trove` redemption cumulatives** (debt, collateral, fees) while keeping replayed `statusAfter`/`debtAfter` and permanently null `debtBefore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774372b504349395798aa87ff4f0e4bbae48bdaa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redemption impact details now remain available when some debt snapshots are missing.
  * Batch-managed redemption rows display reconciled per-event figures, including net equity and rebalancing values.
  * Redemption totals no longer show an unnecessary “Batch data unavailable” notice.
  * Redemption reconciliation now accurately reflects debt, collateral, redeemed amounts, counts, and fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->