### PR TITLE
test(docs): isolate qualification scoring from live bytes

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -16,19 +16,19 @@ garden_lane: operator-runbooks
 Codex PR babysitting. It answers whether the current head's required GitHub and
 repo-policy gates are clear.
 
-The command is the final required-gate source of truth, not a replacement for
-the feedback sweep. Before either agent signals all-clear, `pr:feedback-state`
-must have a clean feedback ledger and the subsequent current-head
-`pr:ready-state` result must be ready. Agent-specific loops may gather extra
-context or post replies, but they must preserve that two-projection contract.
+The command is the final required-gate source of truth and does not replace the
+feedback sweep. Before either agent signals all-clear, `pr:feedback-state` must
+have a clean feedback ledger and the subsequent current-head `pr:ready-state`
+result must be ready. Agent-specific loops may gather extra context or post
+replies, but must preserve that two-projection contract.
 
 The probe shells out to gh, so it cannot run in Claude cloud sessions whose
-proxy blocks GraphQL and where gh is not reliably available; a variant passing the REST + GraphQL +
-`--slurp` capability gate runs it as written, passing `--repo <owner/name>`
-since gh cannot infer the repo from the proxy remote. Blocked sessions use
-the MCP emulation documented in
+proxy blocks GraphQL and where gh is unreliable. A session passing the REST +
+GraphQL + `--slurp` capability gate runs it as written, passing
+`--repo <owner/name>` because gh cannot infer the repo from the proxy remote.
+Blocked sessions use the MCP emulation in
 [`github-tooling-surfaces.md`](github-tooling-surfaces.md) and label their
-all-clear MCP-emulated rather than probe-verified.
+all-clear MCP-emulated, not probe-verified.
 
 ## Readiness model
 
@@ -39,9 +39,9 @@ them required for the current PR.
 Required blockers:
 
 - Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
-  expensive readiness sweep because there is nothing left to fix or wait on.
-  Closed-unmerged PRs report only the terminal `state` blocker; review gates are
-  non-required because no Codex or reviewer action can unblock a closed PR.
+  expensive readiness sweep, since nothing is left to fix or wait on. A
+  closed-unmerged PR reports only the terminal `state` blocker; review gates are
+  non-required because no Codex or reviewer action can unblock it.
 - Required check runs or status contexts that are failing, pending, queued, or
   missing from the branch-protection rollup.
 - Branch-protection context lookup failures caused by unreadable or
@@ -49,17 +49,16 @@ Required blockers:
   required-vs-optional status. If the classic branch-protection endpoint returns
   GitHub's `Branch not protected (HTTP 404)` response, the probe reads active
   branch rulesets and derives required status contexts from any
-  `required_status_checks` and named `workflows` rule before using the fallback
-  split.
+  `required_status_checks` and named `workflows` rule before the fallback split.
 - Required GitHub review state, including requested changes or required review
   still pending.
 - Unreplied review comments that repo policy requires agents to answer. A
   direct reply satisfies this gate when it comes from the PR author, the Codex
-  review bot, or a different human GitHub `OWNER`, `MEMBER`, or
-  `COLLABORATOR`. This lets a maintainer take over a teammate's PR without
-  borrowing the original author's credentials. A reviewer's reply to their own
-  root comment does not satisfy the gate, and neither does a reply from an
-  untrusted contributor or a bot merely carrying a trusted association.
+  review bot, or a different human GitHub `OWNER`, `MEMBER`, or `COLLABORATOR`,
+  so a maintainer can take over a teammate's PR without borrowing the original
+  author's credentials. A reviewer's reply to their own root comment does not
+  satisfy the gate, nor does a reply from an untrusted contributor or a bot
+  merely carrying a trusted association.
 - The Codex PR-description approval gate for the current head. The bot `+1`
   reaction must be created at or after the current-head update lower bound:
   the head commit's GitHub push timestamp when available, otherwise the first
@@ -74,10 +73,10 @@ Required blockers:
   ```
 
   The override is scoped to the exact current head SHA, so any new push expires
-  it. It is reported as gate state `overridden` with `readinessOverrides[]`
-  evidence; it is not hidden as a normal Codex approval. It never overrides
-  failing or pending required checks, merge conflicts, draft state, requested
-  changes, unresolved review threads, or unreplied review comments.
+  it. It reports gate state `overridden` with `readinessOverrides[]` evidence
+  rather than hiding as a normal Codex approval. It never overrides failing or
+  pending required checks, merge conflicts, draft state, requested changes,
+  unresolved review threads, or unreplied review comments.
 
 Optional signals:
 
@@ -88,36 +87,25 @@ Optional signals:
 - Older bot comments or reviews that do not apply to the current head, provided
   every required current-head comment has been handled.
 
-Legacy Cursor Bugbot check lag can still appear on PRs opened before its
-2026-08-31 disablement. Report the check as advisory, but do not hold the
-all-clear on it unless branch protection requires it. Actionable Cursor
-feedback and an aggregate `CHANGES_REQUESTED` verdict remain required blockers.
+Actionable Cursor feedback and an aggregate `CHANGES_REQUESTED` verdict remain
+required blockers even though the check itself is advisory.
 
 CodeRabbit's `CodeRabbit` check context (ADR 0066) is advisory the same way,
 with one added trap: it reports `SUCCESS` even when no review ran. A
 rate-limited push gets a PR comment carrying
 `<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->`
 and the check still passes. A passing `CodeRabbit` check alongside a
-current-head rate-limit comment means "no review ran," not "reviewed and
-clean" — read the comment, not the check conclusion, and rerun
-`pr:feedback-state` once a later push clears the rate limit.
-`.coderabbit.yaml` leaves `request_changes_workflow` at its `false` default,
-so CodeRabbit does not submit a GitHub `CHANGES_REQUESTED` review today. If
-that setting is ever turned on, a `CHANGES_REQUESTED` review does not clear
-itself on a later clean push and needs the same manual fix as any other
-stuck bot review verdict: dismiss it with
+current-head rate-limit comment means "no review ran" — read the comment, not
+the check conclusion, and rerun `pr:feedback-state` once a later push clears
+the rate limit. `.coderabbit.yaml` leaves `request_changes_workflow` at its
+`false` default, so CodeRabbit submits no GitHub `CHANGES_REQUESTED` review
+today. Turned on, such a review would not clear itself on a later clean push
+and would need the same manual fix as any stuck bot verdict: dismiss it with
 `gh api repos/<owner>/<repo>/pulls/<pr>/reviews/<review_id>/dismissals -X PUT -f message='<why>' -f event=DISMISS`.
 
-The JSON projections expose `gates.codeRabbitReviewSignal` with `missing`,
-`requested`, `stale`, `reviewed`, or `not_applicable`. A `reviewed` signal
-requires either a CodeRabbit review body with its `**Run ID**` marker and a
-review commit equal to the full current head, or a trusted CodeRabbit top-level
-clean-run block enclosed by `<!-- recent_review_start -->` and
-`<!-- recent_review_end -->`. The clean-run block must contain the Run ID and a
-reviewed commit range that ends at the full current head. Its comment update
-time must be at or after the head update time. Empty review records, skipped
-runs, and rate-limit notices do not count. A head-bound closeout request uses
-this exact body:
+The JSON projections expose `gates.codeRabbitReviewSignal`; the
+`codeRabbitReviewSignal` field expectation below defines its values and what
+makes a signal `reviewed`. A head-bound closeout request uses this exact body:
 
 ```text
 @coderabbitai review
@@ -133,46 +121,43 @@ After the optional CodeRabbit check becomes terminal, refresh the projection
 once. If the signal is `missing` or `stale`, re-resolve `headRefOid` immediately
 before posting and require it to equal the marker head. A `requested` signal
 suppresses ordinary duplicate posts for the same head. GitHub's issue-comment
-API has no conditional-create operation, so the marker is a detection and
-best-effort suppression mechanism rather than an atomic claim. The CodeRabbit
-check and review remain advisory: report a pending or rate-limited result as
-optional lag. The rate limit is a shared quota, not a per-PR allowance.
-[ADR 0066](../adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) records
-the two tiers: the free OSS tier meters per repository on a star-scaled 1–10
-reviews/hour, and a paid seat meters per developer identity across every PR
-that identity opened. This org runs a paid Pro+ seat, so the ceiling is the
-identity's, currently about 4 reviews/hour at this repo's review volume.
-Either way, watching several PRs at once draws down one allowance, so a
-re-request inside the window queues or no-ops on whichever PR reaches the
-limit first — do not tight-loop `@coderabbitai review` posts waiting for a
-faster turnaround. If a requested review finishes while the PR is still under
-watch, rerun `pr:feedback-state` and handle its findings before all-clear.
+API has no conditional-create operation, so the marker detects and suppresses
+best-effort rather than claiming atomically. The check and review stay
+advisory: report a pending or rate-limited result as optional lag. The rate
+limit is a shared quota, not a per-PR allowance.
+[ADR 0066](../adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) owns the
+two-tier metering model. This org runs a paid Pro+ seat, so the ceiling is the
+developer identity's across every PR it opened, currently about 4 reviews/hour
+at this repo's review volume. Watching several PRs at once draws down one
+allowance, so a re-request inside the window queues or no-ops on whichever PR
+hits the limit first — do not tight-loop `@coderabbitai review` posts. If a
+requested review finishes while the PR is still under watch, rerun
+`pr:feedback-state` and handle its findings before all-clear.
 
 Some non-required workflows still post feedback that becomes a repo-policy
 blocker after the required status surface is green. Their workflow status stays
-optional, but inline threads, unreplied review comments, and actionable
-top-level bot feedback do not. `pr:feedback-state` owns that ledger;
-`pr:ready-state` does not project actionable top-level summaries into its
-required blockers. If a review-producing workflow is visibly in progress,
-report it as optional lag and rerun `pr:feedback-state` after it reaches a
-terminal state so late feedback is not missed.
+optional; inline threads, unreplied review comments, and actionable top-level
+bot feedback do not. `pr:feedback-state` owns that ledger; `pr:ready-state`
+does not project actionable top-level summaries into its required blockers. If
+a review-producing workflow is visibly in progress, report it as optional lag
+and rerun `pr:feedback-state` after it reaches a terminal state so late
+feedback is not missed.
 
 ### Bounded clean-Claude protocol
 
 `pr:feedback-state` keeps older exceptions in an exact compatibility registry.
 Each entry binds the raw body digest to its Claude author, PR, comment, and
-head. An entry can also bind the source timestamp. PR #1965 comment 5355983385
-uses an exact record because its composite heading, verdict emoji, and
+head, and may also bind the source timestamp. PR #1965 comment 5355983385 uses
+an exact record because its composite heading, verdict emoji, and
 post-conclusion review-method note stay outside the reusable grammar. The
 record binds author `claude[bot]`, creation time `2026-08-20T12:37:45Z`, head
 `0884780bfe1d5ae8710a6f845c3a6199f1bf365d`, and raw body digest
 `6ebf5de00fde8c46040def096e4c0c02ee0ab02b9fae20130e1ba8e6e84037e3`.
 A changed body or binding cannot reuse this record. The compatibility test also
-confirms that the general parser blocks the body without the exact record.
+confirms the general parser blocks the body without the exact record.
 
-Newer reviews go through a small prose-pattern library instead.
-
-The library clears a review only when **every line is positively recognized**.
+Newer reviews go through a small prose-pattern library, which clears a review
+only when **every line is positively recognized**.
 A line is recognized when it is blank, the Claude task-completion header, a
 thematic break, a review heading that harvest already validated, the single
 unhedged `Verdict: LGTM` or `Overall verdict: LGTM` line, a bare `Findings` or
@@ -186,51 +171,46 @@ blocks, including ordinary narrative prose that carries no finding vocabulary.
 Two consequences are deliberate and easy to trip over:
 
 - **A clean review written as free prose blocks.** The observed PR #1848 body
-  is the reference case and is pinned blocking by test. It reads clean to a
-  human, but its narrative paragraphs assert nothing the gate can verify — and
-  one of them in fact asks the reader to confirm CI before merge.
+  is the reference case, pinned blocking by test. It reads clean to a human,
+  but its narrative paragraphs assert nothing the gate can verify — and one
+  asks the reader to confirm CI before merge.
 - **A no-action marker alone is not a disposition.** `No action`, `None
-blocking`, and similar leads must be followed by curated positive evidence.
-  The older behaviour, where such a marker cleared a line on its own, let a
-  defect ride along behind it.
+blocking`, and similar leads need curated positive evidence after them. The
+  older behaviour, where such a marker cleared a line on its own, let a defect
+  ride along behind it.
 
-A clean verdict or conclusion may end only in a bare sentence terminator, or an
-approval mark as described below. Any trailing sentence blocks, because a tail
-is unconstrained English and no term list separates praise from a defect stated
-plainly.
+A clean verdict or conclusion may end only in a bare sentence terminator or the
+approval mark below. Any trailing sentence blocks: a tail is unconstrained
+English, and no term list separates praise from a defect stated plainly.
 
-A `What I checked` checklist is recognized whether or not the body also carries
-paired `Findings`/`Roll-up` headings — the standalone form and the preamble form
-read one definition. The checklist is evidence of review, never the conclusion:
-the body still needs an explicit no-findings line. An unticked or negated box
-blocks, and so does any subject outside the curated topic set, since a free
-subject is unconstrained English.
+A `What I checked` checklist is recognized with or without paired
+`Findings`/`Roll-up` headings — the standalone and preamble forms read one
+definition. The checklist is evidence of review, never the conclusion: the body
+still needs an explicit no-findings line. An unticked or negated box blocks, as
+does any subject outside the curated topic set.
 
 A trailing approval mark (`✅`, `✔️`, `👍`) is allowed after the verdict word
 **or a no-findings conclusion** — `No P1/P2 findings ✅` clears exactly as
 `**Verdict:** LGTM ✅` does. A mark asserts nothing a reader could act on, and
-one rule governs both tails deliberately: the two are the same question, and a
-second rule would be a second thing to keep in step. Any word after either is
-prose and still blocks.
+one rule governs both tails because they are the same question. Any word after
+either is prose and still blocks.
 
 The canonical registry and named phrase groups live in
 `scripts/pr/pr-feedback-state-claude.mjs`, which is now the only copy: D3 phase
 three removed the flat wrapper fallback. Add a named phrase only with a real
 review fixture and nearby blocking mutations. Add a compatibility record only
-with a byte-exact source fixture and single-field binding mutations. The library does not try to prove the meaning
-of arbitrary English prose — it refuses prose it cannot recognize, and the
-compatibility registry is the escape hatch for a specific historical body.
+with a byte-exact source fixture and single-field binding mutations.
 Current-head and unresolved-feedback checks remain separate and mandatory.
 
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via
-`--json`. Human formatting is allowed as the default for interactive use. Use
+`--json`. Human formatting stays the default for interactive use. Use
 `--watch --compact` for low-noise foreground babysitting. `pnpm
 pr:feedback-state` is the feedback-only projection for unresolved threads,
 unreplied root review comments, blocking top-level bot feedback, contextual
-top-level bot comments, normalized `findings[]`, and Codex gates; it is
-intended to replace ad hoc read-only `gh api` scraping during review sweeps.
+top-level bot comments, normalized `findings[]`, and Codex gates; it replaces
+ad hoc read-only `gh api` scraping during review sweeps.
 
 Suggested invocation:
 
@@ -241,14 +221,14 @@ pnpm --silent pr:feedback-state [<number-or-url>] [--pr <number-or-url>] [--repo
 
 `--watch --json` emits one JSON summary per poll, separated by newlines. Use
 `--watch --compact` for human babysitting and reserve JSON output for machine
-consumers that can parse newline-delimited JSON. Use `pnpm --silent` for
+consumers that parse newline-delimited JSON. Use `pnpm --silent` for
 feedback-state machine consumers so pnpm does not prepend its run-script
 banner. The `pr:feedback-state` Node entry point always prints JSON; in watch
 mode it emits one compact JSON object per poll. Add `--until-ready` to
 `pr:ready-state --watch` when the foreground loop should exit automatically:
 it exits 0 once the summary is ready or the PR is merged, exits nonzero for a
-closed-unmerged PR, and otherwise keeps polling. Without `--until-ready`, watch
-mode keeps the existing behavior and runs until interrupted.
+closed-unmerged PR, and otherwise keeps polling. Without it, watch mode runs
+until interrupted.
 
 Expected top-level fields:
 
@@ -345,20 +325,19 @@ Expected top-level fields:
 Field expectations:
 
 - `ready`: `true` only when every required blocker is clear. Optional lag must
-  not flip this to `false`. A PR whose `pr.state` is `MERGED` is terminal-ready;
-  a PR whose `pr.state` is `CLOSED` without merge is terminal-blocked with a
-  `state` blocker.
+  not flip this to `false`. A `MERGED` `pr.state` is terminal-ready; a `CLOSED`
+  one without merge is terminal-blocked with a `state` blocker.
 - `required.ready`: mirrors the required-readiness half of the decision. Agents
-  use it only after `pr:feedback-state` has a clean feedback ledger; it is not
-  sufficient for all-clear by itself.
-- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe uses
-  this before fetching comments, reactions, check sources, and branch
-  protection so post-merge babysitting exits quickly and does not mistake
-  GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
+  use it only after `pr:feedback-state` has a clean ledger; alone it is not
+  sufficient for all-clear.
+- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe reads
+  it before fetching comments, reactions, check sources, and branch protection,
+  so post-merge babysitting exits quickly and does not mistake GitHub's
+  post-merge `mergeable: UNKNOWN` for a blocker.
 - `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
 - Terminal closed PR summaries may use gate state `not_applicable` for gates
-  that are normally required on open PRs. Agents should act on the terminal
-  `state` blocker instead of requesting more review.
+  normally required on open PRs. Act on the terminal `state` blocker instead of
+  requesting more review.
 - `required.blockers[]`: only required blockers. Every item needs `kind`,
   `name`, `state`, `required: true`, and a URL when GitHub provides one.
 - `optional.items[]`: advisory signals worth reporting separately. Every item
@@ -367,11 +346,9 @@ Field expectations:
   `required.blockers[]` derives from. Each item has `name`, `required: true`,
   and a `classifyCheck()` `state` — `pass`, `fail`, `pending`, or `skipped`
   (a `NEUTRAL`/`SKIPPED` conclusion), so consumers tolerate all four. Count
-  required checks
-  from this field, never by filtering `statusChecks`: that grouping describes
-  every check the PR has and carries no `required` flag at all, so a filter on
-  one is a permanent zero. `pnpm pr:merge` reports its briefing counts from
-  here.
+  required checks here, never by filtering `statusChecks`: that grouping
+  describes every check the PR has and carries no `required` flag, so filtering
+  it is a permanent zero. `pnpm pr:merge` reports its briefing counts from here.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
 - `readinessOverrides[]`: active human break-glass overrides that affected a
@@ -383,32 +360,31 @@ Field expectations:
   `author`, URL/location fields, a short `title`/`excerpt`, `state`, and
   booleans for `currentHead`, `outdated`, `replied`, `unresolved`, and
   `blocking`. Use it as the feedback ledger for batching and deduplicating
