### PR TITLE
fix(ci): re-attest retained audit graph

### DIFF
--- a/docs/adr/0072-md-only-docs-checks-job.md
+++ b/docs/adr/0072-md-only-docs-checks-job.md
@@ -19,7 +19,7 @@ garden_lane: adrs-architecture
 ## Context
 
 The `rootScripts` paths-filter carried `*.md` and `**/*.md`, so any Markdown
-edit fired the `scripts` job: 51 steps, a long timeout, a full-history
+edit fired the `scripts` job: 52 steps, a long timeout, a full-history
 checkout, and a whole-workspace `pnpm install`. A one-line typo fix in a note
 under `docs/notes/` paid the same CI bill as a rewrite of the quality gate.
 
@@ -154,7 +154,7 @@ over a Markdown-only diff was two cosmetic wording findings across eleven PRs,
 and neither came from a CI step.
 
 **Make the `scripts` job faster instead.** Rejected: it is not slow by
-accident. Its 51 steps are load-bearing regression suites for gate routing,
+accident. Its 52 steps are load-bearing regression suites for gate routing,
 supply-chain policy, workflow trust, and alert rules, and its own comment
 records that the quality-gate routing regression suite reached 39m02s in main
 CI run `33535970973`, attempt 1, job `99950409872`. Cutting the job to fit
@@ -279,7 +279,7 @@ costs a duplicate run on mixed diffs and nothing else.
 
 ## Evidence
 
-- `.github/workflows/ci.yml`: the `scripts` job carries 51 steps and
+- `.github/workflows/ci.yml`: the `scripts` job carries 52 steps and
   `timeout-minutes: 55`; `docs-checks` carries 13 steps and
   `timeout-minutes: 10`.
 - `stalenessSubjects(ROUTING_GROUPS)` from `scripts/gate/routing-table/`

--- a/scripts/workflows/check-no-skip-audit.mjs
+++ b/scripts/workflows/check-no-skip-audit.mjs
@@ -30,7 +30,7 @@ const READ_SCOPES = Object.freeze({ actions: "read", contents: "read", "pull-req
 // prettier-ignore
 const ADMISSION_STEP_HASH = "18f1c3741064363a488462c96fd34772c3b66eeee4a3f4bd2fb2a86275c3a203", CHECKOUT_STEP_HASH = "2d39e2e5293845e1c63f0f2e95ab8eb7e3d65360955c5b2c54ea1bddff57c22d", PROTECTED_DRIFT_STEP_HASH = "384f12fd7350be70968c0eb10a8613017a1ddc32dda1e54514f0cd6632420fa7", SUMMARY_STEP_HASH = "b6def63e8f5ccb7e13a6460f546cb391bf0e86350876470a787f038ea7cebb10";
 const CI_GRAPH_HASH =
-    "98fb0c2945d78059147cfe7b9ccbd8d00e3b2be9a2bb9edc76c104a4c9ca7eef",
+    "f6ca3dcc0d25bfafb4e9da11df0bb1d380e5373db5b0cfcd17aaafc53df2d530",
   BASELINE_HASH =
     "467641beda8b2b45d49d0c62429d8e95f62b05c1db96f6665b106012a09cef12";
 // prettier-ignore


### PR DESCRIPTION
## The Problem

- PR #2207 pinned the parsed retained-audit workflow graph. PR #2206 then changed the root `scripts` timeout from 40 to 55 minutes, so their first combined `main` tree failed the exact graph check.
- The same combined tree has 52 `scripts` steps, but ADR 0072 still records 51.
- Main CI run `33608061912` is red. This blocks a green post-merge baseline and the scheduler closeout.

## The Solution

Re-attest the existing parsed workflow graph and update all live ADR step-count claims. The checker keeps exact hash equality and all other fail-closed checks. This PR does not change the workflow, weaken the retained-audit gate, or repair the separate quality-gate test race.

## Details

- Pin `CI_GRAPH_HASH` to `f6ca3dcc0d25bfafb4e9da11df0bb1d380e5373db5b0cfcd17aaafc53df2d530`.
- Record 52 `scripts` steps at every live count in ADR 0072.
- Leave `.github/workflows/ci.yml` unchanged. The current workflow is the reviewed graph.
- Keep `last_verified: 2026-08-27`. This repair verifies the current count fields, not the full ADR and all historical evidence.
- Use `Refs #2211`. The issue remains open until post-merge `main` CI passes.

Refs #2211

## Validation

- `pnpm ci:contract:test` passed all 177 tests. It proves the checker accepts the current parsed graph and rejects its tested mutations. It does not prove execution on GitHub runners.
- An independent recomputation produced graph hash `f6ca3dcc0d25bfafb4e9da11df0bb1d380e5373db5b0cfcd17aaafc53df2d530`, 52 `scripts` steps, and a 55-minute timeout. It proves the pinned source facts. It does not prove runtime behavior.
- `pnpm docs:index --check` and `pnpm agent:context-check` passed. They prove the edited canonical document satisfies current repository metadata and link contracts. They do not re-verify every historical claim in ADR 0072.
- `node scripts/docs/docs-navigation-eval.test.mjs` passed all 34 tests. `node scripts/docs/docs-navigation-eval.mjs --check-fixtures` returned `valid: true`.
- `pnpm lint:scripts`, `pnpm tf:test`, and `./tools/trunk check --ci scripts/workflows/check-no-skip-audit.mjs docs/adr/0072-md-only-docs-checks-job.md` passed.
- `git diff --check` passed.
- Independent read-only review passed with no blocking finding. The reviewer suggested updating `last_verified`; the patch leaves it unchanged because a full semantic ADR review was outside scope.
- `pnpm agent:quality-gate --run` and prepared-bundle autoreview both stopped before execution because the local Darwin recovery authority could not establish the required process lineage. The user authorized exact-head CI as the local-gate replacement for this session. Required PR CI remains the authoritative behavioral proof.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2212 tracks the pre-existing replacement-holder and drain-refresh test race.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the material non-goals.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision: not applicable. This PR re-attests an existing decision and changes no architecture.
