### PR TITLE
docs(review): record CodeRabbit cutover outcome

### DIFF
--- a/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
+++ b/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
@@ -3,7 +3,7 @@ title: Local agent quality gate plus two-projection PR all-clear and Codex gate
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-29
+last_verified: 2026-08-31
 scope: ci/process
 date: 2026-05
 doc_type: adr
@@ -38,8 +38,9 @@ Two layers:
 - **Hosted all-clear** uses two machine-readable projections in order:
   `pnpm pr:feedback-state` must first report a clean feedback ledger, then
   `pnpm pr:ready-state` is the final required-readiness oracle for current-head
-  CI, review gates, and the Codex PR-description gate. Advisory bot lag (for
-  example, Cursor) does not block unless branch protection requires it.
+  CI, review gates, and the Codex PR-description gate. Advisory review status
+  does not block unless branch protection requires it. Actionable feedback
+  still blocks through the feedback ledger.
 
 ## Alternatives considered
 

--- a/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
+++ b/docs/adr/0007-agent-quality-gate-and-merge-oracle.md
@@ -38,9 +38,10 @@ Two layers:
 - **Hosted all-clear** uses two machine-readable projections in order:
   `pnpm pr:feedback-state` must first report a clean feedback ledger, then
   `pnpm pr:ready-state` is the final required-readiness oracle for current-head
-  CI, review gates, and the Codex PR-description gate. Advisory review status
-  does not block unless branch protection requires it. Actionable feedback
-  still blocks through the feedback ledger.
+  CI, review gates, and the Codex PR-description gate. Advisory check or run
+  lag does not block unless branch protection requires it. Actionable feedback
+  blocks through the feedback ledger, and any aggregate `CHANGES_REQUESTED`
+  review verdict blocks readiness.
 
 ## Alternatives considered
 

--- a/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
+++ b/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
@@ -3,7 +3,7 @@ title: CodeRabbit replaces Cursor BugBot as the third PR review bot
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-30
+last_verified: 2026-08-31
 scope: ci/process
 date: 2026-08
 doc_type: adr
@@ -13,23 +13,28 @@ garden_lane: adrs-architecture
 
 # ADR 0066 — CodeRabbit replaces Cursor BugBot as the third PR review bot
 
-**Status:** Accepted (Aug 2026) — cutover per the plan under Decision.
+**Status:** Accepted (Aug 2026) — BugBot disabled on 2026-08-31.
 **Scope:** ci/process
 
 ## Context
 