-  review follow-ups; do not treat it as a replacement for the final
-  `pr:ready-state` all-clear gate.
+  review follow-ups; it never replaces the final `pr:ready-state` all-clear
+  gate.
 - `codexReviewSignal`: current-head Codex review state. Values are
   `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
-  means a current-head `@codex review` request exists but no bot reaction or
-  review has been observed yet. `in_flight` means the current head has a Codex
-  `eyes` reaction, a current-head Codex review, or a current-head Codex
-  top-level result. `approved` means the final PR-description `+1` gate is
-  present. `stale` means only older-head Codex signals exist.
+  means a current-head `@codex review` request exists with no bot reaction or
+  review observed yet. `in_flight` means the current head has a Codex `eyes`
+  reaction, review, or top-level result. `approved` means the final
+  PR-description `+1` gate is present. `stale` means only older-head Codex
+  signals exist.
 - `codeRabbitReviewSignal`: current-head CodeRabbit review state. Values are
   `missing`, `requested`, `stale`, `reviewed`, and `not_applicable`. A
-  CodeRabbit review with a run marker and review commit equal to the current
-  head is `reviewed`. A trusted top-level clean-run block also counts when
+  CodeRabbit review with its `**Run ID**` marker and a review commit equal to
+  the full current head is `reviewed`. A trusted top-level clean-run block also
+  counts when
   `<!-- recent_review_start -->` and `<!-- recent_review_end -->` enclose it, it
   contains a Run ID, its full commit range ends at the current head, and its
-  comment update time is at or after the current head update time. Empty
-  reply-only reviews, skipped runs, and rate-limit notices do not count. A
-  head-bound request is `requested` until a real run lands.
+  comment update time is at or after the head update time. Empty reply-only
+  reviews, skipped runs, and rate-limit notices do not count. A head-bound
+  request is `requested` until a real run lands.
 - `requiredStatusContexts[]`: required check contexts from classic branch
   protection or branch rulesets. Ruleset-derived entries include status-check
-  rules and required-workflow rules when their check names are present in the
-  ruleset or resolvable from local workflow metadata. Entries preserve
-  `integrationId` so a same-name check from the wrong GitHub App does not
-  satisfy readiness.
-- `summary`: one concise human-readable sentence suitable for a babysitter
-  status update.
+  and required-workflow rules when their check names appear in the ruleset or
+  resolve from local workflow metadata. Entries preserve `integrationId` so a
+  same-name check from the wrong GitHub App does not satisfy readiness.
+- `summary`: one concise sentence for a babysitter status update.
 
 ## Agent workflow
 
@@ -422,27 +398,27 @@ Field expectations:
    near twice the baseline, and do not pause solely for cycle count before five
    review-triggered patch cycles are complete. Pause for reclassification before
    starting a sixth.
-3. Before invoking the gate, ensure that no direct validation, dashboard server,
-   or browser suite outside the coordinator is active on the same machine.
-   Concurrent `--run` gates from other worktrees can continue through the
-   coordinator. They share weighted machine capacity. From invocation until
-   this gate exits, do not start uncoordinated work there. Use same-machine spare
-   workers only for read-only work. Run `pnpm agent:quality-gate --run` once for
-   the batch. Run validation outside the coordinator from a fully hydrated
-   checkout on another machine.
+3. Before invoking the gate, ensure no direct validation, dashboard server, or
+   browser suite outside the coordinator is active on the same machine.
+   Concurrent `--run` gates from other worktrees continue through the
+   coordinator and share weighted machine capacity. From invocation until this
+   gate exits, start no uncoordinated work there; use same-machine spare workers
+   only for read-only work. Run `pnpm agent:quality-gate --run` once for the
+   batch. Run validation outside the coordinator from a fully hydrated checkout
+   on another machine.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
    run `pnpm agent:autoreview` as a structured source-review closeout at the
-   batch boundary rather than as an inner loop. Verify accepted findings before
-   editing and rerun focused checks plus autoreview if those fixes change the
-   batch. The exact target, prepared-bundle, isolation, and trust contracts live
-   in [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md);
-   keep behavioral and runtime verification in the validation record.
+   batch boundary, not as an inner loop. Verify accepted findings before editing
+   and rerun focused checks plus autoreview if those fixes change the batch. The
+   exact target, prepared-bundle, isolation, and trust contracts live in
+   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
+   behavioral and runtime verification in the validation record.
 5. Run the suggested invocation pair above: `pnpm --silent pr:feedback-state`
    for the feedback sweep, then, once its ledger is clean, `pnpm pr:ready-state`
    for the final required-readiness decision. Add `--watch --compact
---until-ready` to the readiness call for a foreground wait loop. Bind
-   `--repo` to the base repository — checkout inference can select the wrong
-   same-number PR on fork PRs.
+--until-ready` to the readiness call for a foreground wait loop. Bind `--repo`
+   to the base repository — checkout inference can pick the wrong same-number PR
+   on fork PRs.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
    `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any
@@ -455,8 +431,8 @@ Field expectations:
    head-bound closeout request with the body above. Do not post when the state
    is `requested` or `reviewed`.
 9. Report optional lag separately, especially legacy Cursor Bugbot check lag and
-   visibly in-progress review-producing workflows. If you are still watching the
-   PR when one finishes, rerun `pr:feedback-state` to catch late feedback; do not
+   visibly in-progress review-producing workflows. If you still watch the PR
+   when one finishes, rerun `pr:feedback-state` to catch late feedback; never
    treat the optional workflow status itself as a blocker.
 10. After the CodeRabbit closeout step and any final optional-review refresh,
     rerun `pr:feedback-state` and then `pr:ready-state`. Signal all-clear only
@@ -464,20 +440,19 @@ Field expectations:
     for the current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
-Differences between Claude `Monitor` wiring and Codex polling should stay
-outside the readiness decision.
+Differences between Claude `Monitor` wiring and Codex polling stay outside the
+readiness decision.
 
 Codex re-reviews new pushes automatically. Do not post `@codex review` as a
-routine post-push action, and never post duplicate review requests while an
-existing current-head request is `requested`, `in_flight`, or `approved`. A
-manual `@codex review` is only a fallback when the current head has no Codex
-signal after the normal automatic-review window.
-If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
-reached, stop posting duplicate `@codex review` requests and inspect whether
-the limit reply is the current-head Codex result. If it is current-head and
-approval is still missing, treat the Codex PR-description approval as
+routine post-push action, and never duplicate a request while a current-head one
+is `requested`, `in_flight`, or `approved`. A manual `@codex review` is only a
+fallback when the current head has no Codex signal after the normal
+automatic-review window. If `chatgpt-codex-connector[bot]` replies that
+code-review usage limits are reached, stop posting duplicates and inspect
+whether the limit reply is the current-head Codex result. If it is current-head
+and approval is still missing, treat the Codex PR-description approval as
 externally blocked even if `codexReviewSignal` reports `in_flight`; quota or
-settings must change, or the gate must be intentionally overridden with the
-head-scoped comment syntax above. If the limit reply is only historical and the
-current head is `requested` or `in_flight` for another Codex signal, keep
-watching until Codex approves, posts new feedback, or the signal becomes stale.
+settings must change, or the gate must be overridden with the head-scoped
+comment syntax above. If the limit reply is only historical and the current head
+is `requested` or `in_flight` for another Codex signal, keep watching until
+Codex approves, posts new feedback, or the signal becomes stale.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -16,19 +16,19 @@ garden_lane: operator-runbooks
 Codex PR babysitting. It answers whether the current head's required GitHub and
 repo-policy gates are clear.
 
-The command is the final required-gate source of truth and does not replace the
-feedback sweep. Before either agent signals all-clear, `pr:feedback-state` must
-have a clean feedback ledger and the subsequent current-head `pr:ready-state`
-result must be ready. Agent-specific loops may gather extra context or post
-replies, but must preserve that two-projection contract.
+The command is the final required-gate source of truth, not a replacement for
+the feedback sweep. Before either agent signals all-clear, `pr:feedback-state`
+must have a clean feedback ledger and the subsequent current-head
+`pr:ready-state` result must be ready. Agent-specific loops may gather extra
+context or post replies, but they must preserve that two-projection contract.
 
 The probe shells out to gh, so it cannot run in Claude cloud sessions whose
-proxy blocks GraphQL and where gh is unreliable. A session passing the REST +
-GraphQL + `--slurp` capability gate runs it as written, passing
-`--repo <owner/name>` because gh cannot infer the repo from the proxy remote.
-Blocked sessions use the MCP emulation in
+proxy blocks GraphQL and where gh is not reliably available; a variant passing the REST + GraphQL +
+`--slurp` capability gate runs it as written, passing `--repo <owner/name>`
+since gh cannot infer the repo from the proxy remote. Blocked sessions use
+the MCP emulation documented in
 [`github-tooling-surfaces.md`](github-tooling-surfaces.md) and label their
-all-clear MCP-emulated, not probe-verified.
+all-clear MCP-emulated rather than probe-verified.
 
 ## Readiness model
 
@@ -39,9 +39,9 @@ them required for the current PR.
 Required blockers:
 
 - Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
-  expensive readiness sweep, since nothing is left to fix or wait on. A
-  closed-unmerged PR reports only the terminal `state` blocker; review gates are
-  non-required because no Codex or reviewer action can unblock it.
+  expensive readiness sweep because there is nothing left to fix or wait on.
+  Closed-unmerged PRs report only the terminal `state` blocker; review gates are
+  non-required because no Codex or reviewer action can unblock a closed PR.
 - Required check runs or status contexts that are failing, pending, queued, or
   missing from the branch-protection rollup.
 - Branch-protection context lookup failures caused by unreadable or
@@ -49,16 +49,17 @@ Required blockers:
   required-vs-optional status. If the classic branch-protection endpoint returns
   GitHub's `Branch not protected (HTTP 404)` response, the probe reads active
   branch rulesets and derives required status contexts from any
-  `required_status_checks` and named `workflows` rule before the fallback split.
+  `required_status_checks` and named `workflows` rule before using the fallback
+  split.
 - Required GitHub review state, including requested changes or required review
   still pending.
 - Unreplied review comments that repo policy requires agents to answer. A
   direct reply satisfies this gate when it comes from the PR author, the Codex
-  review bot, or a different human GitHub `OWNER`, `MEMBER`, or `COLLABORATOR`,
-  so a maintainer can take over a teammate's PR without borrowing the original
-  author's credentials. A reviewer's reply to their own root comment does not
-  satisfy the gate, nor does a reply from an untrusted contributor or a bot
-  merely carrying a trusted association.
+  review bot, or a different human GitHub `OWNER`, `MEMBER`, or
+  `COLLABORATOR`. This lets a maintainer take over a teammate's PR without
+  borrowing the original author's credentials. A reviewer's reply to their own
+  root comment does not satisfy the gate, and neither does a reply from an
+  untrusted contributor or a bot merely carrying a trusted association.
 - The Codex PR-description approval gate for the current head. The bot `+1`
   reaction must be created at or after the current-head update lower bound:
   the head commit's GitHub push timestamp when available, otherwise the first
@@ -73,10 +74,10 @@ Required blockers:
   ```
 
   The override is scoped to the exact current head SHA, so any new push expires
