### PR TITLE
docs: restore navigation-eval per-question headroom

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -23,10 +23,10 @@ must have a clean feedback ledger and the subsequent current-head
 context or post replies, but they must preserve that two-projection contract.
 
 The probe shells out to gh, so it cannot run in Claude cloud sessions whose
-proxy blocks GraphQL and where gh is not reliably available; a variant passing the REST + GraphQL +
-`--slurp` capability gate runs it as written, passing `--repo <owner/name>`
-since gh cannot infer the repo from the proxy remote. Blocked sessions use
-the MCP emulation documented in
+proxy blocks GraphQL and where gh is not reliably available. A variant passing
+the REST + GraphQL + `--slurp` capability gate runs it as written, with
+`--repo <owner/name>` because gh cannot infer the repo from the proxy remote.
+Blocked sessions use the MCP emulation in
 [`github-tooling-surfaces.md`](github-tooling-surfaces.md) and label their
 all-clear MCP-emulated rather than probe-verified.
 
@@ -39,53 +39,50 @@ them required for the current PR.
 Required blockers:
 
 - Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
-  expensive readiness sweep because there is nothing left to fix or wait on.
-  Closed-unmerged PRs report only the terminal `state` blocker; review gates are
-  non-required because no Codex or reviewer action can unblock a closed PR.
+  expensive sweep, since nothing is left to fix or wait on. A closed-unmerged PR
+  reports only the terminal `state` blocker; review gates go non-required
+  because no Codex or reviewer action can unblock it.
 - Required check runs or status contexts that are failing, pending, queued, or
   missing from the branch-protection rollup.
-- Branch-protection context lookup failures caused by unreadable or
-  unauthorized protection data; the probe fails closed rather than guessing
-  required-vs-optional status. If the classic branch-protection endpoint returns
-  GitHub's `Branch not protected (HTTP 404)` response, the probe reads active
-  branch rulesets and derives required status contexts from any
-  `required_status_checks` and named `workflows` rule before using the fallback
-  split.
+- Branch-protection context lookup failures from unreadable or unauthorized
+  protection data; the probe fails closed rather than guessing
+  required-vs-optional status. On GitHub's `Branch not protected (HTTP 404)`
+  response from the classic endpoint, it reads active branch rulesets and
+  derives required status contexts from any `required_status_checks` and named
+  `workflows` rule before using the fallback split.
 - Required GitHub review state, including requested changes or required review
   still pending.
-- Unreplied review comments that repo policy requires agents to answer. A
-  direct reply satisfies this gate when it comes from the PR author, the Codex
-  review bot, or a different human GitHub `OWNER`, `MEMBER`, or
-  `COLLABORATOR`. This lets a maintainer take over a teammate's PR without
-  borrowing the original author's credentials. A reviewer's reply to their own
-  root comment does not satisfy the gate, and neither does a reply from an
-  untrusted contributor or a bot merely carrying a trusted association.
+- Unreplied review comments that repo policy requires agents to answer. A direct
+  reply satisfies this gate from the PR author, the Codex review bot, or a
+  different human GitHub `OWNER`, `MEMBER`, or `COLLABORATOR`, so a maintainer
+  can take over a teammate's PR without borrowing their credentials. A
+  reviewer's reply to their own root comment does not satisfy it, and neither
+  does an untrusted contributor or a bot merely carrying a trusted association.
 - The Codex PR-description approval gate for the current head. The bot `+1`
   reaction must be created at or after the current-head update lower bound:
   the head commit's GitHub push timestamp when available, otherwise the first
   current-head check/status observation timestamp.
-- A human break-glass override for the Codex PR-description approval gate only,
-  when Codex review is externally blocked after the rest of the required
-  readiness surface is clean. The override must be a PR comment from a GitHub
-  `OWNER`, `MEMBER`, or `COLLABORATOR` human author:
+- A human break-glass override, for that Codex gate alone, when Codex review is
+  externally blocked and the rest of the required surface is clean. It must be a
+  PR comment from a GitHub `OWNER`, `MEMBER`, or `COLLABORATOR` human author:
 
   ```text
   /pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>
   ```
 
   The override is scoped to the exact current head SHA, so any new push expires
-  it. It is reported as gate state `overridden` with `readinessOverrides[]`
-  evidence; it is not hidden as a normal Codex approval. It never overrides
-  failing or pending required checks, merge conflicts, draft state, requested
-  changes, unresolved review threads, or unreplied review comments.
+  it. It reports gate state `overridden` with `readinessOverrides[]` evidence
+  rather than hiding as a normal Codex approval, and never overrides failing or
+  pending required checks, merge conflicts, draft state, requested changes,
+  unresolved review threads, or unreplied review comments.
 
 Optional signals:
 
 - Legacy Cursor Bugbot checks on PRs opened before its 2026-08-31 disablement,
   when branch protection does not require them.
-- Non-required check runs, flaky advisory jobs, or lint/report jobs configured
-  outside the required status rollup.
-- Older bot comments or reviews that do not apply to the current head, provided
+- Non-required check runs, flaky advisory jobs, or lint/report jobs outside the
+  required status rollup.
+- Older bot comments or reviews that do not apply to the current head, once
   every required current-head comment has been handled.
 
 Legacy Cursor Bugbot check lag can still appear on PRs opened before its
@@ -97,15 +94,13 @@ CodeRabbit's `CodeRabbit` check context (ADR 0066) is advisory the same way,
 with one added trap: it reports `SUCCESS` even when no review ran. A
 rate-limited push gets a PR comment carrying
 `<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->`
-and the check still passes. A passing `CodeRabbit` check alongside a
-current-head rate-limit comment means "no review ran," not "reviewed and
-clean" — read the comment, not the check conclusion, and rerun
+and the check still passes. That combination means "no review ran," not
+"reviewed and clean" — read the comment, not the check conclusion, and rerun
 `pr:feedback-state` once a later push clears the rate limit.
-`.coderabbit.yaml` leaves `request_changes_workflow` at its `false` default,
-so CodeRabbit does not submit a GitHub `CHANGES_REQUESTED` review today. If
-that setting is ever turned on, a `CHANGES_REQUESTED` review does not clear
-itself on a later clean push and needs the same manual fix as any other
-stuck bot review verdict: dismiss it with
+`.coderabbit.yaml` leaves `request_changes_workflow` at its `false` default, so
+CodeRabbit submits no GitHub `CHANGES_REQUESTED` review today. Turn that on and
+such a review will not clear itself on a later clean push; it needs the same
+manual fix as any stuck bot verdict:
 `gh api repos/<owner>/<repo>/pulls/<pr>/reviews/<review_id>/dismissals -X PUT -f message='<why>' -f event=DISMISS`.
 
 The JSON projections expose `gates.codeRabbitReviewSignal` with `missing`,
@@ -133,104 +128,94 @@ After the optional CodeRabbit check becomes terminal, refresh the projection
 once. If the signal is `missing` or `stale`, re-resolve `headRefOid` immediately
 before posting and require it to equal the marker head. A `requested` signal
 suppresses ordinary duplicate posts for the same head. GitHub's issue-comment
-API has no conditional-create operation, so the marker is a detection and
-best-effort suppression mechanism rather than an atomic claim. The CodeRabbit
-check and review remain advisory: report a pending or rate-limited result as
-optional lag. The rate limit is a shared quota, not a per-PR allowance.
+API has no conditional-create operation, so the marker detects and suppresses on
+a best-effort basis rather than claiming atomically. The CodeRabbit check and
+review stay advisory: report a pending or rate-limited result as optional lag.
+The rate limit is a shared quota, not a per-PR allowance.
 [ADR 0066](../adr/0066-coderabbit-replaces-bugbot-third-reviewer.md) records
 the two tiers: the free OSS tier meters per repository on a star-scaled 1–10
-reviews/hour, and a paid seat meters per developer identity across every PR
-that identity opened. This org runs a paid Pro+ seat, so the ceiling is the
-identity's, currently about 4 reviews/hour at this repo's review volume.
-Either way, watching several PRs at once draws down one allowance, so a
-re-request inside the window queues or no-ops on whichever PR reaches the
-limit first — do not tight-loop `@coderabbitai review` posts waiting for a
-faster turnaround. If a requested review finishes while the PR is still under
-watch, rerun `pr:feedback-state` and handle its findings before all-clear.
+reviews/hour, a paid seat per developer identity across every PR that identity
+opened. This org runs a paid Pro+ seat, so the ceiling is the identity's,
+currently about 4 reviews/hour at this repo's volume. Either way, watching
+several PRs draws down one allowance, so a re-request inside the window queues
+or no-ops on whichever PR hits the limit first — do not tight-loop
+`@coderabbitai review` posts waiting for a faster turnaround. If a requested
+review finishes while the PR is still watched, rerun `pr:feedback-state` and
+handle its findings before all-clear.
 
 Some non-required workflows still post feedback that becomes a repo-policy
 blocker after the required status surface is green. Their workflow status stays
-optional, but inline threads, unreplied review comments, and actionable
-top-level bot feedback do not. `pr:feedback-state` owns that ledger;
-`pr:ready-state` does not project actionable top-level summaries into its
-required blockers. If a review-producing workflow is visibly in progress,
-report it as optional lag and rerun `pr:feedback-state` after it reaches a
-terminal state so late feedback is not missed.
+optional; inline threads, unreplied review comments, and actionable top-level
+bot feedback do not. `pr:feedback-state` owns that ledger, and `pr:ready-state`
+does not project actionable top-level summaries into its required blockers.
+Report a visibly in-progress review-producing workflow as optional lag, then
+rerun `pr:feedback-state` once it is terminal so late feedback is not missed.
 
 ### Bounded clean-Claude protocol
 
 `pr:feedback-state` keeps older exceptions in an exact compatibility registry.
 Each entry binds the raw body digest to its Claude author, PR, comment, and
-head. An entry can also bind the source timestamp. PR #1965 comment 5355983385
-uses an exact record because its composite heading, verdict emoji, and
-post-conclusion review-method note stay outside the reusable grammar. The
-record binds author `claude[bot]`, creation time `2026-08-20T12:37:45Z`, head
-`0884780bfe1d5ae8710a6f845c3a6199f1bf365d`, and raw body digest
-`6ebf5de00fde8c46040def096e4c0c02ee0ab02b9fae20130e1ba8e6e84037e3`.
-A changed body or binding cannot reuse this record. The compatibility test also
-confirms that the general parser blocks the body without the exact record.
+head, and may bind the source timestamp. PR #1965 comment 5355983385 needs one
+because its composite heading, verdict emoji, and post-conclusion review-method
+note fall outside the reusable grammar. It binds author `claude[bot]`, creation
+time `2026-08-20T12:37:45Z`, head
+`0884780bfe1d5ae8710a6f845c3a6199f1bf365d`, and body digest
+`6ebf5de00fde8c46040def096e4c0c02ee0ab02b9fae20130e1ba8e6e84037e3`. A changed
+body or binding cannot reuse it, and the compatibility test confirms the
+general parser blocks that body without it.
 
-Newer reviews go through a small prose-pattern library instead.
-
-The library clears a review only when **every line is positively recognized**.
-A line is recognized when it is blank, the Claude task-completion header, a
-thematic break, a review heading that harvest already validated, the single
-unhedged `Verdict: LGTM` or `Overall verdict: LGTM` line, a bare `Findings` or
-`Roll-up` section label, an explicit no-findings conclusion, a `What I checked`
-checklist heading, a ticked checklist entry whose subject is one to three
-curated `SAFE_CLAUDE_CHECKLIST_TOPICS` entries joined by `and` (or one of the
-four frozen `LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT` phrases), or a P3 line whose
-every clause matches the curated `POSITIVE_EVIDENCE` allowlist. Anything else
-blocks, including ordinary narrative prose that carries no finding vocabulary.
+Newer reviews go through a small prose-pattern library, which clears a review
+only when **every line is positively recognized**. A recognized line is blank,
+the Claude task-completion header, a thematic break, a review heading harvest
+already validated, the single unhedged `Verdict: LGTM` or `Overall verdict:
+LGTM` line, a bare `Findings` or `Roll-up` label, an explicit no-findings
+conclusion, a `What I checked` heading, a ticked checklist entry whose subject
+is one to three curated `SAFE_CLAUDE_CHECKLIST_TOPICS` entries joined by `and`
+(or one of the four frozen `LEGACY_SAFE_CLAUDE_CHECKLIST_SUBJECT` phrases), or
+a P3 line whose every clause matches the curated `POSITIVE_EVIDENCE` allowlist.
+Anything else blocks, including narrative prose carrying no finding vocabulary.
 
 Two consequences are deliberate and easy to trip over:
 
-- **A clean review written as free prose blocks.** The observed PR #1848 body
-  is the reference case and is pinned blocking by test. It reads clean to a
-  human, but its narrative paragraphs assert nothing the gate can verify — and
-  one of them in fact asks the reader to confirm CI before merge.
+- **A clean review written as free prose blocks.** The observed PR #1848 body is
+  the reference case, pinned blocking by test. It reads clean to a human, but
+  its paragraphs assert nothing the gate can verify — and one asks the reader to
+  confirm CI before merge.
 - **A no-action marker alone is not a disposition.** `No action`, `None
-blocking`, and similar leads must be followed by curated positive evidence.
-  The older behaviour, where such a marker cleared a line on its own, let a
-  defect ride along behind it.
+blocking`, and similar leads need curated positive evidence behind them. The
+  older behaviour, where the marker cleared a line on its own, let defects ride
+  along.
 
-A clean verdict or conclusion may end only in a bare sentence terminator, or an
-approval mark as described below. Any trailing sentence blocks, because a tail
-is unconstrained English and no term list separates praise from a defect stated
-plainly.
+A clean verdict or conclusion may end only in a bare sentence terminator or an
+approval mark (`✅`, `✔️`, `👍`), allowed after the verdict word **or a
+no-findings conclusion** — `No P1/P2 findings ✅` clears exactly as
+`**Verdict:** LGTM ✅` does. One rule governs both tails so a second cannot fall
+out of step. Any word after either blocks: a tail is unconstrained English, and
+no term list separates praise from a defect stated plainly.
 
-A `What I checked` checklist is recognized whether or not the body also carries
-paired `Findings`/`Roll-up` headings — the standalone form and the preamble form
-read one definition. The checklist is evidence of review, never the conclusion:
-the body still needs an explicit no-findings line. An unticked or negated box
-blocks, and so does any subject outside the curated topic set, since a free
-subject is unconstrained English.
-
-A trailing approval mark (`✅`, `✔️`, `👍`) is allowed after the verdict word
-**or a no-findings conclusion** — `No P1/P2 findings ✅` clears exactly as
-`**Verdict:** LGTM ✅` does. A mark asserts nothing a reader could act on, and
-one rule governs both tails deliberately: the two are the same question, and a
-second rule would be a second thing to keep in step. Any word after either is
-prose and still blocks.
+A `What I checked` checklist reads one definition whether or not the body also
+carries paired `Findings`/`Roll-up` headings. It is evidence of review, never
+the conclusion: the body still needs an explicit no-findings line. An unticked
+or negated box blocks, as does any subject outside the curated topic set.
 
 The canonical registry and named phrase groups live in
-`scripts/pr/pr-feedback-state-claude.mjs`, which is now the only copy: D3 phase
-three removed the flat wrapper fallback. Add a named phrase only with a real
-review fixture and nearby blocking mutations. Add a compatibility record only
-with a byte-exact source fixture and single-field binding mutations. The library does not try to prove the meaning
-of arbitrary English prose — it refuses prose it cannot recognize, and the
-compatibility registry is the escape hatch for a specific historical body.
-Current-head and unresolved-feedback checks remain separate and mandatory.
+`scripts/pr/pr-feedback-state-claude.mjs`, the only copy since D3 phase three
+removed the flat wrapper fallback. Add a named phrase only with a real review
+fixture and nearby blocking mutations; add a compatibility record only with a
+byte-exact source fixture and single-field binding mutations. The library never
+proves the meaning of arbitrary English — it refuses prose it cannot recognize,
+and the registry is the escape hatch for one historical body. Current-head and
+unresolved-feedback checks remain separate and mandatory.
 
 ## Expected CLI contract
 
 `pnpm pr:ready-state` must expose a stable JSON shape for agent loops via
-`--json`. Human formatting is allowed as the default for interactive use. Use
+`--json`; human formatting stays the interactive default. Use
 `--watch --compact` for low-noise foreground babysitting. `pnpm
 pr:feedback-state` is the feedback-only projection for unresolved threads,
 unreplied root review comments, blocking top-level bot feedback, contextual
-top-level bot comments, normalized `findings[]`, and Codex gates; it is
-intended to replace ad hoc read-only `gh api` scraping during review sweeps.
+top-level bot comments, normalized `findings[]`, and Codex gates. It replaces
+ad hoc read-only `gh api` scraping during review sweeps.
 
 Suggested invocation:
 
@@ -239,16 +224,15 @@ pnpm pr:ready-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]own
 pnpm --silent pr:feedback-state [<number-or-url>] [--pr <number-or-url>] [--repo <[host/]owner/name>] [--json] [--watch]
 ```
 
-`--watch --json` emits one JSON summary per poll, separated by newlines. Use
-`--watch --compact` for human babysitting and reserve JSON output for machine
-consumers that can parse newline-delimited JSON. Use `pnpm --silent` for
-feedback-state machine consumers so pnpm does not prepend its run-script
-banner. The `pr:feedback-state` Node entry point always prints JSON; in watch
-mode it emits one compact JSON object per poll. Add `--until-ready` to
-`pr:ready-state --watch` when the foreground loop should exit automatically:
-it exits 0 once the summary is ready or the PR is merged, exits nonzero for a
-closed-unmerged PR, and otherwise keeps polling. Without `--until-ready`, watch
-mode keeps the existing behavior and runs until interrupted.
+`--watch --json` emits one newline-separated JSON summary per poll; reserve it
+for consumers that parse newline-delimited JSON and use `--watch --compact` for
+human babysitting. Pass `pnpm --silent` for feedback-state machine consumers so
+pnpm does not prepend its run-script banner. The `pr:feedback-state` Node entry
+point always prints JSON, one compact object per poll in watch mode. Add
+`--until-ready` to `pr:ready-state --watch` when the foreground loop should
+exit on its own: it exits 0 once the summary is ready or the PR is merged,
+nonzero for a closed-unmerged PR, and otherwise keeps polling. Without it,
+watch mode runs until interrupted.
 
 Expected top-level fields:
 
@@ -345,20 +329,18 @@ Expected top-level fields:
 Field expectations:
 
 - `ready`: `true` only when every required blocker is clear. Optional lag must
-  not flip this to `false`. A PR whose `pr.state` is `MERGED` is terminal-ready;
-  a PR whose `pr.state` is `CLOSED` without merge is terminal-blocked with a
-  `state` blocker.
-- `required.ready`: mirrors the required-readiness half of the decision. Agents
-  use it only after `pr:feedback-state` has a clean feedback ledger; it is not
-  sufficient for all-clear by itself.
-- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe uses
-  this before fetching comments, reactions, check sources, and branch
-  protection so post-merge babysitting exits quickly and does not mistake
-  GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
+  not flip it to `false`. A `MERGED` `pr.state` is terminal-ready; `CLOSED`
+  without merge is terminal-blocked with a `state` blocker.
+- `required.ready`: the required-readiness half of the decision. Use it only
+  after `pr:feedback-state` has a clean ledger; alone it is not all-clear.
+- `pr.state`: GitHub's PR state (`OPEN`, `MERGED`, or `CLOSED`). The probe reads
+  it before fetching comments, reactions, check sources, and branch protection,
+  so post-merge babysitting exits quickly and does not mistake GitHub's
+  post-merge `mergeable: UNKNOWN` for a blocker.
 - `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
 - Terminal closed PR summaries may use gate state `not_applicable` for gates
-  that are normally required on open PRs. Agents should act on the terminal
-  `state` blocker instead of requesting more review.
+  normally required on open PRs. Act on the terminal `state` blocker instead of
+  requesting more review.
 - `required.blockers[]`: only required blockers. Every item needs `kind`,
   `name`, `state`, `required: true`, and a URL when GitHub provides one.
 - `optional.items[]`: advisory signals worth reporting separately. Every item
@@ -367,11 +349,10 @@ Field expectations:
   `required.blockers[]` derives from. Each item has `name`, `required: true`,
   and a `classifyCheck()` `state` — `pass`, `fail`, `pending`, or `skipped`
   (a `NEUTRAL`/`SKIPPED` conclusion), so consumers tolerate all four. Count
-  required checks
-  from this field, never by filtering `statusChecks`: that grouping describes
-  every check the PR has and carries no `required` flag at all, so a filter on
-  one is a permanent zero. `pnpm pr:merge` reports its briefing counts from
-  here.
+  required checks from this field, never by filtering `statusChecks`: that
+  grouping describes every check the PR has and carries no `required` flag, so
+  a filter on one is a permanent zero. `pnpm pr:merge` reports its briefing
+  counts from here.
 - `gates`: named repo-policy gates that are not obvious from raw check status.
   Each gate should say whether it is required for readiness.
 - `readinessOverrides[]`: active human break-glass overrides that affected a
@@ -382,25 +363,18 @@ Field expectations:
   review bodies. Each entry has a stable `fingerprint`, `source`, `sourceId`,
   `author`, URL/location fields, a short `title`/`excerpt`, `state`, and
   booleans for `currentHead`, `outdated`, `replied`, `unresolved`, and
-  `blocking`. Use it as the feedback ledger for batching and deduplicating
-  review follow-ups; do not treat it as a replacement for the final
-  `pr:ready-state` all-clear gate.
-- `codexReviewSignal`: current-head Codex review state. Values are
-  `missing`, `requested`, `in_flight`, `stale`, and `approved`. `requested`
-  means a current-head `@codex review` request exists but no bot reaction or
-  review has been observed yet. `in_flight` means the current head has a Codex
-  `eyes` reaction, a current-head Codex review, or a current-head Codex
-  top-level result. `approved` means the final PR-description `+1` gate is
-  present. `stale` means only older-head Codex signals exist.
-- `codeRabbitReviewSignal`: current-head CodeRabbit review state. Values are
-  `missing`, `requested`, `stale`, `reviewed`, and `not_applicable`. A
-  CodeRabbit review with a run marker and review commit equal to the current
-  head is `reviewed`. A trusted top-level clean-run block also counts when
-  `<!-- recent_review_start -->` and `<!-- recent_review_end -->` enclose it, it
-  contains a Run ID, its full commit range ends at the current head, and its
-  comment update time is at or after the current head update time. Empty
-  reply-only reviews, skipped runs, and rate-limit notices do not count. A
-  head-bound request is `requested` until a real run lands.
+  `blocking`. It is the feedback ledger for batching and deduplicating review
+  follow-ups, not a replacement for the final `pr:ready-state` all-clear gate.
+- `codexReviewSignal`: current-head Codex review state — `missing`,
+  `requested`, `in_flight`, `stale`, or `approved`. `requested` means a
+  current-head `@codex review` request exists with no bot reaction or review
+  observed yet. `in_flight` means the current head has a Codex `eyes` reaction,
+  review, or top-level result. `approved` means the final PR-description `+1`
+  gate is present. `stale` means only older-head Codex signals exist.
+- `codeRabbitReviewSignal`: current-head CodeRabbit review state — `missing`,
+  `requested`, `stale`, `reviewed`, or `not_applicable`. The Readiness model
+  section above defines what each state requires; a head-bound request stays
+  `requested` until a real run lands.
 - `requiredStatusContexts[]`: required check contexts from classic branch
   protection or branch rulesets. Ruleset-derived entries include status-check
   rules and required-workflow rules when their check names are present in the
@@ -412,9 +386,9 @@ Field expectations:
 
 ## Agent workflow
 
-1. Sweep feedback surfaces and build the feedback ledger before editing, then
-   reply to every review comment. Use `Fixed in <commit> — <what changed>` or
-   `Won't fix: <technical reason why>`; never resolve a thread before replying.
+1. Sweep feedback surfaces and build the ledger before editing, then reply to
+   every review comment with `Fixed in <commit> — <what changed>` or
+   `Won't fix: <technical reason why>`. Never resolve a thread before replying.
 2. Freeze the original request, target/owner, changed files, and non-test
    changed-line count as the scope baseline. Batch review fixes locally,
    auditing sibling surfaces before pushing. Classify additions as in-scope,
@@ -422,32 +396,31 @@ Field expectations:
    near twice the baseline, and do not pause solely for cycle count before five
    review-triggered patch cycles are complete. Pause for reclassification before
    starting a sixth.
-3. Before invoking the gate, ensure that no direct validation, dashboard server,
-   or browser suite outside the coordinator is active on the same machine.
-   Concurrent `--run` gates from other worktrees can continue through the
-   coordinator. They share weighted machine capacity. From invocation until
-   this gate exits, do not start uncoordinated work there. Use same-machine spare
-   workers only for read-only work. Run `pnpm agent:quality-gate --run` once for
-   the batch. Run validation outside the coordinator from a fully hydrated
-   checkout on another machine.
+3. Before invoking the gate, ensure no direct validation, dashboard server, or
+   browser suite outside the coordinator is active on the same machine, and
+   start no uncoordinated work there until the gate exits. Concurrent `--run`
+   gates from other worktrees continue through the coordinator on shared
+   weighted capacity. Use same-machine spare workers only for read-only work,
+   and run validation outside the coordinator from a fully hydrated checkout on
+   another machine. Run `pnpm agent:quality-gate --run` once for the batch.
 4. For non-trivial behavioral, workflow, security, data-flow, or UI batches,
    run `pnpm agent:autoreview` as a structured source-review closeout at the
    batch boundary rather than as an inner loop. Verify accepted findings before
-   editing and rerun focused checks plus autoreview if those fixes change the
-   batch. The exact target, prepared-bundle, isolation, and trust contracts live
-   in [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md);
-   keep behavioral and runtime verification in the validation record.
-5. Run the suggested invocation pair above: `pnpm --silent pr:feedback-state`
-   for the feedback sweep, then, once its ledger is clean, `pnpm pr:ready-state`
-   for the final required-readiness decision. Add `--watch --compact
---until-ready` to the readiness call for a foreground wait loop. Bind
-   `--repo` to the base repository — checkout inference can select the wrong
-   same-number PR on fork PRs.
-6. If feedback-state `ready` is false, inspect and handle
-   `requiredFeedbackBlockers`, `unresolvedReviewThreads`,
-   `unrepliedRootReviewComments`, `blockingTopLevelBotComments`, and any
-   non-ready required feedback `gates`. Also scan `topLevelBotComments` as
-   context; deployment/status bot comments may be informational.
+   editing, and rerun focused checks plus autoreview if those fixes change the
+   batch. The target, prepared-bundle, isolation, and trust contracts live in
+   [`agent-quality-gate-mechanics.md`](agent-quality-gate-mechanics.md); keep
+   behavioral and runtime verification in the validation record.
+5. Run the invocation pair above: `pnpm --silent pr:feedback-state` for the
+   feedback sweep, then, once its ledger is clean, `pnpm pr:ready-state` for the
+   final required-readiness decision. Add `--watch --compact --until-ready` to
+   the readiness call for a foreground wait loop. Bind `--repo` to the base
+   repository — checkout inference can select the wrong same-number PR on fork
+   PRs.
+6. If feedback-state `ready` is false, handle `requiredFeedbackBlockers`,
+   `unresolvedReviewThreads`, `unrepliedRootReviewComments`,
+   `blockingTopLevelBotComments`, and any non-ready required feedback `gates`.
+   Scan `topLevelBotComments` for context too; deployment and status bot
+   comments may be informational.
 7. If ready-state `ready` is false, fix or wait only on `required.blockers` and
    required `gates`.
 8. After the optional CodeRabbit check becomes terminal, refresh once. If
@@ -463,21 +436,21 @@ Field expectations:
     when feedback-state has no required blocker and ready-state `ready` is true
     for the current head.
 
-Claude Code and Codex intentionally use the same command and readiness fields.
-Differences between Claude `Monitor` wiring and Codex polling should stay
-outside the readiness decision.
+Claude Code and Codex use the same command and readiness fields by design.
+Differences between Claude `Monitor` wiring and Codex polling stay outside the
+readiness decision.
 
 Codex re-reviews new pushes automatically. Do not post `@codex review` as a
-routine post-push action, and never post duplicate review requests while an
-existing current-head request is `requested`, `in_flight`, or `approved`. A
-manual `@codex review` is only a fallback when the current head has no Codex
-signal after the normal automatic-review window.
+routine post-push action, and never post a duplicate while a current-head
+request is `requested`, `in_flight`, or `approved`. A manual `@codex review` is
+a fallback only when the current head has no Codex signal after the normal
+automatic-review window.
 If `chatgpt-codex-connector[bot]` replies that code-review usage limits are
-reached, stop posting duplicate `@codex review` requests and inspect whether
-the limit reply is the current-head Codex result. If it is current-head and
-approval is still missing, treat the Codex PR-description approval as
-externally blocked even if `codexReviewSignal` reports `in_flight`; quota or
-settings must change, or the gate must be intentionally overridden with the
-head-scoped comment syntax above. If the limit reply is only historical and the
-current head is `requested` or `in_flight` for another Codex signal, keep
-watching until Codex approves, posts new feedback, or the signal becomes stale.
+reached, stop posting duplicates and check whether that reply is the
+current-head Codex result. If it is, and approval is still missing, treat the
+Codex PR-description approval as externally blocked even when
+`codexReviewSignal` reports `in_flight`: quota or settings must change, or the
+gate must be overridden with the head-scoped comment syntax above. If the limit
+reply is only historical and the current head is `requested` or `in_flight` for
+another Codex signal, keep watching until Codex approves, posts new feedback,
+or the signal goes stale.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -17,7 +17,7 @@ file when a common repo command changes.
 
 ```bash
 # pnpm-workspace.yaml minimumReleaseAge blocks registry versions under 3 days,
-# including new frozen-lockfile entries; @mento-protocol/* and reviewed security releases are exempt.
+# frozen-lockfile entries included; @mento-protocol/* and reviewed security releases are exempt.
 pnpm install
 
 # Indexer: mainnet covers Ethereum reserve-yield, Celo, Monad, Polygon
@@ -31,9 +31,9 @@ pnpm deploy:indexer:logs <commit> --errors-only --since 2h  # Errors; narrow --s
 pnpm deploy:indexer:metrics <commit>  # Per-chain hosted indexing progress
 pnpm deploy:indexer:info <commit>     # Hosted deployment info/cache state
 pnpm deploy:indexer:perf <commit>     # Combined status/metrics/log snapshot for perf comparisons
-pnpm deploy:indexer:verify <commit>   # Require sync, core rows, schema-compatible sUSDS baseline/sampler integrity, and Polygon replay
+pnpm deploy:indexer:verify <commit>   # Require sync, core rows, schema-compatible sUSDS baseline/sampler integrity, Polygon replay
 pnpm deploy:indexer:promote <commit>  # Promote a synced deployment to prod
-pnpm deploy:indexer:verify <commit> --prod  # After propagation, match fixed-endpoint _meta identity to target; verify semantic data
+pnpm deploy:indexer:verify <commit> --prod  # After propagation, match fixed-endpoint _meta identity to target; verify data
 pnpm deploy:indexer:rollback <last-good-sha>  # Restore prod: re-promote if registered, else rebuild + resync
 
 # Code health (CodeScene-equivalent OSS checks)
@@ -47,41 +47,40 @@ pnpm code-health:schema-diff       # GraphQL breaking-change diff vs origin/main
 pnpm code-health                   # Run knip + deps; exclude history + duplication
 pnpm agent:quality-gate            # Map changed paths to required local checks and PR checklists
 pnpm agent:quality-gate --run      # Run mapped checks through the fair coordinator; default capacity 3
-# Package scripts, package-manager settings, and lockfiles can change install code. Review before acknowledgment:
+# Package scripts, package-manager settings, and lockfiles can change install code; review before acknowledging:
 pnpm agent:quality-gate --run --allow-package-script-changes
 pnpm agent:context-check           # Validate repo-visible agent instructions, links, and routing
 pnpm agent:review-materiality      # Classify review depth + context-update signals for current diff
-pnpm agent:autoreview              # Isolated closeout; multi-pass uses --prepare-bundle-dir DIR + a fresh reviewer; gate owns tests
+pnpm agent:autoreview              # Isolated closeout; multi-pass uses --prepare-bundle-dir DIR + fresh reviewer; gate owns tests
 pnpm agent:autoreview:test         # Full regressions; defaults to up to 3 workers with progress + timings
 pnpm agent:autoreview:test -- --jobs 1  # Sequential full closeout for autoreview runtime changes
 pnpm agent:autoreview --verify-bundle-dir DIR  # Pre-review rehash; retain the printed manifest digest
 pnpm agent:autoreview --verify-bundle-dir DIR --expected-bundle-manifest DIGEST  # Bound post-review rehash
 pnpm docs:index --write            # Regenerate docs/README.md from tracked + non-ignored untracked Markdown
 pnpm docs:index --check            # Fail on catalog drift, invalid classification, or broken internal Markdown links
-pnpm docs:audit --dry-run          # Print this week's bounded semantic-review packet without mutating documentation
-pnpm docs:garden --dry-run --json  # Read the queue; preview the exact weekly garden issue decision; no mutation
+pnpm docs:audit --dry-run          # Print this week's bounded semantic-review packet; no mutation
+pnpm docs:garden --dry-run --json  # Read the queue; preview the weekly garden issue decision; no mutation
 pnpm docs:navigation-eval -- --check-fixtures  # Check fresh-agent navigation questions, routes, and budgets
 pnpm docs:navigation-eval -- --prompt          # Print the bounded read-only prompt; no model call
-pnpm docs:navigation-eval -- --prompt --base-commit <full-sha>  # Pin a committed result to a reachable default-branch ancestor
+pnpm docs:navigation-eval -- --prompt --base-commit <full-sha>  # Pin a result to a reachable default-branch ancestor
 pnpm docs:navigation-eval -- --validate <result.json>  # Recompute authority, evidence, route, and context scores
 pnpm ci:contract:test             # Test fixed CI and protected no-skip admission, cache, base, and aggregate contracts
-# After M4 reaches main and before each approved proof, read the current immutable inputs:
+# After M4 reaches main, read fresh immutable inputs before each approved proof;
+# the audit refuses a stale baseRefOid, so update or rebase the branch first.
+# Stop after any run exceeds 45 runner-minutes, or 450 cumulative.
 gh pr view <pr> --json number,state,headRefOid,baseRefName,baseRefOid,headRepositoryOwner
-# The audit refuses a stale baseRefOid. Update or rebase the PR branch, then read fresh inputs.
-# Stop after any run exceeds 45 runner-minutes. Do not exceed 450 cumulative runner-minutes.
 gh workflow run no-skip-audit.yml --ref main -f pr_number=<pr> -f source_sha=<headRefOid> -f base_sha=<baseRefOid>
 pnpm verification:inventory:check  # Validate Phase 0 inventory schema, unique IDs, and complete dispositions
-pnpm verification:manifest:write   # Regenerate the terminal pre-M1 gate-rooted control-plane baseline manifest
-pnpm verification:manifest:check   # Recompute and compare the terminal pre-M1 baseline manifest
-pnpm verification:evidence:check   # Test the Phase 0 checker, replay the source patch, and run both non-writing evidence checks
+pnpm verification:manifest:write   # Regenerate the pre-M1 gate-rooted control-plane baseline manifest
+pnpm verification:manifest:check   # Recompute and compare that pre-M1 baseline manifest
+pnpm verification:evidence:check   # Test the Phase 0 checker, replay the source patch, run both non-writing evidence checks
 pnpm agent:context-budget --strict # Enforce root, scoped-file, and aggregate-route AGENTS byte caps
-# Run feedback-state first. Final all-clear needs the current-head Codex
-# PR-description +1 or this exact-head human override:
-# /pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>
+# Run feedback-state first. All-clear needs the current-head Codex PR-description
+# +1 or an exact-head /pr-ready-override comment; syntax in docs/notes/pr-ready-state.md.
 pnpm --silent pr:feedback-state --pr 123 --json  # Normalize unresolved/reply-required feedback before all-clear
 pnpm pr:ready-state --pr 123 --json              # Final current-head required-readiness probe
 pnpm pr:merge --pr 123   # Human-only sanctioned merge; --not-ready-reason "<why>" overrides
-node scripts/pr/review-process-metrics.mjs --prs <pr1,pr2,...> --output <result.json>  # Collect a new cohort after defining its boundary and tracking issue
+node scripts/pr/review-process-metrics.mjs --prs <pr1,pr2,...> --output <result.json>  # New cohort; define boundary + tracking issue first
 pnpm lockfile:lint                 # Fail-closed integrity/registry/override-floor check; no install
 pnpm skew:check                    # Fail on dependency skew vs pnpm catalog; no install
 pnpm sanitize:test                 # Fixture-test scripts/sanitize-terraform-output.sh secret redaction
@@ -91,8 +90,8 @@ pnpm adr:check                      # Advisory architecture reminder for new pac
 pnpm adr:check:test                 # Offline ADR-reminder tests
 node scripts/workflows/check-github-action-pins.mjs  # Verify SHA-pinned workflow/composite-action `uses:`
 node scripts/repo-health/check-hermetic-vitest-setup.mjs  # Verify byte-identical workspace Vitest network guards
-node scripts/repo-health/check-guardrail-prose.mjs  # Verify scripts/repo-health/guardrail-prose.json text in AGENTS.md + operating card
-node scripts/repo-health/file-size-watchlist.mjs  # Refresh package src/scripts source watchlist; --format issue targets GitHub, not BACKLOG.md
+node scripts/repo-health/check-guardrail-prose.mjs  # Verify guardrail-prose.json text in AGENTS.md + operating card
+node scripts/repo-health/file-size-watchlist.mjs  # Refresh package src/scripts watchlist; --format issue targets GitHub, not BACKLOG.md
 pnpm indexer:testnet:codegen       # Generate types (multichain testnet: Celo Sepolia + Monad testnet + Polygon Amoy)
 pnpm indexer:testnet:dev           # Start indexer (multichain testnet)
 
@@ -101,8 +100,8 @@ pnpm dashboard:dev            # Dev server; auth-state checks: docs/notes/dashbo
 pnpm dashboard:codegen        # Generate GraphQL operation types from indexer-envio/schema.graphql
 pnpm dashboard:build          # Production build
 pnpm dashboard:size-limit     # Check post-build bundle budgets
-pnpm dashboard:lighthouse:pool-fixture # Blocking deterministic production-build canonical pool fixture; delayed breaker revalidation; 1 700 ms median LCP
-pnpm --filter @mento-protocol/ui-dashboard test:browser                   # Fixture browser + visual snapshot tests on cached next build via next start
+pnpm dashboard:lighthouse:pool-fixture # Blocking deterministic canonical pool fixture; delayed breaker revalidation; 1 700 ms median LCP
+pnpm --filter @mento-protocol/ui-dashboard test:browser                   # Fixture browser + visual snapshot tests on cached next build
 pnpm --filter @mento-protocol/ui-dashboard test:browser:production        # Same with a fresh fixture build
 pnpm --filter @mento-protocol/ui-dashboard test:browser:update-snapshots # Rebaseline legitimate visual snapshot changes
 pnpm dashboard:mutation       # Targeted StrykerJS baseline for dashboard pure logic
@@ -119,29 +118,28 @@ pnpm integrations:probe:test   # Unit tests for probe adapters/parsers
 pnpm issue:claim --count 3 --agent codex       # Claim ready issues, record ownership, preserve Project Status
 pnpm issue:claim --issue 901 --agent codex --branch fix/901 --claim-id sweep-901 --sweep-eligible --body-sha256 <digest> # Claim one inspected sweep snapshot
 pnpm issue:review --pr 123 --issue 901         # Move claimed issue to in-pr / review
-pnpm issue:review --pr 123 --issue 901 --claim-id <id> --rebind-branch # Prove and bind a PR branch created after claim
+pnpm issue:review --pr 123 --issue 901 --claim-id <id> --rebind-branch # Bind a PR branch created after the claim
 pnpm issue:release --issue 901 --claim-id <id> # Release the matching claim back to agent-ready
 pnpm issue:release --issue 901 --claim-id <id> --closed-unmerged-pr # Release after the stored PR closes unmerged
-pnpm issue:release --issue 901 --claim-id <id> --merged-pr --needs-grooming # Continue a still-open issue after its stored PR merges
+pnpm issue:release --issue 901 --claim-id <id> --merged-pr --needs-grooming # Continue a still-open issue past its merged PR
 pnpm issue:board sync --dry-run                # Preview the repository-wide queue-label and Project projection
 pnpm issue:board sync                          # Apply the authorized projection; preserve Project Status
-pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
+pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only owner-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper
 
 # Sentry triage pipeline (Stage A — deterministic ingest; Stage B — read-only triage + digest; ADR 0036)
 pnpm sentry:ingest --dry-run                   # Print queue-issue mutations without applying (needs local SENTRY_TRIAGE_TOKEN)
-pnpm sentry:ingest:test                        # Offline tests for the ingest helper (docs/notes/sentry-triage-pipeline.md)
+pnpm sentry:ingest:test                        # Offline ingest-helper tests (docs/notes/sentry-triage-pipeline.md)
 pnpm sentry:digest:test                        # Offline tests for the per-run Slack verdict-digest collector
 pnpm sentry:broker:test                        # Offline tests for the triage agent's loopback credential broker (ADR 0056)
-SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#sentry-triage'  # Print a batch's Slack digest payload (gh auth; does not post)
+SENTRY_TRIAGE_ISSUES='[123]' pnpm sentry:digest --channel '#sentry-triage'  # Print a batch's Slack digest payload; does not post
 
 # Public config package
 pnpm --filter @mento-protocol/config build     # Clean-build the public protocol metadata package
 npm pack ./shared-config --dry-run             # Inspect the files that would publish to npm
-# First-time bootstrap: an npm maintainer must seed @mento-protocol/config once,
-# then configure trusted publishing for workflow filename `publish-config.yml`
-# in repository `mento-protocol/monitoring-monorepo`.
-# Manual workflow_dispatch runs validate and pack only; only config-v* tags publish.
+# First-time bootstrap: an npm maintainer seeds @mento-protocol/config once, then
+# configures trusted publishing for `publish-config.yml` in this repository.
+# Manual workflow_dispatch validates and packs only; only config-v* tags publish.
 git tag "config-v$(node -p "require('./shared-config/package.json').version")"  # Create the publish tag from main
 git push origin "config-v$(node -p "require('./shared-config/package.json').version")"  # Publish via .github/workflows/publish-config.yml
 
@@ -162,9 +160,9 @@ pnpm aegis:tf:init                         # Grafana folder/dashboard stack
 pnpm aegis:tf:plan
 
 # Infrastructure (Terraform)
-# `terraform.stacks.json` owns routing. `platform` uses human-approved local
-# apply; `peg-policy-publication` is workflow-only. Other stacks normally apply
-# on `main` behind `production-infra`; local apply needs clean current `main` or
+# `terraform.stacks.json` owns routing. `platform` applies locally with human
+# approval; `peg-policy-publication` is workflow-only. Other stacks apply on
+# `main` behind `production-infra`; local apply needs clean current `main` or a
 # deliberate `--force-local-apply`.
 pnpm tf list                  # Registered Terraform stacks from terraform.stacks.json
 pnpm tf validate <stack>      # fmt/init -backend=false/validate for one stack
@@ -183,9 +181,9 @@ pnpm tf validate alerts-rules
 pnpm alerts:rules:init
 pnpm alerts:rules:plan
 # CI applies alerts-rules, alerts-delivery, and Aegis after `production-infra`
-# reviewer approval; that acknowledges the commit and earlier plan, not the exact apply plan.
+# reviewer approval, which acknowledges the commit and earlier plan, not the exact apply plan.
 
 # Dev janitor
-bash scripts/repo-health/dev-janitor.sh          # Dry-run: report stale trunk repo caches, pnpm store, git worktrees, /private/tmp trees
-bash scripts/repo-health/dev-janitor.sh --apply  # Delete stale trunk repo caches, prune pnpm store, and run git worktree prune
+bash scripts/repo-health/dev-janitor.sh          # Dry-run: stale trunk caches, pnpm store, git worktrees, /private/tmp trees
+bash scripts/repo-health/dev-janitor.sh --apply  # Delete stale trunk caches, prune pnpm store, run git worktree prune
 ```


### PR DESCRIPTION
## The Problem

- `pnpm docs:navigation-eval:test` fails on unmodified `main`: the
  `commands-pr-readiness` question's loaded set measures 45,380 bytes against
  the 45,000-byte per-question cap.
- Documentation merges that each fit on their own consumed the headroom reserve
  PRs 2100/2105 restored; `4a4b2894` (#2186) added the last 492 bytes.
- Every PR whose diff routes the documentation corpus checks is red on this
  until `main` comes back under the cap, so the breach blocks unrelated work.

## The Solution

Tighten prose in the two canonical runbooks that dominate that question's
loaded set, bringing it to 43,191 bytes and restoring 1,809 bytes of headroom
below the cap. No command, rule, contract, or documented behavior is removed —
every statement survives in shorter form, and the budget targets themselves are
untouched.

The material limit: this restores the reserve, it does not stop the reserve
being consumed again. `docs/notes/pr-ready-state.md` is 53% of the loaded set
and grows with every PR-tooling change, which is why this class has now
recurred four times (#1427, #1677, #2045, #2102, #2190). A durable fix needs
either a guard that warns as remaining reserve approaches zero or a structural
consolidation of that runbook; neither is in this PR.

Closes #2190.

## Details

- `docs/notes/pr-ready-state.md`: 25,478 → 23,481 bytes. Compacted the cloud/gh
  availability note, the required-blocker list, the CodeRabbit advisory and
  rate-limit paragraphs, the bounded clean-Claude protocol, the CLI-contract
  prose, the field expectations, agent-workflow steps 1–6, and the Codex
  quota paragraphs. Deduplicated the `codeRabbitReviewSignal` field bullet,
  which restated the state definitions given in full under Readiness model.
- `docs/notes/quick-commands.md`: 14,594 → 14,402 bytes. Compacted the
  multi-line comment blocks for the no-skip audit, npm bootstrap, Terraform
  routing, and CI apply approval, plus long trailing comments. The
  `/pr-ready-override` syntax comment now points at `docs/notes/pr-ready-state.md`
  rather than repeating the line verbatim.
- The third document in the question's loaded set,
  `docs/PLAN-ai-review-process.md` (5,308 bytes), is untouched: it is
  historical planning context and the fixture's designated
  `sources_requiring_verification` case.

## Validation

- Direct measurement of the scorer against this branch's content:
  `source_bytes` 43,191, `questions_over_budget` 0, `max_question_source_bytes`
  45,000, and every scoring target satisfied. This proves the loaded set now
  fits the per-question cap. It does not prove the reserve survives future
  documentation growth.
- `pnpm docs:navigation-eval -- --check-fixtures` passes:
  `max_question_route_bytes` 27,994, `total_unique_headroom_bytes` 46,519,
  `total_unique_reserve_surplus_bytes` 13,751. This proves every cheapest
  accepted route still fits both caps and the suite reserve. It says nothing
  about the non-route sources the failing test adds on top.
- `pnpm docs:index --check`, `pnpm agent:context-check` (168 managed files), and
  `node scripts/repo-health/check-guardrail-prose.mjs` (12 pinned sentences
  across 3 files) all pass, so the edits break no catalog entry, internal link,
  frontmatter contract, or pinned guardrail sentence. They do not review the
  prose for meaning.
- `./tools/trunk check` passed on both files through the pre-commit hook.
- **`pnpm docs:navigation-eval:test` is still red on this branch, and will be
  red in CI.** The test reads every source at
  `git merge-base HEAD origin/main`, so it measures `main`'s bytes, not this
  branch's; a fix for this breach cannot turn it green until the fix is on
  `main`. Verified by running the suite on a clean `origin/main` worktree
  (same single failure) and on this branch before and after the trim
  (unchanged). The direct measurement above is the evidence that the repair
  works; the check itself can only confirm it post-merge.
- The repository pre-push gate maps and fails on that same check, so this
  commit was pushed with the gate bypassed under the operator's explicit
  consent to this specific repair, per the "control blocks its own repair"
  clause in `docs/notes/pr-operating-card.md`. Every other mapped command for
  this diff passes locally.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2190 stays the
  home for the recurrence guard the issue's own fix direction proposes; this PR
  restores the reserve but adds no guard. If you would rather track that
  separately, say so and I will open a follow-up issue instead of closing
  #2190 here.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No. This trims documentation prose and changes no interface, contract, or budget target.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsgJua3oxCa9b5jUNu5LV2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PR readiness runbook with clearer guidance for proxy-based CLI use, terminal pull requests, branch protection, reviewer responses, rate limits, review parsing, watch modes, required checks, and agent coordination.
  * Revised the quick-command runbook with current commands for verification, quality gates, documentation audits, dashboards, issue workflows, monitoring, configuration publishing, infrastructure, and cleanup.
  * Added guidance for indexer promotion checks, review metrics, navigation validation, verification manifests, readiness checks, monitoring tests, and dashboard fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->