### PR TITLE
fix(review-eval): disable unintended judge tools

### DIFF
--- a/scripts/review/review-eval-run-execution.mjs
+++ b/scripts/review/review-eval-run-execution.mjs
@@ -188,11 +188,15 @@ export function claudeArgv({
     "json",
     "--permission-mode",
     "bypassPermissions",
-    // `--allowed-tools` is a required variadic option. Emitting it with an
-    // empty list makes the CLI swallow the following `--max-turns 1` as two
-    // tool names, so every blind judge and calibration replay would run
-    // unbounded. Omit the flag when there are no tools to allow.
-    ...(allowedTools.length > 0 ? ["--allowed-tools", ...allowedTools] : []),
+    // `--allowed-tools` grants permission but does not limit which built-in
+    // tools the model can see. `--tools` owns availability. Pass the requested
+    // set through both controls. Its comma-joined value also keeps the variadic
+    // options from swallowing the next flag. An empty set must use the CLI's
+    // explicit `--tools ""` form, or the default tools remain available and a
+    // blind judge can spend its only turn on a tool call and exit without JSON.
+    ...(allowedTools.length > 0
+      ? ["--tools", allowedTools.join(","), "--allowed-tools", ...allowedTools]
+      : ["--tools", ""]),
     "--max-turns",
     String(maxTurns),
   ];

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -257,8 +257,8 @@ let blindCwd = null;
 
 /**
  * An empty scratch directory for the blind judges. Created once per process
- * and never written to: it exists so a judge that ignores `allowedTools: []`
- * still starts nowhere near the repository that holds the answer key.
+ * and never written to. It keeps the judge away from the repository that holds
+ * the answer key if the CLI ever stops honoring the explicit no-tools flag.
  */
 export function blindJudgeCwd() {
   if (!blindCwd) {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4498,7 +4498,7 @@ test("scoring resets each fixture, uses the contract judge, and totals its cost"
   }
 });
 
-test("a blind judge keeps its turn bound and emits no --allowed-tools", () => {
+test("a blind judge disables tools and keeps its turn bound", () => {
   const blind = claudeArgv({
     prompt: "judge this",
     model: "claude-opus-5",
@@ -4507,10 +4507,15 @@ test("a blind judge keeps its turn bound and emits no --allowed-tools", () => {
     maxTurns: BLIND_JUDGE_MAX_TURNS,
   });
   // An empty `--allowed-tools` makes the CLI eat the next flag and its value as
-  // tool names, which silently unbounds the judge. The flag must be absent.
+  // tool names. Omitting it exposes the defaults. Use the explicit no-tools
+  // form and keep the one-turn bound separate.
   assert.equal(blind.includes("--allowed-tools"), false);
+  const blindToolsAt = blind.indexOf("--tools");
+  assert.notEqual(blindToolsAt, -1);
+  assert.equal(blind[blindToolsAt + 1], "");
   const turnsAt = blind.indexOf("--max-turns");
   assert.notEqual(turnsAt, -1);
+  assert.equal(blindToolsAt + 2, turnsAt);
   assert.equal(blind[turnsAt + 1], "1");
 
   const tooled = claudeArgv({
@@ -4520,10 +4525,16 @@ test("a blind judge keeps its turn bound and emits no --allowed-tools", () => {
     allowedTools: ["Read", "Grep"],
     maxTurns: 60,
   });
-  const toolsAt = tooled.indexOf("--allowed-tools");
-  assert.notEqual(toolsAt, -1);
-  assert.deepEqual(tooled.slice(toolsAt + 1, toolsAt + 3), ["Read", "Grep"]);
-  assert.deepEqual(tooled.slice(toolsAt + 3), ["--max-turns", "60"]);
+  const availableToolsAt = tooled.indexOf("--tools");
+  assert.notEqual(availableToolsAt, -1);
+  assert.equal(tooled[availableToolsAt + 1], "Read,Grep");
+  const allowedToolsAt = tooled.indexOf("--allowed-tools");
+  assert.equal(allowedToolsAt, availableToolsAt + 2);
+  assert.deepEqual(tooled.slice(allowedToolsAt + 1, allowedToolsAt + 3), [
+    "Read",
+    "Grep",
+  ]);
+  assert.deepEqual(tooled.slice(allowedToolsAt + 3), ["--max-turns", "60"]);
 });
 
 test("a scoring subprocess inherits no GitHub credential", () => {


### PR DESCRIPTION
## The Problem

- Blind review-eval judges are intended to run with no tools and one turn.
- The scorer omitted `--allowed-tools` for an empty tool set. Claude Code then exposed its default tools. A judge could spend its only turn on a tool call and exit before it returned judge JSON.
- `--allowed-tools` grants permission for a tool. It does not limit which built-in tools the model can see.

## The Solution

- Pass every non-empty scorer tool set through both `--tools` and `--allowed-tools`.
- Pass `--tools ""` for blind judges.
- Keep the empty blind working directory as defense in depth.
- Add argument-vector regression coverage for blind and tool-bearing judges.

Closes #2167.

## Details

- The change keeps the existing one-turn blind-judge bound and fail-closed error path.
- The scorer digest and comparability key change because judge execution semantics changed. The next complete run starts a new baseline lineage.
- A model-free plan predicts comparability key `2f7ee5f7…` on this branch.
- All 24 retained contestant-cell results pass the new plan's cell fingerprint. They do not need to run again.
- No paid model ran while implementing or validating this fix.

## Validation

- Targeted Trunk passed for the three changed files.
- `CI=true pnpm lint:scripts` passed.
- `CI=true pnpm review:eval:test` passed all 266 tests.
- `CI=true pnpm tf:test` passed.
- `/Users/chapati/.local/bin/claude --tools "" --max-turns 1 --version` accepted the no-tools argument vector without a model call.
- A model-free full plan found 24/24 retained cells reusable and no refused cell.
- Two independent source reviews found no remaining issue in the final argument-vector design and regression coverage.
- The operator authorized a local gate skip for this workstream. Exact-head CI and bot review remain required before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how eval scoring subprocesses invoke the Claude CLI, which alters judge behavior and breaks comparability with prior scorer digests until a new baseline run.
> 
> **Overview**
> Blind review-eval judges (match, claim extraction, calibration) were meant to run with **no tools** and **one turn**, but the scorer only omitted `--allowed-tools` for an empty set. That flag **permits** tools; it does not hide defaults, so judges could still call tools and exit without judge JSON.
> 
> **`claudeArgv`** now drives availability with **`--tools`**: empty sets use **`--tools ""`**, and non-empty sets pass a comma-joined **`--tools`** list plus the existing variadic **`--allowed-tools`** entries so the next flag is not swallowed. Comments on the blind scratch **`cwd`** describe it as backup if the CLI ever ignores the no-tools flag.
> 
> Regression tests assert blind argv has **no** `--allowed-tools`, **`--tools`** with an empty value immediately before **`--max-turns 1`**, and tool-bearing runs expose **`Read,Grep`** via **`--tools`** before **`--allowed-tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbf4efd636b324f6003828ba3bd5be94901435b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool-access controls for review evaluations.
  - Ensured evaluations with no permitted tools explicitly disable tool availability.
  - Preserved separate configuration for available tools and allowed tool permissions.

- **Documentation**
  - Clarified that blind-judge scratch directories remain unwritten and isolated from the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->