-  it. It reports gate state `overridden` with `readinessOverrides[]` evidence
-  rather than hiding as a normal Codex approval. It never overrides failing or
-  pending required checks, merge conflicts, draft state, requested changes,
-  unresolved review threads, or unreplied review comments.
+  it. It is reported as gate state `overridden` with `readinessOverrides[]`
+  evidence; it is not hidden as a normal Codex approval. It never overrides
+  failing or pending required checks, merge conflicts, draft state, requested
+  changes, unresolved review threads, or unreplied review comments.
 
 Optional signals:
 
@@ -87,25 +88,36 @@ Optional signals:
 - Older bot comments or reviews that do not apply to the current head, provided
   every required current-head comment has been handled.
 
-Actionable Cursor feedback and an aggregate `CHANGES_REQUESTED` verdict remain
-required blockers even though the check itself is advisory.
+Legacy Cursor Bugbot check lag can still appear on PRs opened before its
+2026-08-31 disablement. Report the check as advisory, but do not hold the
+all-clear on it unless branch protection requires it. Actionable Cursor
+feedback and an aggregate `CHANGES_REQUESTED` verdict remain required blockers.
 
 CodeRabbit's `CodeRabbit` check context (ADR 0066) is advisory the same way,
 with one added trap: it reports `SUCCESS` even when no review ran. A
 rate-limited push gets a PR comment carrying
 `<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->`
 and the check still passes. A passing `CodeRabbit` check alongside a
-current-head rate-limit comment means "no review ran" — read the comment, not
-the check conclusion, and rerun `pr:feedback-state` once a later push clears
-the rate limit. `.coderabbit.yaml` leaves `request_changes_workflow` at its
-`false` default, so CodeRabbit submits no GitHub `CHANGES_REQUESTED` review
-today. Turned on, such a review would not clear itself on a later clean push
-and would need the same manual fix as any stuck bot verdict: dismiss it with
+current-head rate-limit comment means "no review ran," not "reviewed and
+clean" — read the comment, not the check conclusion, and rerun
+`pr:feedback-state` once a later push clears the rate limit.
+`.coderabbit.yaml` leaves `request_changes_workflow` at its `false` default,
+so CodeRabbit does not submit a GitHub `CHANGES_REQUESTED` review today. If
+that setting is ever turned on, a `CHANGES_REQUESTED` review does not clear
+itself on a later clean push and needs the same manual fix as any other
+stuck bot review verdict: dismiss it with
 `gh api repos/<owner>/<repo>/pulls/<pr>/reviews/<review_id>/dismissals -X PUT -f message='<why>' -f event=DISMISS`.
 
