### PR TITLE
fix(dashboard): disclose ledger probe states

### DIFF
--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-detail-client.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-detail-client.test.tsx
@@ -299,6 +299,7 @@ describe("TroveDetailClient", () => {
     troveError = null,
     operationRows = [op()],
     troveSchema = TROVE_SCHEMA_WITH_TX,
+    troveSchemaResolved = true,
     troveSchemaError = null,
     interestBatchRows,
     interestBatchError = null,
@@ -316,8 +317,11 @@ describe("TroveDetailClient", () => {
       | typeof TROVE_SCHEMA_WITH_TX
       | typeof TROVE_SCHEMA_WITHOUT_TX
       | typeof TROVE_SCHEMA_WITH_LEDGER;
-    /** When set, the probe reports never-succeeded + errored (`data`
-     *  undefined), the check-failed case — `troveSchema` is ignored. */
+    /** False leaves probe data undefined. Pair it with no error for the
+     *  unresolved state or an error for the never-succeeded failure. */
+    troveSchemaResolved?: boolean;
+    /** Independent of cached data: with resolved data this is stale;
+     *  without data it is a never-succeeded check failure. */
     troveSchemaError?: Error | null;
     /** `undefined` (default) simulates "never resolved" (loading, or a
      *  failure with nothing cached) — `data` stays `undefined`, matching
@@ -345,9 +349,11 @@ describe("TroveDetailClient", () => {
         return { data: markets, error: marketsError, isLoading: false };
       }
       if (query === CDP_TROVE_SCHEMA_FIELDS) {
-        return troveSchemaError != null
-          ? { data: undefined, error: troveSchemaError, isLoading: false }
-          : { data: troveSchema, error: null, isLoading: false };
+        return {
+          data: troveSchemaResolved ? troveSchema : undefined,
+          error: troveSchemaError,
+          isLoading: !troveSchemaResolved && troveSchemaError == null,
+        };
       }
       if (query === CDP_TROVE_BY_ID || query === CDP_TROVE_BY_ID_WITHOUT_TX) {
         return {
@@ -1004,14 +1010,53 @@ describe("TroveDetailClient", () => {
     expect(text).toContain("Per-redemption detail pending indexer rollout");
     // Checked-absent: the check-failed disclosure must NOT render.
     expect(text).not.toContain("availability check failed");
+    const statuses = Array.from(
+      handle!.container.querySelectorAll('[role="status"]'),
+    ).map((node) => node.textContent ?? "");
+    expect(
+      statuses.filter((status) => status.includes("pending indexer rollout")),
+    ).toHaveLength(2);
     expect(text).not.toContain("Trove ledger");
     expect(mockUseGQL.mock.calls.some(([q]) => q === CDP_TROVE_LEDGER)).toBe(
       false,
     );
   });
 
+  it("uses neutral status copy in both partial surfaces while the schema probe is unresolved", () => {
+    mockQueries({ troveSchemaResolved: false });
+    render(handle!);
+
+    const text = handle!.container.textContent ?? "";
+    expect(text).toContain("Trove operations");
+    expect(text).not.toContain("pending indexer rollout");
+    expect(text).not.toContain("availability check failed");
+    const statuses = Array.from(
+      handle!.container.querySelectorAll('[role="status"]'),
+    ).map((node) => node.textContent ?? "");
+    expect(
+      statuses.some((status) =>
+        status.includes(
+          "Checking complete-history availability — showing the interim view",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      statuses.some((status) =>
+        status.includes(
+          "Checking complete-history availability before per-hit detail",
+        ),
+      ),
+    ).toBe(true);
+    expect(mockUseGQL.mock.calls.some(([q]) => q === CDP_TROVE_LEDGER)).toBe(
+      false,
+    );
+  });
+
   it("discloses a failed schema probe instead of claiming a pending rollout", () => {
-    mockQueries({ troveSchemaError: new Error("probe timeout") });
+    mockQueries({
+      troveSchemaResolved: false,
+      troveSchemaError: new Error("probe timeout"),
+    });
     render(handle!);
 
     const text = handle!.container.textContent ?? "";
@@ -1023,6 +1068,35 @@ describe("TroveDetailClient", () => {
     // But the cause is named — the rollout wording alone would misattribute
     // a backend failure to a pending rollout.
     expect(text).toContain("complete-history availability check failed");
+    expect(text).not.toContain("pending indexer rollout");
+    const statuses = Array.from(
+      handle!.container.querySelectorAll('[role="status"]'),
+    ).map((node) => node.textContent ?? "");
+    expect(
+      statuses.filter((status) =>
+        status.includes("complete-history availability check failed"),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("discloses a failed refresh behind a cached absent answer without claiming a pending rollout", () => {
+    mockQueries({ troveSchemaError: new Error("probe refresh failed") });
+    render(handle!);
+
+    const text = handle!.container.textContent ?? "";
+    expect(text).toContain("Trove operations");
+    expect(text).not.toContain("pending indexer rollout");
+    const statuses = Array.from(
+      handle!.container.querySelectorAll('[role="status"]'),
+    ).map((node) => node.textContent ?? "");
+    expect(
+      statuses.filter((status) =>
+        status.includes("availability check could not refresh"),
+      ),
+    ).toHaveLength(2);
+    expect(mockUseGQL.mock.calls.some(([q]) => q === CDP_TROVE_LEDGER)).toBe(
+      false,
+    );
   });
 
   it("renders the complete ledger — and disables the interim query — once the gate opens", () => {
@@ -1066,6 +1140,31 @@ describe("TroveDetailClient", () => {
       troveEntityId: "gbpm-0x8abc",
       limit: 1000,
     });
+  });
+
+  it("keeps a cached supported gate open and discloses its failed availability refresh", () => {
+    mockQueries({
+      troveSchema: TROVE_SCHEMA_WITH_LEDGER,
+      troveSchemaError: new Error("probe refresh failed"),
+      ledgerRows: [ledgerEvent()],
+    });
+    render(handle!);
+
+    const text = handle!.container.textContent ?? "";
+    expect(text).toContain("Trove ledger");
+    expect(text).toContain("using the last confirmed available result");
+    expect(text).not.toContain("pending indexer rollout");
+    const statuses = Array.from(
+      handle!.container.querySelectorAll('[role="status"]'),
+    ).map((node) => node.textContent ?? "");
+    expect(
+      statuses.some((status) =>
+        status.includes("availability check could not refresh"),
+      ),
+    ).toBe(true);
+    expect(mockUseGQL.mock.calls.some(([q]) => q === CDP_TROVE_LEDGER)).toBe(
+      true,
+    );
   });
 
   it("upgrades from interim to full ledger when a probe poll finds the entity — a re-evaluation, not a latch", () => {

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-operations-list.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-operations-list.test.tsx
@@ -10,7 +10,16 @@ vi.mock("@/components/tx-hash-cell", () => ({
   TxHashCell: ({ txHash }: { txHash: string }) => <td>{txHash}</td>,
 }));
 
-import { TroveOperationsList } from "../trove-operations-list";
+import { TroveOperationsList as TroveOperationsListComponent } from "../trove-operations-list";
+
+function TroveOperationsList(
+  props: Omit<
+    React.ComponentProps<typeof TroveOperationsListComponent>,
+    "probeState"
+  >,
+) {
+  return <TroveOperationsListComponent {...props} probeState="checked" />;
+}
 
 const D18 = BigInt(10) ** BigInt(18);
 

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-redemption-impact.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/__tests__/trove-redemption-impact.test.tsx
@@ -105,7 +105,7 @@ function ledgerState(
 ): TroveLedgerState {
   return {
     supported: true,
-    probeFailed: false,
+    probeState: "checked",
     rows: [],
     truncated: false,
     complete: true,
@@ -386,6 +386,9 @@ describe("TroveRedemptionImpact", () => {
     const body = text();
     expect(body).toContain("Lifetime totals from the trove");
     expect(body).toContain("pending indexer rollout");
+    expect(
+      handle!.container.querySelector('[role="status"]')?.textContent,
+    ).toContain("pending indexer rollout");
     // Cumulative totals still answer half the ticket (from the header row).
     expect(body).toContain("-18,450.82 GBPm");
     expect(body).toContain("-25,163.91 USDm");

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-detail-client.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-detail-client.tsx
@@ -35,6 +35,7 @@ import {
   useTroveLedger,
   type TroveLedgerState,
 } from "../_lib/use-trove-ledger";
+import { troveLedgerSupportedProbeMessage } from "../_lib/trove-ledger-probe";
 import { useTroveQueue, type TroveQueueState } from "../_lib/use-trove-queue";
 import { TroveBalanceChart } from "./trove-balance-chart";
 import { TroveDetailSkeleton } from "./trove-detail-skeleton";
@@ -531,8 +532,16 @@ function TroveEventHistory({
   truncated: boolean;
 }) {
   if (ledger.supported) {
+    const availabilityMessage = troveLedgerSupportedProbeMessage(
+      ledger.probeState,
+    );
     return (
       <>
+        {availabilityMessage != null && (
+          <p role="status" className="text-xs text-amber-400">
+            {availabilityMessage}
+          </p>
+        )}
         <TroveBalanceChart
           rows={ledger.rows}
           truncated={ledger.truncated}
@@ -559,32 +568,22 @@ function TroveEventHistory({
       </>
     );
   }
+  const hasLifetimeTotals = hasTroveLifetimeTotals(trove);
   return (
-    <>
-      {ledger.probeFailed && (
-        // A never-succeeded, errored probe means "could not check the
-        // schema" — without this line the interim view's rollout wording
-        // would misattribute a backend failure to a pending rollout.
-        <p role="status" className="text-xs text-amber-400">
-          The complete-history availability check failed — showing the interim
-          view while it retries automatically. Per-redemption detail may exist
-          but cannot be confirmed right now.
-        </p>
-      )}
-      <TroveOperationsList
-        rows={operationRows}
-        truncated={truncated}
-        isLoading={operations.isLoading}
-        error={operations.error}
-        // `operations.data != null`, not `operationRows.length > 0`: the
-        // latter can't tell "never loaded" from "loaded, confirmed empty"
-        // (see the prop's doc comment on TroveOperationsList).
-        hasLoadedOnce={operations.data != null}
-        hasLifetimeTotals={hasTroveLifetimeTotals(trove)}
-        chainId={collateral.chainId}
-        debtSymbol={collateral.symbol}
-      />
-    </>
+    <TroveOperationsList
+      rows={operationRows}
+      truncated={truncated}
+      isLoading={operations.isLoading}
+      error={operations.error}
+      probeState={ledger.probeState}
+      // `operations.data != null`, not `operationRows.length > 0`: the
+      // latter can't tell "never loaded" from "loaded, confirmed empty"
+      // (see the prop's doc comment on TroveOperationsList).
+      hasLoadedOnce={operations.data != null}
+      hasLifetimeTotals={hasLifetimeTotals}
+      chainId={collateral.chainId}
+      debtSymbol={collateral.symbol}
+    />
   );
 }
 

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-operations-list.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-operations-list.tsx
@@ -15,6 +15,10 @@ import {
 import { formatSignedWei } from "../../../../_lib/format";
 import type { CdpTroveOperationEventRow } from "../../../../_lib/types";
 import { formatInterestRate } from "../_lib/format";
+import {
+  troveLedgerInterimProbeMessage,
+  type TroveLedgerProbeState,
+} from "../_lib/trove-ledger-probe";
 
 // Operation codes 3 (adjustInterestRate), 8 (setBatchManager), and 9
 // (removeFromBatch) — see CdpTroveOperationEventRow's `operation` doc —
@@ -132,6 +136,7 @@ export function TroveOperationsList({
   truncated,
   isLoading,
   error,
+  probeState,
   hasLoadedOnce = rows.length > 0,
   hasLifetimeTotals = false,
   chainId,
@@ -141,6 +146,8 @@ export function TroveOperationsList({
   truncated: boolean;
   isLoading: boolean;
   error: Error | undefined;
+  /** The schema-probe state that selects this interim view's disclosure. */
+  probeState: TroveLedgerProbeState;
   /** True once the fetch has resolved at least once (`data !== undefined`),
    *  captured by the caller BEFORE any `?? []` fallback collapses "never
    *  loaded" and "loaded, confirmed empty" to the same `rows.length === 0`.
@@ -162,16 +169,17 @@ export function TroveOperationsList({
   chainId: number;
   debtSymbol: string;
 }) {
+  const partialNotice = troveLedgerInterimProbeMessage(
+    probeState,
+    hasLifetimeTotals,
+  );
   return (
     <section>
       <h2 className="text-lg font-semibold text-white mb-1">
         Trove operations
       </h2>
       <p role="status" className="mb-3 text-xs text-amber-400">
-        Per-redemption detail pending indexer rollout — this list shows only
-        this trove&apos;s own borrow/repay/adjust operations. Redemptions and
-        liquidations that touched this trove are not yet attributable here
-        {hasLifetimeTotals ? "; see the redemption impact totals above." : "."}
+        {partialNotice}
       </p>
       {/* Mirrors the parent view's other three notices (markets/trove/batch
           rate): once the fetch has resolved at least once, a later poll

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-redemption-impact.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_components/trove-redemption-impact.tsx
@@ -6,6 +6,7 @@ import type { CdpTrove } from "../../../../_lib/types";
 import type { TroveRedemptionLedgerSums } from "../_lib/impact";
 import type { TroveRedemptionCumulatives } from "../_lib/ledger";
 import type { TroveLedgerState } from "../_lib/use-trove-ledger";
+import { troveLedgerImpactPartialMessage } from "../_lib/trove-ledger-probe";
 import {
   useTroveRedemptionImpact,
   type TroveRedemptionImpactModel,
@@ -211,7 +212,10 @@ function ReconciledFigures({
   );
 }
 
-function impactDescription(model: TroveRedemptionImpactModel): string {
+function impactDescription(
+  model: TroveRedemptionImpactModel,
+  ledger: TroveLedgerState,
+): string {
   if (model.kind === "reconciled") {
     return "Per-redemption ledger figures, reconciled to the trove's recorded cumulatives at the same indexed position.";
   }
@@ -222,7 +226,7 @@ function impactDescription(model: TroveRedemptionImpactModel): string {
       // Wording deliberately avoids naming the suppressed figures — the
       // interim view must never surface even the phrase "net equity" next
       // to a number.
-      return `${base} Per-hit detail — the user vs rebalance split and the oracle-price valuation — is pending indexer rollout.`;
+      return `${base} ${troveLedgerImpactPartialMessage(ledger.probeState)}`;
     case "pending":
       return `${base} Per-hit detail loads with the ledger below.`;
     case "unverified":
@@ -365,10 +369,16 @@ export function TroveRedemptionImpact({
   ledger: TroveLedgerState;
 }) {
   const model = useTroveRedemptionImpact(trove, ledger);
+  const partial = model.kind === "totals" && model.reason === "partial";
   return (
     <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-5">
       <h2 className="text-sm font-semibold text-white">Redemption impact</h2>
-      <p className="mt-1 text-xs text-slate-500">{impactDescription(model)}</p>
+      <p
+        role={partial ? "status" : undefined}
+        className="mt-1 text-xs text-slate-500"
+      >
+        {impactDescription(model, ledger)}
+      </p>
       {/* A failed poll leaves SWR's prior data on screen — say so here, not
           only far below in the ledger table, or the support summary reads
           as current while a recent redemption is missing. */}

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/use-trove-ledger.test.tsx
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/__tests__/use-trove-ledger.test.tsx
@@ -169,6 +169,7 @@ describe("useTroveLedger", () => {
     render(handle!);
 
     expect(latest!.supported).toBe(false);
+    expect(latest!.probeState).toBe("unresolved");
     expect(latest!.watermark).toBeNull();
     expect(
       mockUseGQL.mock.calls.some(([query]) => query === CDP_TROVE_LEDGER),
@@ -184,7 +185,7 @@ describe("useTroveLedger", () => {
     expect(latest!.supported).toBe(false);
     // Checked-absent, not check-failed: the interim rollout wording is
     // honest here.
-    expect(latest!.probeFailed).toBe(false);
+    expect(latest!.probeState).toBe("checked");
     expect(
       mockUseGQL.mock.calls.some(([query]) => query === CDP_TROVE_LEDGER),
     ).toBe(false);
@@ -198,15 +199,31 @@ describe("useTroveLedger", () => {
     render(handle!);
 
     expect(latest!.supported).toBe(false);
-    expect(latest!.probeFailed).toBe(true);
+    expect(latest!.probeState).toBe("check-failed");
   });
 
-  it("keeps probeFailed false when a probe refresh fails behind a stale success", () => {
-    mockQueries({ probeError: new Error("refresh failed") });
+  it("marks a cached answer stale after a refresh error and keeps that answer's gate direction", () => {
+    mockQueries({
+      probe: PROBE_WITHOUT_LEDGER,
+      probeError: new Error("refresh failed"),
+    });
+    render(handle!);
+
+    expect(latest!.supported).toBe(false);
+    expect(latest!.probeState).toBe("stale");
+    expect(
+      mockUseGQL.mock.calls.some(([query]) => query === CDP_TROVE_LEDGER),
+    ).toBe(false);
+
+    mockQueries({
+      probeError: new Error("refresh failed"),
+      ledger: ledgerData([ledgerRow()]),
+    });
     render(handle!);
 
     expect(latest!.supported).toBe(true);
-    expect(latest!.probeFailed).toBe(false);
+    expect(latest!.probeState).toBe("stale");
+    expect(latest!.rows).toHaveLength(1);
   });
 
   it("fires the gated query with the sentinel request limit and the Zod guard once supported", () => {
@@ -214,6 +231,7 @@ describe("useTroveLedger", () => {
     render(handle!);
 
     expect(latest!.supported).toBe(true);
+    expect(latest!.probeState).toBe("checked");
     const call = mockUseGQL.mock.calls.find(
       ([query]) => query === CDP_TROVE_LEDGER,
     );

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/trove-ledger-probe.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/trove-ledger-probe.ts
@@ -1,0 +1,57 @@
+export type TroveLedgerProbeState =
+  | "unresolved"
+  | "check-failed"
+  | "stale"
+  | "checked";
+
+/** Classifies the schema probe without changing its fail-closed gate.
+ *  Cached data remains the last confirmed answer after a refresh error. */
+export function classifyTroveLedgerProbe(
+  data: unknown,
+  error: unknown,
+): TroveLedgerProbeState {
+  if (data == null) return error == null ? "unresolved" : "check-failed";
+  return error == null ? "checked" : "stale";
+}
+
+/** Copy for the interim operations view while the schema gate is closed. */
+export function troveLedgerInterimProbeMessage(
+  state: TroveLedgerProbeState,
+  hasLifetimeTotals: boolean,
+): string {
+  switch (state) {
+    case "unresolved":
+      return "Checking complete-history availability — showing the interim view while the check completes. Per-redemption detail cannot be confirmed yet.";
+    case "check-failed":
+      return "The complete-history availability check failed — showing the interim view while it retries automatically. Per-redemption detail may exist but cannot be confirmed right now.";
+    case "stale":
+      return "The complete-history availability check could not refresh — showing the interim view from the last confirmed schema answer while it retries automatically. Per-redemption detail may now exist but cannot be confirmed.";
+    case "checked":
+      return `Per-redemption detail pending indexer rollout — this list shows only this trove's own borrow/repay/adjust operations. Redemptions and liquidations that touched this trove are not yet attributable here${hasLifetimeTotals ? "; see the redemption impact totals above." : "."}`;
+  }
+}
+
+/** Copy for a stale cached-supported answer. Fresh supported answers need no
+ *  availability notice. */
+export function troveLedgerSupportedProbeMessage(
+  state: TroveLedgerProbeState,
+): string | null {
+  if (state !== "stale") return null;
+  return "The complete-history availability check could not refresh — using the last confirmed available result while it retries automatically.";
+}
+
+/** Copy appended to the impact card's cumulative-only description. */
+export function troveLedgerImpactPartialMessage(
+  state: TroveLedgerProbeState,
+): string {
+  switch (state) {
+    case "unresolved":
+      return "Checking complete-history availability before per-hit detail can be enabled.";
+    case "check-failed":
+      return "The complete-history availability check failed, so per-hit detail cannot be confirmed right now.";
+    case "stale":
+      return "The complete-history availability check could not refresh, so per-hit detail remains off under the last confirmed schema answer while it retries automatically.";
+    case "checked":
+      return "Per-hit detail — the user vs rebalance split and the oracle-price valuation — is pending indexer rollout.";
+  }
+}

--- a/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/use-trove-ledger.ts
+++ b/ui-dashboard/src/app/cdps/[symbol]/troves/[troveId]/_lib/use-trove-ledger.ts
@@ -26,6 +26,10 @@ import {
   type TroveLedgerWatermark,
   type TroveRedemptionCumulatives,
 } from "./ledger";
+import {
+  classifyTroveLedgerProbe,
+  type TroveLedgerProbeState,
+} from "./trove-ledger-probe";
 
 export type TroveLedgerState = {
   /** The introspection gate: the live schema serves `TroveLedgerEvent` and
@@ -34,13 +38,10 @@ export type TroveLedgerState = {
    *  direction swaps the view (upgrade on promotion, honest fallback on
    *  rollback). Fails closed while the probe loads or errors. */
   supported: boolean;
-  /** True when the probe has NEVER succeeded and its latest attempt
-   *  errored: `supported` false then means "could not check the schema",
-   *  not "checked, entity absent" — the caller renders an honest
-   *  check-failed notice instead of the rollout wording. A failed refresh
-   *  AFTER a success keeps SWR's stale probe data, so the gate holds the
-   *  last real answer and this stays false. */
-  probeFailed: boolean;
+  /** Full schema-probe disclosure state. `supported` still fails closed for
+   *  unresolved and check-failed probes. A stale probe keeps the cached
+   *  checked answer, so the gate holds its last confirmed direction. */
+  probeState: TroveLedgerProbeState;
   /** Chronological (oldest-first) ledger rows, capped at the render limit.
    *  When truncated, the OLDEST rows were dropped (desc fetch, reversed
    *  client-side) so the recent events under investigation survive. */
@@ -140,7 +141,7 @@ export function useTroveLedger(troveEntityId: string | null): TroveLedgerState {
   const anchor = resolveLedgerWatermark(ledger.data);
   return {
     supported,
-    probeFailed: probe.data == null && probe.error != null,
+    probeState: classifyTroveLedgerProbe(probe.data, probe.error),
     rows,
     truncated,
     complete: hasLoadedOnce && !truncated,


### PR DESCRIPTION
## The Problem

- The trove history page treated an unresolved schema probe as a checked-absent result. It showed pending-rollout copy before the check completed.
- A failed refresh behind cached probe data did not disclose that the displayed answer was stale.
- The hook exposed only `probeFailed`. The history section and impact card could not select accurate copy for the full probe lifecycle.

## The Solution

Expose `unresolved`, `check-failed`, `stale`, and `checked` probe states. Route each state to accurate status copy in the history section and redemption impact card.

The gate still opens only after a confirmed supported answer. Unresolved and never-succeeded error states remain closed. A stale result keeps the last confirmed gate direction while the probe retries.

This PR does not change the schema check, 300-second polling interval, SWR retry policy, ledger query, or indexed data.

## Visual verification

Route: `/cdps/chfm/troves/0x754` at 1280 x 720, public and logged out. A deterministic production fixture and schema-probe overlay drove each state.

| State | Candidate result |
| --- | --- |
| Unresolved | Two neutral checking statuses; no rollout claim; ledger query closed |
| Check failed | Two check-failed statuses; no rollout claim; ledger query closed |
| Fresh checked absent | Two pending-rollout statuses; ledger query closed |
| Stale cached absent | Two stale statuses; no rollout claim; ledger query closed |
| Stale cached supported | Complete ledger plus one stale-result status; ledger query open |

Chrome virtual time advanced the shared 300-second refresh interval for both stale cases. The checks found no application-specific runtime error.

## Details

| Probe data | Latest error | State | Gate | Disclosure |
| --- | --- | --- | --- | --- |
| None | None | `unresolved` | Closed | Neutral checking copy |
| None | Present | `check-failed` | Closed | Availability-check failure copy |
| Cached absent | Present | `stale` | Closed | Stale cached-answer copy |
| Cached supported | Present | `stale` | Open | Complete ledger plus stale-result status |
| Fresh absent | None | `checked` | Closed | Pending-indexer-rollout copy |
| Fresh supported | None | `checked` | Open | Complete ledger with no availability notice |

- Review target: base `ceb73a7305cd5f864a461fbda6d0a6e5c51fe7ec`; candidate `0518629eaba14f77060a660545af102d7f3c01fe`.
- Centralize state classification and copy in `trove-ledger-probe.ts`.
- Keep the ledger query disabled until a confirmed supported answer exists.
- Preserve the last confirmed gate direction behind a refresh error.
- Use `role="status"` on every dynamic availability notice.
- Keep static `EmptyBox` empty states outside live regions.
- Keep `trove-detail-client.tsx` below the 600-line source soft cap at 591 physical lines.

Risk: incorrect state classification could open a ledger query without confirmed schema support or hide stale data. The gate derives only from confirmed probe data, and tests cover every matrix state. A stale notice can remain until a later poll succeeds because the polling policy is unchanged.

## Validation

- Four focused dashboard test files passed 93 tests. The fixtures cover unresolved, check-failed, stale cached-absent, stale cached-supported, fresh checked-absent, and fresh checked-supported states. They do not prove that hosted infrastructure will enter each state.
- The full dashboard test suite passed 5,079 tests before the final source-identical rebase. This proves the dashboard suite for the unchanged patch. It does not replace GitHub CI.
- `pnpm dashboard:react-doctor` scored 100/100, and `pnpm dashboard:react-doctor:diff` passed. These static checks do not prove runtime query gating or rendered copy.
- Chrome/CDP browser verification covered every row in the matrix, including refresh errors after a 300-second virtual-time advance. It proved copy, `role="status"`, and query gating under the deterministic fixture. It does not prove the hosted GraphQL schema state.
- `git diff --check` passed at the rebased head. The binary source patch remained unchanged across the final rebase with hash `a632af15679ab9bee5b685dbdbe2015f224690dbc53cff013692a63951d1deb8`.
- Autoreview preparation, manifest verification, fresh-context review, and bound post-review verification passed at the exact head with manifest `ec702fc052e4fc648ed6305fa3c1539935ff824518b458165250b081a512c74e` and no findings. This source review does not replace runtime tests or human merge approval.
- Local full `agent-quality-gate` was explicitly waived by the operator for this session; GitHub CI is the required full gate. This records the waiver and does not claim a local full-gate result.

## Deferrals

- None.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, benefit, and material limit.
- [x] The stateful-data UI checklist applies. The gate stays fail-closed in every unresolved or absent state.
- [x] Dynamic notices use `role="status"`; static empty states remain non-live regions.
- [x] React Doctor remains at 100/100.
- [x] Browser verification covers every UI-visible probe state.
- [x] No new architecture decision is required. This PR models existing disclosure states.
- [x] No known work is deferred.

Closes #2117.
Refs #2086, #2089.

Originating reviews: [stale refresh](https://github.com/mento-protocol/monitoring-monorepo/pull/2115#discussion_r3880372687) and [unresolved probe](https://github.com/mento-protocol/monitoring-monorepo/pull/2115#discussion_r3880441315).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Probe state drives disclosure and fail-closed gating for the ledger query; misclassification could show wrong copy or briefly affect when the ledger loads, though behavior is heavily tested.
> 
> **Overview**
> The trove history page no longer treats an in-flight schema probe like a confirmed “indexer not rolled out” answer. **`useTroveLedger`** replaces the boolean **`probeFailed`** with **`probeState`** (`unresolved`, `check-failed`, `stale`, `checked`) via **`classifyTroveLedgerProbe`** in new **`trove-ledger-probe.ts`**, which also owns the user-facing copy for each state.
> 
> **Interim view** (**`TroveOperationsList`**) and **redemption impact** partial mode pick messages from that module and expose them with **`role="status"`** where appropriate—neutral “checking” while unresolved, explicit failure vs stale refresh vs honest rollout wording when checked-absent. **Full ledger mode** shows a stale-availability notice when the gate stays open on cached supported data but the probe refresh failed.
> 
> Ledger query gating is unchanged: fail-closed until a confirmed supported answer; stale keeps the last confirmed gate direction. Tests and mocks were extended for the full probe matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0518629eaba14f77060a660545af102d7f3c01fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trove ledger messaging while availability is being checked, unavailable, or refreshed.
  * Preserved previously loaded ledger details when a refresh fails.
  * Prevented unnecessary ledger loading when support is unavailable.
  * Added clearer messaging for partial operations and redemption-impact views.

* **Accessibility**
  * Status updates are now announced consistently across interim, complete, and partial trove views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->