### PR TITLE
fix(dashboard): preserve ICR points and live ranges

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
@@ -206,7 +206,11 @@ describe("TroveBalanceChart", () => {
     render(handle!, chartProps());
 
     expect(handle!.container.querySelector('[data-testid="plot"]')).toBeNull();
-    expect(handle!.container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(
+      handle!.container.querySelector(
+        '[role="status"][aria-label="Loading trove chart"]',
+      ),
+    ).not.toBeNull();
 
     nowSecondsOverride.value = NOW;
     render(handle!, chartProps());

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
@@ -13,6 +13,9 @@ import type { CdpTroveLedgerEventRow } from "../../_lib/ledger";
 // Captures every Plot render's props (data/layout/config) so assertions run
 // against what Plotly would actually receive — the real chunk never loads.
 const plotCaptures = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const nowSecondsOverride = vi.hoisted(
+  () => ({ value: undefined }) as { value: number | null | undefined },
+);
 
 vi.mock("next/dynamic", () => ({
   default: () =>
@@ -21,6 +24,20 @@ vi.mock("next/dynamic", () => ({
       return <div data-testid="plot" />;
     },
 }));
+
+vi.mock("@/hooks/use-now-seconds", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/use-now-seconds")>();
+  return {
+    ...actual,
+    useNowSeconds: () => {
+      const liveNowSeconds = actual.useNowSeconds();
+      return nowSecondsOverride.value === undefined
+        ? liveNowSeconds
+        : nowSecondsOverride.value;
+    },
+  };
+});
 
 import { TroveBalanceChart } from "../trove-balance-chart";
 
@@ -139,6 +156,7 @@ describe("TroveBalanceChart", () => {
     vi.setSystemTime(new Date(NOW * 1000));
     vi.stubGlobal("IntersectionObserver", undefined);
     plotCaptures.length = 0;
+    nowSecondsOverride.value = undefined;
     handle = setup();
   });
 
@@ -181,6 +199,22 @@ describe("TroveBalanceChart", () => {
     expect(coll!.x).toHaveLength(3);
     expect(coll!.x[2]).toBe(new Date(NOW * 1000).toISOString());
     expect(coll!.y).toEqual([40_000, 15_000, 15_000]);
+  });
+
+  it("keeps the chart neutral until the shared client clock resolves", () => {
+    nowSecondsOverride.value = null;
+    render(handle!, chartProps());
+
+    expect(handle!.container.querySelector('[data-testid="plot"]')).toBeNull();
+    expect(handle!.container.querySelector(".animate-pulse")).not.toBeNull();
+
+    nowSecondsOverride.value = NOW;
+    render(handle!, chartProps());
+
+    expect(
+      handle!.container.querySelector('[data-testid="plot"]'),
+    ).not.toBeNull();
+    expect(traces()[0]!.x.at(-1)).toBe(new Date(NOW * 1000).toISOString());
   });
 
   it("defaults to All and re-windows with the pre-window step anchor when a range pill is pressed", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
@@ -288,9 +288,43 @@ describe("TroveBalanceChart", () => {
     // between events while the oracle price moved.
     expect(icr!.mode).toBe("markers");
     expect(icr!.line).toBeUndefined();
+    expect(layout().hovermode).toBe("x");
     expect(handle!.container.textContent).not.toContain(
       "ICR panel unavailable",
     );
+  });
+
+  it("uses closest hover so same-second ICR markers expose their own values", () => {
+    const observedAt = NOW - DAY;
+    render(
+      handle!,
+      chartProps({
+        rows: [
+          ledgerRow({
+            id: "42220_200_10",
+            timestamp: String(observedAt),
+            blockNumber: "200",
+            logIndex: 10,
+            priceAtEvent: wei(2),
+            icrAfterBps: 17_000,
+          }),
+          ledgerRow({
+            id: "42220_200_9",
+            timestamp: String(observedAt),
+            blockNumber: "200",
+            logIndex: 9,
+            priceAtEvent: wei(1),
+            icrAfterBps: 13_000,
+          }),
+        ],
+      }),
+    );
+
+    const icr = traces().find((trace) => trace.yaxis === "y3");
+    const observedAtIso = new Date(observedAt * 1000).toISOString();
+    expect(icr!.x).toEqual([observedAtIso, observedAtIso]);
+    expect(icr!.y).toEqual([130, 170]);
+    expect(layout().hovermode).toBe("closest");
   });
 
   it("drops the ICR panel and says so when no row carries price data", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-balance-chart.test.tsx
@@ -217,6 +217,44 @@ describe("TroveBalanceChart", () => {
     expect(coll!.y).toEqual([40_000, 15_000, 15_000]);
   });
 
+  it("moves the active range cutoff when the shared clock advances", () => {
+    render(
+      handle!,
+      chartProps({
+        rows: [
+          ledgerRow({
+            id: "42220_100_1",
+            timestamp: String(NOW - 2 * DAY),
+            collAfter: wei(40_000),
+          }),
+          ledgerRow({
+            id: "42220_200_1",
+            timestamp: String(NOW - DAY + 15),
+            blockNumber: "200",
+            collAfter: wei(15_000),
+          }),
+        ],
+      }),
+    );
+
+    const oneDay = handle!.container.querySelector<HTMLButtonElement>(
+      '[role="group"][aria-label="Trove chart time range"] button',
+    );
+    act(() =>
+      oneDay!.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    expect(traces()[0]!.x[0]).toBe(new Date((NOW - DAY) * 1000).toISOString());
+
+    act(() => vi.advanceTimersByTime(30_000));
+
+    expect(traces()[0]!.x[0]).toBe(
+      new Date((NOW + 30 - DAY) * 1000).toISOString(),
+    );
+    expect(traces()[0]!.x.at(-1)).toBe(
+      new Date((NOW + 30) * 1000).toISOString(),
+    );
+  });
+
   it("adds the ICR percentage panel only when price data exists — its own axis, never shared", () => {
     render(
       handle!,

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
@@ -369,7 +369,7 @@ function TroveChartBody({
   error: Error | undefined;
   hasLoadedOnce: boolean;
   shouldMountPlot: boolean;
-  model: TroveChartModel;
+  model: TroveChartModel | null;
   chartAriaLabel: string;
   chartSummary: string;
 }) {
@@ -422,7 +422,7 @@ function TroveChartBody({
       </p>
     );
   }
-  if (!shouldMountPlot) {
+  if (!shouldMountPlot || model == null) {
     return <ChartShimmer />;
   }
   return (
@@ -550,14 +550,17 @@ export function TroveBalanceChart({
   );
   const nowSeconds = useNowSeconds();
   const model = useMemo(
-    () => buildTroveChartModel(series, range, debtSymbol, nowSeconds ?? 0),
+    () =>
+      nowSeconds === null
+        ? null
+        : buildTroveChartModel(series, range, debtSymbol, nowSeconds),
     [series, range, debtSymbol, nowSeconds],
   );
   const shouldRenderPlot = rows.length > 0 && !truncated && anchored;
   const shouldMountPlot = useDeferredMount(
     "visible",
     containerRef,
-    shouldRenderPlot,
+    shouldRenderPlot && model != null,
   );
 
   const activeRangeLabel =

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
@@ -422,8 +422,11 @@ function TroveChartBody({
       </p>
     );
   }
-  if (!shouldMountPlot || model == null) {
+  if (!shouldMountPlot) {
     return <ChartShimmer />;
+  }
+  if (model == null) {
+    return <ChartShimmer announce />;
   }
   return (
     <Plot
@@ -560,7 +563,7 @@ export function TroveBalanceChart({
   const shouldMountPlot = useDeferredMount(
     "visible",
     containerRef,
-    shouldRenderPlot && model != null,
+    shouldRenderPlot,
   );
 
   const activeRangeLabel =

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { useMemo, useRef, useState } from "react";
 import { StaleRefreshNotice } from "@/components/feedback";
 import { useDeferredMount } from "@/components/use-deferred-mount";
+import { useNowSeconds } from "@/hooks/use-now-seconds";
 import {
   escapePlotText,
   PLOTLY_AXIS_DEFAULTS,
@@ -538,15 +539,10 @@ export function TroveBalanceChart({
     () => buildTroveChartSeries(rows, { debtSnapshotsComplete }),
     [rows, debtSnapshotsComplete],
   );
+  const nowSeconds = useNowSeconds();
   const model = useMemo(
-    () =>
-      buildTroveChartModel(
-        series,
-        range,
-        debtSymbol,
-        Math.floor(Date.now() / 1000),
-      ),
-    [series, range, debtSymbol],
+    () => buildTroveChartModel(series, range, debtSymbol, nowSeconds ?? 0),
+    [series, range, debtSymbol, nowSeconds],
   );
   const shouldRenderPlot = rows.length > 0 && !truncated && anchored;
   const shouldMountPlot = useDeferredMount(

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-balance-chart.tsx
@@ -169,6 +169,7 @@ function buildLayout(options: {
   debtSymbol: string;
   tickformat: string;
   shapes: Plotly.Layout["shapes"];
+  hovermode: "x" | "closest";
 }): Partial<Plotly.Layout> {
   const domains = panelDomains(options.showIcr);
   const debtTitle = {
@@ -246,7 +247,10 @@ function buildLayout(options: {
     autosize: true,
     showlegend: false,
     dragmode: false,
-    hovermode: "x",
+    // Plotly's x-hover mode chooses one point per trace. Use 2D proximity
+    // when same-second ICR observations share an x-coordinate so each marker
+    // exposes its own value; keep the existing cross-panel x hover otherwise.
+    hovermode: options.hovermode,
     hoverlabel: {
       bgcolor: "#0f172a",
       bordercolor: "#6366f1",
@@ -281,6 +285,10 @@ function buildTroveChartModel(
   // with dots so a lone observation still shows.
   const icr = series.icr.filter(
     (point) => cutoff == null || point.timestamp >= cutoff,
+  );
+  const hasDuplicateIcrTimestamp = icr.some(
+    (point, index) =>
+      index > 0 && point.timestamp === icr[index - 1]?.timestamp,
   );
   const showIcr = series.icrCoverage !== "none";
   const hoverDate = "%{x|%b %d, %Y %H:%M}";
@@ -326,6 +334,7 @@ function buildTroveChartModel(
       // a years-old trove viewed at 7d would otherwise get month/year ticks.
       tickformat: range === "1d" ? "%H:%M" : dateTickFormatForSeries(coll),
       shapes: markerShapes(markersInWindow(series.markers, cutoff)),
+      hovermode: hasDuplicateIcrTimestamp ? "closest" : "x",
     }),
   };
 }

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/chart.test.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/chart.test.ts
@@ -109,7 +109,7 @@ describe("buildTroveChartSeries", () => {
     ]);
   });
 
-  it("collapses same-second rows to the LAST row's value on the log-index tiebreak", () => {
+  it("collapses same-second balance steps but keeps both ICR observations", () => {
     // Two ops in one block share a timestamp; log 10 is the later op and
     // its resulting state is the truth for that second — a string sort
     // ("_9" > "_10") would keep the wrong one.
@@ -121,6 +121,8 @@ describe("buildTroveChartSeries", () => {
         logIndex: 10,
         collAfter: wei(700),
         debtAfter: wei(70),
+        priceAtEvent: wei(2),
+        icrAfterBps: 17_000,
       }),
       ledgerRow({
         id: "42220_100_9",
@@ -129,11 +131,14 @@ describe("buildTroveChartSeries", () => {
         logIndex: 9,
         collAfter: wei(500),
         debtAfter: wei(50),
+        priceAtEvent: wei(1),
+        icrAfterBps: 13_000,
       }),
     ];
     const series = buildTroveChartSeries(rows, { debtSnapshotsComplete: true });
     expect(series.coll).toEqual([point(1000, 700)]);
     expect(series.debt).toEqual([point(1000, 70)]);
+    expect(series.icr).toEqual([point(1000, 130), point(1000, 170)]);
   });
 
   it("returns a null debt series when debt snapshots are incomplete — never a gapped or zero-coerced one", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/chart.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/chart.ts
@@ -151,12 +151,13 @@ export function buildTroveChartSeries(
   const icrRows = ascending.filter(
     (row) => row.icrAfterBps != null && row.icrAfterBps >= 0,
   );
-  const icr = collapseSameSecond(
-    icrRows.map((row) => ({
-      timestamp: Number(row.timestamp),
-      value: (row.icrAfterBps ?? 0) / 100,
-    })),
-  );
+  // ICR renders as independent observations, so same-second rows stay
+  // distinct even though they share an x-coordinate. Only balance steps
+  // collapse to the second's final state.
+  const icr = icrRows.map((row) => ({
+    timestamp: Number(row.timestamp),
+    value: (row.icrAfterBps ?? 0) / 100,
+  }));
   const icrCoverage =
     icrRows.length === 0
       ? ("none" as const)

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/chart.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/chart.ts
@@ -70,7 +70,8 @@ export type TroveChartSeries = {
    *  explicit "batch data unavailable" notice, never a gapped or
    *  zero-coerced series. */
   debt: TroveChartPoint[] | null;
-  /** Indexed ICR (percent) at events that carry price data; can be empty. */
+  /** Indexed ICR (percent) at events that carry price data; can be empty.
+   *  Same-second observations remain distinct marker points. */
   icr: TroveChartPoint[];
   /** Drives the ICR panel + its disclosure: `none` drops the panel and says
    *  so (historical-replay rows persist no price by design), `partial`


### PR DESCRIPTION
## The Problem

- The chart collapsed same-second collateral, debt, and ICR points. Balance steps need that behavior, but independent ICR markers lost earlier observations from the same block.
- The 1-day, 7-day, and 30-day windows read `Date.now()` only when data or controls changed. Their cutoff and extend-to-now endpoint stopped moving on a long-open page with an unchanged ledger.

## The Solution

Collapse same-second points only for collateral and debt step series. Keep every valid ICR observation. Subscribe the chart model to the shared 30-second live clock so relative windows remain current.

Duplicate-timestamp ICR markers use closest-point hover behavior. A user can inspect each marker independently.

Keep the chart in its neutral shimmer state until the client clock resolves. This avoids an epoch-zero model during hydration.

Announce that visible clock-wait shimmer as a polite loading status. Keep the viewport-deferred shimmer silent until the chart is near the viewport.

This PR changes chart display only. It does not change indexer data, ledger rows, ICR coverage rules, debt snapshot suppression, or reconciliation.

## Visual verification

Route: `/cdps/chfm/troves/0x754` at 1280 x 720, public and logged out. The deterministic fixture included two same-block price hits at the same timestamp.

- Plotly rendered both ICR observations at the same x-coordinate with values `75.0%` and `375.2%`.
- Hovering each marker produced one independent ICR label with the correct value.
- With the 1-day range selected, a virtual-time advance moved the model cutoff and endpoint by the same shared-clock increment without a ledger change.
- The checks found no application-specific runtime error.

## Details

- Review target: base `ceb73a7305cd5f864a461fbda6d0a6e5c51fe7ec`; candidate `184492201df78cd10bfc078bb9e2f3bb95640181`.
- Keep the existing sorted row copy and timestamp, block, and log ordering.
- Collapse only collateral and debt to the final step for each second.
- Map every valid ICR observation from the sorted rows.
- Use a same-block fixture with two different prices and ICR values.
- Pass `useNowSeconds()` to `buildTroveChartModel` and include it in memo dependencies.
- Defer model construction and Plotly mounting while `useNowSeconds()` is unresolved.
- Give the visible unresolved-clock shimmer `role="status"` and keep the offscreen deferred shimmer unannounced.
- Use `hovermode="closest"` only when the ICR series contains duplicate timestamps. Keep the normal x-axis hover mode otherwise.
- Keep the component under the accepted effective-line cap: 625 physical lines and 543 effective lines, below the 600-line limit. Tests are exempt.

Risk: the shared clock recomputes the chart model every 30 seconds. The fixed cadence bounds that cost. This PR does not claim sub-30-second window precision or change background-tab timer behavior.

## Validation

- The full dashboard suite passed 333 files and 5,110 tests at `faabf11d`. The focused chart suite then passed 19/19 tests at the exact head after the ARIA-only follow-up. The fixtures cover same-block ICR retention, duplicate-marker hover behavior, the moving cutoff, the unresolved-to-live clock transition, and the loading-status contract. GitHub CI is the required full gate for the exact head.
- `pnpm dashboard:react-doctor:diff` scored 100/100 at the exact head. This static check does not prove Plotly runtime behavior.
- Chrome/CDP browser verification on `faabf11d` captured the chart transition as `shimmer` with zero plots, then a single resolved Plotly chart. Its collateral and debt endpoints were `2026-08-29T21:12:56.000Z`, not epoch zero. The ARIA-only exact-head rerun loaded the figure and one Plot wrapper with no residual shimmer or loading status. The browser transport could not install a pre-document observer for the brief status transition, so the deterministic transition test supplies that branch proof. The only console error was the known development-only CSP `eval()` warning. Earlier browser proof for the unchanged ICR and live-range paths found nine ICR markers, two distinct same-x observations, independent hover labels, and matching cutoff/endpoint movement. These fixtures do not prove every browser or live indexer state.
- `git diff --check` and `./tools/trunk fmt` passed at the exact head.
- Autoreview preparation, manifest verification, a fresh read-only review, and bound post-review verification passed at the exact head with manifest `bf831ff8125dc302a53116c7bc917c802c066d703e47a9d59fcf55856ae2c18d` and no findings. This source review does not replace runtime tests or human merge approval.
- Local full `agent-quality-gate` was explicitly waived by the operator for this session; GitHub CI is the required full gate. This records the waiver and does not claim a local full-gate result.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, benefit, and material limit.
- [x] The stateful-data UI checklist applies. The model preserves observations instead of approximating them.
- [x] `sortedCopy` ordering remains in use.
- [x] React Doctor remains at 100/100.
- [x] Browser verification covers both UI-visible refinements.
- [x] The visible unresolved-clock loading state uses `role="status"`; the viewport-deferred placeholder remains silent.
- [x] No new architecture decision is required. This PR refines an existing chart model and shared clock dependency.
- [x] No known work is deferred.

Closes #2118.
Refs #2087, #2089.

Originating review: [PR #2115 same-second ICR thread](https://github.com/mento-protocol/monitoring-monorepo/pull/2115#discussion_r3880372694).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved all ICR observations occurring within the same second, allowing each value to be viewed individually.
  * Improved hover behavior for overlapping ICR markers by selecting the closest value.
  * Ensured chart ranges and “now” indicators update correctly as time advances.
  * Prevented charts from displaying time-based data until the current time is available.
* **Tests**
  * Added coverage for same-second ICR values, hover interactions, and live chart time updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->