### PR TITLE
fix(gate): repair the stamps-freshness fixtures broken by the Darwin broker

### DIFF
--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -10064,11 +10064,14 @@ STUB
   # The stub makes mapped commands free. It must still delegate every inline
   # Node helper and gate module used to build and execute the plan. A stubbed-out
   # helper makes the gate refuse the run, which is the guard working, not the
-  # fixture.
+  # fixture. `-p` carries the Darwin broker's `node -p 'process.execPath'`
+  # runtime probe: stub it out and the broker reads an empty runtime path and
+  # refuses to bind before first dispatch.
   cat > bin/node <<'STUB'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "--input-type=module" ||
   "${1:-}" == -e ||
+  "${1:-}" == -p ||
   "${1:-}" == */quality-gate-coordinator.mjs ||
   "${1:-}" == */quality-gate-coordinator-environment.mjs ]]; then
   exec "${REAL_NODE:?}" "$@"
@@ -10295,7 +10298,12 @@ STUB
   base_ref="$(git rev-parse --verify HEAD)"
   counter="$index_state_stamp_repo/.tmp/agent-quality-gate/trunk-count"
   printf 'changed\n' >> fixture.txt
-  printf 'brand new\n' > new.txt
+  # This file is made executable further down to prove that a mode change
+  # invalidates the stamp. The Darwin broker preflight refuses to dispatch when
+  # a routed path carries the executable bit but no inspectable source contract
+  # (rule `opaque-executable`), so the file needs a shebang to stay routable.
+  # The shebang changes nothing the assertions below observe.
+  printf '#!/usr/bin/env bash\nbrand new\n' > new.txt
 
   index_state_gate() {
     COUNTER_FILE="$counter" \
@@ -10357,7 +10365,16 @@ rm -rf "$index_state_stamp_repo"
 # path/command plan and the fixture's gate implementation independently. Every
 # change must execute the mapped command again instead of reusing the stamp.
 signature_stamp_repo="$(mktemp -d)"
-signature_runtime_root="$gate_cache_dir/signature-runtime-source"
+# The staged gate runtime must sit on a canonical path. On macOS `mktemp -d`
+# hands back a /var path that symlinks to /private/var, and
+# scripts/gate/darwin-process-lineage.mjs gates its CLI entrypoint on
+# `resolve(process.argv[1]) === fileURLToPath(import.meta.url)`. Node's ESM
+# loader resolves the symlink on the import.meta.url side only, so the two
+# disagree, the entrypoint never runs, and the gate reports malformed
+# exact-identity evidence. Canonicalizing the staging root keeps both sides
+# equal. Issue 2156 tracks removing the mismatch in the module itself.
+mkdir -p "$gate_cache_dir/signature-runtime-source"
+signature_runtime_root="$(cd "$gate_cache_dir/signature-runtime-source" && pwd -P)"
 mkdir -p \
   "$signature_runtime_root/scripts/docs" \
   "$signature_runtime_root/scripts/gate/mapping" \
@@ -10372,6 +10389,11 @@ cp "$repo_root/scripts/gate/run-handles.sh" \
   "$signature_runtime_root/scripts/gate/run-handles.sh"
 cp "$repo_root/scripts/gate/darwin-broker-launch-preflight.mjs" \
   "$signature_runtime_root/scripts/gate/darwin-broker-launch-preflight.mjs"
+# BROKER_CLIENT_ALLOWLIST pins four policy sources by SHA-256 and refuses to
+# dispatch when one is absent. The coordinator glob below stages the other
+# three; this suite is the fourth.
+cp "$repo_root/scripts/gate/darwin-broker-launch-preflight.test.mjs" \
+  "$signature_runtime_root/scripts/gate/darwin-broker-launch-preflight.test.mjs"
 cp "$repo_root/scripts/gate/darwin-process-identity.c" \
   "$signature_runtime_root/scripts/gate/darwin-process-identity.c"
 cp "$repo_root/scripts/gate/darwin-process-identity-runtime.inc.c" \


### PR DESCRIPTION
## The Problem

- The `stamps-freshness` gate self-test family failed on every macOS run against
  unmodified `main`. It aborted at exit 2 with "Node did not resolve to an
  executable real runtime. / could not bind the Darwin broker preflight before
  first dispatch."
- Any branch that touches gate files routes the full self-test through the
  pre-push hook, so no gate-touching branch could pass its own gate from a Mac.
  Two ready branches were stuck behind it.
- PR 2131 added the Darwin process-identity broker and left four fixtures in
  this family staging an environment the broker rejects. The suite stops at its
  first failure, so only the first was visible; each later one surfaced as the
  previous was fixed.

## The Solution

The family now passes on macOS. Four fixtures stage what the broker actually
needs: the `bin/node` stub delegates the broker's runtime probe, the file a
fixture makes executable carries a shebang, the staged gate runtime sits on a
canonical path, and the fourth allowlisted policy source is staged.

This restores coverage rather than relaxing it. No assertion changed, no
assertion was removed, and no gate code changed — the diff is one test file.
Every counter assertion and failure message in these fixtures is byte-identical
to `main`. Each repair has a negative control: remove it and the family fails
again at exactly its own abort.

Material limit: repair 3 works around a real defect in
`scripts/gate/darwin-process-lineage.mjs` rather than fixing it. That module
gates its CLI entrypoint on `resolve(process.argv[1]) === fileURLToPath(import.meta.url)`,
so invoking it through any path containing a symlink makes it silently no-op.
Production is unaffected today because the repo lives under `/Users`, but the
defect is real and stays open as issue #2156.

## Details

The broker resolves its runtime with `node -p 'process.execPath'`
(`scripts/gate/darwin-process-lineage.sh:93`).

1. **`workflow_fresh_stamp_repo` `bin/node` stub.** Its allowlist covered
   `--input-type=module`, `-e`, the two coordinator modules and
   `scripts/gate/mapping.mjs`, and answered everything else with `exit 0`. The
   `-p` probe fell through, so the broker read an empty runtime path and refused
   to bind. Instrumenting the stub's reject path over a full family run logged
   exactly one turned-away invocation: `-p process.execPath`. Adding `-p` beside
   `-e` restores delegation. The stub still answers mapped commands with
   `exit 0`, so the Trunk counter assertions keep their meaning.

2. **`index_state_stamp_repo` executable target.** The fixture makes a routed
   file executable to prove a mode change invalidates the stamp. The broker
   preflight refuses to dispatch when a routed path holds the executable bit
   without an inspectable source contract — rule `opaque-executable`,
   `scripts/gate/darwin-broker-launch-preflight.mjs:2179`. The file now starts
   with a shebang; `isExecutableSource` accepts one regardless of extension.

3. **`signature_stamp_repo` staging root.** The fixture staged the gate runtime
   under `mktemp -d`. On macOS that returns a `/var` path that symlinks to
   `/private/var`. Node's ESM loader resolves the symlink for
   `import.meta.url` but `resolve(process.argv[1])` keeps the literal path, so
   the entrypoint guard at `darwin-process-lineage.mjs:1587` never matched and
   the module exited 0 printing nothing. The gate read that as "Darwin
   exact-identity authority returned malformed evidence". The staging root is
   now canonicalized with `pwd -P`. Tracked for a real fix in #2156.

4. **`signature_stamp_repo` policy sources.** `BROKER_CLIENT_ALLOWLIST` pins
   four policy sources by SHA-256 and refuses to dispatch when one is absent.
   The existing `quality-gate-coordinator*.mjs` glob staged three;
   `darwin-broker-launch-preflight.test.mjs` is now staged too.

## Validation

- `GATE_TEST_FOCUS=stamps-freshness bash scripts/agent-quality-gate.test.sh` —
  three consecutive runs, each exit 0, "agent quality gate focused tests passed:
  stamps-freshness". This shows the family passes repeatedly on this macOS host;
  it does not show the family passes on Linux or on other macOS
  configurations, and CI does not exercise the Darwin broker path at all.
- Negative control per repair, each isolating one variable. Removing only `-p`
  from the final tree reproduces the issue's abort at the
  `workflow_fresh_stamp_repo` fixture with both original error lines. The other
  three were isolated by the failure progression: with repair 1 only, the family
  aborted at `index_state_stamp_repo` on `opaque-executable`; with 1 and 2, at
  `signature_stamp_repo` on malformed exact-identity evidence; with 1, 2 and 3,
  on the missing allowlisted policy source. Each abort names its own repair.
  This shows each repair is load-bearing; it does not prove the four are
  jointly sufficient on a host unlike this one.
- Root cause was measured, not inferred: the stub's reject path was instrumented
  to log argv, and it logged only `-p process.execPath`. Repair 3's mechanism
  was confirmed by A/B on an identical staged file set — invoked via
  `/var/folders/…` the module exits 0 printing nothing, via `/private/var/folders/…`
  it prints `ready`.
- Full pre-push gate from the worktree,
  `bash scripts/agent-quality-gate.sh --run --base origin/main`, run against this
  branch rebased onto `37ac4b7b`. Four of the five mapped commands passed:
  `bash -n scripts/agent-quality-gate.test.sh` (5s),
  `./tools/trunk check --ci scripts/agent-quality-gate.test.sh` (1m39s),
  `pnpm gate:routing-table:test` (1m37s), and `pnpm tf:test` (55s).
- The fifth, `pnpm agent:quality-gate:test`, fails on one test this branch does
  not touch: `scripts/gate/agent-quality-gate-scheduler.integration.test.mjs:1318`,
  "a coordinator-disabled gate handles a killed coordinator leader safely". That
  failure is pre-existing and tracked as #2160. Control: checking out clean
  `origin/main` at `37ac4b7b` and running that suite standalone
  (`node --test scripts/gate/agent-quality-gate-scheduler.integration.test.mjs`)
  reproduces the identical assertion failure, exit 1, on an otherwise idle
  machine. The suite contains no reference to `scripts/agent-quality-gate.test.sh`,
  and this branch is exactly `origin/main` plus that one file. Observed failing
  four times out of four — twice in the full gate here, once standalone here,
  once standalone on clean main.
- So the local gate is green except for #2160. This evidence shows the four
  repairs hold and that the one red command is not caused by them; it does not
  show the full self-test passes end to end on macOS, which #2160 blocks. Linux
  CI owns the full suite.

## Deferrals

- #2156 — `scripts/gate/darwin-process-lineage.mjs:1587` compares a symlink-resolved path against an unresolved one, so the module silently no-ops when invoked through a symlinked path. Repair 3 works around it in the fixture rather than fixing the module.
- #2158 — Darwin coordinator-owner recovery could not reclaim a same-machine dead-PID owner, wedging every gate run on this host until the markers were cleared by hand. Hit while validating this PR; not caused by it.
- #2160 — `agent-quality-gate-scheduler.integration.test.mjs:1318` fails on macOS: the scenario-legacy-recovery client times out on the run lock instead of reaching the legacy-recovery path. Pre-existing on `origin/main` at `37ac4b7b` and reproducible standalone there; it is the one red mapped command in the local gate run above.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable — this stages fixtures correctly for an existing design; it makes no new decision.

Closes #2154