-Every PR gets three AI reviewers: Cursor BugBot (`cursor[bot]`), OpenAI Codex
-(`chatgpt-codex-connector[bot]`), and Claude Code (`claude[bot]`), plus a local
-pre-push Codex autoreview. BugBot is advisory only for CI status: its check is
-not required and its lag does not block (ADR 0007). Its comment content is not
-fully advisory, though — `pr:feedback-state` treats `BUGBOT_BUG_ID` as an
-actionable marker and blocks `pr:ready-state` until every flagged comment is
-answered (`scripts/pr/pr-feedback-state-core.mjs`). The Dependabot auto-merge
-flow that existed when this ADR was accepted cited BugBot's risk summary as
-advisory only. The current narrow workflow pair does not use a review bot as
-an eligibility input. Codex and Claude run
-on subscriptions the team already pays for other reasons. BugBot is the only
-reviewer with its own bill.
+Before this decision, every PR got three AI reviewers: Cursor BugBot
+(`cursor[bot]`), OpenAI Codex (`chatgpt-codex-connector[bot]`), and Claude Code
+(`claude[bot]`), plus a local pre-push Codex autoreview. BugBot's check was not
+required, and its lag did not block under ADR 0007. Its actionable comments
+still blocked the feedback ledger. The Dependabot auto-merge flow that existed
+when this ADR was accepted cited BugBot's risk summary as advisory. The current
+narrow workflow pair does not use a review bot as an eligibility input. The
+current review stack replaces BugBot with CodeRabbit. Codex and Claude continue
+to run on subscriptions that the team pays for other reasons.
+
+BugBot was disabled in the Cursor dashboard on 2026-08-31. Legacy feedback
+still uses its original policy. `pr:feedback-state` continues to recognize
+`BUGBOT_BUG_ID` and `cursor[bot]` until every open legacy PR is terminal. The
+open-PR sweep on 2026-08-31 found one active case: PR #2036 has a current-head,
+unresolved, unreplied Cursor finding. The `Cursor Bugbot` check also remains an
+optional context during this compatibility period. These compatibility paths
+do not trigger new BugBot reviews.
 
 That bill changed shape. Cursor announced on 2026-05-11 (effective at each
 customer's first renewal after 2026-06-08) that BugBot dropped its flat
@@ -78,6 +83,22 @@ precision-first member of the stack — a role Codex (deliberately P0/P1-only)
 already fills. CodeRabbit and Greptile are the two credible replacements, and
 both measured lower false-positive rates than BugBot in the independent
 study.
+
+### Two-week comparison outcome
+
+The repository completed the planned parallel comparison before the operator
+disabled BugBot. CodeRabbit touched 141 of 145 PRs. It posted 326 inline
+findings on 93 PRs. The audit classified 319 findings: maintainers marked 284
+fixed and 35 as won't-fix. CodeRabbit conceded 28 of the won't-fix findings as
+false positives. It posted six Critical findings: five were fixed and one was
+conceded.
+
+Twenty PRs received findings from both reviewers. CodeRabbit posted 105
+findings on those PRs, and BugBot posted 29. Only nine findings matched the
+same file and line. The low overlap supports the original conclusion that the
+reviewers were complementary, but CodeRabbit supplied more review coverage
+during the comparison. The operator chose to keep the Pro+ plan and disabled
+BugBot after reviewing these results.
 
 ### Cost at this repo's shape (1 PR-author seat, ~280 PRs/month, public repo)
 
@@ -137,31 +158,17 @@ Replace BugBot with CodeRabbit as the third advisory reviewer.
    treating one normal fix round as active development. The ship and babysit
    closeout requests one manual review for an exact head when the automatic
    review is stale or missing after the optional check becomes terminal.
-3. **Parallel-run for ~2 weeks.** Switch BugBot to manual triggering
-   (`bugbot run`) during the window to bound how often it runs — a trigger
-   limit, not a spending cap; the account-level monthly spend limit is the
-   only hard ceiling — compare both bots' findings on the same PRs, then
-   disable BugBot in the Cursor dashboard.
-   Until step 4 lands, CodeRabbit is not in the feedback-ledger bot roster, so
-   its comments do not block `pr:ready-state` — triage them manually during
-   the window.
-4. **Update the bot rosters and docs — two phases, not one cutover PR.** The
-   ADD side lands here, side by side with BugBot, nothing BugBot-related
-   removed: `scripts/pr/pr-feedback-state-core.mjs`,
-   `scripts/pr/pr-feedback-state-claude.mjs` (CodeRabbit's markers enter;
-   `BUGBOT_BUG_ID` stays live), `scripts/pr/pr-ready-state-core.mjs`,
-   `scripts/pr/review-process-metrics.mjs`, their tests,
-   `docs/notes/pr-ready-state.md`, and `docs/pr-checklists/ci-workflow-gates.md`.
-   The BugBot sweep — retiring `BUGBOT_BUG_ID`,
-   `docs/adr/0007-agent-quality-gate-and-merge-oracle.md`'s "Advisory bot lag
-   (for example, Cursor)" line, and the comment in
-   the then-current Dependabot auto-merge workflow — follows once the ~2-week
-   parallel window (step 3) ends and BugBot is disabled in the Cursor
-   dashboard. The current narrow workflow pair no longer contains that comment.
-5. **Measure.** Run `scripts/pr/review-process-metrics.mjs` on before/after
-   cohorts and re-check the fixed/won't-fix reply ratio per bot after ~40
-   merged PRs. If CodeRabbit's accepted-finding rate is materially below
-   BugBot's or noise stays high after tuning, revisit (fallbacks below).
+3. **Run both reviewers for two weeks** (complete 2026-08-31). Compare their
+   findings on the same PRs. Use the result to confirm or reverse the decision.
+4. **Disable BugBot** (complete 2026-08-31). Stop new reviews and preserve
+   legacy feedback enforcement for open PRs. The live sweep found that PR
+   #2036 still needs this compatibility. Remove it only after every PR with a
+   legacy Cursor feedback or check surface is terminal. Issue #2178 owns the
+   related readiness projection update.
+5. **Keep measurement repeatable.** Preserve historical Cursor recognition in
+   `scripts/pr/review-process-metrics.mjs`. Use before and after cohorts to
+   assess future review changes. Do not erase historical evidence when the
+   live compatibility path retires.
 
 ## Alternatives considered
 
@@ -221,11 +228,12 @@ Replace BugBot with CodeRabbit as the third advisory reviewer.
   preventing duplicate requests for the same head.
   `@coderabbitai rate limit` reports remaining capacity without consuming
   a review.
-- The cutover PR must sweep every live `cursor[bot]`/BugBot reference — the
-  step-4 list above, re-verified by grep at cutover time rather than a fixed
-  count, since references have already drifted once during this ADR's own
-  review. `pr:feedback-state` severity regexes keyed on `BUGBOT_BUG_ID` retire
-  with it.
+- The 2026-08-31 open-PR sweep found one current-head Cursor finding on PR
+  #2036. Keep `cursor[bot]`, `BUGBOT_BUG_ID`, and the optional `Cursor Bugbot`
+  check classification until that PR and any other open legacy PR are
+  terminal. Retire these paths only after another live sweep returns no active
+  legacy feedback. Preserve Cursor recognition in historical metrics and
+  frozen review fixtures after the live path retires.
 - CodeRabbit is a new third-party GitHub App with repo read access and PR
   comment/review write access, steered by `.coderabbit.yaml` — and CodeRabbit
   resolves that file from the **source branch** of the PR under review,
@@ -283,6 +291,12 @@ Replace BugBot with CodeRabbit as the third advisory reviewer.
   PRs created after `.coderabbit.yaml` merged carried CodeRabbit's generated
   pause marker. Six of those PRs had only 2-4 total commits. Two of the 29 PRs
   carried the rate-limit marker, and neither also carried the pause marker.
+- Two-week cutover sample, queried from GitHub on 2026-08-31: 145 PRs after
+  installation; CodeRabbit touched 141 and posted 326 inline findings on 93.
+  The audit classified 319 findings: 284 fixed and 35 won't-fix, including 28
+  vendor-conceded false positives. On 20 shared finding PRs, CodeRabbit
+  posted 105 findings and BugBot posted 29; nine matched the same file and
+  line. The same sweep found one open current-head Cursor finding on PR #2036.
 - Greptile pricing and OSS terms: greptile.com/pricing,
   greptile.com/blog/greptile-v4 (2026-03-05 model change),
   greptile.com/docs/code-review-bot/trigger-code-review (re-review is opt-in

--- a/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
+++ b/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
@@ -148,16 +148,14 @@ Replace BugBot with CodeRabbit as the third advisory reviewer.
    billing. The $0 OSS tier (Pro+ features, ~1/hour, manual-trigger-only
    under 10 stars, no add-on) remains the documented fallback if spend must
    return to zero.
-2. **Commit `.coderabbit.yaml`** before the first review lands: start from the
-   assertive-adjacent default only if noise proves low; otherwise use the
-   `chill` profile or the July 2026 `quiet` profile (critical findings inline,
-   the rest summarized), `path_filters` excluding lockfiles and generated
-   trees, and `auto_pause_after_reviewed_commits: 5`. The initial value of 2
-   paused normal one-fix PRs because the opening review counts as the first
-   reviewed commit. The vendor default of 5 preserves the burst guard without
-   treating one normal fix round as active development. The ship and babysit
-   closeout requests one manual review for an exact head when the automatic
-   review is stale or missing after the optional check becomes terminal.
+2. **Commit `.coderabbit.yaml`** (done 2026-08-19 in PR #1927): use the `chill`
+   profile, `path_filters` that exclude lockfiles and generated trees, and
+   `auto_pause_after_reviewed_commits: 5`. The initial value of 2 paused normal
+   one-fix PRs because the opening review counts as the first reviewed commit.
+   The vendor default of 5 preserves the burst guard without treating one
+   normal fix round as active development. The ship and babysit closeout
+   requests one manual review for an exact head when the automatic review is
+   stale or missing after the optional check becomes terminal.
 3. **Run both reviewers for two weeks** (complete 2026-08-31). Compare their
    findings on the same PRs. Use the result to confirm or reverse the decision.
 4. **Disable BugBot** (complete 2026-08-31). Stop new reviews and preserve
@@ -239,8 +237,8 @@ Replace BugBot with CodeRabbit as the third advisory reviewer.
   resolves that file from the **source branch** of the PR under review,
   falling back to defaults when absent, so a PR can weaken or replace the
   profile that reviews it. That was acceptable only while the bot's output
-  fed nothing required. This PR (the ADD side of step 4) satisfies the
-  pre-gate condition this bullet used to defer:
+  fed nothing required. PR #1927, the 2026-08-19 CodeRabbit ADD phase,
+  satisfied the pre-gate condition this bullet used to defer:
   `scripts/coderabbit-config.test.mjs` pins the
   committed config by exact equality and runs in required CI
   (`pnpm coderabbit:config:test`), so a source-branch edit to

--- a/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
+++ b/docs/adr/0066-coderabbit-replaces-bugbot-third-reviewer.md
@@ -62,8 +62,8 @@ Decision criteria: review quality and cost.
 - **This repo's own history** (last 40 merged PRs, #1843–#1911, sampled
   2026-08-18): 26 inline bot findings, all 26 answered "Fixed in `<commit>`",
   zero won't-fix. BugBot contributed 5 findings on 4 PRs, Codex 15 on 3 PRs,
-  Claude 6 on 3 PRs. All three bots currently deliver accepted findings; the
-  sample is too small and bursty to measure noise rates.
+  Claude 6 on 3 PRs. All three bots delivered accepted findings in this sample;
+  the sample is too small and bursty to measure noise rates.
 - **The strongest independent head-to-head** (146 PRs / 679 findings, four
   bots run in parallel for 3 weeks, published May 2026): false-positive
   rates — the study counts FP/(fixed+FP), excluding pending findings — were
@@ -78,11 +78,11 @@ Decision criteria: review quality and cost.
   an independent re-run of Greptile's own 50-bug set measured 45% recall
   against the self-reported 82%.
 
-Read together: no candidate has a decisive quality edge. BugBot is the quiet,
-precision-first member of the stack — a role Codex (deliberately P0/P1-only)
-already fills. CodeRabbit and Greptile are the two credible replacements, and
-both measured lower false-positive rates than BugBot in the independent
-study.
+Read together: no candidate had a decisive quality edge. During the comparison,
+BugBot was the quiet, precision-first reviewer — a role Codex (deliberately
+P0/P1-only) already filled. CodeRabbit and Greptile were the two credible
+replacements, and both measured lower false-positive rates than BugBot in the
+independent study.
 
 ### Two-week comparison outcome
 

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -3,7 +3,7 @@ title: PR Ready State
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-26
+last_verified: 2026-08-31
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -81,17 +81,17 @@ Required blockers:
 
 Optional signals:
 
-- Cursor Bugbot or other advisory bot reviews when they are not required by
-  branch protection.
+- Legacy Cursor Bugbot checks on PRs opened before its 2026-08-31 disablement,
+  when branch protection does not require them.
 - Non-required check runs, flaky advisory jobs, or lint/report jobs configured
   outside the required status rollup.
 - Older bot comments or reviews that do not apply to the current head, provided
   every required current-head comment has been handled.
 
-Cursor Bugbot commonly lags behind the raw status rollup. Treat that lag as a
-separate advisory state: report it in the readiness output, but do not hold the
-all-clear on it unless the Cursor check or review is required by branch
-protection.
+Legacy Cursor Bugbot check lag can still appear on PRs opened before its
+2026-08-31 disablement. Report the check as advisory, but do not hold the
+all-clear on it unless branch protection requires it. Actionable Cursor
+feedback and an aggregate `CHANGES_REQUESTED` verdict remain required blockers.
 
 CodeRabbit's `CodeRabbit` check context (ADR 0066) is advisory the same way,
 with one added trap: it reports `SUCCESS` even when no review ran. A
@@ -454,10 +454,10 @@ Field expectations:
    `gates.codeRabbitReviewSignal.state` is `missing` or `stale`, post one
    head-bound closeout request with the body above. Do not post when the state
    is `requested` or `reviewed`.
-9. Report optional lag separately, especially Cursor Bugbot lag and visibly
-   in-progress review-producing workflows. If you are still watching the PR when
-   one finishes, rerun `pr:feedback-state` to catch late feedback; do not treat
-   the optional workflow status itself as a blocker.
+9. Report optional lag separately, especially legacy Cursor Bugbot check lag and
+   visibly in-progress review-producing workflows. If you are still watching the
+   PR when one finishes, rerun `pr:feedback-state` to catch late feedback; do not
+   treat the optional workflow status itself as a blocker.
 10. After the CodeRabbit closeout step and any final optional-review refresh,
     rerun `pr:feedback-state` and then `pr:ready-state`. Signal all-clear only
     when feedback-state has no required blocker and ready-state `ready` is true

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -286,7 +286,7 @@ Expected top-level fields:
     "ready": false,
     "items": [
       {
-        "kind": "review",
+        "kind": "check",
         "name": "Cursor Bugbot",
         "state": "pending",
         "required": false,


### PR DESCRIPTION
## The Problem

- BugBot is disabled, but the review ADR still described a planned CodeRabbit cutover.
- Open PR #2036 still has current-head Cursor feedback that uses the legacy `BUGBOT` marker. Removing the legacy parser now would hide active feedback.
- The repository did not record the two-week comparison or the decision to keep CodeRabbit Pro+.

## The Solution

Record the completed cutover, the measured comparison, and the Pro+ decision. Keep legacy Cursor marker recognition until every open legacy PR reaches a terminal state. This PR changes review policy documentation only. It does not change CodeRabbit configuration, branch protection, or readiness behavior.

Refs #1917.

## Details

- Update ADR 0066 with the cutover date, measured outcome, compatibility condition, and current Dependabot review behavior.
- Update ADR 0007 so the quality-gate record distinguishes advisory check lag from actionable feedback and aggregate `CHANGES_REQUESTED` state.
- Update the readiness runbook so agents do not wait for or request new BugBot reviews while legacy Cursor feedback remains visible.

## Validation

- The cutover audit sampled 145 PRs. CodeRabbit touched 141 PRs and left 326 inline comments on 93 PRs. The classifier assigned 319 inline comments: 284 fixed and 35 won't-fix. Reviewers recorded 28 CodeRabbit concessions. The shared-review sample covered 20 PRs. CodeRabbit posted 105 findings and BugBot posted 29 on those PRs; nine findings matched the same file and line. This audit supports the cutover decision. It does not measure future review quality.
- `pnpm pr:feedback-state --pr 2036 --json` inspected current head `02c0e3bea48824937b067c152b2d37e1d7330ce1` and found three unresolved, unreplied threads, including a Cursor comment with the `BUGBOT` marker. This proves that the current compatibility path is needed for that PR. It does not prove that no other legacy PR needs it.
- The final diff at exact head `3fbd6bebcc423922a2fba7171ad69264cdf868e8` against `b4bf201c3b87580771c55ec615fcc9a4e51ae267` contains three documentation files.
- At that head, `pnpm agent:context-check` passed with 168 managed files, `pnpm docs:index --check` passed, `pnpm docs:navigation-eval:test` passed 34/34 tests, and `git diff --check b4bf201c3b87580771c55ec615fcc9a4e51ae267...HEAD` passed. These checks validate the final documentation diff. They do not validate hosted review behavior.
- `pnpm agent:quality-gate --base origin/main --head HEAD --dry-run` mapped the expected documentation checks. The full Darwin/coordinator gate did not complete because the coordinator failed before any mapped command. The user approved a one-time waiver for exact head `3fbd6bebcc423922a2fba7171ad69264cdf868e8`; hosted CI and current-head review replace that run.
- A fresh sealed read-only source review found no actionable findings at exact head `3fbd6bebcc423922a2fba7171ad69264cdf868e8` against `b4bf201c3b87580771c55ec615fcc9a4e51ae267`. This review does not replace hosted CI or runtime proof.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2178 tracks CodeRabbit path-filter readiness support.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2179 tracks reproducible review metrics.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2158 tracks the quality-gate coordinator failure.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? This PR updates ADRs 0007 and 0066.
