### PR TITLE
fix(alerts): lower Celo reserve USD thresholds

### DIFF
--- a/alerts/rules/rules-reserve-balances.tf
+++ b/alerts/rules/rules-reserve-balances.tf
@@ -8,8 +8,8 @@ resource "grafana_rule_group" "reserve_balances" {
       # Removed CELO because it's not being actively managed in the Reserve at the moment
       # trunk-ignore(checkov/CKV_SECRET_6)
       # CELO    = { token = "CELOToken", threshold = 5000000 }
-      USDC    = { token = "USDC", threshold = 100000 }
-      USDT    = { token = "USDT", threshold = 100000 }
+      USDC    = { token = "USDC", threshold = 90000 }
+      USDT    = { token = "USDT", threshold = 90000 }
       axlUSDC = { token = "axlUSDC", threshold = 50000 }
     }
     content {


### PR DESCRIPTION
## Summary

- lower the Celo Reserve USDC low-balance alert threshold from 100,000 to 90,000
- lower the Celo Reserve USDT low-balance alert threshold from 100,000 to 90,000

## Verification

- `pnpm agent:quality-gate --run`
- `pnpm agent:autoreview --mode local --base origin/main --engine local`
- three local review passes (scope/correctness, Terraform reference consistency, rollout/docs/tests)
- fresh-context adversarial reviewer: clean, no findings

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
