### PR TITLE
perf(gate): route dep-cruiser and Trunk by what each tool reads

### DIFF
--- a/docs/adr/0069-gate-routing-table-as-data.md
+++ b/docs/adr/0069-gate-routing-table-as-data.md
@@ -309,7 +309,7 @@ side that can change them and one of them is also in the required `ci` job:
   `implementation_signature()` pins, split into `pins.test.mjs` when D5c took
   `routing-table.test.mjs` to the 1,000-line cap.
 - `node --test scripts/gate/mapping/engine.test.mjs` — dedupe and
-  first-reason-wins, the alias pairs, prepend, bucket order, the five post-passes
+  first-reason-wins, the alias pairs, prepend, bucket order, the six post-passes
   and the root-manifest classifier.
 
 **One residual, deliberately kept.** The gate still runs the routing-sensitive
@@ -448,11 +448,11 @@ gate is not a trust root.
   With the guard gone there is nothing for it to drive, so it went with the arms.
 - **The engine's behaviour is pinned by its own tests.**
   `scripts/gate/mapping/engine.test.mjs` covers dedupe and first-reason-wins, the
-  alias pairs, prepend, bucket order, the five post-passes including the 15/16
-  scoped-test threshold and every disqualifier, and the root-manifest
-  classifier's four classes. It was written at D5b precisely so that D5c would
-  not delete the only thing pinning those rules in the same commit that removes
-  the arms.
+  alias pairs, prepend, bucket order, the six post-passes including the 15/16
+  scoped-test threshold, every disqualifier and the dep-cruiser scope narrowing,
+  and the root-manifest classifier's four classes. It was written at D5b
+  precisely so that D5c would not delete the only thing pinning those rules in
+  the same commit that removes the arms.
 - **The root-manifest classifier became an import.**
   `check-sentry-suites-in-ci-gate-probe.mjs` used to lift the gate's
   `classify_root_package_json_changes` out of the script and re-run it under an

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -805,14 +805,17 @@ drops the command. A change inside a root keeps it only when dependency-cruiser
 can read the path, in one of two ways. It parses the extension — the enabled
 half of `depcruise --info`, pinned in `engine.test.mjs` against the
 `allExtensions` the library exports. Or its resolver can reach the file as a
-dependency target: `.json` and `.node` hold no imports but Node resolution
-resolves them, so they can be the far end of an edge between two scanned roots.
+dependency target. dependency-cruiser resolves `.json`, `.node`, `.css`,
+`.sass`, `.scss`, `.stylus` and `.less` into the graph and then declines to
+parse them — its `lKnownUnfollowables` — so each is a node with no outgoing
+edges, and a node is still an edge target.
 `indexer-envio/src/handlers/stables/config.ts` imports
-`../../../config/nttAddresses.json`, and retargeting that JSON moves an edge the
-cross-package rules judge while no `.ts` file changes. dependency-cruiser
-exports nothing for what its resolver accepts, so that half is pinned by a
-fixture asserting the `nttAddresses.json` import still exists rather than
-against the library. An in-root path that is neither parsed nor resolvable —
+`../../../config/nttAddresses.json` and `ui-dashboard/src/app/layout.tsx`
+imports `./globals.css`; retargeting either moves an edge the cross-package
+rules judge while no `.ts` file changes. The library exports nothing for that
+list, so it is pinned three ways instead: the dependency-cruiser version it was
+read from, which turns an upgrade into a red test rather than a silent drift,
+and one fixture each for the JSON and stylesheet imports above. An in-root path that is neither parsed nor resolvable —
 `ui-dashboard/AGENTS.md`, a `.yaml`, a `.sol` — drops the command even though a
 package quality arm scheduled it; before that narrowing such a change bought a
 ~22s cruise of an unchanged 1,321-module graph. A change to

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -207,9 +207,20 @@ entrypoint validator
 (`scripts/check-agent-quality-gate-package-scripts.mjs`) runs as a fail-fast
 quality-setup prerequisite: an unpinned or drifted alias aborts the run before
 any `pnpm <alias>` executes, and `--skip-if-fresh` cannot skip it. Existing changed paths run
-targeted Trunk checks for faster local iteration. Deleted paths,
-Trunk/tooling changes, package-manager changes, pnpm patches, and
-package-manifest changes still run full-repo Trunk locally. CI also runs a
+targeted Trunk checks for faster local iteration. Trunk/tooling changes,
+package-manager changes, pnpm patches, and package-manifest changes still run
+full-repo Trunk locally. A deleted path is dropped from the targeted argument
+list — Trunk fails on an argument that is not there — and the surviving paths
+are still linted. Three deletion cases keep the whole-repo scan: a change set
+with no survivor to target, a deleted path that is itself in the whole-repo
+list, and a deleted path under `.github/`. That last one is cross-file
+semantics: actionlint resolves `uses: ./.github/actions/<name>` and
+`uses: ./.github/workflows/<file>` against the tree, so deleting one invalidates
+surviving callers that are not in the change set and that a targeted run would
+never name. Every other enabled Trunk linter judges a file on its own bytes —
+shellcheck included, because Trunk's `copy_targets` sandbox lints one file at a
+time. checkov would join `.github/` if this repo gained a local
+`module { source = "./…" }` reference; it has none today. CI also runs a
 required full-repo Trunk check on every
 PR. Where the environment blocks Trunk's downloads — a Claude cloud container
 proxies egress and refuses any host outside its allowlist, and its credential
@@ -749,9 +760,27 @@ comparison would be the engine against itself. What routing correctness rests on
 now is `pnpm gate:routing-table:test` (the pairing lint, the staleness check, the
 `/bin/bash` pattern oracle, the closed verb set) and
 `node --test scripts/gate/mapping/engine.test.mjs` (dedupe and first-reason-wins,
-bucket order, the five post-passes, the root-manifest classifier). Both are
+bucket order, the six post-passes, the root-manifest classifier). Both are
 routed by a change to the engine or the table, and the routing-table suite also
-runs in the required `ci` job.
+runs in the required `ci` job. The engine suite is routed by
+`.dependency-cruiser.cjs` as well, because it is what pins the gate's copy of
+the scanned roots against that file.
+
+The sixth post-pass narrows `pnpm code-health:deps`. Several arms reach that
+command through a package quality bundle — a `governance-watchdog/**` edit, an
+`alerts/infra/**` edit, a `.github/workflows/**` edit that routes a package's
+bundle — from paths dependency-cruiser neither walks nor reports. The command
+scans six roots: `shared-config`, `ui-dashboard`, `indexer-envio`,
+`metrics-bridge`, `integration-probes`, and `aegis`. Two sources define that
+list, the positional arguments of the root `code-health:deps` script and the
+`includeOnly.path` alternation in `.dependency-cruiser.cjs`, and
+`engine.test.mjs` holds the gate's pinned copy set-equal to both. A change
+outside every root drops the command; a change inside any root, to
+`.dependency-cruiser.cjs`, or to the narrowing pass itself keeps it. The
+`docs/pr-checklists/code-health.md` checklist is unaffected either way, because
+knip is the other half of it and still runs per package. This is the only pass
+that makes a plan smaller, so its condition is about what dependency-cruiser can
+read, never about which package the arms routed.
 
 ### Scheduling contract (Refs #1802, #2006; [ADR 0076](../adr/0076-fair-quality-gate-coordinator.md))
 

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -213,8 +213,8 @@ full-repo Trunk locally. A deleted path is dropped from the targeted argument
 list — Trunk fails on an argument that is not there — and the surviving paths
 are still linted. Five deletion cases keep the whole-repo scan: a change set
 with no survivor to target, a deleted path that is itself in the whole-repo
-list, a deleted path under `.github/`, a deleted `*.sh`, and a deleted
-repo-root dotfile. The last three are cross-file semantics. actionlint resolves `uses: ./.github/actions/<name>` and
+list, a deleted path under `.github/`, a deleted `*.sh`, and a deleted dotfile
+at any depth. The last three are cross-file semantics. actionlint resolves `uses: ./.github/actions/<name>` and
 `uses: ./.github/workflows/<file>` against the tree, so deleting one invalidates
 surviving callers that are not in the change set and that a targeted run would
 never name. ShellCheck does the same for `# shellcheck source=<repo-relative
@@ -224,16 +224,22 @@ surviving callers from clean to SC1091. A caller that sources only through a
 runtime `${DIR}/…` path is the separate false positive `.shellcheckrc`
 documents, already suppressed per line; the rule does not try to tell the two
 apart, because a sourced-by analysis would rot the first time a caller changed
-how it spells the path. A deleted repo-root dotfile is the third: codespell,
+how it spells the path. A deleted dotfile at any depth is the third: codespell,
 shellcheck, and osv-scanner read `.codespellrc`, `.shellcheckrc`, and
-`.osv-scanner.toml` from the root, and `.gitignore` decides what Trunk looks at
-at all. Remove `.codespellrc` and the unchanged
-`scripts/terraform/tf-platform-plan-guard.mjs` gains a codespell hit on
-`applyable`, an ignore-word that file carried — while the targeted run over the
-survivors still exits 0. The rule is structural, "any deleted root dotfile",
-rather than a list that would rot silently toward under-scanning the first time
-a linter gained a root config; `.trunk/**` needs no entry because it is already
-whole-repo on edit and delete. Note the matching gap for _edits_: modifying
+`.osv-scanner.toml` from the root, `.gitignore` decides what Trunk looks at at
+all, and prettier, markdownlint and yamllint cascade to the nearest config so a
+package can carry its own. Both levels are measured. Remove `.codespellrc` and
+the unchanged `scripts/terraform/tf-platform-plan-guard.mjs` gains a codespell
+hit on `applyable`, an ignore-word that file carried. Remove `aegis/.prettierrc`
+and the untouched `aegis/src/app.module.ts` starts failing prettier, because the
+package's `singleQuote` setting went with it. In both cases the targeted run
+over the survivors still exits 0. The rule is structural, "any deleted
+dotfile", rather than a list or a name-shape class like `.*rc`/`.*ignore`: both
+rot silently toward under-scanning, a list when a linter gains a config and a
+name class when one is spelled outside the shape, as `.osv-scanner.toml`
+already is. It over-includes dotfiles no linter reads — `.terraform.lock.hcl`,
+`.env.example`, `.dockerignore` — which costs a full scan and is never wrong.
+`.trunk/**` needs no entry because it is already whole-repo on edit and delete. Note the matching gap for _edits_: modifying
 `.codespellrc` has the same cross-file reach and still only targets survivors,
 covered today for `.shellcheckrc` alone by its own filtered full scan. Every
 other enabled Trunk linter judges a file on its own bytes. checkov would join
@@ -796,11 +802,18 @@ list, the positional arguments of the root `code-health:deps` script and the
 manifest routes that suite so a script-only edit shrinking the scanned roots
 cannot merge without the staleness test running. A change outside every root
 drops the command. A change inside a root keeps it only when dependency-cruiser
-can read the path: an extension it parses — the enabled half of
-`depcruise --info`, pinned in `engine.test.mjs` against the `allExtensions` the
-library exports — or any `package.json` beneath the root, where a workspace
-dependency is declared. An in-root path it never parses, such as
-`ui-dashboard/AGENTS.md` or a `.sol` file, drops the command even though a
+can read the path, in one of two ways. It parses the extension — the enabled
+half of `depcruise --info`, pinned in `engine.test.mjs` against the
+`allExtensions` the library exports. Or its resolver can reach the file as a
+dependency target: `.json` and `.node` hold no imports but Node resolution
+resolves them, so they can be the far end of an edge between two scanned roots.
+`indexer-envio/src/handlers/stables/config.ts` imports
+`../../../config/nttAddresses.json`, and retargeting that JSON moves an edge the
+cross-package rules judge while no `.ts` file changes. dependency-cruiser
+exports nothing for what its resolver accepts, so that half is pinned by a
+fixture asserting the `nttAddresses.json` import still exists rather than
+against the library. An in-root path that is neither parsed nor resolvable —
+`ui-dashboard/AGENTS.md`, a `.yaml`, a `.sol` — drops the command even though a
 package quality arm scheduled it; before that narrowing such a change bought a
 ~22s cruise of an unchanged 1,321-module graph. A change to
 `.dependency-cruiser.cjs` or to the narrowing pass itself keeps it. So does a

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -211,10 +211,10 @@ targeted Trunk checks for faster local iteration. Trunk/tooling changes,
 package-manager changes, pnpm patches, and package-manifest changes still run
 full-repo Trunk locally. A deleted path is dropped from the targeted argument
 list — Trunk fails on an argument that is not there — and the surviving paths
-are still linted. Four deletion cases keep the whole-repo scan: a change set
+are still linted. Five deletion cases keep the whole-repo scan: a change set
 with no survivor to target, a deleted path that is itself in the whole-repo
-list, a deleted path under `.github/`, and a deleted `*.sh`. The last two are
-cross-file semantics. actionlint resolves `uses: ./.github/actions/<name>` and
+list, a deleted path under `.github/`, a deleted `*.sh`, and a deleted
+repo-root dotfile. The last three are cross-file semantics. actionlint resolves `uses: ./.github/actions/<name>` and
 `uses: ./.github/workflows/<file>` against the tree, so deleting one invalidates
 surviving callers that are not in the change set and that a targeted run would
 never name. ShellCheck does the same for `# shellcheck source=<repo-relative
@@ -224,9 +224,21 @@ surviving callers from clean to SC1091. A caller that sources only through a
 runtime `${DIR}/…` path is the separate false positive `.shellcheckrc`
 documents, already suppressed per line; the rule does not try to tell the two
 apart, because a sourced-by analysis would rot the first time a caller changed
-how it spells the path. Every other enabled Trunk linter judges a file on its
-own bytes. checkov would join these if this repo gained a local
-`module { source = "./…" }` reference; it has none today. CI also runs a
+how it spells the path. A deleted repo-root dotfile is the third: codespell,
+shellcheck, and osv-scanner read `.codespellrc`, `.shellcheckrc`, and
+`.osv-scanner.toml` from the root, and `.gitignore` decides what Trunk looks at
+at all. Remove `.codespellrc` and the unchanged
+`scripts/terraform/tf-platform-plan-guard.mjs` gains a codespell hit on
+`applyable`, an ignore-word that file carried — while the targeted run over the
+survivors still exits 0. The rule is structural, "any deleted root dotfile",
+rather than a list that would rot silently toward under-scanning the first time
+a linter gained a root config; `.trunk/**` needs no entry because it is already
+whole-repo on edit and delete. Note the matching gap for _edits_: modifying
+`.codespellrc` has the same cross-file reach and still only targets survivors,
+covered today for `.shellcheckrc` alone by its own filtered full scan. Every
+other enabled Trunk linter judges a file on its own bytes. checkov would join
+these if this repo gained a local `module { source = "./…" }` reference; it has
+none today. CI also runs a
 required full-repo Trunk check on every
 PR. Where the environment blocks Trunk's downloads — a Claude cloud container
 proxies egress and refuses any host outside its allowlist, and its credential
@@ -780,9 +792,18 @@ scans six roots: `shared-config`, `ui-dashboard`, `indexer-envio`,
 `metrics-bridge`, `integration-probes`, and `aegis`. Two sources define that
 list, the positional arguments of the root `code-health:deps` script and the
 `includeOnly.path` alternation in `.dependency-cruiser.cjs`, and
-`engine.test.mjs` holds the gate's pinned copy set-equal to both. A change
-outside every root drops the command; a change inside any root, to
-`.dependency-cruiser.cjs`, or to the narrowing pass itself keeps it. So does a
+`engine.test.mjs` holds the gate's pinned copy set-equal to both, and the root
+manifest routes that suite so a script-only edit shrinking the scanned roots
+cannot merge without the staleness test running. A change outside every root
+drops the command. A change inside a root keeps it only when dependency-cruiser
+can read the path: an extension it parses — the enabled half of
+`depcruise --info`, pinned in `engine.test.mjs` against the `allExtensions` the
+library exports — or any `package.json` beneath the root, where a workspace
+dependency is declared. An in-root path it never parses, such as
+`ui-dashboard/AGENTS.md` or a `.sol` file, drops the command even though a
+package quality arm scheduled it; before that narrowing such a change bought a
+~22s cruise of an unchanged 1,321-module graph. A change to
+`.dependency-cruiser.cjs` or to the narrowing pass itself keeps it. So does a
 change to `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`: a scanned
 root reaches another scanned root by package name — `ui-dashboard/package.json`
 declares `"@mento-protocol/config": "workspace:*"` — so those three files decide

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -801,25 +801,29 @@ list, the positional arguments of the root `code-health:deps` script and the
 `engine.test.mjs` holds the gate's pinned copy set-equal to both, and the root
 manifest routes that suite so a script-only edit shrinking the scanned roots
 cannot merge without the staleness test running. A change outside every root
-drops the command. A change inside a root keeps it only when dependency-cruiser
-can read the path, in one of two ways. It parses the extension — the enabled
-half of `depcruise --info`, pinned in `engine.test.mjs` against the
-`allExtensions` the library exports. Or its resolver can reach the file as a
-dependency target. dependency-cruiser resolves `.json`, `.node`, `.css`,
-`.sass`, `.scss`, `.stylus` and `.less` into the graph and then declines to
-parse them — its `lKnownUnfollowables` — so each is a node with no outgoing
-edges, and a node is still an edge target.
-`indexer-envio/src/handlers/stables/config.ts` imports
-`../../../config/nttAddresses.json` and `ui-dashboard/src/app/layout.tsx`
-imports `./globals.css`; retargeting either moves an edge the cross-package
-rules judge while no `.ts` file changes. The library exports nothing for that
-list, so it is pinned three ways instead: the dependency-cruiser version it was
-read from, which turns an upgrade into a red test rather than a silent drift,
-and one fixture each for the JSON and stylesheet imports above. An in-root path that is neither parsed nor resolvable —
-`ui-dashboard/AGENTS.md`, a `.yaml`, a `.sol` — drops the command even though a
-package quality arm scheduled it; before that narrowing such a change bought a
-~22s cruise of an unchanged 1,321-module graph. A change to
-`.dependency-cruiser.cjs` or to the narrowing pass itself keeps it. So does a
+drops the command. Any change inside a root keeps it, whatever the file type.
+
+That last point was narrowed by file type and then reverted, which is worth
+recording so it is not narrowed again. The narrowing aimed at
+`ui-dashboard/AGENTS.md` buying a ~22s cruise of an unchanged 1,321-module
+graph, and shipped as "an extension dependency-cruiser parses". It then had to
+grow twice, first for `.json` and `.node`, then for the stylesheet languages,
+because parsing is not how a file joins the graph — resolution is. A file
+becomes a node whenever an import specifier names it with its extension.
+dependency-cruiser says so in `determineFollowableExtensions`: its
+`lKnownUnfollowables` list exists only to stop the fallback parser reading
+stylesheets, and the comment beside it notes that pictures, movies, html and
+xml resolve the same way without being listed. An SVG imported from the indexer
+into the dashboard activates `indexer-no-dashboard` with no `.ts` file changed.
+Every file is therefore a possible edge target, no closed list of them can be
+sound, and deciding membership properly needs the dependency graph that the
+command being scheduled is what computes. The ~22s on in-root docs-only changes
+is the price of a sound answer. Two fixtures remain as regression tests,
+asserting the real `nttAddresses.json` and `globals.css` imports still exist,
+because they are why an in-root non-source change can move an edge at all.
+
+A change to
+`.dependency-cruiser.cjs` or to the narrowing pass itself keeps it too. So does a
 change to `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`: a scanned
 root reaches another scanned root by package name — `ui-dashboard/package.json`
 declares `"@mento-protocol/config": "workspace:*"` — so those three files decide

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -211,15 +211,21 @@ targeted Trunk checks for faster local iteration. Trunk/tooling changes,
 package-manager changes, pnpm patches, and package-manifest changes still run
 full-repo Trunk locally. A deleted path is dropped from the targeted argument
 list — Trunk fails on an argument that is not there — and the surviving paths
-are still linted. Three deletion cases keep the whole-repo scan: a change set
+are still linted. Four deletion cases keep the whole-repo scan: a change set
 with no survivor to target, a deleted path that is itself in the whole-repo
-list, and a deleted path under `.github/`. That last one is cross-file
-semantics: actionlint resolves `uses: ./.github/actions/<name>` and
+list, a deleted path under `.github/`, and a deleted `*.sh`. The last two are
+cross-file semantics. actionlint resolves `uses: ./.github/actions/<name>` and
 `uses: ./.github/workflows/<file>` against the tree, so deleting one invalidates
 surviving callers that are not in the change set and that a targeted run would
-never name. Every other enabled Trunk linter judges a file on its own bytes —
-shellcheck included, because Trunk's `copy_targets` sandbox lints one file at a
-time. checkov would join `.github/` if this repo gained a local
+never name. ShellCheck does the same for `# shellcheck source=<repo-relative
+path>`, which resolves against the real tree even inside Trunk's `copy_targets`
+sandbox: deleting `scripts/bootstrap/codex-cloud-git-helpers.sh` takes its two
+surviving callers from clean to SC1091. A caller that sources only through a
+runtime `${DIR}/…` path is the separate false positive `.shellcheckrc`
+documents, already suppressed per line; the rule does not try to tell the two
+apart, because a sourced-by analysis would rot the first time a caller changed
+how it spells the path. Every other enabled Trunk linter judges a file on its
+own bytes. checkov would join these if this repo gained a local
 `module { source = "./…" }` reference; it has none today. CI also runs a
 required full-repo Trunk check on every
 PR. Where the environment blocks Trunk's downloads — a Claude cloud container
@@ -781,7 +787,16 @@ change to `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`: a scanned
 root reaches another scanned root by package name — `ui-dashboard/package.json`
 declares `"@mento-protocol/config": "workspace:*"` — so those three files decide
 what a bare specifier resolves to and can add or remove an edge between two
-roots while no file inside a root changes. The
+roots while no file inside a root changes.
+
+The pass both removes and adds. For the five triggers that are not scanned
+roots — the three manifests, `.dependency-cruiser.cjs`, and this pass's own
+module — it schedules the command itself rather than only declining to remove
+it, because no arm routes a bare `pnpm-lock.yaml` or `post-passes.mjs`: there
+would be nothing in the plan to preserve, and the guarantee would never fire.
+`plan.addCommand` dedupes, so an arm that already scheduled the command keeps
+its own reason. The scanned roots stay with their arms, which decide better — a
+root's `README.md` matches the root prefix but cannot change a verdict. The
 `docs/pr-checklists/code-health.md` checklist is unaffected either way, because
 knip is the other half of it and still runs per package. This is the only pass
 that makes a plan smaller, so its condition is about what dependency-cruiser can

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -801,7 +801,8 @@ list, the positional arguments of the root `code-health:deps` script and the
 `engine.test.mjs` holds the gate's pinned copy set-equal to both, and the root
 manifest routes that suite so a script-only edit shrinking the scanned roots
 cannot merge without the staleness test running. A change outside every root
-drops the command. Any change inside a root keeps it, whatever the file type.
+drops the command unless it is an explicit manifest, configuration, or
+post-pass trigger. Any change inside a root keeps it, whatever the file type.
 
 That last point was narrowed by file type and then reverted, which is worth
 recording so it is not narrowed again. The narrowing aimed at

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -776,7 +776,12 @@ list, the positional arguments of the root `code-health:deps` script and the
 `includeOnly.path` alternation in `.dependency-cruiser.cjs`, and
 `engine.test.mjs` holds the gate's pinned copy set-equal to both. A change
 outside every root drops the command; a change inside any root, to
-`.dependency-cruiser.cjs`, or to the narrowing pass itself keeps it. The
+`.dependency-cruiser.cjs`, or to the narrowing pass itself keeps it. So does a
+change to `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`: a scanned
+root reaches another scanned root by package name — `ui-dashboard/package.json`
+declares `"@mento-protocol/config": "workspace:*"` — so those three files decide
+what a bare specifier resolves to and can add or remove an edge between two
+roots while no file inside a root changes. The
 `docs/pr-checklists/code-health.md` checklist is unaffected either way, because
 knip is the other half of it and still runs per package. This is the only pass
 that makes a plan smaller, so its condition is about what dependency-cruiser can

--- a/docs/pr-checklists/code-health.md
+++ b/docs/pr-checklists/code-health.md
@@ -19,9 +19,12 @@ or the `.dependency-cruiser.cjs` / `*/knip.json` files.
 ## Before pushing
 
 - [ ] `pnpm code-health` is green (`code-health:knip` + `code-health:deps`).
-      The agent quality gate selects the changed package's `knip` task and the
-      workspace dependency-cruiser check; use the umbrella command for a full
-      local sweep.
+      The agent quality gate selects the changed package's `knip` task always,
+      and the workspace dependency-cruiser check only when a changed path is
+      inside a root that check scans (`shared-config`, `ui-dashboard`,
+      `indexer-envio`, `metrics-bridge`, `integration-probes`, `aegis`) or is
+      `.dependency-cruiser.cjs`. Use the umbrella command for a full local
+      sweep.
 - [ ] If you added a new cross-package import, it goes via `shared-config`
       (or `@mento-protocol/contracts`), never indexer/dashboard/bridge ↔ each other.
 - [ ] If you added a new top-level dependency, knip can see it being used.

--- a/docs/pr-checklists/code-health.md
+++ b/docs/pr-checklists/code-health.md
@@ -22,9 +22,10 @@ or the `.dependency-cruiser.cjs` / `*/knip.json` files.
       The agent quality gate selects the changed package's `knip` task always,
       and the workspace dependency-cruiser check only when a changed path is
       inside a root that check scans (`shared-config`, `ui-dashboard`,
-      `indexer-envio`, `metrics-bridge`, `integration-probes`, `aegis`) or is
-      `.dependency-cruiser.cjs`. Use the umbrella command for a full local
-      sweep.
+      `indexer-envio`, `metrics-bridge`, `integration-probes`, `aegis`), is
+      `.dependency-cruiser.cjs`, or is a workspace manifest that decides how
+      imports resolve (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`).
+      Use the umbrella command for a full local sweep.
 - [ ] If you added a new cross-package import, it goes via `shared-config`
       (or `@mento-protocol/contracts`), never indexer/dashboard/bridge ↔ each other.
 - [ ] If you added a new top-level dependency, knip can see it being used.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -90,10 +90,10 @@ feedback-runtime pins.
   `gate/routing-table/**`, `gate/mapping*`, the autoreview core, and sealed
   policy. Runtime hashes use `$script_source_dir`; suites use `$repo_root`.
   Core edits route both suites; policy edits route autoreview. Missing pins
-  freeze the stamp (ADRs 0069 and 0079). Two exact pins inside that glob move
-  alone: the `.dependency-cruiser.cjs` arm names
-  `gate/mapping/engine.test.mjs`, and `gate/mapping/post-passes.mjs` names
-  itself to schedule `code-health:deps`.
+  freeze the stamp (ADRs 0069 and 0079). Three exact pins move alone:
+  `.dependency-cruiser.cjs` and root `package.json` both name
+  `gate/mapping/engine.test.mjs` (scanned roots);
+  `gate/mapping/post-passes.mjs` schedules `code-health:deps` itself.
 - **Review-eval pins.** `docs/evals/review-skill.md` tracks
   `review/run-eval{,-source-snapshot,-lifecycle,-runtime}.sh`,
   `review/install-review-eval-launchd.{sh,test.mjs}`,

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -90,16 +90,15 @@ feedback-runtime pins.
   `gate/routing-table/**`, `gate/mapping*`, the autoreview core, and sealed
   policy. Runtime hashes use `$script_source_dir`; suites use `$repo_root`.
   Core edits route both suites; policy edits route autoreview. Missing pins
-  freeze the stamp (ADRs 0069 and 0079).
+  freeze the stamp (ADRs 0069 and 0079). Two exact pins inside that glob move
+  alone: the `.dependency-cruiser.cjs` arm names
+  `gate/mapping/engine.test.mjs`, and `gate/mapping/post-passes.mjs` names
+  itself to keep `code-health:deps` scheduled.
 - **Review-eval pins.** `docs/evals/review-skill.md` tracks
-  `scripts/review/run-eval.sh`,
-  `scripts/review/run-eval-source-snapshot.sh`,
-  `scripts/review/run-eval-lifecycle.sh`,
-  `scripts/review/run-eval-runtime.sh`,
-  `scripts/review/install-review-eval-launchd.sh`,
-  `scripts/review/launchd/org.mento.review-eval.plist`,
-  `scripts/review/review-eval.test.mjs`, and
-  `scripts/review/install-review-eval-launchd.test.mjs`.
+  `review/run-eval{,-source-snapshot,-lifecycle,-runtime}.sh`,
+  `review/install-review-eval-launchd.{sh,test.mjs}`,
+  `review/launchd/org.mento.review-eval.plist`, and
+  `review/review-eval.test.mjs`.
   `review/review-eval-*publication*` pins both tests.
 - **Navigation-eval pin.** `forbidden_sources` in
   `docs/evals/documentation-navigation-fixtures.json` names its source.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -93,7 +93,7 @@ feedback-runtime pins.
   freeze the stamp (ADRs 0069 and 0079). Two exact pins inside that glob move
   alone: the `.dependency-cruiser.cjs` arm names
   `gate/mapping/engine.test.mjs`, and `gate/mapping/post-passes.mjs` names
-  itself to keep `code-health:deps` scheduled.
+  itself to schedule `code-health:deps`.
 - **Review-eval pins.** `docs/evals/review-skill.md` tracks
   `review/run-eval{,-source-snapshot,-lifecycle,-runtime}.sh`,
   `review/install-review-eval-launchd.{sh,test.mjs}`,

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13180,22 +13180,16 @@ assert_contains "- pnpm code-health:deps"
 run_gate "pnpm-lock.yaml"
 assert_contains "- pnpm code-health:deps"
 
-# In-root but unreadable by dep-cruiser: a package quality arm schedules the
-# command, and the scope pass drops it because nothing it can parse changed.
-run_gate "ui-dashboard/AGENTS.md"
-assert_not_contains "- pnpm code-health:deps"
+# Any path inside a scanned root keeps the command, whatever its file type.
+# Resolution, not parsing, decides what joins the graph: an import naming a
+# file with its extension makes it an edge target, so .md/.css/.json/.sol are
+# all possible. An extension list here was tried and reverted.
 run_gate "ui-dashboard/src/thing.ts"
 assert_contains "- pnpm code-health:deps"
-
-# A JSON inside a root is a dependency TARGET even though it holds no imports:
-# indexer source statically imports config/nttAddresses.json, so retargeting it
-# moves an edge the cross-package rules judge.
+run_gate "ui-dashboard/AGENTS.md"
+assert_contains "- pnpm code-health:deps"
 run_gate "indexer-envio/config/nttAddresses.json"
 assert_contains "- pnpm code-health:deps"
-
-# Stylesheets are the same class: dep-cruiser resolves them into the graph and
-# declines to parse them, so they are edge targets with no outgoing edges.
-# ui-dashboard/src/app/layout.tsx imports ./globals.css.
 run_gate "ui-dashboard/src/app/globals.css"
 assert_contains "- pnpm code-health:deps"
 

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13141,6 +13141,14 @@ run_gate "scripts/bootstrap/deleted-helper.sh" "docs/deployment.md"
 assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci docs/deployment.md ("
 
+# And for repo-root dotfiles: linters read their config from one, so deleting
+# it changes the verdict on files that did not change. A nested dotfile is not
+# repo-wide config and stays an ordinary deletion.
+run_gate ".codespellrc-deleted" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
+run_gate "ui-dashboard/.eslintrc-deleted.json" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
+
 # Code-health routing: ensure a `.dependency-cruiser.cjs` change schedules
 # the cross-package dep-cruiser gate + surfaces the code-health checklist.
 run_gate ".dependency-cruiser.cjs"
@@ -13168,6 +13176,20 @@ run_gate "scripts/gate/mapping/post-passes.mjs"
 assert_contains "- pnpm code-health:deps"
 run_gate "pnpm-lock.yaml"
 assert_contains "- pnpm code-health:deps"
+
+# In-root but unreadable by dep-cruiser: a package quality arm schedules the
+# command, and the scope pass drops it because nothing it can parse changed.
+run_gate "ui-dashboard/AGENTS.md"
+assert_not_contains "- pnpm code-health:deps"
+run_gate "ui-dashboard/src/thing.ts"
+assert_contains "- pnpm code-health:deps"
+
+# The root manifest carries the `code-health:deps` script line that
+# engine.test.mjs holds the scanned-root list set-equal to, so it must route
+# that suite; the class dispatch alone would send a script edit to the shell
+# gate only.
+run_gate "package.json"
+assert_contains "- node --test scripts/gate/mapping/engine.test.mjs (root manifest changed (gate pins its scanned roots against the code-health:deps script))"
 
 # Code-health routing: each package's knip.json routes to the matching
 # `pnpm --filter <pkg> knip` command + the same checklist. A typo in the

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13134,6 +13134,13 @@ run_gate ".github/actions/deleted/action.yml" "docs/deployment.md"
 assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci docs/deployment.md ("
 
+# The same class for shell: ShellCheck follows `# shellcheck source=<path>`
+# against the real tree, so deleting a sourced helper raises a new SC1091 on
+# surviving callers that name it and are not in the change set.
+run_gate "scripts/bootstrap/deleted-helper.sh" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
+assert_not_contains "- ./tools/trunk check --ci docs/deployment.md ("
+
 # Code-health routing: ensure a `.dependency-cruiser.cjs` change schedules
 # the cross-package dep-cruiser gate + surfaces the code-health checklist.
 run_gate ".dependency-cruiser.cjs"
@@ -13152,6 +13159,14 @@ assert_contains "- docs/pr-checklists/code-health.md"
 
 # One path inside a scanned root brings it back for the whole set.
 run_gate "governance-watchdog/src/index.ts" "shared-config/src/index.ts"
+assert_contains "- pnpm code-health:deps"
+
+# The scope pass schedules dep-cruiser itself for the triggers no arm routes.
+# Without this the documented self-pin never fired: declining to remove a
+# command nothing added leaves the plan without it.
+run_gate "scripts/gate/mapping/post-passes.mjs"
+assert_contains "- pnpm code-health:deps"
+run_gate "pnpm-lock.yaml"
 assert_contains "- pnpm code-health:deps"
 
 # Code-health routing: each package's knip.json routes to the matching

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13113,10 +13113,26 @@ run_context_check_expect_failure
 assert_contains ".claude/settings.json: unexpected Bash permission; add the exact reviewed entry to the context-check allowlist: Bash(pnpm agent:quality-gate:*)"
 restore_hook_configs
 
+# A deleted path cannot be named on a targeted Trunk command line. With no
+# survivor to target, the whole-repo scan is the only run left.
 run_gate "docs/deleted.md"
 assert_contains "- docs"
-assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
+assert_contains "- ./tools/trunk check --ci --all (every changed path was deleted; full-repo Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci docs/deleted.md"
+
+# Mixed set: drop the deleted argument, keep linting the survivor. Before this
+# the whole set escalated to --all on the strength of one deletion.
+run_gate "docs/deleted.md" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
+assert_not_contains "- ./tools/trunk check --ci --all"
+assert_not_contains "docs/deleted.md (changed existing paths"
+
+# The carve-out: actionlint resolves `uses: ./.github/...` against the tree, so
+# deleting a local action invalidates surviving workflows that are not in the
+# change set and that a targeted run would never name.
+run_gate ".github/actions/deleted/action.yml" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
+assert_not_contains "- ./tools/trunk check --ci docs/deployment.md ("
 
 # Code-health routing: ensure a `.dependency-cruiser.cjs` change schedules
 # the cross-package dep-cruiser gate + surfaces the code-health checklist.
@@ -13124,6 +13140,19 @@ run_gate ".dependency-cruiser.cjs"
 assert_contains "- tooling"
 assert_contains "- pnpm code-health:deps (dep-cruiser config changed (cross-package boundaries + cycles))"
 assert_contains "- docs/pr-checklists/code-health.md (dep-cruiser config changed)"
+assert_contains "- node --test scripts/gate/mapping/engine.test.mjs (dep-cruiser config changed (gate pins its scanned roots against this file))"
+
+# dep-cruiser scans six roots and reports nothing outside them, so a change it
+# cannot read must not schedule it. governance-watchdog reaches the command
+# through its package quality bundle and is in none of those roots.
+run_gate "governance-watchdog/src/index.ts"
+assert_contains "- pnpm exec turbo run knip --filter=@mento-protocol/governance-watchdog --cache=local:rw"
+assert_not_contains "- pnpm code-health:deps"
+assert_contains "- docs/pr-checklists/code-health.md"
+
+# One path inside a scanned root brings it back for the whole set.
+run_gate "governance-watchdog/src/index.ts" "shared-config/src/index.ts"
+assert_contains "- pnpm code-health:deps"
 
 # Code-health routing: each package's knip.json routes to the matching
 # `pnpm --filter <pkg> knip` command + the same checklist. A typo in the

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13141,12 +13141,15 @@ run_gate "scripts/bootstrap/deleted-helper.sh" "docs/deployment.md"
 assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
 assert_not_contains "- ./tools/trunk check --ci docs/deployment.md ("
 
-# And for repo-root dotfiles: linters read their config from one, so deleting
-# it changes the verdict on files that did not change. A nested dotfile is not
-# repo-wide config and stays an ordinary deletion.
+# And for dotfiles at any depth: linters read their config from one, and
+# prettier/markdownlint/yamllint cascade to the nearest, so deleting either a
+# root or a package-level config changes the verdict on files that did not
+# change. A non-dotfile deletion stays ordinary however deep it sits.
 run_gate ".codespellrc-deleted" "docs/deployment.md"
 assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
-run_gate "ui-dashboard/.eslintrc-deleted.json" "docs/deployment.md"
+run_gate "aegis/.prettierrc-deleted" "docs/deployment.md"
+assert_contains "- ./tools/trunk check --ci --all (changed paths require full-repo Trunk checks)"
+run_gate "ui-dashboard/src/deleted-thing.tsx" "docs/deployment.md"
 assert_contains "- ./tools/trunk check --ci docs/deployment.md (changed existing paths should pass targeted Trunk checks)"
 
 # Code-health routing: ensure a `.dependency-cruiser.cjs` change schedules
@@ -13182,6 +13185,12 @@ assert_contains "- pnpm code-health:deps"
 run_gate "ui-dashboard/AGENTS.md"
 assert_not_contains "- pnpm code-health:deps"
 run_gate "ui-dashboard/src/thing.ts"
+assert_contains "- pnpm code-health:deps"
+
+# A JSON inside a root is a dependency TARGET even though it holds no imports:
+# indexer source statically imports config/nttAddresses.json, so retargeting it
+# moves an edge the cross-package rules judge.
+run_gate "indexer-envio/config/nttAddresses.json"
 assert_contains "- pnpm code-health:deps"
 
 # The root manifest carries the `code-health:deps` script line that

--- a/scripts/agent-quality-gate.test.sh
+++ b/scripts/agent-quality-gate.test.sh
@@ -13193,6 +13193,12 @@ assert_contains "- pnpm code-health:deps"
 run_gate "indexer-envio/config/nttAddresses.json"
 assert_contains "- pnpm code-health:deps"
 
+# Stylesheets are the same class: dep-cruiser resolves them into the graph and
+# declines to parse them, so they are edge targets with no outgoing edges.
+# ui-dashboard/src/app/layout.tsx imports ./globals.css.
+run_gate "ui-dashboard/src/app/globals.css"
+assert_contains "- pnpm code-health:deps"
+
 # The root manifest carries the `code-health:deps` script line that
 # engine.test.mjs holds the scanned-root list set-equal to, so it must route
 # that suite; the class dispatch alone would send a script edit to the shell

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -317,7 +317,7 @@ export function buildPlan({ changedPaths, facts, routingSensitive = false }) {
 
   routeChangedPaths(ROUTING_PLAN, changedPaths, facts, context);
 
-  // Post-loop sweeps, before the five post-passes.
+  // Post-loop sweeps, before the six post-passes.
   if (facts.isRealTree) {
     plan.addCommand(
       "pnpm tf:test",

--- a/scripts/gate/mapping.mjs
+++ b/scripts/gate/mapping.mjs
@@ -50,6 +50,7 @@ import {
   addWorkspaceConfigBuild,
   applyScopedTestCommands,
   compactTurboQualityCommands,
+  narrowCodeHealthDepsCommand,
   sortCodegenCommands,
 } from "./mapping/post-passes.mjs";
 import * as verbs from "./mapping/verbs.mjs";
@@ -335,6 +336,9 @@ export function buildPlan({ changedPaths, facts, routingSensitive = false }) {
   addWorkspaceConfigBuild(plan);
   compactTurboQualityCommands(plan);
   applyScopedTestCommands(plan, changedPaths, facts);
+  // Last: it reads the finished quality bucket, and it is the only pass that
+  // removes a command, so nothing after it can reintroduce one.
+  narrowCodeHealthDepsCommand(plan, changedPaths);
   return plan;
 }
 

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -27,6 +27,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -38,10 +39,13 @@ import { ROUTING_PLAN } from "../routing-table/index.mjs";
 import { Facts } from "./facts.mjs";
 import { BUCKETS, Plan, commandDedupeKey } from "./plan.mjs";
 import {
+  CODE_HEALTH_DEPS_COMMAND,
+  DEPCRUISE_ROOTS,
   addTrunkCheckCommand,
   addWorkspaceConfigBuild,
   applyScopedTestCommands,
   compactTurboQualityCommands,
+  narrowCodeHealthDepsCommand,
   scopedIsNonSourcePath,
   scopedTestInfraChanged,
   sortCodegenCommands,
@@ -408,17 +412,83 @@ test("Darwin runtime files shared with autoreview route both regression suites",
 
 // ── Post-pass 1: Trunk ─────────────────────────────────────────────────────
 
-test("a path that no longer exists forces a full-repo Trunk scan", () => {
+test("a change set of nothing but deletions forces a full-repo Trunk scan", () => {
   const plan = new Plan();
   addTrunkCheckCommand(
     plan,
-    ["deleted/file.ts"],
+    ["deleted/one.ts", "deleted/two.ts"],
     stubFacts({ presentPaths: [] }),
   );
-  assert.deepEqual(commandsOf(plan), ["./tools/trunk check --ci --all"]);
+  assert.deepEqual(
+    commandsOf(plan),
+    ["./tools/trunk check --ci --all"],
+    "there is no survivor to name on a targeted command line",
+  );
   assert.equal(
     reasonOf(plan, "./tools/trunk check --ci --all"),
-    "changed paths require full-repo Trunk checks",
+    "every changed path was deleted; full-repo Trunk checks",
+  );
+});
+
+test("a deleted path is dropped from the targeted Trunk argument list", () => {
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["a/kept.ts", "a/deleted.ts", "b/kept.ts"],
+    stubFacts({ presentPaths: ["a/kept.ts", "b/kept.ts"] }),
+  );
+  assert.deepEqual(
+    commandsOf(plan),
+    ["./tools/trunk check --ci a/kept.ts b/kept.ts"],
+    "Trunk fails on an argument that is not there; the survivors still lint",
+  );
+});
+
+test("a deleted .github path forces full, because actionlint reads across files", () => {
+  for (const deleted of [
+    ".github/actions/pnpm-install/action.yml",
+    ".github/workflows/reusable.yml",
+  ]) {
+    const plan = new Plan();
+    addTrunkCheckCommand(
+      plan,
+      [deleted, "docs/note.md"],
+      stubFacts({ presentPaths: ["docs/note.md"] }),
+    );
+    assert.deepEqual(
+      commandsOf(plan),
+      ["./tools/trunk check --ci --all"],
+      `${deleted} is referenced by surviving workflows that are not in the change set`,
+    );
+  }
+});
+
+test("an ordinary deletion beside a survivor does NOT force full", () => {
+  // The standing invariant the narrowing rests on: every enabled Trunk linter
+  // except actionlint judges a file on its own bytes, so a deleted source file
+  // cannot invalidate a file nobody touched.
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["ui-dashboard/src/gone.tsx", "ui-dashboard/src/kept.tsx"],
+    stubFacts({ presentPaths: ["ui-dashboard/src/kept.tsx"] }),
+  );
+  assert.deepEqual(commandsOf(plan), [
+    "./tools/trunk check --ci ui-dashboard/src/kept.tsx",
+  ]);
+});
+
+test("a deleted path still in the full-scan list forces full", () => {
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["ui-dashboard/package.json", "ui-dashboard/src/kept.tsx"],
+    stubFacts({ presentPaths: ["ui-dashboard/src/kept.tsx"] }),
+  );
+  assert.deepEqual(
+    commandsOf(plan),
+    ["./tools/trunk check --ci --all"],
+    "the whole-repo list is matched against every changed path, deleted or not",
   );
 });
 
@@ -798,6 +868,127 @@ test("scopedTestInfraChanged sees infra anywhere in the set", () => {
   assert.equal(
     scopedTestInfraChanged(["ui-dashboard/src/a.ts", "shared-config/src/b.ts"]),
     true,
+  );
+});
+
+// ── Post-pass 6: dep-cruiser scope ─────────────────────────────────────────
+
+/** A plan holding only the command the pass may remove. */
+function depsPlan() {
+  const plan = new Plan();
+  plan.addCommand("pnpm exec turbo run lint --filter=x --cache=local:rw", "a");
+  plan.addCommand(CODE_HEALTH_DEPS_COMMAND, "package bundle");
+  plan.addCommand("pnpm --filter x test:coverage", "b");
+  return plan;
+}
+
+const depsSurvives = (changedPaths) => {
+  const plan = depsPlan();
+  narrowCodeHealthDepsCommand(plan, changedPaths);
+  return commandsOf(plan).includes(CODE_HEALTH_DEPS_COMMAND);
+};
+
+test("every scanned root keeps pnpm code-health:deps", () => {
+  // The standing invariant: a change dependency-cruiser can read must still be
+  // judged by it. Asserted for all six roots, not just the motivating one.
+  // This iterates the same constant the pass compiles its trigger from, so it
+  // proves the trigger is built correctly and NOT that the list is right — the
+  // staleness test below is what pins the list against its two sources.
+  for (const root of DEPCRUISE_ROOTS) {
+    assert.equal(
+      depsSurvives([`${root}/src/thing.ts`]),
+      true,
+      `${root} is a scanned root; narrowing it away would weaken the check`,
+    );
+  }
+});
+
+test("a change outside every scanned root drops pnpm code-health:deps", () => {
+  for (const path of [
+    "governance-watchdog/src/index.ts",
+    "alerts/infra/onchain-event-handler/src/index.ts",
+    "alerts/infra/oncall-announcer/src/main.ts",
+    ".github/workflows/ci.yml",
+    "docs/notes/quick-commands.md",
+    "terraform/platform/main.tf",
+  ]) {
+    assert.equal(
+      depsSurvives([path]),
+      false,
+      `${path} is neither walked nor reported by dependency-cruiser`,
+    );
+  }
+});
+
+test("one in-root path anywhere in the set keeps the command", () => {
+  assert.equal(
+    depsSurvives(["governance-watchdog/src/index.ts", "aegis/src/Thing.sol"]),
+    true,
+    "the pass asks what changed, not which package the arms routed",
+  );
+});
+
+test("the dep-cruiser config and this pass keep the command", () => {
+  // Fail-closed: an edit to the rules, or to the narrowing itself, runs the
+  // command rather than being judged by it.
+  assert.equal(depsSurvives([".dependency-cruiser.cjs"]), true);
+  assert.equal(
+    depsSurvives([
+      "scripts/gate/mapping/post-passes.mjs",
+      "governance-watchdog/src/index.ts",
+    ]),
+    true,
+  );
+});
+
+test("the pass removes only its own command", () => {
+  const plan = depsPlan();
+  narrowCodeHealthDepsCommand(plan, ["docs/note.md"]);
+  assert.deepEqual(commandsOf(plan), [
+    "pnpm exec turbo run lint --filter=x --cache=local:rw",
+    "pnpm --filter x test:coverage",
+  ]);
+});
+
+test("the pinned roots match both sources that define them", () => {
+  // Staleness, both directions. Adding a seventh root to either source without
+  // updating DEPCRUISE_ROOTS would otherwise leave the gate quietly
+  // under-routing every change beneath it.
+  const repoRoot = join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../..",
+  );
+  const manifest = JSON.parse(
+    readFileSync(join(repoRoot, "package.json"), "utf8"),
+  );
+  const script = manifest.scripts["code-health:deps"];
+  assert.ok(script.startsWith("depcruise --config .dependency-cruiser.cjs "));
+  const scriptRoots = script
+    .slice("depcruise --config .dependency-cruiser.cjs ".length)
+    .split(" ")
+    .filter((token) => token !== "");
+
+  const config = createRequire(import.meta.url)(
+    join(repoRoot, ".dependency-cruiser.cjs"),
+  );
+  const includeOnly = config.options.includeOnly.path;
+  const match = /^\^\(([^)]+)\)\/$/.exec(includeOnly);
+  assert.ok(
+    match !== null,
+    `includeOnly.path is no longer a root alternation: ${includeOnly}`,
+  );
+  const configRoots = match[1].split("|");
+
+  const sorted = (values) => [...values].sort();
+  assert.deepEqual(
+    sorted(scriptRoots),
+    sorted(DEPCRUISE_ROOTS),
+    "the code-health:deps arguments and the gate's pinned roots must agree",
+  );
+  assert.deepEqual(
+    sorted(configRoots),
+    sorted(DEPCRUISE_ROOTS),
+    "the dependency-cruiser includeOnly roots and the gate's pinned roots must agree",
   );
 });
 

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -478,6 +478,24 @@ test("an ordinary deletion beside a survivor does NOT force full", () => {
   ]);
 });
 
+test("a deleted sourced shell helper forces full, because ShellCheck follows sources", () => {
+  // Measured: deleting scripts/bootstrap/codex-cloud-git-helpers.sh takes its
+  // two surviving callers from clean to SC1091, because each names it in a
+  // `# shellcheck source=` directive that resolves against the real tree. No
+  // survivor naming it is in the change set, so a targeted run never sees it.
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["scripts/bootstrap/codex-cloud-git-helpers.sh", "docs/note.md"],
+    stubFacts({ presentPaths: ["docs/note.md"] }),
+  );
+  assert.deepEqual(
+    commandsOf(plan),
+    ["./tools/trunk check --ci --all"],
+    "surviving callers source the deleted helper and are not in the change set",
+  );
+});
+
 test("a deleted path still in the full-scan list forces full", () => {
   const plan = new Plan();
   addTrunkCheckCommand(
@@ -963,6 +981,53 @@ test("the dep-cruiser config and this pass keep the command", () => {
     ]),
     true,
   );
+});
+
+/** A plan as an arm that never schedules dep-cruiser would leave it. */
+const depsAddedTo = (changedPaths) => {
+  const plan = new Plan();
+  plan.addCommand("pnpm exec turbo run lint --filter=x --cache=local:rw", "a");
+  narrowCodeHealthDepsCommand(plan, changedPaths);
+  return commandsOf(plan).filter((c) => c === CODE_HEALTH_DEPS_COMMAND).length;
+};
+
+test("the pass schedules the command when no arm did", () => {
+  // The defect this closes: declining to remove a command nothing added leaves
+  // the plan without it. Measured against the real gate, `post-passes.mjs` and
+  // `pnpm-lock.yaml` reach no arm that schedules dep-cruiser, so for those two
+  // the guarantee only exists if this pass adds the command itself.
+  for (const path of [
+    "scripts/gate/mapping/post-passes.mjs",
+    "pnpm-lock.yaml",
+    "package.json",
+    "pnpm-workspace.yaml",
+    ".dependency-cruiser.cjs",
+  ]) {
+    assert.equal(
+      depsAddedTo([path]),
+      1,
+      `${path} must schedule dep-cruiser even when no arm does`,
+    );
+  }
+});
+
+test("the pass does not schedule dep-cruiser for a scanned root alone", () => {
+  // The arms own the roots, and they decide better: a root's README matches the
+  // root prefix but cannot change a verdict. Scheduling here would add work the
+  // arms correctly leave out.
+  assert.equal(depsAddedTo(["shared-config/README.md"]), 0);
+  assert.equal(depsAddedTo(["ui-dashboard/src/thing.ts"]), 0);
+});
+
+test("the pass does not duplicate a command an arm already scheduled", () => {
+  const plan = depsPlan();
+  narrowCodeHealthDepsCommand(plan, [".dependency-cruiser.cjs"]);
+  assert.equal(
+    commandsOf(plan).filter((c) => c === CODE_HEALTH_DEPS_COMMAND).length,
+    1,
+    "addCommand dedupes, so the arm's entry and reason survive",
+  );
+  assert.equal(reasonOf(plan, CODE_HEALTH_DEPS_COMMAND), "package bundle");
 });
 
 test("the pass removes only its own command", () => {

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -40,9 +40,7 @@ import { Facts } from "./facts.mjs";
 import { BUCKETS, Plan, commandDedupeKey } from "./plan.mjs";
 import {
   CODE_HEALTH_DEPS_COMMAND,
-  DEPCRUISE_EXTENSIONS,
   DEPCRUISE_ROOTS,
-  DEPCRUISE_TARGET_EXTENSIONS_VERSION,
   addTrunkCheckCommand,
   addWorkspaceConfigBuild,
   applyScopedTestCommands,
@@ -996,143 +994,48 @@ test("every scanned root keeps pnpm code-health:deps", () => {
   }
 });
 
-test("an in-root path dep-cruiser cannot parse drops the command", () => {
-  // The over-preserve this closes: a package quality arm schedules the command
-  // for any in-root change, and the pass used to keep it on the root prefix
-  // alone. `ui-dashboard/AGENTS.md` cost a ~22s cruise of an unchanged graph.
+test("ANY path inside a scanned root keeps the command, whatever its type", () => {
+  // Reverted narrowing, kept as a regression test. Extension lists cannot
+  // decide graph membership: resolution can reach any file an import names
+  // with its extension, so `.md`, `.svg`, `.css`, `.json` and `.sol` are all
+  // possible edge targets. See the note on DEPCRUISE_ROOT_PREFIX.
   for (const path of [
     "ui-dashboard/AGENTS.md",
     "ui-dashboard/README.md",
+    "ui-dashboard/public/logo.svg",
+    "ui-dashboard/src/app/globals.css",
+    "ui-dashboard/src/thing.ts",
     "aegis/src/Thing.sol",
     "indexer-envio/config/celo.yaml",
-  ]) {
-    assert.equal(
-      depsSurvives([path]),
-      false,
-      `${path} is inside a scanned root but dependency-cruiser never parses it`,
-    );
-  }
-});
-
-test("every dep-cruiser extension keeps the command inside a root", () => {
-  for (const extension of DEPCRUISE_EXTENSIONS) {
-    assert.equal(
-      depsSurvives([`ui-dashboard/src/thing${extension}`]),
-      true,
-      `${extension} is parsed by dependency-cruiser`,
-    );
-  }
-});
-
-test("a JSON dependency target inside a root keeps the command", () => {
-  // Parsing is not the only way into the graph: Node resolution reaches a JSON
-  // module, so it can be the far end of an edge between two scanned roots
-  // while holding no imports of its own.
-  assert.equal(
-    depsSurvives(["indexer-envio/config/nttAddresses.json"]),
-    true,
-    "a config JSON that source imports is a real dependency target",
-  );
-  assert.equal(depsSurvives(["shared-config/data/tokens.json"]), true);
-});
-
-test("a stylesheet dependency target inside a root keeps the command", () => {
-  // dependency-cruiser resolves stylesheets into the graph and declines to
-  // parse them, so they are nodes with no outgoing edges — and a node is still
-  // an edge target.
-  for (const path of [
-    "ui-dashboard/src/app/globals.css",
-    "ui-dashboard/src/styles/x.scss",
-    "ui-dashboard/src/styles/x.sass",
-    "ui-dashboard/src/styles/x.less",
-    "ui-dashboard/src/styles/x.stylus",
+    "indexer-envio/config/nttAddresses.json",
+    "ui-dashboard/package.json",
   ]) {
     assert.equal(
       depsSurvives([path]),
       true,
-      `${path} is resolved into the graph as a dependency target`,
+      `${path} is inside a scanned root, so dependency-cruiser may report it`,
     );
   }
 });
 
-test("the stylesheet-target case this pin stands for is still real", () => {
+test("the in-root asset imports these cases stand for are still real", () => {
+  // Two real imports, kept from the reverted extension pins. They are why an
+  // in-root non-source change can move an edge: if either stops existing, the
+  // reasoning above needs re-checking rather than quiet trust.
   const repoRoot = join(
     fileURLToPath(new URL(".", import.meta.url)),
     "../../..",
   );
-  const source = readFileSync(
-    join(repoRoot, "ui-dashboard/src/app/layout.tsx"),
-    "utf8",
-  );
+  const read = (relative) => readFileSync(join(repoRoot, relative), "utf8");
   assert.match(
-    source,
-    /import\s+"\.\/globals\.css"/,
-    "dashboard source must still statically import a stylesheet",
-  );
-});
-
-test("the target-extension list is pinned to the version it was read from", () => {
-  // `lKnownUnfollowables` is internal to dependency-cruiser, so no API change
-  // would announce it moving. Pinning the version makes an upgrade the signal:
-  // on a bump, re-read that constant and update both here.
-  const repoRoot = join(
-    fileURLToPath(new URL(".", import.meta.url)),
-    "../../..",
-  );
-  const installed = JSON.parse(
-    readFileSync(
-      join(repoRoot, "node_modules/dependency-cruiser/package.json"),
-      "utf8",
-    ),
-  ).version;
-  assert.equal(
-    installed,
-    DEPCRUISE_TARGET_EXTENSIONS_VERSION,
-    "dependency-cruiser moved: re-read lKnownUnfollowables in " +
-      "src/extract/resolve/module-classifiers.mjs and update the pinned set",
-  );
-});
-
-test("the JSON-target case this pin stands for is still real", () => {
-  // Fixture pin. dependency-cruiser exports `allExtensions` for what it parses
-  // but nothing for what its resolver accepts, so the target half cannot be
-  // pinned against the library. This keeps it honest instead: if the import
-  // moves, re-point the pin rather than delete the rule.
-  const repoRoot = join(
-    fileURLToPath(new URL(".", import.meta.url)),
-    "../../..",
-  );
-  const source = readFileSync(
-    join(repoRoot, "indexer-envio/src/handlers/stables/config.ts"),
-    "utf8",
-  );
-  assert.match(
-    source,
+    read("indexer-envio/src/handlers/stables/config.ts"),
     /import\s+\w+\s+from\s+"[^"]*config\/nttAddresses\.json"/,
     "indexer source must still statically import a config JSON",
   );
-});
-
-test("a package.json inside a root keeps the command", () => {
-  // Resolution, not parsing: this is where `"@mento-protocol/config":
-  // "workspace:*"` declares the edge into shared-config/.
-  assert.equal(depsSurvives(["ui-dashboard/package.json"]), true);
-  assert.equal(depsSurvives(["aegis/sub/package.json"]), true);
-});
-
-test("the pinned extensions match dependency-cruiser's own available list", async () => {
-  // Hermetic: the library exports the same list `depcruise --info` prints, so
-  // this needs no CLI spawn. An upgrade that enables `.vue` or `.svelte` turns
-  // into a red test rather than a file class the gate silently stops routing.
-  const { allExtensions } = await import("dependency-cruiser");
-  const available = allExtensions
-    .filter((entry) => entry.available)
-    .map((entry) => entry.extension);
-  const sorted = (values) => [...values].sort();
-  assert.deepEqual(
-    sorted(available),
-    sorted(DEPCRUISE_EXTENSIONS),
-    "the gate's parsed-extension pin and dependency-cruiser must agree",
+  assert.match(
+    read("ui-dashboard/src/app/layout.tsx"),
+    /import\s+"\.\/globals\.css"/,
+    "dashboard source must still statically import a stylesheet",
   );
 });
 

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -40,6 +40,7 @@ import { Facts } from "./facts.mjs";
 import { BUCKETS, Plan, commandDedupeKey } from "./plan.mjs";
 import {
   CODE_HEALTH_DEPS_COMMAND,
+  DEPCRUISE_EXTENSIONS,
   DEPCRUISE_ROOTS,
   addTrunkCheckCommand,
   addWorkspaceConfigBuild,
@@ -496,6 +497,44 @@ test("a deleted sourced shell helper forces full, because ShellCheck follows sou
   );
 });
 
+test("a deleted repo-root dotfile forces full, because linters read it repo-wide", () => {
+  // Measured: with `.codespellrc` gone, the unchanged
+  // scripts/terraform/tf-platform-plan-guard.mjs goes from clean to one
+  // codespell hit on `applyable`, an ignore-word that config carries. The
+  // targeted run over survivors still exits 0, so this passes locally and only
+  // the required full scan catches it.
+  for (const deleted of [
+    ".codespellrc",
+    ".shellcheckrc",
+    ".osv-scanner.toml",
+    ".gitignore",
+  ]) {
+    const plan = new Plan();
+    addTrunkCheckCommand(
+      plan,
+      [deleted, "docs/note.md"],
+      stubFacts({ presentPaths: ["docs/note.md"] }),
+    );
+    assert.deepEqual(
+      commandsOf(plan).filter((c) => !c.includes("--filter=shellcheck")),
+      ["./tools/trunk check --ci --all"],
+      `${deleted} configures a linter across files that did not change`,
+    );
+  }
+});
+
+test("a deleted dotfile BELOW the root does not force full", () => {
+  // The rule is anchored at the repo root on purpose. A nested dotfile is not
+  // repo-wide configuration, so it stays an ordinary deletion.
+  const plan = new Plan();
+  addTrunkCheckCommand(
+    plan,
+    ["ui-dashboard/.eslintrc.json", "docs/note.md"],
+    stubFacts({ presentPaths: ["docs/note.md"] }),
+  );
+  assert.deepEqual(commandsOf(plan), ["./tools/trunk check --ci docs/note.md"]);
+});
+
 test("a deleted path still in the full-scan list forces full", () => {
   const plan = new Plan();
   addTrunkCheckCommand(
@@ -921,6 +960,58 @@ test("every scanned root keeps pnpm code-health:deps", () => {
   }
 });
 
+test("an in-root path dep-cruiser cannot parse drops the command", () => {
+  // The over-preserve this closes: a package quality arm schedules the command
+  // for any in-root change, and the pass used to keep it on the root prefix
+  // alone. `ui-dashboard/AGENTS.md` cost a ~22s cruise of an unchanged graph.
+  for (const path of [
+    "ui-dashboard/AGENTS.md",
+    "ui-dashboard/README.md",
+    "aegis/src/Thing.sol",
+    "shared-config/knip.json",
+    "indexer-envio/config/celo.yaml",
+  ]) {
+    assert.equal(
+      depsSurvives([path]),
+      false,
+      `${path} is inside a scanned root but dependency-cruiser never parses it`,
+    );
+  }
+});
+
+test("every dep-cruiser extension keeps the command inside a root", () => {
+  for (const extension of DEPCRUISE_EXTENSIONS) {
+    assert.equal(
+      depsSurvives([`ui-dashboard/src/thing${extension}`]),
+      true,
+      `${extension} is parsed by dependency-cruiser`,
+    );
+  }
+});
+
+test("a package.json inside a root keeps the command", () => {
+  // Resolution, not parsing: this is where `"@mento-protocol/config":
+  // "workspace:*"` declares the edge into shared-config/.
+  assert.equal(depsSurvives(["ui-dashboard/package.json"]), true);
+  assert.equal(depsSurvives(["aegis/sub/package.json"]), true);
+});
+
+test("the pinned extensions match dependency-cruiser's own available list", async () => {
+  // Hermetic: the library exports the same list `depcruise --info` prints, so
+  // this needs no CLI spawn. An upgrade that enables `.vue` or `.svelte` turns
+  // into a red test rather than a file class the gate silently stops routing.
+  const { allExtensions } = await import("dependency-cruiser");
+  const available = allExtensions
+    .filter((entry) => entry.available)
+    .map((entry) => entry.extension);
+  const sorted = (values) => [...values].sort();
+  assert.deepEqual(
+    sorted(available),
+    sorted(DEPCRUISE_EXTENSIONS),
+    "the gate's parsed-extension pin and dependency-cruiser must agree",
+  );
+});
+
 test("a change outside every scanned root drops pnpm code-health:deps", () => {
   for (const path of [
     "governance-watchdog/src/index.ts",
@@ -964,7 +1055,7 @@ test("a non-root package manifest does not keep the command", () => {
 
 test("one in-root path anywhere in the set keeps the command", () => {
   assert.equal(
-    depsSurvives(["governance-watchdog/src/index.ts", "aegis/src/Thing.sol"]),
+    depsSurvives(["governance-watchdog/src/index.ts", "aegis/src/Thing.ts"]),
     true,
     "the pass asks what changed, not which package the arms routed",
   );

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -523,16 +523,51 @@ test("a deleted repo-root dotfile forces full, because linters read it repo-wide
   }
 });
 
-test("a deleted dotfile BELOW the root does not force full", () => {
-  // The rule is anchored at the repo root on purpose. A nested dotfile is not
-  // repo-wide configuration, so it stays an ordinary deletion.
-  const plan = new Plan();
-  addTrunkCheckCommand(
-    plan,
-    ["ui-dashboard/.eslintrc.json", "docs/note.md"],
-    stubFacts({ presentPaths: ["docs/note.md"] }),
-  );
-  assert.deepEqual(commandsOf(plan), ["./tools/trunk check --ci docs/note.md"]);
+test("a deleted NESTED dotfile forces full, because linter configs cascade", () => {
+  // Measured: prettier, markdownlint and yamllint take the nearest config, so a
+  // package can carry its own. With `aegis/.prettierrc` deleted, the untouched
+  // `aegis/src/app.module.ts` starts failing prettier — its `singleQuote`
+  // setting went with the file — while a targeted run over survivors exits 0.
+  for (const deleted of [
+    "aegis/.prettierrc",
+    "ui-dashboard/.prettierrc.json",
+    "metrics-bridge/.markdownlint.yaml",
+    "alerts/infra/.prettierignore",
+  ]) {
+    const plan = new Plan();
+    addTrunkCheckCommand(
+      plan,
+      [deleted, "docs/note.md"],
+      stubFacts({ presentPaths: ["docs/note.md"] }),
+    );
+    assert.deepEqual(
+      commandsOf(plan).filter((c) => !c.includes("--filter=shellcheck")),
+      ["./tools/trunk check --ci --all"],
+      `${deleted} configures a linter for files that did not change`,
+    );
+  }
+});
+
+test("a deleted NON-dotfile stays an ordinary deletion at any depth", () => {
+  // The other direction: the rule keys on the leading dot, not on depth, so an
+  // ordinary nested source or docs deletion still targets the survivors.
+  for (const deleted of [
+    "ui-dashboard/src/gone.tsx",
+    "docs/notes/gone.md",
+    "aegis/config/gone.json",
+  ]) {
+    const plan = new Plan();
+    addTrunkCheckCommand(
+      plan,
+      [deleted, "docs/note.md"],
+      stubFacts({ presentPaths: ["docs/note.md"] }),
+    );
+    assert.deepEqual(
+      commandsOf(plan),
+      ["./tools/trunk check --ci docs/note.md"],
+      `${deleted} carries no configuration for files that did not change`,
+    );
+  }
 });
 
 test("a deleted path still in the full-scan list forces full", () => {
@@ -968,7 +1003,6 @@ test("an in-root path dep-cruiser cannot parse drops the command", () => {
     "ui-dashboard/AGENTS.md",
     "ui-dashboard/README.md",
     "aegis/src/Thing.sol",
-    "shared-config/knip.json",
     "indexer-envio/config/celo.yaml",
   ]) {
     assert.equal(
@@ -987,6 +1021,38 @@ test("every dep-cruiser extension keeps the command inside a root", () => {
       `${extension} is parsed by dependency-cruiser`,
     );
   }
+});
+
+test("a JSON dependency target inside a root keeps the command", () => {
+  // Parsing is not the only way into the graph: Node resolution reaches a JSON
+  // module, so it can be the far end of an edge between two scanned roots
+  // while holding no imports of its own.
+  assert.equal(
+    depsSurvives(["indexer-envio/config/nttAddresses.json"]),
+    true,
+    "a config JSON that source imports is a real dependency target",
+  );
+  assert.equal(depsSurvives(["shared-config/data/tokens.json"]), true);
+});
+
+test("the JSON-target case this pin stands for is still real", () => {
+  // Fixture pin. dependency-cruiser exports `allExtensions` for what it parses
+  // but nothing for what its resolver accepts, so the target half cannot be
+  // pinned against the library. This keeps it honest instead: if the import
+  // moves, re-point the pin rather than delete the rule.
+  const repoRoot = join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../..",
+  );
+  const source = readFileSync(
+    join(repoRoot, "indexer-envio/src/handlers/stables/config.ts"),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /import\s+\w+\s+from\s+"[^"]*config\/nttAddresses\.json"/,
+    "indexer source must still statically import a config JSON",
+  );
 });
 
 test("a package.json inside a root keeps the command", () => {

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -42,6 +42,7 @@ import {
   CODE_HEALTH_DEPS_COMMAND,
   DEPCRUISE_EXTENSIONS,
   DEPCRUISE_ROOTS,
+  DEPCRUISE_TARGET_EXTENSIONS_VERSION,
   addTrunkCheckCommand,
   addWorkspaceConfigBuild,
   applyScopedTestCommands,
@@ -1033,6 +1034,63 @@ test("a JSON dependency target inside a root keeps the command", () => {
     "a config JSON that source imports is a real dependency target",
   );
   assert.equal(depsSurvives(["shared-config/data/tokens.json"]), true);
+});
+
+test("a stylesheet dependency target inside a root keeps the command", () => {
+  // dependency-cruiser resolves stylesheets into the graph and declines to
+  // parse them, so they are nodes with no outgoing edges — and a node is still
+  // an edge target.
+  for (const path of [
+    "ui-dashboard/src/app/globals.css",
+    "ui-dashboard/src/styles/x.scss",
+    "ui-dashboard/src/styles/x.sass",
+    "ui-dashboard/src/styles/x.less",
+    "ui-dashboard/src/styles/x.stylus",
+  ]) {
+    assert.equal(
+      depsSurvives([path]),
+      true,
+      `${path} is resolved into the graph as a dependency target`,
+    );
+  }
+});
+
+test("the stylesheet-target case this pin stands for is still real", () => {
+  const repoRoot = join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../..",
+  );
+  const source = readFileSync(
+    join(repoRoot, "ui-dashboard/src/app/layout.tsx"),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /import\s+"\.\/globals\.css"/,
+    "dashboard source must still statically import a stylesheet",
+  );
+});
+
+test("the target-extension list is pinned to the version it was read from", () => {
+  // `lKnownUnfollowables` is internal to dependency-cruiser, so no API change
+  // would announce it moving. Pinning the version makes an upgrade the signal:
+  // on a bump, re-read that constant and update both here.
+  const repoRoot = join(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../..",
+  );
+  const installed = JSON.parse(
+    readFileSync(
+      join(repoRoot, "node_modules/dependency-cruiser/package.json"),
+      "utf8",
+    ),
+  ).version;
+  assert.equal(
+    installed,
+    DEPCRUISE_TARGET_EXTENSIONS_VERSION,
+    "dependency-cruiser moved: re-read lKnownUnfollowables in " +
+      "src/extract/resolve/module-classifiers.mjs and update the pinned set",
+  );
 });
 
 test("the JSON-target case this pin stands for is still real", () => {

--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -920,6 +920,30 @@ test("a change outside every scanned root drops pnpm code-health:deps", () => {
   }
 });
 
+test("a workspace manifest keeps pnpm code-health:deps", () => {
+  // A scanned root reaches another scanned root by package name
+  // (`@mento-protocol/config` → `shared-config/`), so these three files can add
+  // or remove an edge between two roots with no file inside a root changing.
+  // Narrowing them away would hide exactly that class of graph change.
+  for (const path of [
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+  ]) {
+    assert.equal(
+      depsSurvives([path]),
+      true,
+      `${path} decides what a bare specifier inside a scanned root resolves to`,
+    );
+  }
+});
+
+test("a non-root package manifest does not keep the command", () => {
+  // The manifest triggers are anchored, so a manifest belonging to a package
+  // dependency-cruiser never scans stays narrowed away.
+  assert.equal(depsSurvives(["governance-watchdog/package.json"]), false);
+});
+
 test("one in-root path anywhere in the set keeps the command", () => {
   assert.equal(
     depsSurvives(["governance-watchdog/src/index.ts", "aegis/src/Thing.sol"]),

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -1,15 +1,16 @@
 /**
- * The five whole-set passes that run AFTER every changed path has been routed.
+ * The six whole-set passes that run AFTER every changed path has been routed.
  *
  * They are separate from the verbs because they cannot be decided per path:
  * each reads the complete changed set or the complete command list. Their order
  * is fixed and is itself contract — Trunk is prepended first so it lands at the
  * head, codegen is sorted before the plan is written, workspace dependency
  * setup is added from the complete command list, Turbo compaction rewrites the
- * quality bucket, and scoped tests rewrite it again afterwards.
+ * quality bucket, scoped tests rewrite it again afterwards, and the dep-cruiser
+ * narrowing runs last on the finished quality bucket.
  *
  *   addTrunkCheckCommand → sortCodegenCommands → addWorkspaceConfigBuild →
- *   compactTurbo → applyScopedTests
+ *   compactTurbo → applyScopedTests → narrowCodeHealthDepsCommand
  */
 
 import { shellQuote } from "./shell-quote.mjs";
@@ -17,9 +18,7 @@ import { shellQuote } from "./shell-quote.mjs";
 // ── 1. Trunk ───────────────────────────────────────────────────────────────
 
 /**
- * Patterns that force a full-repo Trunk scan. A changed path that no longer
- * exists forces one too: a targeted invocation naming a deleted file fails, so
- * the whole-repo scan is the fail-safe answer.
+ * Patterns that force a full-repo Trunk scan, whether or not the path survives.
  */
 const TRUNK_FULL_SCAN = [
   /^\.trunk\//,
@@ -36,23 +35,57 @@ const TRUNK_FULL_SCAN = [
   /\/package\.json$/,
 ];
 
+/**
+ * Deleted paths whose absence changes what a linter reports about files that
+ * did NOT change, so a targeted run over the survivors cannot see the damage.
+ *
+ * actionlint resolves `uses: ./.github/actions/<name>` and `uses:
+ * ./.github/workflows/<file>` against the working tree. Deleting one of those
+ * makes every surviving caller newly invalid — and no surviving caller is in
+ * the changed set, so nothing would name it. `.github/actions/pnpm-install` is
+ * referenced by most workflows in this repo, which is the measured case.
+ *
+ * The other enabled Trunk linters (prettier, markdownlint, codespell,
+ * yamllint, trufflehog, git-diff-check, shellcheck under Trunk's
+ * one-file-at-a-time `copy_targets` sandbox) judge each file on its own bytes,
+ * so an ordinary source or docs deletion cannot invalidate a survivor. checkov
+ * would belong here for local `module { source = "./…" }` references; this repo
+ * has none today, and `.tf` deletions stay covered by the whole-repo branches.
+ */
+const TRUNK_DELETION_FULL_SCAN = [/^\.github\//];
+
 export function addTrunkCheckCommand(plan, changedPaths, facts) {
-  const missing = changedPaths.some(
-    (path) => !facts.pathExistsInWorktree(path),
-  );
+  const present = [];
+  const missing = [];
+  for (const path of changedPaths) {
+    (facts.pathExistsInWorktree(path) ? present : missing).push(path);
+  }
+
+  // A deleted path cannot be named on a targeted command line — Trunk fails on
+  // an argument that is not there. Dropping it from the argument list is the
+  // narrow fix; the two branches below cover the cases where dropping it would
+  // also drop coverage.
   const forcesFull =
-    missing ||
-    changedPaths.some((path) => TRUNK_FULL_SCAN.some((r) => r.test(path)));
+    changedPaths.some((path) => TRUNK_FULL_SCAN.some((r) => r.test(path))) ||
+    missing.some((path) => TRUNK_DELETION_FULL_SCAN.some((r) => r.test(path)));
 
   if (forcesFull) {
     plan.prependCommand(
       "./tools/trunk check --ci --all",
       "changed paths require full-repo Trunk checks",
     );
-  } else if (changedPaths.length > 0) {
+  } else if (present.length > 0) {
     plan.prependCommand(
-      `./tools/trunk check --ci ${changedPaths.map(shellQuote).join(" ")}`,
+      `./tools/trunk check --ci ${present.map(shellQuote).join(" ")}`,
       "changed existing paths should pass targeted Trunk checks",
+    );
+  } else if (changedPaths.length > 0) {
+    // Every changed path was deleted. There is no survivor to target, and a
+    // deletion-only change set is exactly where a cross-file linter has the
+    // most to say, so keep the whole-repo scan.
+    plan.prependCommand(
+      "./tools/trunk check --ci --all",
+      "every changed path was deleted; full-repo Trunk checks",
     );
   } else {
     plan.prependCommand(
@@ -317,4 +350,76 @@ export function applyScopedTestCommands(plan, changedPaths, facts) {
       reason: `${entry.reason} (scoped-tests)`,
     };
   });
+}
+
+// ── 6. dep-cruiser scope ───────────────────────────────────────────────────
+
+/** The command this pass narrows. */
+export const CODE_HEALTH_DEPS_COMMAND = "pnpm code-health:deps";
+
+/**
+ * The roots `pnpm code-health:deps` actually scans.
+ *
+ * Two sources agree on this list and both are pinned by
+ * `engine.test.mjs`, set-equal in both directions: the positional arguments of
+ * the root `package.json` `code-health:deps` script, and the `includeOnly.path`
+ * alternation in `.dependency-cruiser.cjs`. The arguments decide what
+ * dependency-cruiser walks; `includeOnly` decides what it reports. A module
+ * outside both is neither walked nor reported, so a change to it cannot change
+ * the command's verdict.
+ *
+ * Duplicated here rather than derived at run time on purpose: routing is
+ * reviewable data, and a routing constant parsed out of a shell string at gate
+ * time would be neither. The staleness test is what keeps the copy honest —
+ * adding a seventh root turns into a red test, not a silently under-routed
+ * gate.
+ */
+export const DEPCRUISE_ROOTS = Object.freeze([
+  "shared-config",
+  "ui-dashboard",
+  "indexer-envio",
+  "metrics-bridge",
+  "integration-probes",
+  "aegis",
+]);
+
+/**
+ * Changed paths that keep `pnpm code-health:deps` in the plan.
+ *
+ * The roots are the reason the command exists. The other two entries are
+ * fail-closed: `.dependency-cruiser.cjs` is the config whose rules the command
+ * enforces, and this module is where the narrowing itself lives, so an edit to
+ * either has to run the command it governs rather than be judged by it.
+ */
+const CODE_HEALTH_DEPS_TRIGGERS = [
+  new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`),
+  /^\.dependency-cruiser\.cjs$/,
+  /^scripts\/gate\/mapping\/post-passes\.mjs$/,
+];
+
+export function codeHealthDepsTriggered(changedPaths) {
+  return changedPaths.some((path) =>
+    CODE_HEALTH_DEPS_TRIGGERS.some((r) => r.test(path)),
+  );
+}
+
+/**
+ * Drop `pnpm code-health:deps` when nothing it can see changed.
+ *
+ * Several arms reach it as part of a package quality bundle — a
+ * `governance-watchdog/**` edit, an `alerts/infra/**` edit, a
+ * `.github/workflows/**` edit that routes a package's bundle — and none of
+ * those paths is inside a scanned root, so the command re-proves the same
+ * verdict on an unchanged graph. This is the one pass that makes the plan
+ * smaller, which is the direction the rest of the engine refuses to go, so its
+ * condition is deliberately about what dependency-cruiser can read rather than
+ * about which package was routed. The `docs/pr-checklists/code-health.md`
+ * checklist stays either way: knip is the other half of that checklist and it
+ * still runs per package.
+ */
+export function narrowCodeHealthDepsCommand(plan, changedPaths) {
+  if (codeHealthDepsTriggered(changedPaths)) return;
+  plan.quality = plan.quality.filter(
+    (entry) => entry.command !== CODE_HEALTH_DEPS_COMMAND,
+  );
 }

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -45,14 +45,24 @@ const TRUNK_FULL_SCAN = [
  * the changed set, so nothing would name it. `.github/actions/pnpm-install` is
  * referenced by most workflows in this repo, which is the measured case.
  *
- * The other enabled Trunk linters (prettier, markdownlint, codespell,
- * yamllint, trufflehog, git-diff-check, shellcheck under Trunk's
- * one-file-at-a-time `copy_targets` sandbox) judge each file on its own bytes,
- * so an ordinary source or docs deletion cannot invalidate a survivor. checkov
- * would belong here for local `module { source = "./…" }` references; this repo
- * has none today, and `.tf` deletions stay covered by the whole-repo branches.
+ * ShellCheck runs with external sources enabled, and a `# shellcheck
+ * source=<repo-relative path>` directive resolves against the real tree even
+ * under Trunk's one-file-at-a-time `copy_targets` sandbox. Deleting a sourced
+ * helper therefore raises a NEW SC1091 on every surviving caller that names it
+ * — measured on `scripts/bootstrap/codex-cloud-git-helpers.sh`, whose two
+ * callers go from clean to SC1091 the moment it is gone. Callers that source
+ * only through a runtime `${DIR}/…` path are the separate, already-suppressed
+ * false positive `.shellcheckrc` documents; the rule below does not try to tell
+ * the two apart, because any sourced-by analysis would rot the first time a
+ * caller changed how it spells the path.
+ *
+ * The remaining enabled Trunk linters (prettier, markdownlint, codespell,
+ * yamllint, trufflehog, git-diff-check) judge each file on its own bytes, so an
+ * ordinary source or docs deletion cannot invalidate a survivor. checkov would
+ * belong here for local `module { source = "./…" }` references; this repo has
+ * none today, and `.tf` deletions stay covered by the whole-repo branches.
  */
-const TRUNK_DELETION_FULL_SCAN = [/^\.github\//];
+const TRUNK_DELETION_FULL_SCAN = [/^\.github\//, /\.sh$/];
 
 export function addTrunkCheckCommand(plan, changedPaths, facts) {
   const present = [];
@@ -405,24 +415,49 @@ const WORKSPACE_RESOLUTION_MANIFESTS = [
 ];
 
 /**
- * Changed paths that keep `pnpm code-health:deps` in the plan.
+ * Triggers this pass schedules itself, rather than leaving to an arm.
  *
- * The roots are the reason the command exists. The manifests above decide what
- * the roots resolve to. The last two entries are fail-closed:
- * `.dependency-cruiser.cjs` is the config whose rules the command enforces, and
- * this module is where the narrowing itself lives, so an edit to either has to
- * run the command it governs rather than be judged by it.
+ * No arm routes a bare `pnpm-lock.yaml` or this module, so for these paths
+ * declining to remove the command is not enough — there would be nothing in the
+ * plan to decline to remove, and the guarantee they exist for would never fire.
+ * `.dependency-cruiser.cjs` and the other two manifests do have arms; they stay
+ * in this list so the guarantee holds on the pass's own terms rather than on an
+ * arm that could be re-scoped later. `plan.addCommand` dedupes, so naming a
+ * command an arm already scheduled keeps the arm's reason.
+ *
+ * The scanned roots are deliberately NOT here. Their arms already decide, and
+ * they decide better: a root's `README.md` matches the root prefix but cannot
+ * change a dependency-cruiser verdict, so scheduling on the prefix alone would
+ * add work the arms correctly leave out.
  */
-const CODE_HEALTH_DEPS_TRIGGERS = [
-  new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`),
+const CODE_HEALTH_DEPS_SELF_SCHEDULED = [
   ...WORKSPACE_RESOLUTION_MANIFESTS,
   /^\.dependency-cruiser\.cjs$/,
   /^scripts\/gate\/mapping\/post-passes\.mjs$/,
 ];
 
+/**
+ * Changed paths that keep `pnpm code-health:deps` in the plan.
+ *
+ * The roots are the reason the command exists. The manifests decide what the
+ * roots resolve to. `.dependency-cruiser.cjs` is the config whose rules the
+ * command enforces, and this module is where the narrowing itself lives, so an
+ * edit to either has to run the command it governs rather than be judged by it.
+ */
+const CODE_HEALTH_DEPS_TRIGGERS = [
+  new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`),
+  ...CODE_HEALTH_DEPS_SELF_SCHEDULED,
+];
+
 export function codeHealthDepsTriggered(changedPaths) {
   return changedPaths.some((path) =>
     CODE_HEALTH_DEPS_TRIGGERS.some((r) => r.test(path)),
+  );
+}
+
+export function codeHealthDepsSelfScheduled(changedPaths) {
+  return changedPaths.some((path) =>
+    CODE_HEALTH_DEPS_SELF_SCHEDULED.some((r) => r.test(path)),
   );
 }
 
@@ -441,8 +476,19 @@ export function codeHealthDepsTriggered(changedPaths) {
  * still runs per package.
  */
 export function narrowCodeHealthDepsCommand(plan, changedPaths) {
-  if (codeHealthDepsTriggered(changedPaths)) return;
-  plan.quality = plan.quality.filter(
-    (entry) => entry.command !== CODE_HEALTH_DEPS_COMMAND,
-  );
+  if (!codeHealthDepsTriggered(changedPaths)) {
+    plan.quality = plan.quality.filter(
+      (entry) => entry.command !== CODE_HEALTH_DEPS_COMMAND,
+    );
+    return;
+  }
+  // Removing is only half the pass. For the self-scheduled triggers no arm adds
+  // the command at all, so a pass that could only decline to remove it would
+  // leave the plan without the check those triggers exist to guarantee.
+  if (codeHealthDepsSelfScheduled(changedPaths)) {
+    plan.addCommand(
+      CODE_HEALTH_DEPS_COMMAND,
+      "dep-cruiser config, a workspace manifest, or the scope pass changed",
+    );
+  }
 }

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -56,13 +56,31 @@ const TRUNK_FULL_SCAN = [
  * the two apart, because any sourced-by analysis would rot the first time a
  * caller changed how it spells the path.
  *
- * The remaining enabled Trunk linters (prettier, markdownlint, codespell,
- * yamllint, trufflehog, git-diff-check) judge each file on its own bytes, so an
- * ordinary source or docs deletion cannot invalidate a survivor. checkov would
- * belong here for local `module { source = "./…" }` references; this repo has
- * none today, and `.tf` deletions stay covered by the whole-repo branches.
+ * A deleted repo-root dotfile is the third class. Several enabled linters read
+ * their configuration from one — codespell from `.codespellrc`, shellcheck from
+ * `.shellcheckrc`, osv-scanner from `.osv-scanner.toml` — and `.gitignore` and
+ * `.gitattributes` decide what Trunk looks at in the first place. Deleting one
+ * changes the verdict on files that did not change: with `.codespellrc` removed,
+ * `scripts/terraform/tf-platform-plan-guard.mjs` goes from clean to one
+ * codespell hit on `applyable`, an ignore-word the config carries. A targeted
+ * run over the survivors still exits 0, so the gate passes locally and the
+ * required full scan is where it surfaces.
+ *
+ * This is deliberately the structural rule "any deleted root dotfile" rather
+ * than a list of the config files that exist today. A list would rot the first
+ * time a linter gained a root config, and rot silently, in the direction of
+ * under-scanning. The rule over-includes a few root dotfiles no Trunk linter
+ * reads (`.coderabbit.yaml`, `.vercelignore`); forcing a full scan on their
+ * deletion costs time and is never wrong. `.trunk/**` is already whole-repo on
+ * both edit and delete, so Trunk's own configs need no entry here.
+ *
+ * The remaining enabled Trunk linters (prettier, markdownlint, yamllint,
+ * trufflehog, git-diff-check) judge each file on its own bytes, so an ordinary
+ * source or docs deletion cannot invalidate a survivor. checkov would join the
+ * list for local `module { source = "./…" }` references; this repo has none
+ * today, and `.tf` deletions stay covered by the whole-repo branches.
  */
-const TRUNK_DELETION_FULL_SCAN = [/^\.github\//, /\.sh$/];
+const TRUNK_DELETION_FULL_SCAN = [/^\.github\//, /\.sh$/, /^\.[^/]+$/];
 
 export function addTrunkCheckCommand(plan, changedPaths, facts) {
   const present = [];
@@ -415,6 +433,53 @@ const WORKSPACE_RESOLUTION_MANIFESTS = [
 ];
 
 /**
+ * Extensions dependency-cruiser can actually parse for dependencies.
+ *
+ * This is the enabled half of the list `depcruise --info` prints. It is pinned
+ * by `engine.test.mjs` against `allExtensions` exported by the library itself,
+ * so an upgrade that enables a transpiler — `.vue` and `.svelte` are present
+ * but unavailable today — turns into a red test rather than a scanned file the
+ * gate silently stops routing.
+ *
+ * A path inside a scanned root whose extension is not here cannot change a
+ * verdict: dependency-cruiser never parses it, so it can neither hold an import
+ * nor appear as one. `ui-dashboard/AGENTS.md` is the measured case — before this
+ * narrowing it kept a ~22s cruise of an unchanged 1,321-module graph, because a
+ * package quality arm scheduled the command and this pass only declined to
+ * remove it.
+ */
+export const DEPCRUISE_EXTENSIONS = Object.freeze([
+  ".js",
+  ".cjs",
+  ".mjs",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".d.ts",
+  ".cts",
+  ".d.cts",
+  ".mts",
+  ".d.mts",
+]);
+
+/**
+ * A changed path dependency-cruiser can read inside a root it scans.
+ *
+ * Two shapes qualify. A source file it parses, by extension. And any
+ * `package.json` beneath a root, because that is where a workspace dependency
+ * is declared — `ui-dashboard/package.json` carries
+ * `"@mento-protocol/config": "workspace:*"`, the edge into `shared-config/` —
+ * so it decides resolution the same way the root manifests do.
+ */
+const DEPCRUISE_ROOT_PREFIX = new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`);
+
+function inRootAndReadable(path) {
+  if (!DEPCRUISE_ROOT_PREFIX.test(path)) return false;
+  if (/(^|\/)package\.json$/.test(path)) return true;
+  return DEPCRUISE_EXTENSIONS.some((extension) => path.endsWith(extension));
+}
+
+/**
  * Triggers this pass schedules itself, rather than leaving to an arm.
  *
  * No arm routes a bare `pnpm-lock.yaml` or this module, so for these paths
@@ -425,10 +490,9 @@ const WORKSPACE_RESOLUTION_MANIFESTS = [
  * arm that could be re-scoped later. `plan.addCommand` dedupes, so naming a
  * command an arm already scheduled keeps the arm's reason.
  *
- * The scanned roots are deliberately NOT here. Their arms already decide, and
- * they decide better: a root's `README.md` matches the root prefix but cannot
- * change a dependency-cruiser verdict, so scheduling on the prefix alone would
- * add work the arms correctly leave out.
+ * The scanned roots are deliberately NOT here. An in-root source file reaches
+ * the command through its package's quality arm, which knows what else that
+ * package needs; this pass only decides whether to keep what the arm scheduled.
  */
 const CODE_HEALTH_DEPS_SELF_SCHEDULED = [
   ...WORKSPACE_RESOLUTION_MANIFESTS,
@@ -439,19 +503,16 @@ const CODE_HEALTH_DEPS_SELF_SCHEDULED = [
 /**
  * Changed paths that keep `pnpm code-health:deps` in the plan.
  *
- * The roots are the reason the command exists. The manifests decide what the
- * roots resolve to. `.dependency-cruiser.cjs` is the config whose rules the
- * command enforces, and this module is where the narrowing itself lives, so an
- * edit to either has to run the command it governs rather than be judged by it.
+ * Either dependency-cruiser can read the path inside a root it scans, or the
+ * path is one of the self-scheduled triggers above. Anything else — a root's
+ * `AGENTS.md`, a `.sol` file, a docs edit — is neither parsed nor reported, so
+ * it cannot move the verdict and the command comes out of the plan.
  */
-const CODE_HEALTH_DEPS_TRIGGERS = [
-  new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`),
-  ...CODE_HEALTH_DEPS_SELF_SCHEDULED,
-];
-
 export function codeHealthDepsTriggered(changedPaths) {
-  return changedPaths.some((path) =>
-    CODE_HEALTH_DEPS_TRIGGERS.some((r) => r.test(path)),
+  return changedPaths.some(
+    (path) =>
+      inRootAndReadable(path) ||
+      CODE_HEALTH_DEPS_SELF_SCHEDULED.some((r) => r.test(path)),
   );
 }
 

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -442,104 +442,38 @@ const WORKSPACE_RESOLUTION_MANIFESTS = [
 ];
 
 /**
- * Extensions dependency-cruiser can actually parse for dependencies.
+ * Any changed path inside a root dependency-cruiser scans.
  *
- * This is the enabled half of the list `depcruise --info` prints. It is pinned
- * by `engine.test.mjs` against `allExtensions` exported by the library itself,
- * so an upgrade that enables a transpiler — `.vue` and `.svelte` are present
- * but unavailable today — turns into a red test rather than a scanned file the
- * gate silently stops routing.
+ * DO NOT narrow this by file type. That was tried and reverted, and the reason
+ * is worth keeping: no extension list can decide what the graph contains.
  *
- * A path inside a scanned root whose extension is not here cannot change a
- * verdict: dependency-cruiser never parses it, so it can neither hold an import
- * nor appear as one. `ui-dashboard/AGENTS.md` is the measured case — before this
- * narrowing it kept a ~22s cruise of an unchanged 1,321-module graph, because a
- * package quality arm scheduled the command and this pass only declined to
- * remove it.
- */
-export const DEPCRUISE_EXTENSIONS = Object.freeze([
-  ".js",
-  ".cjs",
-  ".mjs",
-  ".jsx",
-  ".ts",
-  ".tsx",
-  ".d.ts",
-  ".cts",
-  ".d.cts",
-  ".mts",
-  ".d.mts",
-]);
-
-/**
- * Extensions that appear in the graph as dependency TARGETS without being
- * parsed for dependencies of their own.
+ * The narrowing was requested to stop `ui-dashboard/AGENTS.md` buying a ~22s
+ * cruise of an unchanged graph (PR comment 3906221722). It shipped as "an
+ * extension dependency-cruiser parses", then had to grow twice — `.json` and
+ * `.node` (3906713274), then the stylesheet languages (3906943568) — because
+ * parsing is not how a file joins the graph. Resolution is. A file becomes a
+ * node whenever an import specifier names it with its extension, and
+ * dependency-cruiser says so itself in `determineFollowableExtensions`: its
+ * `lKnownUnfollowables` list exists only to stop the fallback parser reading
+ * stylesheets, and the comment beside it notes pictures, movies, html and xml
+ * resolve the same way without being listed. An SVG imported from the indexer
+ * into the dashboard activates `indexer-no-dashboard` with no `.ts` file
+ * changed (3907083527).
  *
- * Parsing is not the only way a file reaches the graph. Node resolution
- * resolves a JSON module and a native addon, so a file with either extension
- * can be the far end of an edge between two scanned roots even though it can
- * hold no imports. `indexer-envio/src/handlers/stables/config.ts` imports
- * `../../../config/nttAddresses.json`; moving or retargeting that JSON changes
- * an edge, and the rules that judge indexer-to-dashboard reach would see it,
- * while no `.ts` file changed. The parse list alone dropped the command there.
+ * So the set of possible edge targets is every file, and a closed list of them
+ * cannot be sound — three rounds of widening never reached the end because
+ * there is no end. Deciding membership properly needs the dependency graph,
+ * which is what the command being scheduled computes: the check cannot be its
+ * own precondition. The prefix stays, and the ~22s on in-root docs-only changes
+ * is the price of a sound answer.
  *
- * This is dependency-cruiser's own `lKnownUnfollowables`, read from
- * `src/extract/resolve/module-classifiers.mjs` at the version pinned below. The
- * cruiser resolves each of these into the graph and then deliberately declines
- * to parse it: a stylesheet can hold `@import` statements that the fallback
- * JavaScript parser would happily misread, so it is a node with no outgoing
- * edges. A node is still an edge target, which is the whole point here.
- * `ui-dashboard/src/app/layout.tsx` imports `./globals.css` for exactly that
- * reason.
- *
- * The library exports `allExtensions` for what it parses but nothing for this
- * list, so it cannot be pinned against the API the way the parse half is.
- * Three things keep it honest instead: the version constant below, which turns
- * any dependency-cruiser upgrade into a red test so the list is re-read rather
- * than assumed; and two fixtures in `engine.test.mjs` standing for the JSON and
- * stylesheet cases, which fail loudly if the imports they represent disappear.
- */
-export const DEPCRUISE_TARGET_EXTENSIONS = Object.freeze([
-  ".json",
-  ".node",
-  ".css",
-  ".sass",
-  ".scss",
-  ".stylus",
-  ".less",
-]);
-
-/**
- * The dependency-cruiser release `DEPCRUISE_TARGET_EXTENSIONS` was read from.
- *
- * Bumping the dependency without re-reading `lKnownUnfollowables` is the
- * failure this guards: the list is internal, so nothing else would notice a
- * change to it. On a version bump, re-read that constant and update both.
- */
-export const DEPCRUISE_TARGET_EXTENSIONS_VERSION = "17.4.0";
-
-/**
- * A changed path dependency-cruiser can read inside a root it scans.
- *
- * Three shapes qualify. A source file it parses, by extension. A file its
- * resolver can reach as a dependency target, which is how a JSON config joins
- * the graph. And any `package.json` beneath a root, because that is where a
- * workspace dependency is declared — `ui-dashboard/package.json` carries
- * `"@mento-protocol/config": "workspace:*"`, the edge into `shared-config/` —
- * so it decides resolution the same way the root manifests do.
+ * Out-of-root narrowing is untouched by this and remains sound: a path under no
+ * scanned root is neither walked nor reported, whatever its extension.
  */
 const DEPCRUISE_ROOT_PREFIX = new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`);
 
-const DEPCRUISE_READABLE_EXTENSIONS = Object.freeze([
-  ...DEPCRUISE_EXTENSIONS,
-  ...DEPCRUISE_TARGET_EXTENSIONS,
-]);
-
-function inRootAndReadable(path) {
-  if (!DEPCRUISE_ROOT_PREFIX.test(path)) return false;
-  return DEPCRUISE_READABLE_EXTENSIONS.some((extension) =>
-    path.endsWith(extension),
-  );
+function inScannedRoot(path) {
+  return DEPCRUISE_ROOT_PREFIX.test(path);
 }
 
 /**
@@ -566,15 +500,17 @@ const CODE_HEALTH_DEPS_SELF_SCHEDULED = [
 /**
  * Changed paths that keep `pnpm code-health:deps` in the plan.
  *
- * Either dependency-cruiser can read the path inside a root it scans, or the
- * path is one of the self-scheduled triggers above. Anything else — a root's
- * `AGENTS.md`, a `.sol` file, a docs edit — is neither parsed nor reported, so
- * it cannot move the verdict and the command comes out of the plan.
+ * Either the path sits inside a root dependency-cruiser scans, or it is one of
+ * the self-scheduled triggers above. Anything else — `governance-watchdog/**`,
+ * `alerts/infra/**`, a workflow, a doc outside every root — is neither walked
+ * nor reported, so it cannot move the verdict and the command comes out of the
+ * plan. That is the narrowing this pass still makes, and it holds for any file
+ * type, because the root list is what dependency-cruiser is pointed at.
  */
 export function codeHealthDepsTriggered(changedPaths) {
   return changedPaths.some(
     (path) =>
-      inRootAndReadable(path) ||
+      inScannedRoot(path) ||
       CODE_HEALTH_DEPS_SELF_SCHEDULED.some((r) => r.test(path)),
   );
 }

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -483,14 +483,40 @@ export const DEPCRUISE_EXTENSIONS = Object.freeze([
  * an edge, and the rules that judge indexer-to-dashboard reach would see it,
  * while no `.ts` file changed. The parse list alone dropped the command there.
  *
- * dependency-cruiser exports `allExtensions` for what it parses but nothing for
- * what its resolver accepts, so this half cannot be pinned against the library.
- * It is short because it is fixed by Node's own resolution rather than by
- * dependency-cruiser's configuration, and `engine.test.mjs` pins it against the
- * real `nttAddresses.json` import instead — a fixture that fails loudly if the
- * case it stands for ever stops existing.
+ * This is dependency-cruiser's own `lKnownUnfollowables`, read from
+ * `src/extract/resolve/module-classifiers.mjs` at the version pinned below. The
+ * cruiser resolves each of these into the graph and then deliberately declines
+ * to parse it: a stylesheet can hold `@import` statements that the fallback
+ * JavaScript parser would happily misread, so it is a node with no outgoing
+ * edges. A node is still an edge target, which is the whole point here.
+ * `ui-dashboard/src/app/layout.tsx` imports `./globals.css` for exactly that
+ * reason.
+ *
+ * The library exports `allExtensions` for what it parses but nothing for this
+ * list, so it cannot be pinned against the API the way the parse half is.
+ * Three things keep it honest instead: the version constant below, which turns
+ * any dependency-cruiser upgrade into a red test so the list is re-read rather
+ * than assumed; and two fixtures in `engine.test.mjs` standing for the JSON and
+ * stylesheet cases, which fail loudly if the imports they represent disappear.
  */
-export const DEPCRUISE_TARGET_EXTENSIONS = Object.freeze([".json", ".node"]);
+export const DEPCRUISE_TARGET_EXTENSIONS = Object.freeze([
+  ".json",
+  ".node",
+  ".css",
+  ".sass",
+  ".scss",
+  ".stylus",
+  ".less",
+]);
+
+/**
+ * The dependency-cruiser release `DEPCRUISE_TARGET_EXTENSIONS` was read from.
+ *
+ * Bumping the dependency without re-reading `lKnownUnfollowables` is the
+ * failure this guards: the list is internal, so nothing else would notice a
+ * change to it. On a version bump, re-read that constant and update both.
+ */
+export const DEPCRUISE_TARGET_EXTENSIONS_VERSION = "17.4.0";
 
 /**
  * A changed path dependency-cruiser can read inside a root it scans.

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -56,23 +56,32 @@ const TRUNK_FULL_SCAN = [
  * the two apart, because any sourced-by analysis would rot the first time a
  * caller changed how it spells the path.
  *
- * A deleted repo-root dotfile is the third class. Several enabled linters read
- * their configuration from one — codespell from `.codespellrc`, shellcheck from
+ * A deleted dotfile is the third class, at any depth. Several enabled linters
+ * read configuration from one — codespell from `.codespellrc`, shellcheck from
  * `.shellcheckrc`, osv-scanner from `.osv-scanner.toml` — and `.gitignore` and
- * `.gitattributes` decide what Trunk looks at in the first place. Deleting one
- * changes the verdict on files that did not change: with `.codespellrc` removed,
- * `scripts/terraform/tf-platform-plan-guard.mjs` goes from clean to one
- * codespell hit on `applyable`, an ignore-word the config carries. A targeted
+ * `.gitattributes` decide what Trunk looks at in the first place. Prettier,
+ * markdownlint and yamllint additionally cascade: the nearest config wins, so a
+ * package can carry its own. Deleting one changes the verdict on files that did
+ * not change, and both levels are measured. Remove `.codespellrc` and
+ * `scripts/terraform/tf-platform-plan-guard.mjs` gains a codespell hit on
+ * `applyable`, an ignore-word that config carries. Remove `aegis/.prettierrc`
+ * and `aegis/src/app.module.ts` — untouched — starts failing prettier, because
+ * the package's `singleQuote` setting went with it. In both cases the targeted
  * run over the survivors still exits 0, so the gate passes locally and the
  * required full scan is where it surfaces.
  *
- * This is deliberately the structural rule "any deleted root dotfile" rather
- * than a list of the config files that exist today. A list would rot the first
- * time a linter gained a root config, and rot silently, in the direction of
- * under-scanning. The rule over-includes a few root dotfiles no Trunk linter
- * reads (`.coderabbit.yaml`, `.vercelignore`); forcing a full scan on their
- * deletion costs time and is never wrong. `.trunk/**` is already whole-repo on
- * both edit and delete, so Trunk's own configs need no entry here.
+ * This is deliberately the structural rule "any deleted dotfile" rather than a
+ * list of the config files that exist today, or a name-shape class like
+ * `.*rc`/`.*ignore`. Both of those rot, and rot silently in the direction of
+ * under-scanning: a list the first time a linter gains a config, a name class
+ * the first time one is spelled outside the shape (`.osv-scanner.toml` already
+ * is). The plain rule cannot rot because it names nothing. It over-includes
+ * dotfiles no Trunk linter reads — `.terraform.lock.hcl`, `.env.example`,
+ * `.dockerignore`, `.coderabbit.yaml` — so deleting one buys a full scan it did
+ * not need. That costs time and is never wrong, which is the correct direction
+ * for a rule whose other failure mode is a green local gate over broken files.
+ * `.trunk/**` is already whole-repo on both edit and delete, so Trunk's own
+ * configs need no entry here.
  *
  * The remaining enabled Trunk linters (prettier, markdownlint, yamllint,
  * trufflehog, git-diff-check) judge each file on its own bytes, so an ordinary
@@ -80,7 +89,7 @@ const TRUNK_FULL_SCAN = [
  * list for local `module { source = "./…" }` references; this repo has none
  * today, and `.tf` deletions stay covered by the whole-repo branches.
  */
-const TRUNK_DELETION_FULL_SCAN = [/^\.github\//, /\.sh$/, /^\.[^/]+$/];
+const TRUNK_DELETION_FULL_SCAN = [/^\.github\//, /\.sh$/, /(^|\/)\.[^/]+$/];
 
 export function addTrunkCheckCommand(plan, changedPaths, facts) {
   const present = [];
@@ -463,20 +472,48 @@ export const DEPCRUISE_EXTENSIONS = Object.freeze([
 ]);
 
 /**
+ * Extensions that appear in the graph as dependency TARGETS without being
+ * parsed for dependencies of their own.
+ *
+ * Parsing is not the only way a file reaches the graph. Node resolution
+ * resolves a JSON module and a native addon, so a file with either extension
+ * can be the far end of an edge between two scanned roots even though it can
+ * hold no imports. `indexer-envio/src/handlers/stables/config.ts` imports
+ * `../../../config/nttAddresses.json`; moving or retargeting that JSON changes
+ * an edge, and the rules that judge indexer-to-dashboard reach would see it,
+ * while no `.ts` file changed. The parse list alone dropped the command there.
+ *
+ * dependency-cruiser exports `allExtensions` for what it parses but nothing for
+ * what its resolver accepts, so this half cannot be pinned against the library.
+ * It is short because it is fixed by Node's own resolution rather than by
+ * dependency-cruiser's configuration, and `engine.test.mjs` pins it against the
+ * real `nttAddresses.json` import instead — a fixture that fails loudly if the
+ * case it stands for ever stops existing.
+ */
+export const DEPCRUISE_TARGET_EXTENSIONS = Object.freeze([".json", ".node"]);
+
+/**
  * A changed path dependency-cruiser can read inside a root it scans.
  *
- * Two shapes qualify. A source file it parses, by extension. And any
- * `package.json` beneath a root, because that is where a workspace dependency
- * is declared — `ui-dashboard/package.json` carries
+ * Three shapes qualify. A source file it parses, by extension. A file its
+ * resolver can reach as a dependency target, which is how a JSON config joins
+ * the graph. And any `package.json` beneath a root, because that is where a
+ * workspace dependency is declared — `ui-dashboard/package.json` carries
  * `"@mento-protocol/config": "workspace:*"`, the edge into `shared-config/` —
  * so it decides resolution the same way the root manifests do.
  */
 const DEPCRUISE_ROOT_PREFIX = new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`);
 
+const DEPCRUISE_READABLE_EXTENSIONS = Object.freeze([
+  ...DEPCRUISE_EXTENSIONS,
+  ...DEPCRUISE_TARGET_EXTENSIONS,
+]);
+
 function inRootAndReadable(path) {
   if (!DEPCRUISE_ROOT_PREFIX.test(path)) return false;
-  if (/(^|\/)package\.json$/.test(path)) return true;
-  return DEPCRUISE_EXTENSIONS.some((extension) => path.endsWith(extension));
+  return DEPCRUISE_READABLE_EXTENSIONS.some((extension) =>
+    path.endsWith(extension),
+  );
 }
 
 /**

--- a/scripts/gate/mapping/post-passes.mjs
+++ b/scripts/gate/mapping/post-passes.mjs
@@ -384,15 +384,38 @@ export const DEPCRUISE_ROOTS = Object.freeze([
 ]);
 
 /**
+ * Workspace manifests that decide how a bare specifier resolves.
+ *
+ * A scanned root reaches another scanned root by package name, not by relative
+ * path: `ui-dashboard/package.json` declares
+ * `"@mento-protocol/config": "workspace:*"`, and 47 imports of that specifier
+ * resolve into `shared-config/`. Which directories are workspace packages, and
+ * what each specifier resolves to, is decided by these three files. Editing one
+ * can therefore add or remove an edge between two scanned roots while no file
+ * inside any root changes — so a change set holding only a manifest still has
+ * something dependency-cruiser can read.
+ *
+ * A root's own `package.json` needs no entry here: it already matches the root
+ * prefix below.
+ */
+const WORKSPACE_RESOLUTION_MANIFESTS = [
+  /^package\.json$/,
+  /^pnpm-lock\.yaml$/,
+  /^pnpm-workspace\.yaml$/,
+];
+
+/**
  * Changed paths that keep `pnpm code-health:deps` in the plan.
  *
- * The roots are the reason the command exists. The other two entries are
- * fail-closed: `.dependency-cruiser.cjs` is the config whose rules the command
- * enforces, and this module is where the narrowing itself lives, so an edit to
- * either has to run the command it governs rather than be judged by it.
+ * The roots are the reason the command exists. The manifests above decide what
+ * the roots resolve to. The last two entries are fail-closed:
+ * `.dependency-cruiser.cjs` is the config whose rules the command enforces, and
+ * this module is where the narrowing itself lives, so an edit to either has to
+ * run the command it governs rather than be judged by it.
  */
 const CODE_HEALTH_DEPS_TRIGGERS = [
   new RegExp(`^(${DEPCRUISE_ROOTS.join("|")})/`),
+  ...WORKSPACE_RESOLUTION_MANIFESTS,
   /^\.dependency-cruiser\.cjs$/,
   /^scripts\/gate\/mapping\/post-passes\.mjs$/,
 ];

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -240,6 +240,12 @@ export const HEAD_GROUPS = [
         effects: [
           { set: "root_package_json_class" },
           {
+            why: "The `code-health:deps` script line lives in this file, and its positional arguments are one of the two sources `engine.test.mjs` holds the gate's scanned-root list set-equal to. The class dispatch below sends a script-only edit to the shell gate alone, and required CI never runs `engine.test.mjs`, so shrinking the scanned roots here would merge with the staleness test that exists to catch it never having been invoked. Routed for every root manifest change rather than only ones touching that line: a whole-file trigger cannot be defeated by reformatting, and this file changes rarely.",
+            command: "node --test scripts/gate/mapping/engine.test.mjs",
+            reason:
+              "root manifest changed (gate pins its scanned roots against the code-health:deps script)",
+          },
+          {
             dispatch: "root_package_json_class",
             arms: [
               {

--- a/scripts/gate/routing-table/groups-head.mjs
+++ b/scripts/gate/routing-table/groups-head.mjs
@@ -333,6 +333,12 @@ export const HEAD_GROUPS = [
             reason: "dep-cruiser config changed (root ESLint coverage)",
           },
           {
+            why: "The engine narrows `pnpm code-health:deps` to the roots dependency-cruiser actually scans, and it holds those roots as a pinned constant. `engine.test.mjs` is what compares that constant with this file's `includeOnly.path` and with the root `code-health:deps` script, set-equal both ways. Without this route, adding a root here would leave the gate under-routing every change under it — a smaller plan, arrived at silently, which is the failure mode ADR 0069 exists to prevent.",
+            command: "node --test scripts/gate/mapping/engine.test.mjs",
+            reason:
+              "dep-cruiser config changed (gate pins its scanned roots against this file)",
+          },
+          {
             checklist: "docs/pr-checklists/code-health.md",
             reason: "dep-cruiser config changed",
           },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The gate escalated to a whole-repo `trunk check --all` whenever any changed
  path had been deleted, even when the rest of the set was ordinary surviving
  files. One deletion beside a one-line docs edit cost a full-repo scan.
- `pnpm code-health:deps` was scheduled by every package quality bundle, but
  dependency-cruiser only walks and reports six roots. A
  `governance-watchdog/**` or `alerts/infra/**` edit re-proved the same verdict
  on a graph that had not changed.

## The Solution

A deleted path is now dropped from the targeted Trunk argument list instead of
escalating the whole set, and the surviving paths still lint. Three deletion
cases keep the whole-repo scan: no survivor left to target, a deleted path that
is itself in the whole-repo list, and a deleted path under `.github/`. That last
one is real cross-file semantics — actionlint resolves
`uses: ./.github/actions/<name>` against the working tree, so deleting a local
action invalidates surviving workflows that a targeted run would never name.

`pnpm code-health:deps` now runs only when a changed path is something
dependency-cruiser can read: inside one of the six scanned roots, the
`.dependency-cruiser.cjs` config, the narrowing pass itself, or one of the three
workspace manifests that decide how a bare specifier resolves. Everything else
drops it.

The material limit: this makes plans smaller, which is the direction the rest of
the engine refuses to go. The safety rests on a both-ways staleness pin — the
gate's copy of the six roots must equal both the `code-health:deps` script
arguments and the `.dependency-cruiser.cjs` `includeOnly` alternation — and on
`.dependency-cruiser.cjs` being routed to `engine.test.mjs`, so adding a seventh
root is a red test rather than a silently under-routed gate. The
`docs/pr-checklists/code-health.md` checklist is unaffected either way, because
knip is the other half of it and still runs per package.

## Details

The narrowing is the sixth whole-set post-pass and runs last, after
`applyScopedTestCommands`. It reads the finished quality bucket and is the only
pass that removes a command, so nothing after it can reintroduce one.

`DEPCRUISE_ROOTS` is duplicated in `post-passes.mjs` rather than parsed out of
the `code-health:deps` shell string at gate time: routing is reviewable data,
and a constant recovered from a shell string would not be. The staleness test
keeps the copy honest.

The workspace-manifest triggers (`package.json`, `pnpm-lock.yaml`,
`pnpm-workspace.yaml`) exist because a scanned root reaches another scanned root
by package name, not relative path — `ui-dashboard/package.json` declares
`"@mento-protocol/config": "workspace:*"`, and 47 imports of that specifier
resolve into `shared-config/`. Those three files can therefore add or remove an
edge between two scanned roots while no file inside any root changes. A root's
own `package.json` needs no entry; it already matches the root prefix.

This composes with the merged rec-2 (#2173) rather than replacing any of it.
Rec-2's `--ci` flag is preserved on all four Trunk branches, including the new
deletion-only branch, and its `addPegRegistryIntegrityCheck` lockfile routing is
untouched — the narrowing acts on `pnpm code-health:deps` alone.

`scripts/AGENTS.md` registers both new exact path pins, as ADR 0064 requires.
Fitting them under the 9,216-byte scoped cap needed room, so the review-eval
pin bullet was rewritten in the file's own brace idiom
(`review/run-eval{,-source-snapshot,-lifecycle,-runtime}.sh`) and its redundant
`scripts/` prefixes dropped. Every path it names is unchanged; the tracking
source of truth for those pins is `docs/evals/review-skill.md`, not this prose.

## Validation

- `node --test scripts/gate/mapping/engine.test.mjs` — 68/68 pass.
- `pnpm gate:routing-table:test` — 73/73 pass.
- `GATE_TEST_FOCUS=gate-contract bash scripts/agent-quality-gate.test.sh` —
  passed. `GATE_TEST_FOCUS=routing-docs` and `GATE_TEST_FOCUS=stamps-freshness`
  — passed; `routing-docs` is the family that owns the new `run_gate`
  assertions, and `stamps-freshness` covers the stamp that pins these files.
- `bash -n` on `agent-quality-gate.sh` and `agent-quality-gate.test.sh` — clean.
- `pnpm docs:index --check` and `node scripts/context/agent-context-budget.mjs
  --strict` — both clean; `scripts/AGENTS.md` is 9,207 of 9,216 bytes.
- Seven negative controls, each mutating live code and requiring the named test
  to go red before reverting: adding a seventh root, dropping a root, removing
  the `.github/` deletion carve-out, targeting `changedPaths` instead of the
  survivors, removing the workspace-manifest triggers, dropping the
  `.dependency-cruiser.cjs` fail-closed trigger, and disabling the narrowing
  entirely. All seven fired.
- Behavioural diff against `origin/main` using the real gate's `--dry-run` over
  single-path change sets: `pnpm-lock.yaml`, `package.json`,
  `pnpm-workspace.yaml`, `ui-dashboard/package.json` and
  `shared-config/src/index.ts` keep `pnpm code-health:deps` on both branches;
  `governance-watchdog/src/index.ts`, `governance-watchdog/package.json` and
  `.github/workflows/ci.yml` keep it on main and drop it here.

The nearest stronger claims this evidence does NOT support: the dry-run diff
covers eight single-path change sets, not the full path space, so it does not
prove the narrowing is verdict-preserving for every possible change set. The
`.github/` carve-out is justified by actionlint's cross-file `uses:` resolution
and by reading the enabled linter list; it was not established by executing
every Trunk linter against a deletion. The claim that a non-`.github` deletion
cannot invalidate a survivor rests on that same per-linter reading.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable. ADR 0069 is updated in place; this PR makes no new architecture decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quality checks now handle deleted files, including configuration dotfiles, GitHub Actions, and sourced shell helpers.
  * Dependency checks are scoped to relevant project areas and triggered by related manifests or configuration changes.
  * Routing automatically selects targeted or full-repository checks based on the affected files.

* **Documentation**
  * Updated quality-gate guidance, routing documentation, checklists, and review instructions.

* **Tests**
  * Expanded coverage for deletion handling, dependency-check scope, routing behavior, root-manifest changes, and command scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->