### PR TITLE
docs: add review safeguards from wrapper retirement

### DIFF
--- a/docs/pr-checklists/architecture-decisions.md
+++ b/docs/pr-checklists/architecture-decisions.md
@@ -75,11 +75,12 @@ supply-chain control, or context rule).
 6. Add or confirm the one-line `docs/adr/` pointer in the owning package's
    `AGENTS.md`.
 
-Before commit or push, recheck the ADR number against the current base. If a
-base update creates a collision, renumber the ADR and update the filename,
-numbered heading, catalog entries, body links, textual references, and
-frontmatter pointers such as `superseded_by`. Run the documentation checks
-after the renumbering.
+Before every commit or push, after every observed base advance, and before
+merge, recheck the ADR number against the current base. If a base update
+creates a collision, renumber the ADR and update the filename, numbered
+heading, catalog entries, body links, textual references, and frontmatter
+pointers such as `superseded_by`. Run the documentation checks after the
+renumbering.
 
 ## Superseding a decision
 

--- a/docs/pr-checklists/architecture-decisions.md
+++ b/docs/pr-checklists/architecture-decisions.md
@@ -75,6 +75,12 @@ supply-chain control, or context rule).
 6. Add or confirm the one-line `docs/adr/` pointer in the owning package's
    `AGENTS.md`.
 
+Before commit or push, recheck the ADR number against the current base. If a
+base update creates a collision, renumber the ADR and update the filename,
+numbered heading, catalog entries, body links, textual references, and
+frontmatter pointers such as `superseded_by`. Run the documentation checks
+after the renumbering.
+
 ## Superseding a decision
 
 Do not silently rewrite an ADR when reality changes. Add a **new** ADR that makes

--- a/docs/pr-checklists/recurring-review-patterns.md
+++ b/docs/pr-checklists/recurring-review-patterns.md
@@ -273,6 +273,13 @@ tldr: **ruleset-required** workflows (`ci`, `Code Quality`, `Sentry suites`, the
 
 - Don't remove an env-var fallback in the same PR that introduces the new var. Keep dual-read for one release so mid-deploy state doesn't break
 
+### Retired local tooling
+
+- When removing a tool that writes local files, audit existing checkouts. Keep
+  the legacy filenames ignored or provide a safe migration when old files can
+  persist. Treat files that contain identities, reasons, or other local data as
+  sensitive even after the writer is removed.
+
 ### Dynamic-route metadata + private data — [checklist](dynamic-route-metadata.md)
 
 tldr: `generateMetadata` reading access-controlled data must gate on `isPublic === true` before emitting tags (no session, tags visible to crawlers). `export const revalidate = 0` for access-controlled sources (ISR would serve stale post-revocation tags from the edge cache). Metadata-fetching body lives in a dedicated `_lib/og-metadata.ts` helper imported by the page — not directly in `layout.tsx` — to keep the RSC label-leak guard allowlist narrow (PR #345 commit `b476776`). Full rules in the linked checklist.


### PR DESCRIPTION
## The Problem

- ADR renumbering guidance did not require every numbered reference and metadata pointer to change after a base collision.
- Tool-retirement guidance did not account for sensitive local artifacts that can remain in old checkouts.
- These gaps allowed a stale `superseded_by` pointer and could let retired local data become stageable.

## The Solution

The review checklists now require complete ADR collision updates and safe handling of legacy local files. These rules reduce repeat review defects. This PR changes guidance only. It does not add an automated check or migration.

## Details

- Require ADR-number rechecks after every observed base advance and before merge.
- Require collision handling to update the filename, heading, catalogs, body references, and frontmatter pointers.
- Require retired local tools to keep persistent artifacts ignored or provide a safe migration.
- Treat legacy files with identities, reasons, or other local data as sensitive after writer removal.

## Validation

- Scope review: the exact-head diff contains 14 documentation lines in two approved checklist files. This proves the intended source scope; it does not prove repository policy checks pass.
- Local checks: skipped by explicit user instruction.
- GitHub CI for head `0153971c9203872d1e209229d2ec3d88725c9942`: all required contexts pass, including `ci`, Code Quality, Sentry suites, Vercel, and Vercel Preview Comments. Documentation corpus checks and the production infrastructure contract also pass. This proves the repository checks selected for this head; it does not prove runtime behavior, which this documentation-only change does not alter.
- Exact-head reviews: Codex and CodeRabbit completed with no actionable findings. The feedback ledger has zero blockers, unresolved threads, or unreplied review comments. Source review does not replace behavioral testing.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This PR documents review practice and does not constrain repository architecture.