### PR TITLE
test(gate): align Darwin retained-owner scenario

### DIFF
--- a/scripts/gate/agent-quality-gate-scheduler.integration.test.mjs
+++ b/scripts/gate/agent-quality-gate-scheduler.integration.test.mjs
@@ -1295,6 +1295,20 @@ test("a coordinator-disabled gate handles a killed coordinator leader safely", a
         },
       );
     }
+    const draining = await fixture.waitForDrain(scenario);
+    assert.equal(draining.drainObligations.length, 1);
+    const retainedCoordinatorPid = draining.coordinatorIdentity.pid;
+    if (process.platform === "darwin") {
+      assert.ok(
+        Number.isSafeInteger(retainedCoordinatorPid) &&
+          retainedCoordinatorPid > 0,
+      );
+      assert.equal(
+        draining.drainObligations[0].lifecycleContract,
+        "darwin-coherent-lineage-v2",
+      );
+      assert.equal(await fixture.processRunning(retainedCoordinatorPid), true);
+    }
 
     const legacy = await fixture.startGate({
       worktree: legacyWorktree,
@@ -1303,10 +1317,7 @@ test("a coordinator-disabled gate handles a killed coordinator leader safely", a
       label: "legacy-recovery-client",
       coordinator: false,
       shortDelayMs: 250,
-      extraEnvironment:
-        process.platform === "darwin"
-          ? { AGENT_QUALITY_GATE_LOCK_ORPHAN_DRAIN_SECONDS: "0" }
-          : {},
+      lockWaitSeconds: process.platform === "darwin" ? 2 : 30,
     });
     const legacyResult = await legacy.done;
     if (process.platform === "darwin") {
@@ -1317,8 +1328,16 @@ test("a coordinator-disabled gate handles a killed coordinator leader safely", a
       );
       assert.match(
         legacyResult.stderr,
-        /requires exact per-command lineage evidence/u,
+        /error: timed out after \d+s waiting for the gate run lock at .+\/run\.lock\./u,
       );
+      assert.match(
+        legacyResult.stderr,
+        new RegExp(
+          `Holder pid ${retainedCoordinatorPid} is still alive; let it finish, then retry\\.`,
+          "u",
+        ),
+      );
+      assert.equal(await fixture.processRunning(retainedCoordinatorPid), true);
     } else {
       assertPassed(legacyResult);
       await waitUntil(


### PR DESCRIPTION
## The Problem

- The Darwin scheduler fixture forced orphan recovery while the coordinator still owned `run.lock` for a retained drain obligation.
- The coordinator-disabled contender therefore timed out behind the live owner, but the test expected it to enter legacy recovery.
- This stale assertion made the full quality-gate regression suite fail on macOS even though the gate kept the required owner barrier.

## The Solution

The test now observes the retained coordinator state and asserts the fail-closed lock timeout on Darwin. The Linux branch still verifies legacy recovery. This PR changes test expectations only. It does not change gate behavior or weaken the owner barrier.

## Details

- Wait for the coordinator drain record before starting the coordinator-disabled contender.
- Assert one `darwin-coherent-lineage-v2` obligation and bind its live coordinator PID.
- Use a two-second Darwin lock wait, then require exit code 2, the live holder PID in stderr, and zero mapped-command starts.
- Remove the orphan-drain override that forced the fixture onto the wrong path.

Closes #2160

## Validation

- `node --test --test-name-pattern='a coordinator-disabled gate handles a killed coordinator leader safely' scripts/gate/agent-quality-gate-scheduler.integration.test.mjs` passed 1/1 on macOS. This proves the corrected Darwin scenario on this host. Linux CI still owns proof for the sibling Linux branch.
- The same scenario passed inside `node --test scripts/gate/agent-quality-gate-scheduler.integration.test.mjs`. The full file completed 22/23 because the untouched `Darwin Trunk guardian reader does not delay gate termination` test timed out once; its focused retry passed 1/1. This does not establish a clean full-file run.
- `./tools/trunk check --ci scripts/gate/agent-quality-gate-scheduler.integration.test.mjs`, `pnpm lint:scripts`, and `pnpm tf:test` passed. These checks prove formatting, script lint, and infrastructure-contract compatibility. They do not replace the full gate regression suite.
- `pnpm agent:quality-gate:test` ran but did not pass. A separate coordinator-family fixture timed out while it waited for worktree admission after descendant cleanup. The changed #2160 scenario passed during that run. Exact-head CI remains the authoritative full-suite result under the operator-approved local-gate bypass.
- The prepared autoreview bundle passed an independent source review with no findings. The bundle manifest was `633b1dc59e6d2450c54dfe66928cffdad5ae3b18de4648d1e9d5b1ec540e90a6` before and after review. Source review does not prove runtime behavior.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the test-only scope and non-goal.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] There are no knowing deferrals.
- [x] Architecture decision: not applicable because this PR changes one test oracle only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes integration test assertions only; no production gate or lock logic is touched.
> 
> **Overview**
> **Test-only fix** for the integration scenario *“a coordinator-disabled gate handles a killed coordinator leader safely”* so macOS matches how the gate actually behaves when a retained coordinator still holds `run.lock`.
> 
> On **Darwin**, the test now waits for drain state, checks a single `darwin-coherent-lineage-v2` obligation and that the retained coordinator PID is still alive, then starts the coordinator-disabled contender with a **2s** lock wait (instead of forcing orphan drain via `AGENT_QUALITY_GATE_LOCK_ORPHAN_DRAIN_SECONDS: "0"`). It expects **exit code 2**, a **run.lock wait timeout** in stderr, and a message naming the **live holder PID**—not legacy “exact per-command lineage evidence” recovery. The **Linux** path is unchanged: legacy recovery should still pass and drain the descendant.
> 
> Gate production behavior is not modified; only the test oracle is updated (closes #2160).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00b631d0e003872df363cb3703a5d4de6568d5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration coverage for legacy recovery scenarios on Darwin.
  * Added validation that stale-drain preserves an active coordinator under the current lineage contract.
  * Updated lock-timeout checks to confirm the expected coordinator is retained and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->