### PR TITLE
fix(alerts): reconcile on-call rotation on Monday

### DIFF
--- a/alerts/infra/.terraform.lock.hcl
+++ b/alerts/infra/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.4.0"
   hashes = [
     "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
     "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
     "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
     "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "7.33.0"
   constraints = ">= 3.43.0, >= 4.28.0, >= 5.41.0, >= 7.0.0, < 8.0.0"
   hashes = [
+    "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",
     "h1:Juvz+QyHaKLTVv/pVo6vnA9V5ZqiFgCJ4FpqGLNl3DY=",
     "zh:10620bf55734d05701852dbbd55aa151860cbaf672001222c29ee93ec02d062e",
     "zh:1ca1a3829a1fdbbce17a540d2be63b1529e46debdb8dbf0057facc992110ff38",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.33.0"
   constraints = ">= 3.43.0, >= 4.11.0, >= 5.41.0, < 8.0.0"
   hashes = [
+    "h1:Vp/UxR1orFX3lpx4iuxIkuRunHkSZfxonwh5P1B8/vE=",
     "h1:tfmZxEZ/qI6XZ3EXAsybUpqQ7cyihTWkUXjZLua45Rw=",
     "zh:0c2a87d4fc6cb4bdce514e02ac41f72b0a0b5c51aaf6ad2e13898344ad08e467",
     "zh:35b1cb96957257a46384e311a547b3ad7de61eb80f677120d48bd11173a2d1bf",
@@ -66,6 +69,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version     = "3.6.0"
   constraints = ">= 3.4.0"
   hashes = [
+    "h1:FekY+4cjIw3QBdpk2dVQ20+t8AeDwCK/VaKOnjfeJvw=",
     "h1:ligOpkIiBTS1ZkLoFp3cwkRYCwYyaZj1Z7t3GdfNa+c=",
     "zh:0996c7db5d7627bc6ab8c4d217f18fb122d60e99e454812b080ee5695cad1003",
     "zh:25b7ee0ba9edc912a00365c776d062ae7c66d94050c6c13038447c8e8b95ddf2",
@@ -87,6 +91,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
   constraints = ">= 2.5.0"
   hashes = [
+    "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
     "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
@@ -109,6 +114,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.1.0, >= 3.2.0"
   hashes = [
     "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
     "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
@@ -130,6 +136,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 2.2.0, >= 3.6.0"
   hashes = [
     "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
     "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
@@ -151,6 +158,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = ">= 0.5.0"
   hashes = [
     "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
     "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
     "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
     "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
@@ -197,6 +205,7 @@ provider "registry.terraform.io/jianyuan/sentry" {
   constraints = "0.15.4"
   hashes = [
     "h1:3/hzlVdIzamZu6CWTAcHfGTDqla0xm3T8IJifRoUyk0=",
+    "h1:V9zQDnO6OvHH9v80KRAanhNsNByuE02eDfFkl/VyMe4=",
     "zh:028d879f7176806245ed4979aceae9566c367598aee5e3aafec366f8786908a0",
     "zh:096dec2a93bfeac1e598a3fe8123c908405e46d0c14617a2c1e70219d1f82268",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
@@ -218,6 +227,7 @@ provider "registry.terraform.io/mastercard/restapi" {
   version     = "3.0.0"
   constraints = ">= 2.0.1"
   hashes = [
+    "h1:Fqxoc6bsydl6iWGx6ZvyqUDdGt7Cb4sW/BSHhBeHGgw=",
     "h1:y1I3azDHOqRySTyDHsb3Xh1waP/99KfykZRagbRx1qI=",
     "zh:0b63bd3c25a31f090a41933f90b7dd6e984add1c4261d8f5caa73f4d5aa065a4",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",

--- a/alerts/infra/README.md
+++ b/alerts/infra/README.md
@@ -176,7 +176,7 @@ chain key.
 
 ### On-call Announcer
 
-- Runs from Cloud Scheduler at 10:05 and 10:20 every Sunday in `Europe/Berlin`
+- Runs from Cloud Scheduler at 10:05 and 10:20 every Monday in `Europe/Berlin`
 - Polls Splunk On-Call `/api-public/v1/oncall/current`
 - Resolves the current Splunk On-Call user email to a Slack user ID with `users.lookupByEmail`
 - Posts one Slack message to `#eng` only when the on-call username changes

--- a/alerts/infra/oncall-announcer/README.md
+++ b/alerts/infra/oncall-announcer/README.md
@@ -19,7 +19,7 @@ Slack.
 4. Reconciles the `@support-engineer` Slack usergroup to exactly one member on
    every run.
 
-The default schedule checks at 10:05 and 10:20 every Sunday in
+The default schedule checks at 10:05 and 10:20 every Monday in
 `Europe/Berlin`, shortly after the observed 10:00 weekly handover. State dedupe
 prevents duplicate Slack messages when the rotation has not changed, and the
 stable Slack `client_msg_id` lets Cloud Scheduler retries dedupe an accepted

--- a/alerts/infra/oncall-announcer/variables.tf
+++ b/alerts/infra/oncall-announcer/variables.tf
@@ -62,9 +62,9 @@ variable "runtime" {
 }
 
 variable "schedule" {
-  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Sunday 10:00 Europe/Berlin handover."
+  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Monday 10:00 Europe/Berlin handover."
   type        = string
-  default     = "5,20 10 * * 0"
+  default     = "5,20 10 * * 1"
 }
 
 variable "scheduler_name" {

--- a/alerts/infra/terraform.tfvars.example
+++ b/alerts/infra/terraform.tfvars.example
@@ -63,9 +63,9 @@ oncall_slack_channel_id = "C0123ABC456"
 # enabled. Create the usergroup in Slack once, then paste its ID here.
 oncall_support_usergroup_id = "S0123ABC456"
 
-# Optional: poll at 10:05 and 10:20 every Sunday in Europe/Berlin by default,
+# Optional: poll at 10:05 and 10:20 every Monday in Europe/Berlin by default,
 # shortly after the observed 10:00 weekly handover.
-# oncall_rotation_check_schedule = "5,20 10 * * 0"
+# oncall_rotation_check_schedule = "5,20 10 * * 1"
 
 #####################
 # Google Cloud Configuration

--- a/alerts/infra/variables.tf
+++ b/alerts/infra/variables.tf
@@ -101,9 +101,9 @@ variable "oncall_announce_on_first_run" {
 }
 
 variable "oncall_rotation_check_schedule" {
-  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Sunday 10:00 Europe/Berlin handover; the function stores last-seen state and only posts when the on-call username changes."
+  description = "Cloud Scheduler cron expression for polling Splunk On-Call. The default checks shortly after the weekly Monday 10:00 Europe/Berlin handover; the function stores last-seen state and only posts when the on-call username changes."
   type        = string
-  default     = "5,20 10 * * 0"
+  default     = "5,20 10 * * 1"
 }
 
 variable "oncall_slack_channel_id" {

--- a/scripts/production-infra-identity-contract/provenance.mjs
+++ b/scripts/production-infra-identity-contract/provenance.mjs
@@ -27,7 +27,7 @@ const SOURCE_BLOCK_SHAPE_SPECIFICATIONS = [
   "alerts/infra:variable.debug_mode|f52b2ce0bd99f8f263fda1fbc5aac0e9b5bce445d603fc45a4d5ec0ac4f472ce",
   "alerts/infra:variable.multisigs|bc6efbb0d5eb414139081182fac6f93647f32b822e9bbd08bc2c17209bce2f29",
   "alerts/infra:variable.oncall_announce_on_first_run|e36344bd00f1f50834bd9243d1c4e059bdb52da9c090c5f1f3876ca6950557bb",
-  "alerts/infra:variable.oncall_rotation_check_schedule|5bc5eda526ec49fbc7534bda52cf242fcbc0b32c19dfc62ebf5ad60a0d895c5d",
+  "alerts/infra:variable.oncall_rotation_check_schedule|a0f9671e9eea0e9a9eca991c6810b400e92c038e92a1426447c58a1114878be2",
   "alerts/infra:variable.oncall_slack_channel_id|de5843b9c72d3b4400b1df21867ca03b969020399514940324fd68c750bc89a6",
   "alerts/infra:variable.oncall_support_usergroup_id|c65531b6a19f26ea2c0efb6196481a8ea9cf0949f219a147fb8a2398b2777903",
   "alerts/infra:variable.org_id|9f4baa3184507cb57b60f341f8a8bd31877289b78cc638e67709406c677f6602",


### PR DESCRIPTION
## The Problem

The on-call rotation check still ran shortly after the former Sunday handover, leaving the @support-engineer announcement stale after the Monday handover.

## The Solution

The check now runs at 10:05 and 10:20 Europe/Berlin on Mondays. The production-infrastructure provenance contract is updated in the same change, so the intentional schedule change remains auditable. This PR changes only the polling schedule; it does not apply Terraform or force an announcement when the assignee has not changed.

## Details

- Updates the default cron expression from `5,20 10 * * 0` to `5,20 10 * * 1`.
- Aligns the Terraform variable descriptions and operator examples with Monday handover.
- Adds Linux provider checksums observed during Terraform validation.
- Updates the audited source-block digest for `alerts/infra:variable.oncall_rotation_check_schedule`.

## Validation

- `pnpm agent:quality-gate --run` passed, including targeted Trunk checks, Terraform fmt/init/validate, `pnpm tf:test`, docs checks, context checks, and script lint. This validates static configuration and local contracts; it does not apply the Terraform change or prove the live scheduler updates.
- Isolated bundle review and deterministic autoreview found no actionable findings. These review the source diff; they do not replace a production plan/apply or runtime verification.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable.