### PR TITLE
docs(verification): upload UI visual evidence with gh --attach

### DIFF
--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -299,11 +299,13 @@ a relative path and put the full label in the Markdown alt text, for example
 `![Before, <route>, base <OID>, <viewport>](./before.png)`. Then pass every
 file with the repeatable `--attach` flag, using the same relative path. `gh`
 resolves the `--attach` paths from its working directory, so run it from the
-directory that holds the images and the body file:
+directory that holds the images and the body file. Outside the repository
+`gh` cannot infer the target from a bare PR number, so name the PR by its
+URL:
 
 ```bash
 cd "$EVIDENCE_DIR" # outside the repository; holds body.md, before.png, after.png
-gh pr edit "$PR" --body-file body.md --attach ./before.png --attach ./after.png
+gh pr edit "$PR_URL" --body-file body.md --attach ./before.png --attach ./after.png
 ```
 
 `gh` uploads each file and rewrites the body reference in place to the

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -294,14 +294,32 @@ the final local `HEAD` OID first.
 
 Store review images outside the repository; never add them to the product
 commit unless the repository already owns screenshot fixtures for that purpose.
-Upload through the authenticated GitHub web description editor (`gh` and the
-public Issues API cannot attach local images), then reopen the description and
-verify both attachment URLs render and the labels map to the correct revisions.
-A local path, broken Markdown, or an unverified upload is not visual evidence.
+Upload with `gh` v2.99.0 or later. In the body file, reference each image by
+a relative path and put the full label in the Markdown alt text, for example
+`![Before, <route>, base <OID>, <viewport>](./before.png)`. Then pass every
+file with the repeatable `--attach` flag, using the same relative path. `gh`
+resolves the `--attach` paths from its working directory, so run it from the
+directory that holds the images and the body file:
 
-If either revision cannot be rendered, or the authenticated attachment surface
-is unavailable, stop before publication and report the blocker; do not call the
-UI PR shipped or ready. The user may waive visual evidence for a specific PR.
+```bash
+cd "$EVIDENCE_DIR" # outside the repository; holds body.md, before.png, after.png
+gh pr edit "$PR" --body-file body.md --attach ./before.png --attach ./after.png
+```
+
+`gh` uploads each file and rewrites the body reference in place to the
+uploaded asset URL, keeping the alt text written in the body. A file attached
+but never referenced in the body is appended at the end; only for such a file
+does `#text` after the path (`--attach './after.png#After, …'`) set the alt
+text. Images are capped at 10 MB, and the upload needs write access to the
+repository. When one upload fails, `gh` still writes the body with the files
+that succeeded and exits non-zero; treat that exit as failed evidence. Then
+reopen the description and verify both attachment URLs render and the labels
+map to the correct revisions. A local path, broken Markdown, or an unverified
+upload is not visual evidence.
+
+If either revision cannot be rendered, or the uploaded images do not render,
+stop before publication and report the blocker; do not call the UI PR shipped
+or ready. The user may waive visual evidence for a specific PR.
 
 ## Dynamic social-preview verification
 

--- a/docs/notes/dashboard-verification.md
+++ b/docs/notes/dashboard-verification.md
@@ -315,11 +315,11 @@ does `#text` after the path (`--attach './after.png#After, …'`) set the alt
 text. Images are capped at 10 MB, and the upload needs write access to the
 repository. When one upload fails, `gh` still writes the body with the files
 that succeeded and exits non-zero; treat that exit as failed evidence. Then
-reopen the description and verify both attachment URLs render and the labels
-map to the correct revisions. A local path, broken Markdown, or an unverified
+reopen the description and verify every attachment URL renders and each label
+maps to its recorded revision. A local path, broken Markdown, or an unverified
 upload is not visual evidence.
 
-If either revision cannot be rendered, or the uploaded images do not render,
+If any revision cannot be rendered, or any uploaded image does not render,
 stop before publication and report the blocker; do not call the UI PR shipped
 or ready. The user may waive visual evidence for a specific PR.
 


### PR DESCRIPTION
## The Problem

- `docs/notes/dashboard-verification.md` said `gh` and the public Issues API cannot attach local images, and sent the agent to the GitHub web description editor for Before/After screenshots.
- Every UI PR therefore stopped at the visual-evidence step and waited for a human to upload two files by hand.

## The Solution

`gh` v2.99.0 (released 2026-09-01) added a repeatable `--attach` flag on `gh pr create`, `gh pr edit`, and `gh pr comment`. The verification contract now tells the agent to reference each screenshot by relative path in the body file, with the full label as the Markdown alt text, and to pass the files with `--attach` from the directory that holds them. `gh` uploads the files and rewrites the references to the asset URLs, so the agent completes the upload and the existing render check without a human.

Limits: hosted bootstrap scripts do not yet enforce `gh` >= 2.99.0, so a hosted session on an older `gh` still stops at this step (issue #2230). GitHub Enterprise Server is not supported by the flag. The command semantics come from `gh pr edit --help` and the GitHub changelog; this PR did not post a live attachment.

## Details

- Body references keep the alt text written in the body. The `#text` suffix on `--attach` sets alt text only for a file the body never references, which `gh` appends at the end.
- `--attach` paths resolve from the working directory, so the example runs from `$EVIDENCE_DIR` outside the repository and uses the same relative path in the body and the flag.
- Recorded limits: 10 MB per image, write access required, and a partial upload failure still writes the body but exits non-zero. The doc treats that exit as failed evidence.
- The global `ship` skill's `references/publish.md` carries the same change outside this repo.

## Validation

- `gh pr edit --help`, `gh pr create --help`, `gh pr comment --help` on gh 2.99.0 confirm the flag, the in-place rewrite of body references, the body-alt-text precedence, the append behaviour for unreferenced files, and the partial-failure exit. This does not prove the rewrite against a live PR; no attachment was posted.
- Changelog: https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/ for the 10 MB cap, write-access requirement, and GHES exclusion.
- `./tools/trunk fmt` and `./tools/trunk check` on the changed file: no issues.
- Codex review (`codex-review.sh origin/main --quick`) raised three findings: cwd-relative paths and the alt-text precedence are fixed in this diff; the hosted-setup version check is deferred to #2230.
- Docs-only lane: the `review` skill and the security-scrutiny gate were skipped because the diff is one prose `.md` file.
- The local quality gate did not run: `--run` exits 2 before executing any mapped command on this host (issue #2231). The operator directed the push with the pre-push hook bypassed for this docs-only change. CI runs the required checks on the PR.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2230

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWhvvmsBctEjqBjRoL2SVj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated visual-comparison verification guidance to use command-line image uploads with pull request descriptions.
  * Added instructions covering upload limits, permissions, partial failures, and post-upload validation.
  * Replaced web-editor requirements with checks for upload and image-rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->