-The JSON projections expose `gates.codeRabbitReviewSignal`; the
-`codeRabbitReviewSignal` field expectation below defines its values and what
-makes a signal `reviewed`. A head-bound closeout request uses this exact body:
+The JSON projections expose `gates.codeRabbitReviewSignal` with `missing`,
+`requested`, `stale`, `reviewed`, or `not_applicable`. A `reviewed` signal
+requires either a CodeRabbit review body with its `**Run ID**` marker and a
+review commit equal to the full current head, or a trusted CodeRabbit top-level
+clean-run block enclosed by `<!-- recent_review_start -->` and
+`<!-- recent_review_end -->`. The clean-run block must contain the Run ID and a
+reviewed commit range that ends at the full current head. Its comment update
+time must be at or after the head update time. Empty review records, skipped
+runs, and rate-limit notices do not count. A head-bound closeout request uses
+this exact body:
 
 ```text
 @coderabbitai review
@@ -121,43 +133,46 @@ After the optional CodeRabbit check becomes terminal, refresh the projection
 once. If the signal is `missing` or `stale`, re-resolve `headRefOid` immediately
 before posting and require it to equal the marker head. A `requested` signal
 suppresses ordinary duplicate posts for the same head. GitHub's issue-comment
-API has no conditional-create operation, so the marker detects and suppresses
-best-effort rather than claiming atomically. The check and review stay
-advisory: report a pending or rate-limited result as optional lag. The rate
-limit is a shared quota, not a per-PR allowance.
-[ADR 0066](../adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) owns the
-two-tier metering model. This org runs a paid Pro+ seat, so the ceiling is the
-developer identity's across every PR it opened, currently about 4 reviews/hour
-at this repo's review volume. Watching several PRs at once draws down one
-allowance, so a re-request inside the window queues or no-ops on whichever PR
-hits the limit first — do not tight-loop `@coderabbitai review` posts. If a
-requested review finishes while the PR is still under watch, rerun
-`pr:feedback-state` and handle its findings before all-clear.
+API has no conditional-create operation, so the marker is a detection and
+best-effort suppression mechanism rather than an atomic claim. The CodeRabbit
+check and review remain advisory: report a pending or rate-limited result as
+optional lag. The rate limit is a shared quota, not a per-PR allowance.
+[ADR 0066](../adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) records
+the two tiers: the free OSS tier meters per repository on a star-scaled 1–10
+reviews/hour, and a paid seat meters per developer identity across every PR
+that identity opened. This org runs a paid Pro+ seat, so the ceiling is the
+identity's, currently about 4 reviews/hour at this repo's review volume.
+Either way, watching several PRs at once draws down one allowance, so a
+re-request inside the window queues or no-ops on whichever PR reaches the
+limit first — do not tight-loop `@coderabbitai review` posts waiting for a
+faster turnaround. If a requested review finishes while the PR is still under
+watch, rerun `pr:feedback-state` and handle its findings before all-clear.
 
 Some non-required workflows still post feedback that becomes a repo-policy
 blocker after the required status surface is green. Their workflow status stays
-optional; inline threads, unreplied review comments, and actionable top-level
-bot feedback do not. `pr:feedback-state` owns that ledger; `pr:ready-state`
-does not project actionable top-level summaries into its required blockers. If
-a review-producing workflow is visibly in progress, report it as optional lag
-and rerun `pr:feedback-state` after it reaches a terminal state so late
-feedback is not missed.
+optional, but inline threads, unreplied review comments, and actionable
+top-level bot feedback do not. `pr:feedback-state` owns that ledger;
+`pr:ready-state` does not project actionable top-level summaries into its
+required blockers. If a review-producing workflow is visibly in progress,
+report it as optional lag and rerun `pr:feedback-state` after it reaches a
+terminal state so late feedback is not missed.
 
 ### Bounded clean-Claude protocol
 
 `pr:feedback-state` keeps older exceptions in an exact compatibility registry.
 Each entry binds the raw body digest to its Claude author, PR, comment, and
-head, and may also bind the source timestamp. PR #1965 comment 5355983385 uses
-an exact record because its composite heading, verdict emoji, and
+head. An entry can also bind the source timestamp. PR #1965 comment 5355983385
+uses an exact record because its composite heading, verdict emoji, and
 post-conclusion review-method note stay outside the reusable grammar. The
 record binds author `claude[bot]`, creation time `2026-08-20T12:37:45Z`, head
 `0884780bfe1d5ae8710a6f845c3a6199f1bf365d`, and raw body digest
 `6ebf5de00fde8c46040def096e4c0c02ee0ab02b9fae20130e1ba8e6e84037e3`.
 A changed body or binding cannot reuse this record. The compatibility test also
-confirms the general parser blocks the body without the exact record.
+confirms that the general parser blocks the body without the exact record.
 
-Newer reviews go through a small prose-pattern library, which clears a review
-only when **every line is positively recognized**.
+Newer reviews go through a small prose-pattern library instead.
+
+The library clears a review only when **every line is positively recognized**.
 A line is recognized when it is blank, the Claude task-completion header, a
 thematic break, a review heading that harvest already validated, the single
 unhedged `Verdict: LGTM` or `Overall verdict: LGTM` line, a bare `Findings` or
@@ -171,46 +186,51 @@ blocks, including ordinary narrative prose that carries no finding vocabulary.
 Two consequences are deliberate and easy to trip over:
 
 - **A clean review written as free prose blocks.** The observed PR #1848 body
-  is the reference case, pinned blocking by test. It reads clean to a human,
-  but its narrative paragraphs assert nothing the gate can verify — and one
-  asks the reader to confirm CI before merge.
+  is the reference case and is pinned blocking by test. It reads clean to a
+  human, but its narrative paragraphs assert nothing the gate can verify — and
+  one of them in fact asks the reader to confirm CI before merge.
 - **A no-action marker alone is not a disposition.** `No action`, `None
-blocking`, and similar leads need curated positive evidence after them. The
-  older behaviour, where such a marker cleared a line on its own, let a defect
-  ride along behind it.
+blocking`, and similar leads must be followed by curated positive evidence.
+  The older behaviour, where such a marker cleared a line on its own, let a
+  defect ride along behind it.
 
-A clean verdict or conclusion may end only in a bare sentence terminator or the
-approval mark below. Any trailing sentence blocks: a tail is unconstrained
-English, and no term list separates praise from a defect stated plainly.
+A clean verdict or conclusion may end only in a bare sentence terminator, or an
+approval mark as described below. Any trailing sentence blocks, because a tail
+is unconstrained English and no term list separates praise from a defect stated
+plainly.
 
-A `What I checked` checklist is recognized with or without paired
-`Findings`/`Roll-up` headings — the standalone and preamble forms read one
-definition. The checklist is evidence of review, never the conclusion: the body
-still needs an explicit no-findings line. An unticked or negated box blocks, as
-does any subject outside the curated topic set.
+A `What I checked` checklist is recognized whether or not the body also carries
+paired `Findings`/`Roll-up` headings — the standalone form and the preamble form
+read one definition. The checklist is evidence of review, never the conclusion:
+the body still needs an explicit no-findings line. An unticked or negated box
+blocks, and so does any subject outside the curated topic set, since a free
+subject is unconstrained English.
 
 A trailing approval mark (`✅`, `✔️`, `👍`) is allowed after the verdict word
 **or a no-findings conclusion** — `No P1/P2 findings ✅` clears exactly as
 `**Verdict:** LGTM ✅` does. A mark asserts nothing a reader could act on, and
-one rule governs both tails because they are the same question. Any word after
-either is prose and still blocks.
+one rule governs both tails deliberately: the two are the same question, and a
+second rule would be a second thing to keep in step. Any word after either is
+prose and still blocks.
 
 The canonical registry and named phrase groups live in
 `scripts/pr/pr-feedback-state-claude.mjs`, which is now the only copy: D3 phase
 three removed the flat wrapper fallback. Add a named phrase only with a real
 review fixture and nearby blocking mutations. Add a compatibility record only
-with a byte-exact source fixture and single-field binding mutations.
+with a byte-exact source fixture and single-field binding mutations. The library does not try to prove the meaning
+of arbitrary English prose — it refuses prose it cannot recognize, and the
+compatibility registry is the escape hatch for a specific historical body.
 Current-head and unresolved-feedback checks remain separate and mandatory.
 
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via
-`--json`. Human formatting stays the default for interactive use. Use
+`--json`. Human formatting is allowed as the default for interactive use. Use
 `--watch --compact` for low-noise foreground babysitting. `pnpm
 pr:feedback-state` is the feedback-only projection for unresolved threads,
 unreplied root review comments, blocking top-level bot feedback, contextual
-top-level bot comments, normalized `findings[]`, and Codex gates; it replaces
-ad hoc read-only `gh api` scraping during review sweeps.
+top-level bot comments, normalized `findings[]`, and Codex gates; it is
+intended to replace ad hoc read-only `gh api` scraping during review sweeps.
 
 Suggested invocation:
 
