### PR TITLE
fix(watchdog): use EUR/USD delivery canary

### DIFF
--- a/governance-watchdog/README.md
+++ b/governance-watchdog/README.md
@@ -4,8 +4,9 @@
 
 The watchdog receives Celo events from QuickNode, rejects unauthenticated or
 replayed deliveries, validates supported events, and posts governance
-notifications to Discord and Telegram. A separate SortedOracles event powers
-the webhook health check.
+notifications to Discord and Telegram. A separate SortedOracles event from the
+Chainlink EUR/USD feed powers a QuickNode-to-watchdog delivery canary. Its
+absence signals a delivery-path gap, not governance or oracle-feed health.
 
 The service owns a dedicated Terraform-created GCP project with a randomized
 ID. It is not part of the `mento-alerts` or `mento-monitoring` projects.

--- a/governance-watchdog/infra/quicknode-filter-functions/sorted-oracles.js
+++ b/governance-watchdog/infra/quicknode-filter-functions/sorted-oracles.js
@@ -16,9 +16,9 @@ function main(stream) {
   const hasContracts = contracts.length > 0;
   const contractSet = hasContracts ? new Set(contracts) : null;
 
-  // Target token address for MedianUpdated events: CELO/cUSD rate feed
-  const targetTokenAddress =
-    "0x765de816845861e75a25fca122bb6898b8b1282a".toLowerCase();
+  // Target token address for MedianUpdated events: Chainlink EUR/USD rate feed
+  const targetRateFeedAddress =
+    "0x26076b9702885d475ac8c3db3bd9f250dc5a318b".toLowerCase();
 
   for (const block of stream.data) {
     const filteredReceipts = block.receipts.map((receipt) => {
@@ -39,7 +39,7 @@ function main(stream) {
           // Only include MedianUpdated events with the specific token address
           if (
             log.name === "MedianUpdated" &&
-            log.token.toLowerCase() === targetTokenAddress
+            log.token.toLowerCase() === targetRateFeedAddress
           ) {
             result.push({
               transactionHash: receipt.transactionHash,

--- a/governance-watchdog/infra/quicknode.tf
+++ b/governance-watchdog/infra/quicknode.tf
@@ -40,9 +40,9 @@ locals {
   }
 }
 
-# A healthcheck webhook to ensure Quicknode is operating as expected.
-# We use a webhook for `MedianUpdated` events for the CELO/USD feed on our SortedOracles contract,
-# Because we know with reasonable certainty that the feed will update every couple of minutes.
+# A delivery canary that verifies QuickNode can send SortedOracles webhooks to the watchdog.
+# It uses `MedianUpdated` events for the active Chainlink EUR/USD feed, which updates every
+# few minutes. It does not indicate governance-watchdog or oracle-feed health by itself.
 resource "restapi_object" "quicknode_webhook_healthcheck" {
   path = "/webhooks/rest/v1/webhooks"
 

--- a/governance-watchdog/src/health-check/__tests__/health-check.test.ts
+++ b/governance-watchdog/src/health-check/__tests__/health-check.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventType, type QuicknodeEvent } from "../../events/types.js";
 
 const SORTED_ORACLES_ADDRESS = "0xefb84935239dacdecf7c5ba76d8de40b077b7b33";
+const CHAINLINK_EUR_USD_RATE_FEED_ADDRESS =
+  "0x26076B9702885d475ac8c3dB3Bd9F250Dc5A318B";
 const CELO_CUSD_RATE_FEED_ADDRESS =
   "0x765DE816845861e75A25fCA122bb6898B8B1282a";
 
@@ -30,10 +32,15 @@ describe("handleHealthCheckEvent", () => {
     vi.restoreAllMocks();
   });
 
-  it("logs [HealthCheck] for a cUSD MedianUpdated event from SortedOracles", async () => {
+  it("logs [HealthCheck] for a Chainlink EUR/USD MedianUpdated event from SortedOracles", async () => {
     const { default: handleHealthCheckEvent } = await import("../index.js");
 
-    handleHealthCheckEvent(makeMedianUpdated(SORTED_ORACLES_ADDRESS));
+    handleHealthCheckEvent(
+      makeMedianUpdated(
+        SORTED_ORACLES_ADDRESS,
+        CHAINLINK_EUR_USD_RATE_FEED_ADDRESS,
+      ),
+    );
 
     expect(console.info).toHaveBeenCalledWith(
       "[HealthCheck]: Block",
@@ -58,6 +65,19 @@ describe("handleHealthCheckEvent", () => {
       makeMedianUpdated(
         SORTED_ORACLES_ADDRESS,
         "0x0000000000000000000000000000000000000001",
+      ),
+    );
+
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it("ignores the retired CELO/cUSD heartbeat feed", async () => {
+    const { default: handleHealthCheckEvent } = await import("../index.js");
+
+    handleHealthCheckEvent(
+      makeMedianUpdated(
+        SORTED_ORACLES_ADDRESS,
+        "0x765DE816845861e75A25fCA122bb6898B8B1282a",
       ),
     );
 

--- a/governance-watchdog/src/health-check/index.ts
+++ b/governance-watchdog/src/health-check/index.ts
@@ -16,9 +16,9 @@ import isHealthCheckEvent from "./is-health-check-event.js";
 const SORTED_ORACLES_ADDRESS =
   "0xefb84935239dacdecf7c5ba76d8de40b077b7b33".toLowerCase();
 
-// CELO/cUSD rate feed address - only log health checks for this feed
-const CELO_CUSD_RATE_FEED_ADDRESS =
-  "0x765de816845861e75a25fca122bb6898b8b1282a".toLowerCase();
+// Chainlink EUR/USD rate feed address - only log health checks for this feed
+const CHAINLINK_EUR_USD_RATE_FEED_ADDRESS =
+  "0x26076b9702885d475ac8c3db3bd9f250dc5a318b".toLowerCase();
 
 export default function handleHealthCheckEvent(event: QuicknodeEvent) {
   assert(isHealthCheckEvent(event), "Expected MedianUpdated event");
@@ -28,8 +28,8 @@ export default function handleHealthCheckEvent(event: QuicknodeEvent) {
     return;
   }
 
-  // Only log health check for cUSD token
-  if (event.token.toLowerCase() === CELO_CUSD_RATE_FEED_ADDRESS) {
+  // Only log the QuickNode delivery canary for the EUR/USD feed.
+  if (event.token.toLowerCase() === CHAINLINK_EUR_USD_RATE_FEED_ADDRESS) {
     console.info("[HealthCheck]: Block", event.blockNumber);
   }
   // Silently ignore health checks for other tokens


### PR DESCRIPTION
## The Problem

- The QuickNode delivery canary used the retiring CELO/cUSD `MedianUpdated` feed.
- A quiet feed could page the governance watchdog even when governance monitoring and the delivery path were healthy.

## The Solution

- Use the active Celo Chainlink EUR/USD rate feed as the canary source.
- Document the signal as a QuickNode-to-watchdog delivery canary, so operators do not interpret it as oracle or governance health.
- This PR updates reviewed filter and bootstrap inputs only; the live QuickNode filter still requires the documented, post-merge approved rollout.

## Details

- Switch the handler and filter from `0x765de816845861e75a25fca122bb6898b8b1282a` to `0x26076b9702885d475ac8c3db3bd9f250dc5a318b`.
- Add regression coverage that the retiring cUSD feed no longer emits a health-check log.

## Validation

- `pnpm --filter @mento-protocol/governance-watchdog lint`, `typecheck`, `test:unit`, and `build` passed; these prove the changed watchdog handler and tests compile and pass, not that the live QuickNode filter has been rolled out.
- `pnpm agent:quality-gate --run` passed, including Terraform format, offline init, and validate. Its init generated an unrelated local lockfile diff, which was reverted before commit; this does not prove a production apply.
- Structured autoreview (fresh-context reviewer plus deterministic local pass) found no actionable findings; source review does not prove production delivery.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
