### PR TITLE
fix(ci): restore root script timeout margin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1164,12 +1164,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.forceAll == 'true' || needs.changes.outputs.rootScripts == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    # The quality-gate routing regression suite reached 24m37s on this runner
-    # after earlier job setup. The prior 25-minute cap cancelled it before
-    # later steps could run. The waits bind real queue, cleanup, and no-signal
+    # The quality-gate routing regression suite reached 39m02s on this runner
+    # in main CI run 33535970973, attempt 1, job 99950409872, after earlier job
+    # setup. The prior 40-minute cap cancelled the job before later steps could
+    # run. The waits bind real queue, cleanup, and no-signal
     # guarantees, so keep a bounded 15-minute margin for the remaining steps
     # and runner variance instead of weakening those assertions.
-    timeout-minutes: 40
+    timeout-minutes: 55
     permissions:
       contents: read
       actions: read

--- a/docs/PLAN-progressive-verification-graph.md
+++ b/docs/PLAN-progressive-verification-graph.md
@@ -114,7 +114,7 @@ cleanup, cross-worktree scheduling, and crash recovery.
   [source patch](metrics/verification-redesign-local-gate-source.patch) permits
   a fresh clone to reproduce the measured tree from a reachable commit. This
   one narrow route does not replace the seven-request distribution.
-- The gate self-test has needed a 40-minute CI timeout.
+- The gate self-test has needed a 55-minute CI timeout.
 - Remote Turbo result caching is disabled.
 
 The generated Phase 0 manifest widens this count to the complete control-plane

--- a/docs/adr/0072-md-only-docs-checks-job.md
+++ b/docs/adr/0072-md-only-docs-checks-job.md
@@ -19,7 +19,7 @@ garden_lane: adrs-architecture
 ## Context
 
 The `rootScripts` paths-filter carried `*.md` and `**/*.md`, so any Markdown
-edit fired the `scripts` job: 44 steps, a long timeout, a full-history
+edit fired the `scripts` job: 51 steps, a long timeout, a full-history
 checkout, and a whole-workspace `pnpm install`. A one-line typo fix in a note
 under `docs/notes/` paid the same CI bill as a rewrite of the quality gate.
 
@@ -154,10 +154,11 @@ over a Markdown-only diff was two cosmetic wording findings across eleven PRs,
 and neither came from a CI step.
 
 **Make the `scripts` job faster instead.** Rejected: it is not slow by
-accident. Its 44 steps are load-bearing regression suites for gate routing,
+accident. Its 51 steps are load-bearing regression suites for gate routing,
 supply-chain policy, workflow trust, and alert rules, and its own comment
-records that the quality-gate routing regression suite reached 24m37s. Cutting
-the job to fit Markdown PRs would weaken it for the code PRs it exists to guard.
+records that the quality-gate routing regression suite reached 39m02s in main
+CI run `33535970973`, attempt 1, job `99950409872`. Cutting the job to fit
+Markdown PRs would weaken it for the code PRs it exists to guard.
 
 **Put a workflow-level `paths:` filter on `ci.yml`, or promote a separate
 required `docs` workflow with one.** Rejected by
@@ -278,8 +279,8 @@ costs a duplicate run on mixed diffs and nothing else.
 
 ## Evidence
 
-- `.github/workflows/ci.yml`: the `scripts` job carries 44 steps and
-  `timeout-minutes: 40`; `docs-checks` carries 13 steps and
+- `.github/workflows/ci.yml`: the `scripts` job carries 51 steps and
+  `timeout-minutes: 55`; `docs-checks` carries 13 steps and
   `timeout-minutes: 10`.
 - `stalenessSubjects(ROUTING_GROUPS)` from `scripts/gate/routing-table/`
   returns 799 path subjects, 631 distinct, of which 23 are Markdown files —

--- a/scripts/workflows/check-ci-contract.mjs
+++ b/scripts/workflows/check-ci-contract.mjs
@@ -47,7 +47,7 @@ const EXPECTED_CONDITIONS = Object.freeze({
 });
 
 // prettier-ignore
-const EXPECTED_TIMEOUTS = Object.freeze({ changes: 2, shared: 10, ui: 25, indexer: 20, bridge: 10, "integration-probes": 10, alerts: 10, "gov-watchdog": 10, terraform: 10, aegis: 15, scripts: 40, "guardrail-prose": 5, "docs-checks": 10, "production-infra-contract": 5, "sentry-suites": 5, "autoreview-suite": 90, "autoreview-root-runtime": 5, "version-skew": 5, deps: 5, ci: 2 });
+const EXPECTED_TIMEOUTS = Object.freeze({ changes: 2, shared: 10, ui: 25, indexer: 20, bridge: 10, "integration-probes": 10, alerts: 10, "gov-watchdog": 10, terraform: 10, aegis: 15, scripts: 55, "guardrail-prose": 5, "docs-checks": 10, "production-infra-contract": 5, "sentry-suites": 5, "autoreview-suite": 90, "autoreview-root-runtime": 5, "version-skew": 5, deps: 5, ci: 2 });
 // prettier-ignore
 const EXPECTED_RUNNERS = Object.freeze({ changes: "blacksmith-2vcpu-ubuntu-2404-arm", shared: "blacksmith-2vcpu-ubuntu-2404", ui: "blacksmith-4vcpu-ubuntu-2404", indexer: "blacksmith-4vcpu-ubuntu-2404", bridge: "blacksmith-2vcpu-ubuntu-2404", "integration-probes": "blacksmith-2vcpu-ubuntu-2404", aegis: "blacksmith-2vcpu-ubuntu-2404", alerts: "blacksmith-2vcpu-ubuntu-2404", "gov-watchdog": "blacksmith-4vcpu-ubuntu-2404", terraform: "blacksmith-2vcpu-ubuntu-2404-arm", deps: "blacksmith-2vcpu-ubuntu-2404", scripts: "blacksmith-2vcpu-ubuntu-2404", "docs-checks": "blacksmith-2vcpu-ubuntu-2404", "autoreview-suite": "ubuntu-latest", "autoreview-root-runtime": "blacksmith-2vcpu-ubuntu-2404", "version-skew": "blacksmith-2vcpu-ubuntu-2404", "guardrail-prose": "ubuntu-latest", "production-infra-contract": "blacksmith-2vcpu-ubuntu-2404", "sentry-suites": "ubuntu-latest", ci: "ubuntu-latest" });
 // prettier-ignore


### PR DESCRIPTION
## The Problem

- The required `Lint + test root scripts` job stopped every run after 40 minutes.
- Main CI run `33535970973` reached 39m02s in the routing regression suite on attempt 1, then canceled before later steps. Attempt 2 canceled while the same suite was still running.
- The workflow and its ADR still cited the earlier 24m37s measurement, so their stated 15-minute margin no longer existed.

## The Solution

Raise only the root-script job timeout to 55 minutes. Keep every step, assertion, trigger, permission, and fail-closed check unchanged. Pin the new value in the structural CI contract and update the live documentation.

The 55-minute cap restores a bounded 15-minute margin over the failed 40-minute budget. It does not make the suite faster or prove that every future run will finish. Exact-head CI must prove the current tree.

Closes #2204.

## Details

- Set `jobs.scripts.timeout-minutes` from 40 to 55.
- Set `EXPECTED_TIMEOUTS.scripts` from 40 to 55 so contract drift still fails closed.
- Cite run `33535970973`, attempt 1, job `99950409872`, for the 39m02s measurement.
- Update ADR 0072 and the active verification plan. Keep the ADR's prior full-verification date because this patch does not revalidate every historical source anchor.
- Preserve all 51 root-script job steps.
- Do not run a paid review evaluation.
- Claude Security scan: skipped (CI control surface).

## Validation

- `./tools/trunk fmt <four changed files>` and `./tools/trunk check --ci <four changed files>` passed. These checks prove formatting and configured static checks. They do not prove GitHub runner behavior.
- `pnpm ci:contract:test` passed all 105 tests. It proves the live workflow has the exact 55-minute pin and satisfies the structural and no-skip contracts. It does not prove the job completes within 55 minutes.
- `pnpm lint:scripts` passed. It proves the modified contract script passes ESLint. It does not execute the GitHub workflow.
- `pnpm docs:index --check` and `pnpm agent:context-check` passed. They prove the edited documents satisfy the catalog and context contracts. They do not revalidate every historical claim in ADR 0072.
- `pnpm docs:navigation-eval:test` passed all 34 tests, and `pnpm docs:navigation-eval -- --check-fixtures` returned `valid: true`. These checks prove the plan edit preserves the navigation contracts. They do not assess the plan's architecture.
- Two independent read-only reviews inspected the pinned patch. The first pass found two documentation drift issues. Both were fixed. The final recheck passed cleanly. This is source review only.
- `pnpm agent:quality-gate --run` stopped before any mapped command because the host retains an unresolved `drain-required` Darwin lineage. This does not establish a local gate pass. The operator-recorded session exception makes exact-head CI the replacement runtime gate.
- `pnpm agent:autoreview --prepare-bundle-dir <temporary directory>` failed before bundle creation because it could not establish Darwin wrapper recovery authority. This does not establish a bundled autoreview pass. Exact-head GitHub review remains required.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2201
- https://github.com/mento-protocol/monitoring-monorepo/issues/2128

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision: not applicable. This patch updates one bounded workflow parameter within ADR 0072.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CI checks to allow the scripts job up to 55 minutes, reducing failures caused by longer verification runs.

- **Documentation**
  - Updated planning and architecture documentation with the current job duration, step count, timeout, and supporting runtime evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->