@@ -221,14 +241,14 @@ pnpm --silent pr:feedback-state [<number-or-url>] [--pr <number-or-url>] [--repo
 
 `--watch --json` emits one JSON summary per poll, separated by newlines. Use
 `--watch --compact` for human babysitting and reserve JSON output for machine
-consumers that parse newline-delimited JSON. Use `pnpm --silent` for
+consumers that can parse newline-delimited JSON. Use `pnpm --silent` for
 feedback-state machine consumers so pnpm does not prepend its run-script
 banner. The `pr:feedback-state` Node entry point always prints JSON; in watch
 mode it emits one compact JSON object per poll. Add `--until-ready` to
 `pr:ready-state --watch` when the foreground loop should exit automatically:
 it exits 0 once the summary is ready or the PR is merged, exits nonzero for a
-closed-unmerged PR, and otherwise keeps polling. Without it, watch mode runs
-until interrupted.
+closed-unmerged PR, and otherwise keeps polling. Without `--until-ready`, watch
+mode keeps the existing behavior and runs until interrupted.
 
 Expected top-level fields:
 
@@ -325,19 +345,20 @@ Expected top-level fields:
 Field expectations:
 
 - `ready`: `true` only when every required blocker is clear. Optional lag must
-  not flip this to `false`. A `MERGED` `pr.state` is terminal-ready; a `CLOSED`
-  one without merge is terminal-blocked with a `state` blocker.
+  not flip this to `false`. A PR whose `pr.state` is `MERGED` is terminal-ready;
+  a PR whose `pr.state` is `CLOSED` without merge is terminal-blocked with a
+  `state` blocker.
 - `required.ready`: mirrors the required-readiness half of the decision. Agents
-  use it only after `pr:feedback-state` has a clean ledger; alone it is not
-  sufficient for all-clear.
-- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe reads
-  it before fetching comments, reactions, check sources, and branch protection,
-  so post-merge babysitting exits quickly and does not mistake GitHub's
-  post-merge `mergeable: UNKNOWN` for a blocker.
+  use it only after `pr:feedback-state` has a clean feedback ledger; it is not
+  sufficient for all-clear by itself.
+- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe uses
+  this before fetching comments, reactions, check sources, and branch
+  protection so post-merge babysitting exits quickly and does not mistake
+  GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
 - `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
 - Terminal closed PR summaries may use gate state `not_applicable` for gates
-  normally required on open PRs. Act on the terminal `state` blocker instead of
-  requesting more review.
+  that are normally required on open PRs. Agents should act on the terminal
+  `state` blocker instead of requesting more review.
 - `required.blockers[]`: only required blockers. Every item needs `kind`,
   `name`, `state`, `required: true`, and a URL when GitHub provides one.
 - `optional.items[]`: advisory signals worth reporting separately. Every item
@@ -346,9 +367,11 @@ Field expectations:
   `required.blockers[]` derives from. Each item has `name`, `required: true`,
   and a `classifyCheck()` `state` — `pass`, `fail`, `pending`, or `skipped`
   (a `NEUTRAL`/`SKIPPED` conclusion), so consumers tolerate all four. Count
-  required checks here, never by filtering `statusChecks`: that grouping
-  describes every check the PR has and carries no `required` flag, so filtering
-  it is a permanent zero. `pnpm pr:merge` reports its briefing counts from here.
+  required checks
+  from this field, never by filtering `statusChecks`: that grouping describes
+  every check the PR has and carries no `required` flag at all, so a filter on
+  one is a permanent zero. `pnpm pr:merge` reports its briefing counts from
+  here.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
 - `readinessOverrides[]`: active human break-glass overrides that affected a
@@ -360,31 +383,32 @@ Field expectations:
   `author`, URL/location fields, a short `title`/`excerpt`, `state`, and
   booleans for `currentHead`, `outdated`, `replied`, `unresolved`, and
   `blocking`. Use it as the feedback ledger for batching and deduplicating
-  review follow-ups; it never replaces the final `pr:ready-state` all-clear
-  gate.
+  review follow-ups; do not treat it as a replacement for the final
+  `pr:ready-state` all-clear gate.
 - `codexReviewSignal`: current-head Codex review state. Values are
   `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
-  means a current-head `@codex review` request exists with no bot reaction or
-  review observed yet. `in_flight` means the current head has a Codex `eyes`
-  reaction, review, or top-level result. `approved` means the final
-  PR-description `+1` gate is present. `stale` means only older-head Codex
-  signals exist.
+  means a current-head `@codex review` request exists but no bot reaction or
+  review has been observed yet. `in_flight` means the current head has a Codex
+  `eyes` reaction, a current-head Codex review, or a current-head Codex
+  top-level result. `approved` means the final PR-description `+1` gate is
+  present. `stale` means only older-head Codex signals exist.
 - `codeRabbitReviewSignal`: current-head CodeRabbit review state. Values are
   `missing`, `requested`, `stale`, `reviewed`, and `not_applicable`. A
-  CodeRabbit review with its `**Run ID**` marker and a review commit equal to
-  the full current head is `reviewed`. A trusted top-level clean-run block also
-  counts when
+  CodeRabbit review with a run marker and review commit equal to the current
+  head is `reviewed`. A trusted top-level clean-run block also counts when
   `<!-- recent_review_start -->` and `<!-- recent_review_end -->` enclose it, it
   contains a Run ID, its full commit range ends at the current head, and its
-  comment update time is at or after the head update time. Empty reply-only
-  reviews, skipped runs, and rate-limit notices do not count. A head-bound
-  request is `requested` until a real run lands.
+  comment update time is at or after the current head update time. Empty
+  reply-only reviews, skipped runs, and rate-limit notices do not count. A
+  head-bound request is `requested` until a real run lands.
 - `requiredStatusContexts[]`: required check contexts from classic branch
   protection or branch rulesets. Ruleset-derived entries include status-check
-  and required-workflow rules when their check names appear in the ruleset or
-  resolve from local workflow metadata. Entries preserve `integrationId` so a
-  same-name check from the wrong GitHub App does not satisfy readiness.
-- `summary`: one concise sentence for a babysitter status update.
+  rules and required-workflow rules when their check names are present in the
+  ruleset or resolvable from local workflow metadata. Entries preserve
+  `integrationId` so a same-name check from the wrong GitHub App does not
+  satisfy readiness.
+- `summary`: one concise human-readable sentence suitable for a babysitter
+  status update.
 
 ## Agent workflow
 
@@ -398,27 +422,27 @@ Field expectations:
    near twice the baseline, and do not pause solely for cycle count before five
    review-triggered patch cycles are complete. Pause for reclassification before
    starting a sixth.
-3. Before invoking the gate, ensure no direct validation, dashboard server, or
-   browser suite outside the coordinator is active on the same machine.
-   Concurrent `--run` gates from other worktrees continue through the
-   coordinator and share weighted machine capacity. From invocation until this
-   gate exits, start no uncoordinated work there; use same-machine spare workers
-   only for read-only work. Run `pnpm agent:quality-gate --run` once for the
-   batch. Run validation outside the coordinator from a fully hydrated checkout
-   on another machine.
+3. Before invoking the gate, ensure that no direct validation, dashboard server,
+   or browser suite outside the coordinator is active on the same machine.
+   Concurrent `--run` gates from other worktrees can continue through the
+   coordinator. They share weighted machine capacity. From invocation until
+   this gate exits, do not start uncoordinated work there. Use same-machine spare
+   workers only for read-only work. Run `pnpm agent:quality-gate --run` once for
+   the batch. Run validation outside the coordinator from a fully hydrated
+   checkout on another machine.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
    run `pnpm agent:autoreview` as a structured source-review closeout at the
-   batch boundary, not as an inner loop. Verify accepted findings before editing
-   and rerun focused checks plus autoreview if those fixes change the batch. The
-   exact target, prepared-bundle, isolation, and trust contracts live in
-   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
-   behavioral and runtime verification in the validation record.
+   batch boundary rather than as an inner loop. Verify accepted findings before
+   editing and rerun focused checks plus autoreview if those fixes change the
+   batch. The exact target, prepared-bundle, isolation, and trust contracts live
+   in [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md);
+   keep behavioral and runtime verification in the validation record.
 5. Run the suggested invocation pair above: `pnpm --silent pr:feedback-state`
    for the feedback sweep, then, once its ledger is clean, `pnpm pr:ready-state`
    for the final required-readiness decision. Add `--watch --compact
---until-ready` to the readiness call for a foreground wait loop. Bind `--repo`
-   to the base repository — checkout inference can pick the wrong same-number PR
-   on fork PRs.
+--until-ready` to the readiness call for a foreground wait loop. Bind
+   `--repo` to the base repository — checkout inference can select the wrong
+   same-number PR on fork PRs.
 6. If feedback-state `ready` is false, inspect and handle
    `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
    `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any
@@ -431,8 +455,8 @@ Field expectations:
    head-bound closeout request with the body above. Do not post when the state
    is `requested` or `reviewed`.
 9. Report optional lag separately, especially legacy Cursor Bugbot check lag and
-   visibly in-progress review-producing workflows. If you still watch the PR
-   when one finishes, rerun `pr:feedback-state` to catch late feedback; never
+   visibly in-progress review-producing workflows. If you are still watching the
+   PR when one finishes, rerun `pr:feedback-state` to catch late feedback; do not
    treat the optional workflow status itself as a blocker.
 10. After the CodeRabbit closeout step and any final optional-review refresh,
     rerun `pr:feedback-state` and then `pr:ready-state`. Signal all-clear only
@@ -440,19 +464,20 @@ Field expectations:
     for the current head.
 
 Claude Code and Codex intentionally use the same command and readiness fields.
-Differences between Claude `Monitor` wiring and Codex polling stay outside the
-readiness decision.
+Differences between Claude `Monitor` wiring and Codex polling should stay
+outside the readiness decision.
 
 Codex re-reviews new pushes automatically. Do not post `@codex review` as a
-routine post-push action, and never duplicate a request while a current-head one
-is `requested`, `in_flight`, or `approved`. A manual `@codex review` is only a
-fallback when the current head has no Codex signal after the normal
-automatic-review window. If `chatgpt-codex-connector[bot]` replies that
-code-review usage limits are reached, stop posting duplicates and inspect
-whether the limit reply is the current-head Codex result. If it is current-head
-and approval is still missing, treat the Codex PR-description approval as
+routine post-push action, and never post duplicate review requests while an
+existing current-head request is `requested`, `in_flight`, or `approved`. A
+manual `@codex review` is only a fallback when the current head has no Codex
+signal after the normal automatic-review window.
+If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
+reached, stop posting duplicate `@codex review` requests and inspect whether
+the limit reply is the current-head Codex result. If it is current-head and
+approval is still missing, treat the Codex PR-description approval as
 externally blocked even if `codexReviewSignal` reports `in_flight`; quota or
-settings must change, or the gate must be overridden with the head-scoped
-comment syntax above. If the limit reply is only historical and the current head
-is `requested` or `in_flight` for another Codex signal, keep watching until
-Codex approves, posts new feedback, or the signal becomes stale.
+settings must change, or the gate must be intentionally overridden with the
+head-scoped comment syntax above. If the limit reply is only historical and the
+current head is `requested` or `in_flight` for another Codex signal, keep
+watching until Codex approves, posts new feedback, or the signal becomes stale.

--- a/scripts/docs/docs-navigation-eval.test.mjs
+++ b/scripts/docs/docs-navigation-eval.test.mjs
@@ -961,15 +961,16 @@ test("unqualified non-canonical reliance is counted and fails", () => {
 });
 
 test("a qualified historical source requires loaded canonical verification", () => {
-  const result = validResult();
+  const contents = fixtureCorpus(context.suite);
+  const result = fixtureResult(contents);
   const answer = result.answers.find(
     (candidate) => candidate.question_id === "commands-pr-readiness",
   );
   const currentAuthority = "docs/notes/pr-ready-state.md";
-  answer.loaded_sources.push(source(currentAuthority));
+  answer.loaded_sources.push(fixtureSource(contents, currentAuthority));
   answer.authority_qualifications.push(qualification(currentAuthority));
   const historical = "docs/PLAN-ai-review-process.md";
-  answer.loaded_sources.push(source(historical));
+  answer.loaded_sources.push(fixtureSource(contents, historical));
   answer.authority_qualifications.push(
     qualification(historical, {
       qualification:
@@ -983,6 +984,7 @@ test("a qualified historical source requires loaded canonical verification", () 
     result,
     repoRoot,
     questionId: "commands-pr-readiness",
+    readSource: fixtureReader(contents),
   });
   assert.equal(
     scored.report.canonical_source_compliance.unqualified_noncanonical_sources,


### PR DESCRIPTION
## The Problem

- M4 added 492 bytes to `docs/notes/quick-commands.md`. One authority-scoring unit test loaded that file plus two other mutable documents and also inherited the 45,000-byte per-question cap.
- The three files reached 45,380 bytes after merge. The semantic test failed on `main`, although the formal live route contract still had 17,006 bytes of per-question headroom.
- The first repair rewrote 311 lines of the canonical PR-readiness runbook. It still failed its own branch test because the test reads source data from the merge base.

## The Solution

Use the existing synthetic scorer corpus only for the qualified historical-source semantic test. The test still proves that a historical source must name a loaded canonical verifier. It no longer depends on unrelated document size.

Production scoring keeps its Git-backed source reader. Live route-budget checks, exact budget-edge tests, historical commit checks, and hash checks are unchanged. The initial runbook rewrite was reverted. The net diff changes one test file by five additions and three deletions.

## Validation

- `pnpm docs:navigation-eval:test` — 34 of 34 pass.
- `pnpm docs:navigation-eval -- --check-fixtures --json` — valid; maximum live route 27,994 bytes; per-question headroom 17,006 bytes; suite reserve surplus 13,473 bytes.
- Historical baseline validation — passed with no scorer errors.
- `pnpm lint:scripts`, `pnpm docs:index --check`, `pnpm agent:context-check`, `pnpm tf:test`, and targeted Trunk — passed.
- Two independent adversarial reviews found no issue. Both confirmed that production reads and live budget controls remain unchanged.
- Deep Claude security review was skipped because this is a test-data isolation change with no production or security boundary.

The legacy local gate did not run. Its Darwin coordinator rejected an invalid runtime receipt before it executed any command. All mapped commands passed directly. The push used the user-approved redesign bypass for exact head `3a5adc787b7abf2879e626592d55de6dc06712a0`; hosted CI remains required.

## Deferrals

- None. Issue #2192 was opened from the rejected live-reserve diagnosis. The formal route reserve remains healthy and does not need a new warning control for this incident.

Closes #2190

## Checklist

- [x] The opening states the old behavior, new behavior, benefit, and limit.
- [x] Validation names the evidence and the skipped legacy gate.
- [x] No command, workflow, environment variable, hook, or canonical process changed.
- [x] Architecture decision not required: this patch isolates unit-test data and changes no production contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved historical-source validation to use consistent, fixture-based content.
  * Ensured byte and hash checks produce deterministic results during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->