### PR TITLE
fix(gate): restore macOS gate dispatch with a contained launchd installer

### DIFF
--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -358,7 +358,9 @@ current `PATH` after the installer verifies `node`, `git`, `codex`, and
 `claude`). launchd does not inherit values that a login startup file exports.
 The installed job uses fixed `/bin/zsh` and `/bin/bash` interpreters. The login
 shell loads model credentials, then the command restores the captured path
-before it invokes the runner. Run this from the root of your checkout.
+before it invokes the runner. Run this from the root of your checkout, in your
+own shell. The installer refuses to start inside a quality-gate run, because the
+Darwin broker preflight allowlists it only on that condition.
 
 ```bash
 ./scripts/review/install-review-eval-launchd.sh

--- a/docs/notes/agent-quality-gate-mechanics.md
+++ b/docs/notes/agent-quality-gate-mechanics.md
@@ -578,8 +578,14 @@ walk excludes only named dependency, tool-cache, generated-build, coverage,
 documentation, and local-evidence directories:
 `.git`, `.cache`, `.investigations`, `.next`, `.pnpm-store`, `.rankings`,
 `.reviews`, `.tmp`, `.trunk`, `.turbo`, `coverage`, `dist`, `docs`,
-`node_modules`, and `vendor`. Its exact allowlist contains only reviewed local
-protocols that cannot request an external process. Static inspection cannot
+`node_modules`, and `vendor`. Its exact allowlist holds reviewed local protocols
+that cannot request an external process, plus one operator-run installer.
+`scripts/review/install-review-eval-launchd.sh` calls `launchctl` to install the
+review-eval scheduler. It is never a mapped command, and it refuses to start
+when the gate exports `AGENTQG_RUN` or `AGENTQG_REQUEST`, so it cannot create a
+process during a gate run that lineage tracking would miss. A source hash binds
+every entry, so one changed byte fails closed until a new capability review.
+Static inspection cannot
 detect arbitrary runtime-built broker calls or calls hidden in excluded
 dependencies and system executables. The coalition mismatch exclusion
 classifies external-service processes only within this preflight contract.

--- a/scripts/gate/darwin-broker-launch-preflight.mjs
+++ b/scripts/gate/darwin-broker-launch-preflight.mjs
@@ -315,6 +315,14 @@ const APPROVED_ALLOWLIST_SHAPE = new Map([
         "This executable test passes broker-shaped text only to the preflight scanner and uses no process broker. Its exact source hash requires a new capability review after any change.",
     },
   ],
+  [
+    "scripts/review/install-review-eval-launchd.sh",
+    {
+      rules: ["shell-process-broker"],
+      reason:
+        "This operator-run installer calls launchctl to install the review-eval scheduler. It is never a mapped command, and it refuses to start when the gate exports AGENTQG_RUN or AGENTQG_REQUEST, so it cannot create a process during a gate run that Darwin lineage tracking would miss. Its exact source hash requires a new capability review after any change.",
+    },
+  ],
 ]);
 
 // A hash binds each exception to reviewed source bytes. A source change must
@@ -351,8 +359,16 @@ export const BROKER_CLIENT_ALLOWLIST = [
       "node-net-dynamic-client",
       "javascript-process-broker",
     ],
-    sha256: "995cd00e61c956a6d77bf36bf366533cec0d493af1e4f7ba9a454b5274a05ae9",
+    sha256: "b870bba633792c5c723f798771dcb5cd0864842f279d603292e14a50cf9c78e9",
     reason: APPROVED_ALLOWLIST_SHAPE.get(TEST_PATH).reason,
+  },
+  {
+    path: "scripts/review/install-review-eval-launchd.sh",
+    rules: ["shell-process-broker"],
+    sha256: "c15a37879035ef1e97a68b5b6fd3b039b000883bb2cfc2c3112da89743c36789",
+    reason: APPROVED_ALLOWLIST_SHAPE.get(
+      "scripts/review/install-review-eval-launchd.sh",
+    ).reason,
   },
 ];
 

--- a/scripts/gate/darwin-broker-launch-preflight.test.mjs
+++ b/scripts/gate/darwin-broker-launch-preflight.test.mjs
@@ -27,6 +27,8 @@ import {
 import { mappedChildScrubbedEnvironmentName } from "./quality-gate-coordinator-environment.mjs";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
+const REVIEW_EVAL_INSTALLER_PATH =
+  "scripts/review/install-review-eval-launchd.sh";
 
 function rulesFor(path, source) {
   return new Set(scanSource(path, source).map((finding) => finding.rule));
@@ -1627,6 +1629,83 @@ test("a source change invalidates an exact coordinator exception", () => {
     assert.ok(
       result.policyErrors.some((error) =>
         error.includes("broker capability is stale"),
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the review-eval launchd installer holds one reviewed shell exception", () => {
+  const entry = BROKER_CLIENT_ALLOWLIST.find(
+    (item) => item.path === REVIEW_EVAL_INSTALLER_PATH,
+  );
+  assert.ok(entry, "the review-eval installer is not on the allowlist");
+  assert.deepEqual(entry.rules, ["shell-process-broker"]);
+  assert.deepEqual(validateAllowlist(), []);
+
+  // The exception rests on one claim: this installer cannot run during a gate
+  // run, so it cannot create a process that Darwin lineage tracking would miss.
+  // Check the claim where the exception is recorded. The refusal must read both
+  // markers the gate exports, and it must precede the first launchctl path the
+  // installer names.
+  const source = readFileSync(
+    join(repoRoot, REVIEW_EVAL_INSTALLER_PATH),
+    "utf8",
+  );
+  assert.match(source, /-n \$\{AGENTQG_RUN:-\}/u);
+  assert.match(source, /-n \$\{AGENTQG_REQUEST:-\}/u);
+  const refusal = source.indexOf("refuses to run inside a quality-gate run");
+  const launchctlPath = source.indexOf("launchctl_path=");
+  assert.ok(refusal > 0);
+  assert.ok(launchctlPath > refusal);
+});
+
+test("the allowlisted review-eval installer passes exact source attestation", () => {
+  const root = makePolicyFixture();
+  try {
+    const paths = BROKER_CLIENT_ALLOWLIST.map((entry) => entry.path);
+    const result = scanRepository(root, { paths, policyRoot: repoRoot });
+    assert.deepEqual(result.policyErrors, []);
+    assert.deepEqual(result.rejected, []);
+    assert.ok(
+      result.accepted.some(
+        (finding) =>
+          finding.path === REVIEW_EVAL_INSTALLER_PATH &&
+          finding.rule === "shell-process-broker",
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("one changed byte in the review-eval installer fails closed again", () => {
+  const root = makePolicyFixture();
+  try {
+    const original = readFileSync(
+      join(repoRoot, REVIEW_EVAL_INSTALLER_PATH),
+      "utf8",
+    );
+    writeFileSync(join(root, REVIEW_EVAL_INSTALLER_PATH), `${original}\n`);
+    const paths = BROKER_CLIENT_ALLOWLIST.map((entry) => entry.path);
+
+    // A changed working tree no longer carries the reviewed exception.
+    const scanned = scanRepository(root, { paths, policyRoot: repoRoot });
+    assert.deepEqual(scanned.policyErrors, []);
+    assert.ok(
+      scanned.rejected.some(
+        (finding) =>
+          finding.path === REVIEW_EVAL_INSTALLER_PATH &&
+          finding.rule === "shell-process-broker",
+      ),
+    );
+
+    // A changed policy source is stale policy, not a new exception.
+    const policy = scanRepository(root, { paths });
+    assert.ok(
+      policy.policyErrors.some((error) =>
+        error.includes(`source hash is stale: ${REVIEW_EVAL_INSTALLER_PATH}`),
       ),
     );
   } finally {

--- a/scripts/review/install-review-eval-launchd.sh
+++ b/scripts/review/install-review-eval-launchd.sh
@@ -7,6 +7,26 @@ fail() {
   exit 1
 }
 
+# This installer is operator-run only. It is never a mapped gate command. The
+# Darwin broker preflight allowlists it on exactly that claim: a launchctl
+# client that cannot execute during a gate run cannot create a process that the
+# gate's Darwin lineage tracking would miss. Enforce the claim here, before any
+# launchctl call and before any file this installer would create.
+#
+# AGENTQG_RUN is the right marker. scripts/agent-quality-gate.sh exports it on
+# every mapped command it dispatches, in every mode: run_with_timeout sets it on
+# the sanitized launcher that runs both the serial and the parallel branch, and
+# the parallel worker exports it again for its own child. It is set for
+# --no-lock runs too, which export no lock state at all, so
+# AGENT_QUALITY_GATE_LOCK_HELD would miss them. The gate's own suite refuses a
+# GATE_TEST_FOCUS inside a gate run on the same marker. AGENTQG_REQUEST is
+# exported beside AGENTQG_RUN at those same sites and is the second key on the
+# same door. Read the values, not the names: a marker exported empty must read
+# the same as one that was never exported.
+if [[ -n ${AGENTQG_RUN:-} || -n ${AGENTQG_REQUEST:-} ]]; then
+  fail "the review-eval scheduler installer is operator-run only and refuses to run inside a quality-gate run; run it from your own shell"
+fi
+
 repo_checkout="$(pwd -P)"
 template="$repo_checkout/scripts/review/launchd/org.mento.review-eval.plist"
 runner="$repo_checkout/scripts/review/run-eval.sh"

--- a/scripts/review/install-review-eval-launchd.test.mjs
+++ b/scripts/review/install-review-eval-launchd.test.mjs
@@ -252,8 +252,18 @@ function /bin/launchctl { "$REVIEW_EVAL_FAKE_LAUNCHCTL" "$@"; }
   }
 
   function environment(options = {}) {
+    // The installer refuses to run inside a quality-gate run, and this suite is
+    // itself a mapped gate command (`pnpm review:eval:test`), so it inherits the
+    // gate's AGENTQG_* markers. Drop them here so the harness invokes the
+    // installer the way an operator does. One test puts a marker back to prove
+    // the refusal.
+    const inherited = { ...process.env };
+    delete inherited.AGENTQG_RUN;
+    delete inherited.AGENTQG_REQUEST;
+    if (options.gateMarker)
+      inherited[options.gateMarkerName ?? "AGENTQG_RUN"] = options.gateMarker;
     return {
-      ...process.env,
+      ...inherited,
       BASH_ENV: options.realPlutil ? realPlutilBashEnv : bashEnv,
       HOME: taskHome,
       PATH: inheritedPath,
@@ -660,3 +670,42 @@ test(
     }
   },
 );
+
+test("the launchd installer refuses to run inside a quality-gate run", () => {
+  const harness = makeHarness();
+  try {
+    for (const gateMarkerName of ["AGENTQG_RUN", "AGENTQG_REQUEST"]) {
+      const blocked = harness.run({
+        gateMarker: "agentqg:install-guard-test",
+        gateMarkerName,
+      });
+      assert.notEqual(blocked.status, 0);
+      assert.match(blocked.stderr, /refuses to run inside a quality-gate run/);
+      // The harness shims /bin/launchctl and logs every call it receives. An
+      // empty log proves the guard refused before the installer reached one.
+      assert.deepEqual(harness.operations(), []);
+      assert.equal(existsSync(harness.runLock), false);
+      assert.equal(existsSync(harness.installLock), false);
+      assert.equal(
+        readFileSync(harness.target, "utf8"),
+        harness.installedSentinel,
+      );
+    }
+
+    // Negative control. The same fixture installs when no marker is set, so the
+    // refusals above come from the marker and not from the harness state.
+    const allowed = harness.run();
+    assert.equal(allowed.status, 0, allowed.stdout + allowed.stderr);
+    assert.deepEqual(harness.operations(), [
+      "print:absent",
+      "print:absent",
+      "bootstrap",
+    ]);
+    assert.notEqual(
+      readFileSync(harness.target, "utf8"),
+      harness.installedSentinel,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- Every local `pnpm agent:quality-gate --run` on macOS failed before it
  dispatched a single mapped command. The Darwin broker preflight rejected
  `scripts/review/install-review-eval-launchd.sh` under the
  `shell-process-broker` rule, and the gate refuses to dispatch when repository
  source can reach a macOS process broker it cannot contain.
- The installer calls `launchctl` by design (PR 2147) and was never allowlisted
  (PR 2131). The control blocked its own repair: no branch could pass the local
  gate, including a branch that fixes this.
- Each failed dispatch left a condemned request-marker record behind, which is
  the state shape issue 2216 describes.

## The Solution

The installer now refuses to start when the gate exports `AGENTQG_RUN` or
`AGENTQG_REQUEST`, and the preflight allowlists it for `shell-process-broker` at
its exact source hash. Local macOS gate runs reach dispatch again, and the
preflight keeps the claim it enforces: an operator-run `launchctl` client that
cannot execute during a gate run cannot create a process that Darwin lineage
tracking would miss.

Material limits:

- The exception buys one file one rule. No preflight rule changed, no other
  allowlist entry was added, and nothing about what the preflight checks for any
  other file changed.
- The entry is bound to the installer's exact bytes. One changed byte fails
  closed again until a new capability review.
- The guard is a runtime refusal keyed on the markers the gate exports, not an
  OS-enforced boundary. It stops the installer from running under a mapped
  command that keeps those markers. A mapped command that strips `AGENTQG_*`
  could still invoke it, and the installer's own test suite does exactly that,
  against a shimmed `launchctl` that never brokers a launch. The preflight's
  threat model is accidental escape, not an adversarial mapped command, and the
  hash binding is what forces a new capability review on any change.

## Details

### The guard

`scripts/review/install-review-eval-launchd.sh` refuses immediately after its
`fail` helper, before any `launchctl` call and before any file it would create.
It reads `AGENTQG_RUN` and `AGENTQG_REQUEST`.

`AGENTQG_RUN` is the load-bearing marker. `scripts/agent-quality-gate.sh` exports
it on every mapped command it dispatches, in every mode: `run_with_timeout` sets
it on the sanitized launcher that runs both the serial and the parallel branch
(`AGENTQG_RUN="$command_tag"`), and the parallel worker exports it again for its
own child (`export AGENTQG_RUN="agentqg:${drain_identity}"`). It is set for
`--no-lock` runs too, which export no lock state at all, so
`AGENT_QUALITY_GATE_LOCK_HELD` would miss them. The gate's own suite already uses
this marker for the same purpose: it refuses a `GATE_TEST_FOCUS` inside a gate
run because `AGENTQG_RUN` "is the one that has to be here"
(`scripts/agent-quality-gate.test.sh`). `AGENTQG_REQUEST` is exported beside it at
those same sites and is the second key on the same door. The guard reads the
values, not the names, so a marker exported empty reads the same as one that was
never exported.

### The allowlist entry

`APPROVED_ALLOWLIST_SHAPE` and `BROKER_CLIENT_ALLOWLIST` each gain one entry:
path `scripts/review/install-review-eval-launchd.sh`, rules
`["shell-process-broker"]`, the sha256 of the final installer bytes, and a reason
that states the containment argument. `validateAllowlist` checks entry count,
exact path, rules, reason, and hash shape, and `scanRepository` accepts a finding
only when the scanned bytes and the policy bytes both hash to the entry. The
`TEST_PATH` hash is updated in the same commit because this PR edits that test
file.

### The test harness

`scripts/review/install-review-eval-launchd.test.mjs` spreads `process.env` into
the installer's child environment, and that suite is itself the mapped command
`pnpm review:eval:test`. Without a change it would inherit the gate's markers and
every installer test would hit the new guard. The harness now deletes
`AGENTQG_RUN` and `AGENTQG_REQUEST`, so it invokes the installer the way an
operator does, and one test puts a marker back to prove the refusal.

### How PR 2147's push passed a macOS gate

Issue 2221 asks this. The answer is in PR 2147's own description, verbatim:

> The user authorized a one-time local quality-gate bypass for exact head
> `32df97bcc8852ee88daed84ca70a0a932195b67e` on 2026-08-31 after the prior gate
> attempt was blocked by a dead Darwin coordinator without journal-aware
> recovery. The push used `--no-verify` once for this head.

Four other explanations were checked and ruled out:

| Hypothesis                | Verdict  | Evidence                                                                                                                                                                                       |
| ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Fresh-stamp reuse         | Ruled out | The `--skip-if-fresh` stamp is content-keyed (`changed_paths_hash`, `command_plan_hash`, `validated_content_hash`), and `collect_current_changed_paths` includes the new file, so it busts the stamp. |
| Preflight dispatch path   | Ruled out | `gate_darwin_broker_preflight` runs on every mapped-command dispatch, called inline right after each command forks.                                                                             |
| Scan scope                | Ruled out | `SOURCE_EXTENSIONS` includes `.sh`; the exclusion lists never contained `scripts/` or `scripts/review/`; `git log --follow` shows one commit on the preflight since it landed, PR 2131 itself.  |
| Routing selects nothing   | Ruled out | `scripts/gate/routing-table/groups-head.mjs` has a `scripts/review/*` arm mapping to `pnpm review:eval*` commands, added 2026-08-27, before both PRs.                                           |

So the preflight, its scan scope, and the routing all worked. The bypass was
authorized for an unrelated blocking defect (a dead Darwin coordinator, fixed
separately), and `--no-verify` disables the whole pre-push hook rather than the
one broken component, so it carried the broker preflight with it. Nothing else
caught the result: the preflight returns 0 without scanning off Darwin, and no
workflow in `.github/workflows/` runs on macOS.

That is a wider control gap than this PR's scope, so it is filed as issue 2222
rather than fixed here. Narrowing it means adding a second enforcement point and
deciding whether it becomes a required status, which changes the `main` ruleset.

## Validation

- `node scripts/gate/darwin-broker-launch-preflight.test.mjs` — 45 tests pass, 0
  fail. Three are new: the allowlist entry validates and its guard precedes the
  installer's `launchctl` path; the installer at its committed bytes produces
  zero rejected findings through `scanRepository`; one added byte is rejected
  again and, as a policy source, reports `source hash is stale`.
- `node --test scripts/review/install-review-eval-launchd.test.mjs` — 3 tests
  pass, 0 fail. The new one runs the real installer with `AGENTQG_RUN` set, then
  with `AGENTQG_REQUEST` set: both exit non-zero with the refusal message and
  leave the harness's `launchctl` log empty, so the guard fires before the first
  `launchctl` call. Its negative control runs the same fixture with no marker and
  the install succeeds (`print:absent`, `print:absent`, `bootstrap`), so the
  refusals come from the marker and not from the fixture state.
- Direct `scanRepository` proof, before and after. Both runs use the same script
  and the same repository root.

  Before, at `main` (2222f4a3):

  ```text
  --- scanRepository rejected ---
  [
    {
      "path": "scripts/review/install-review-eval-launchd.sh",
      "rule": "shell-process-broker",
      "line": 44,
      "evidence": "launchctl_path=/bin/launchctl"
    }
  ]
  ```

  After, on this branch:

  ```text
  --- scanRepository policyErrors ---
  []
  --- scanRepository rejected ---
  []
  --- accepted findings for the installer ---
  [
    {
      "path": "scripts/review/install-review-eval-launchd.sh",
      "rule": "shell-process-broker",
      "line": 64,
      "evidence": "launchctl_path=/bin/launchctl"
    }
  ]
  ```

  The finding still fires. It is now accepted against the reviewed hash instead
  of rejected.

- `pnpm agent:quality-gate --run --lock-wait 3600` — **did not complete on this
  machine.** Four attempts. The first mapped all 12 commands correctly and
  dispatched; its first command, `pnpm agent:quality-gate:test`, failed inside
  the coordinator-admission fixture (`the contender did not start after
  descendant cleanup`, after a 30s `WAIT_TIMEOUT` while a holder fixture still
  ran). That failure left a condemned obligation record, and every later attempt
  stopped in recovery:

  ```text
  error: Darwin lineage recovery stayed fail-closed because exact process identities remain: 47275/42775149:ambiguous, 47295/42775169:ambiguous, 51741/43174127:ambiguous, 57710/43180029:ambiguous, 57714/43180033:ambiguous, 60929/43183233:ambiguous
  error: Darwin process-lineage cohort recovery did not reach empty exact identity sets.
  Nothing has been executed. A Darwin process identity remained live or could not be classified safely.
  Quality-gate coordinator stale-obligation recovery failed. No mapped command ran in this request; this gate exits 2.
  ```

  Every named identity is a Trunk daemon or its `crashpad_handler` belonging to a
  different checkout on this machine, not to this branch's clone: repo hashes
  `7736474…` (`monitoring-monorepo/.claude/worktrees/coderabbit-migration-closeout`),
  `740750…` (`monitoring-monorepo.gate-redesign`), and `afb8839…`
  (`frontend-monorepo/.claude/worktrees/vercel-deploy-perf`). The set rotates and
  grows as those sessions restart their daemons. This is the state shape issue
  2216 describes. No gate state was touched to work around it.
- `pnpm agent:autoreview` (codex engine) — clean. `autoreview clean: no
  accepted/actionable findings reported`, `overall: patch is correct (0.9)`. The
  wrapper then exited 125 in teardown for the same Darwin lineage reason
  (`cannot settle the Darwin contained helper lineage`); the review itself
  completed and reported.
- The operator authorized a one-time local quality-gate bypass for exact head
  `88fae6446a4b2ddda11014236f5d8c7325a2f672` on 2026-09-02, because Darwin
  lineage recovery could not converge on this host (issue 2224). The push used
  `--no-verify` once for this head. The diff was reviewed before the
  authorization: `pnpm agent:autoreview` on the codex engine reported clean, and
  the orchestrating session did a parent-level pass. No gate control changed by
  the bypass. Exact-head GitHub CI is the authoritative replacement and remains
  required.

What this evidence does not support: it does not prove the installer is safe to
run, only that it cannot run inside a gate run and that its bytes are the
reviewed ones. It does not prove the preflight catches every process-broker form;
static inspection cannot identify runtime-built calls or a broker hidden in a
dependency, which the preflight's own contract already states. It does not prove
the marker set is complete for all future gate modes; it proves `AGENTQG_RUN` is
set on every mapped command in every mode that exists today, at the three export
sites cited above.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2222 — a second
  enforcement point for the broker preflight, so a `--no-verify` push cannot land
  an unallowlisted broker client.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2224 — the local
  gate run this PR could not complete. Darwin lineage recovery never settles
  while other checkouts' Trunk daemons stay ambiguous, so no run on this machine
  converges. CI on the exact head is the authoritative check for this PR.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This is a bug fix that uses the
      existing allowlist mechanism recorded in ADR 0076, and the reason for the
      exception is written at the site in both files.

Closes #2221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN
