### PR TITLE
fix(tooling): require risk and pkg labels before agent-ready

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -78,3 +78,15 @@ body:
       placeholder: "A PR may use `Closes #123` only when ..."
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Labels are not part of this form.** GitHub cannot set them from your answers, so submitting applies only `needs-grooming`.
+
+        Before anyone promotes this issue to `agent-ready`, add:
+
+        - a `kind:*` label
+        - at least one `pkg:*` label
+        - exactly one `risk:*` label, decided by the [Low-risk rule](https://github.com/mento-protocol/monitoring-monorepo/blob/main/docs/notes/agent-issue-workflow.md#low-risk-rule)
+
+        `pnpm issue:board sync` reports an `agent-ready` issue that lacks exactly one `risk:*` or lacks any `pkg:*` as incompletely groomed, and the backlog sweep skips it. The `kind:*` label is a filing rule the sync does not check.

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -81,7 +81,8 @@ report covers the `agent-ready` rule above; it does not check `kind:*`.
    `terraform/**` or any `*.tf`; `.github/workflows/**`; `scripts/deploy*`,
    `**/deploy.sh`, `cloudbuild*`; `scripts/agent-quality-gate.sh` and
    `scripts/gate/**`; `scripts/agent-autoreview*` and any autoreview runtime;
-   `scripts/pr/issue-board-*` and `scripts/pr/pr-ready-state*`; `.trunk/**`;
+   `scripts/pr/agent-issue-board*`, `scripts/pr/issue-board-*`, and
+   `scripts/pr/pr-ready-state*`; `.trunk/**`;
    `.claude/hooks` or settings; `package.json`, `pnpm-lock.yaml`,
    `pnpm-workspace.yaml`, `patches/**`; `indexer-envio/schema.graphql`;
    `alerts/rules/**`; anything named `*secret*` or touching IAM, WIF, or

--- a/docs/notes/agent-issue-workflow.md
+++ b/docs/notes/agent-issue-workflow.md
@@ -3,7 +3,7 @@ title: Agent Issue Workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-30
+last_verified: 2026-09-02
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -57,10 +57,51 @@ Routing labels:
 - `kind:*` — work type.
 - `risk:*` — implementation risk: low, medium, or high.
 
+An issue may carry `agent-ready` only with exactly one `risk:*` and at least one
+`pkg:*`. An `agent-ready` issue missing either is **incompletely groomed**:
+consumers treat it as `needs-grooming` until it is repaired, and
+`pnpm issue:board sync` reports it as a per-issue failure. `pnpm issue:claim`
+still claims it, so manual work stays possible. The backlog sweep narrows
+further to exactly one `pkg:*`, so a correctly labeled multi-package issue is
+never sweep-eligible and stays manual.
+
+Every issue an agent files, a PR deferral included, carries a state label,
+exactly one `risk:*`, at least one `pkg:*`, and a `kind:*` at creation. The sync
+report covers the `agent-ready` rule above; it does not check `kind:*`.
+
+### Low-risk rule
+
+`risk:low` requires all four:
+
+1. Every path the issue names or clearly implies lies inside one package area —
+   the `pkg:*` vocabulary: aegis, alerts, dashboard, governance-watchdog,
+   indexer, integration-probes, metrics-bridge, shared-config, terraform,
+   tooling.
+2. None of those paths is a control, deploy, or money-path surface:
+   `terraform/**` or any `*.tf`; `.github/workflows/**`; `scripts/deploy*`,
+   `**/deploy.sh`, `cloudbuild*`; `scripts/agent-quality-gate.sh` and
+   `scripts/gate/**`; `scripts/agent-autoreview*` and any autoreview runtime;
+   `scripts/pr/issue-board-*` and `scripts/pr/pr-ready-state*`; `.trunk/**`;
+   `.claude/hooks` or settings; `package.json`, `pnpm-lock.yaml`,
+   `pnpm-workspace.yaml`, `patches/**`; `indexer-envio/schema.graphql`;
+   `alerts/rules/**`; anything named `*secret*` or touching IAM, WIF, or
+   credentials; anything that writes production data through Upstash, Sentry
+   archive and unarchive, or Hasura.
+3. The body names a verification path: a command, a test file, or a browser
+   check.
+4. It needs no product, policy, or provider-console decision.
+
+Otherwise use `risk:medium`. Use `risk:high` for secrets, IAM, a production
+apply, or deploy identity. Docs-only, test-only, and skill or prose-only changes
+that satisfy all four are `risk:low`. `docs/notes/**`, `docs/adr/**`,
+`.agents/skills/**`, and `.claude/skills/**` are not control surfaces for this
+rule, even when they describe one.
+
 ## Lifecycle
 
 1. Create or migrate the issue with the Agent Task issue form.
-2. Add routing/risk labels and exactly one state label.
+2. Add exactly one state label plus the routing labels the Labels section
+   requires. `agent-ready` needs exactly one `risk:*` and at least one `pkg:*`.
 3. Put ready issues in `agent-ready`; put unclear issues in `needs-grooming`.
 4. When an agent starts work, run `pnpm issue:claim --count <n> --agent <name>`
    before substantive edits. It moves the issue to `agent-active`, records
@@ -95,9 +136,13 @@ Routing labels:
    claim, review, or release authority. A concurrent conflict with a fallback
    `needs-grooming` label stays visible and fails closed for manual resolution.
    It fails if a closed issue retains a queue label or if state does not settle
-   within the bounded attempts. A per-issue failure does not stop later issues.
-   The command exits nonzero after it lists the successful and failed issue
-   numbers. When Done means still requires post-merge production proof, use
+   within the bounded attempts. It also reports each incompletely groomed
+   `agent-ready` issue as a per-issue failure, after that issue's own
+   projection and confirmed by a fresh read, so the report never withholds a
+   Project item and never fires on a stale enumeration snapshot. A per-issue failure
+   does not stop later issues. The command exits nonzero after it lists the
+   successful and failed issue numbers.
+   When Done means still requires post-merge production proof, use
    `Refs`, keep the issue open and `in-pr`, and retain its current owner through
    the live checks. Close and sync only after acceptance passes.
    When the closed issue is listed in an editable canonical parent or tracker,

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -305,9 +305,9 @@ even when you never open an authority.
    inner edit loop. Never force-push or amend while babysitting,
    and `git fetch` before every push because reviewers push mid-session. Check
    new additions against the scope baseline frozen at step 4; classify each as
-   in-scope, follow-up, or stop; **file a GitHub issue before deferring any valid
-   follow-up** and link it from the PR's `## Deferrals` section. Warn as the
-   diff approaches twice the baseline. Do not pause solely for cycle count
+   in-scope, follow-up, or stop; **file a labeled GitHub issue before deferring
+   any valid follow-up** and link it from the PR's `## Deferrals` section. Warn
+   as the diff approaches twice the baseline. Do not pause solely for cycle count
    before five review-triggered patch cycles are complete; pause for
    reclassification before starting a sixth. Authority:
    [`agent-issue-workflow.md`](agent-issue-workflow.md) for the deferral and
@@ -483,7 +483,10 @@ These bind regardless of which step you are on:
   clear reply stops re-raising bots from looping.
 - **`Closes #N` only when Done means is fully met**, else `Refs #N`.
 - **Knowingly deferred work needs a GitHub issue first**, linked from
-  `## Deferrals`. An evidence-backed won't-fix is not a deferral.
+  `## Deferrals`. Every issue an agent files carries a state label, a `kind:*`,
+  at least one `pkg:*`, and exactly one `risk:*` set by the
+  [Low-risk rule](agent-issue-workflow.md#low-risk-rule). An evidence-backed
+  won't-fix is not a deferral.
 - **Never weaken a control that is blocking your own work.** Do not widen,
   disable, or soften the quality gate, the sandbox or permission config, branch
   protection, or a safety-boundary rule to unblock the change you are making

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -441,8 +441,10 @@ Field expectations:
 2. Freeze the original request, target/owner, changed files, and non-test
    changed-line count as the scope baseline. Batch review fixes locally,
    auditing sibling surfaces before pushing. Classify additions as in-scope,
-   follow-up, or stop; open an issue before deferring valid follow-up work, warn
-   near twice the baseline, and do not pause solely for cycle count before five
+   follow-up, or stop; open an issue labeled per
+   [`agent-issue-workflow.md`](agent-issue-workflow.md) before deferring valid
+   follow-up work, warn near twice the baseline, and do not pause solely for
+   cycle count before five
    review-triggered patch cycles are complete. Pause for reclassification before
    starting a sixth.
 3. Before invoking the gate, ensure that no direct validation, dashboard server,

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -130,7 +130,7 @@ pnpm issue:review --pr 123 --issue 901 --claim-id <id> --rebind-branch # Prove a
 pnpm issue:release --issue 901 --claim-id <id> # Release the matching claim back to agent-ready
 pnpm issue:release --issue 901 --claim-id <id> --closed-unmerged-pr # Release after the stored PR closes unmerged
 pnpm issue:release --issue 901 --claim-id <id> --merged-pr --needs-grooming # Continue a still-open issue after its stored PR merges
-pnpm issue:board sync --dry-run                # Preview the repository-wide queue-label and Project projection
+pnpm issue:board sync --dry-run                # Preview the repository-wide projection; reports incompletely groomed agent-ready issues
 pnpm issue:board sync                          # Apply the authorized projection; preserve Project Status
 pnpm issue:board backfill --issue 901 --dry-run # Preview fill-only ownership-field recovery from a trusted claim comment
 pnpm issue:board:test                          # Offline tests for the issue-board helper

--- a/scripts/pr/agent-issue-board.mjs
+++ b/scripts/pr/agent-issue-board.mjs
@@ -59,11 +59,13 @@ export {
   withIssueMutationLock,
 } from "./issue-board-lock.mjs";
 export {
+  agentReadyRoutingGaps,
   chooseUntriedCandidate,
   DEFAULT_PROJECT_NUMBER,
   DEFAULT_PROJECT_OWNER,
   DEFAULT_REPO,
   hasSweepClaimAttributes,
+  incompleteGroomingFinding,
   issueBodySha256,
   IssueClaimCandidateLossError,
   IssueOwnershipConflictError,

--- a/scripts/pr/agent-issue-board.test.mjs
+++ b/scripts/pr/agent-issue-board.test.mjs
@@ -22,12 +22,14 @@ import ts from "typescript";
 
 import {
   acquireIssueMutationLock,
+  agentReadyRoutingGaps,
   buildClaimComment,
   buildBackfillPlan,
   backfill,
   claim,
   chooseUntriedCandidate,
   githubProjectScopeHint,
+  incompleteGroomingFinding,
   issueBodySha256,
   isClaimable,
   isSweepClaimable,
@@ -3491,7 +3493,11 @@ test("sync leaves human-owned Status untouched for a stable open issue", async (
     number: 900,
     title: "human-owned status",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [
       {
         id: "item-900",
@@ -3545,7 +3551,11 @@ test("sync adds a missing open item without writing Project Status", async () =>
     number: 1900,
     title: "missing Project membership",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [],
   };
   let membershipReads = 0;
@@ -3618,7 +3628,11 @@ test("sync reclassifies concurrent open label drift after a membership add", asy
     number: 3900,
     title: "open drift after Project add",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [],
   };
   let ensureCalls = 0;
@@ -3813,7 +3827,11 @@ test("sync reports successful issues before a later label conflict", async () =>
     number: 905,
     title: "stable ready",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
   };
   const conflict = {
     number: 906,
@@ -3840,6 +3858,92 @@ test("sync reports successful issues before a later label conflict", async () =>
   assertDeepEqual(error.results, [
     { number: 905, title: "stable ready", state: "ready" },
   ]);
+});
+
+test("sync reports incompletely groomed ready issues without blocking them", async () => {
+  const groomed = {
+    number: 908,
+    title: "groomed ready",
+    state: "OPEN",
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
+  };
+  const thin = {
+    number: 909,
+    title: "thin ready",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const memberships = [];
+
+  const error = await assertRejects(
+    () =>
+      syncWithTestLock(
+        { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+        {
+          getProject: async () => ownershipProject(),
+          listIssuesByLabels: async () => [groomed, thin],
+          getIssue: async (_options, number) =>
+            number === groomed.number ? groomed : thin,
+          findIssueProjectItem: async () => null,
+          ensureProjectItem: async (_options, _project, issue) => {
+            memberships.push(issue.number);
+            return `item-${issue.number}`;
+          },
+          sleep: async () => {},
+        },
+      ),
+    /Issue #909 is agent-ready but incompletely groomed: no risk:\* label; no pkg:\* label/,
+  );
+  assert(error instanceof IssueBoardSyncError, "aggregate sync error type");
+  assertDeepEqual(error.results, [
+    { number: 908, title: "groomed ready", state: "ready" },
+    { number: 909, title: "thin ready", state: "ready" },
+  ]);
+  assertDeepEqual(
+    memberships,
+    [908, 909],
+    "the finding reports after the projection, so both issues reach the Project",
+  );
+});
+
+test("sync drops a grooming finding the confirming read disproves", async () => {
+  const listed = {
+    number: 913,
+    title: "claimed mid-sync",
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  const claimed = {
+    ...listed,
+    labels: [
+      { name: "agent-active" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
+  };
+  let reads = 0;
+
+  const results = await syncWithTestLock(
+    { repo: "mento-protocol/monitoring-monorepo", dryRun: false },
+    {
+      getProject: async () => ownershipProject(),
+      listIssuesByLabels: async () => [listed],
+      getIssue: async () => {
+        reads += 1;
+        return claimed;
+      },
+      sleep: async () => {},
+    },
+  );
+
+  assertDeepEqual(results, [
+    { number: 913, title: "claimed mid-sync", state: "active" },
+  ]);
+  assert(reads > 0, "the confirming read must run");
 });
 
 test("sync dry-run plans closed-label cleanup without a postcondition read", async () => {
@@ -3969,6 +4073,104 @@ test("sweep claim guard requires low risk, one package, and no blocker", () => {
     isSweepClaimable({ ...eligible, blockedBy: undefined }, project),
     false,
   );
+});
+
+test("incomplete grooming finding names every missing routing label", () => {
+  const groomed = {
+    number: 910,
+    state: "OPEN",
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:medium" },
+      { name: "pkg:dashboard" },
+      { name: "pkg:indexer" },
+    ],
+  };
+  assertDeepEqual(agentReadyRoutingGaps(groomed), []);
+  assertEqual(incompleteGroomingFinding(groomed), null);
+
+  const missingRisk = {
+    ...groomed,
+    labels: [{ name: "agent-ready" }, { name: "pkg:tooling" }],
+  };
+  assertDeepEqual(agentReadyRoutingGaps(missingRisk), ["no risk:* label"]);
+  assertEqual(
+    incompleteGroomingFinding(missingRisk),
+    "Issue #910 is agent-ready but incompletely groomed: no risk:* label",
+  );
+
+  assertDeepEqual(
+    agentReadyRoutingGaps({
+      ...groomed,
+      labels: [
+        { name: "agent-ready" },
+        { name: "risk:medium" },
+        { name: "risk:low" },
+        { name: "pkg:tooling" },
+      ],
+    }),
+    ["conflicting risk labels (risk:low, risk:medium)"],
+  );
+
+  assertDeepEqual(
+    agentReadyRoutingGaps({
+      ...groomed,
+      labels: [{ name: "agent-ready" }, { name: "risk:low" }],
+    }),
+    ["no pkg:* label"],
+  );
+
+  assertEqual(
+    incompleteGroomingFinding({
+      ...groomed,
+      labels: [{ name: "agent-ready" }],
+    }),
+    "Issue #910 is agent-ready but incompletely groomed: no risk:* label; no pkg:* label",
+  );
+});
+
+test("incomplete grooming finding scopes to open agent-ready issues", () => {
+  const bare = { number: 911, state: "OPEN", labels: [] };
+  assertEqual(
+    incompleteGroomingFinding({
+      ...bare,
+      labels: [{ name: "needs-grooming" }],
+    }),
+    null,
+    "needs-grooming makes no routing promise",
+  );
+  assertEqual(
+    incompleteGroomingFinding({ ...bare, labels: [{ name: "agent-active" }] }),
+    null,
+  );
+  assertEqual(
+    incompleteGroomingFinding({ ...bare, labels: [{ name: "in-pr" }] }),
+    null,
+  );
+  assertEqual(incompleteGroomingFinding(bare), null);
+  assertEqual(
+    incompleteGroomingFinding({
+      ...bare,
+      state: "CLOSED",
+      labels: [{ name: "agent-ready" }],
+    }),
+    null,
+    "a closed issue is nobody's ready queue",
+  );
+});
+
+test("an incompletely groomed issue stays claimable by hand", () => {
+  const thin = {
+    number: 912,
+    state: "OPEN",
+    labels: [{ name: "agent-ready" }],
+  };
+  assert(
+    incompleteGroomingFinding(thin) !== null,
+    "fixture must trip the finding",
+  );
+  assertEqual(isClaimable(thin), true);
+  assertEqual(isSweepClaimable(thin, ownershipProject()), false);
 });
 
 test("sweep claim guard scopes Blocked status to the selected Project", () => {
@@ -13614,7 +13816,11 @@ test("sync skips the mutex for exact open queue labels with exact Project member
     number: 2403,
     title: "stable sync item",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [
       {
         title: "Agent Tasks",
@@ -13900,7 +14106,11 @@ test("sync binds stable membership by selected Project ID and ignores Status", a
     number: 2406,
     title: "same-title Project collision",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [
       {
         title: "Agent Tasks",
@@ -13946,7 +14156,11 @@ test("sync preserves a human Status that differs from the queue label", async ()
     number: 2404,
     title: "drifted sync item",
     state: "OPEN",
-    labels: [{ name: "agent-ready" }],
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:low" },
+      { name: "pkg:tooling" },
+    ],
     projectItems: [
       {
         title: "Agent Tasks",

--- a/scripts/pr/issue-board-state.mjs
+++ b/scripts/pr/issue-board-state.mjs
@@ -257,15 +257,53 @@ function hasNativeBlocker(issue) {
   return blockedBy.totalCount > 0 || blockedBy.nodes.filter(Boolean).length > 0;
 }
 
+function labelsWithPrefix(issue, prefix) {
+  return [...labelNames(issue)].filter((label) => label.startsWith(prefix));
+}
+
 function hasSweepRouting(issue) {
-  const labels = [...labelNames(issue)];
-  const riskLabels = labels.filter((label) => label.startsWith("risk:"));
-  const packageLabels = labels.filter((label) => label.startsWith("pkg:"));
+  const riskLabels = labelsWithPrefix(issue, "risk:");
   return (
     riskLabels.length === 1 &&
     riskLabels[0] === "risk:low" &&
-    packageLabels.length === 1
+    labelsWithPrefix(issue, "pkg:").length === 1
   );
+}
+
+/**
+ * Routing-label gaps that make an `agent-ready` issue incompletely groomed.
+ *
+ * `agent-ready` promises an agent can implement the issue without further
+ * grooming. Consumers route on exactly one `risk:*` and at least one `pkg:*`,
+ * so an issue missing either is not yet ready however complete its body reads.
+ * Multiple `pkg:*` labels are correct for cross-package work; the backlog sweep
+ * narrows further to exactly one, and that narrowing is the sweep's own rule.
+ */
+export function agentReadyRoutingGaps(issue) {
+  const riskLabels = labelsWithPrefix(issue, "risk:").sort();
+  const gaps = [];
+  if (riskLabels.length === 0) gaps.push("no risk:* label");
+  if (riskLabels.length > 1) {
+    gaps.push(`conflicting risk labels (${riskLabels.join(", ")})`);
+  }
+  if (labelsWithPrefix(issue, "pkg:").length === 0) {
+    gaps.push("no pkg:* label");
+  }
+  return gaps;
+}
+
+/**
+ * The incomplete-grooming finding, or null when the issue is well formed.
+ *
+ * Reporting only. Nothing here refuses a claim: manual work on a thinly
+ * labeled issue stays possible, and the finding names the repair instead.
+ */
+export function incompleteGroomingFinding(issue) {
+  if (String(issue.state ?? "").toUpperCase() !== "OPEN") return null;
+  if (!labelNames(issue).has("agent-ready")) return null;
+  const gaps = agentReadyRoutingGaps(issue);
+  if (gaps.length === 0) return null;
+  return `Issue #${issue.number} is agent-ready but incompletely groomed: ${gaps.join("; ")}`;
 }
 
 export function hasSweepClaimAttributes(issue, project) {

--- a/scripts/pr/issue-board-sync.mjs
+++ b/scripts/pr/issue-board-sync.mjs
@@ -8,6 +8,7 @@
  */
 
 import {
+  incompleteGroomingFinding,
   ISSUE_STATE_LABELS,
   labelNames,
   labelsForState,
@@ -481,6 +482,23 @@ async function syncIssue(options, project, listedIssue, operations) {
   );
 }
 
+async function syncListedIssue(options, project, listedIssue, operations) {
+  const stable = await operations.preflightStableSyncIssue(
+    options,
+    project,
+    listedIssue,
+    operations,
+  );
+  if (stable) return stable;
+  return runLockedSyncIssue(
+    options,
+    project,
+    listedIssue,
+    operations,
+    syncIssue,
+  );
+}
+
 export async function sync(options, dependencies = {}) {
   const operations = {
     addIssueLabels,
@@ -510,30 +528,52 @@ export async function sync(options, dependencies = {}) {
   const results = [];
   const failures = [];
   for (const listedIssue of byNumber.values()) {
+    let synced = true;
     try {
-      const stable = await operations.preflightStableSyncIssue(
+      const result = await syncListedIssue(
         options,
         project,
         listedIssue,
         operations,
-      );
-      if (stable) {
-        results.push(stable);
-        continue;
-      }
-      const result = await runLockedSyncIssue(
-        options,
-        project,
-        listedIssue,
-        operations,
-        syncIssue,
       );
       if (result) results.push(result);
     } catch (error) {
+      synced = false;
       failures.push({
         number: listedIssue.number,
         title: listedIssue.title,
         error,
+      });
+    }
+    // Label hygiene rides the same repo-wide enumeration. It runs after the
+    // projection, so a thinly labeled issue still reaches the Project, and a
+    // per-issue sync failure leaves its grooming gap to the next run.
+    if (!synced) continue;
+    // The enumeration snapshot is stale by now: this issue may have been
+    // claimed or relabelled while its own sync ran. Use the snapshot only to
+    // decide whether a read is worth spending, then report solely on what that
+    // read proves. An issue promoted into a bare `agent-ready` mid-run is
+    // reported by the next run rather than guessed at here.
+    if (!incompleteGroomingFinding(listedIssue)) continue;
+    try {
+      const finding = incompleteGroomingFinding(
+        await operations.getIssue(options, listedIssue.number),
+      );
+      if (finding) {
+        failures.push({
+          number: listedIssue.number,
+          title: listedIssue.title,
+          error: new Error(finding),
+        });
+      }
+    } catch (error) {
+      failures.push({
+        number: listedIssue.number,
+        title: listedIssue.title,
+        error: new Error(
+          `Issue #${listedIssue.number} looked incompletely groomed, but its confirming read failed: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        ),
       });
     }
   }


### PR DESCRIPTION
## The Problem

- An issue could carry `agent-ready` with no `risk:*` and no `pkg:*` label, and
  nothing said that was wrong. The backlog sweep needs `risk:low` plus exactly
  one `pkg:*`, so its first run on 2026-09-01 selected 0 of 18 `agent-ready`
  issues and shipped nothing.
- The Agent Task issue form applies only `needs-grooming`, and agents filing
  deferral issues mid-PR applied bare `agent-ready` or no label at all. Measured
  2026-09-02, before the operator backfill: 13 of 20 open `agent-ready` issues
  carried no usable routing.
- `docs/notes/agent-issue-workflow.md` said "Add routing/risk labels", but no
  document defined `risk:low` and no control checked the result, so the gap was
  invisible until a consumer selected nothing.

## The Solution

`docs/notes/agent-issue-workflow.md` now states the rule: an issue may carry
`agent-ready` only with exactly one `risk:*` and at least one `pkg:*`, and one
missing either is incompletely groomed until repaired. A new `Low-risk rule`
subsection defines `risk:low` so other documents can link the heading. The
operating card, the ready-state runbook, and the Agent Task form point at it,
and `pnpm issue:board sync` reports every `agent-ready` issue that breaks the
rule. The queue's own tooling now names the repair instead of a consumer
silently selecting nothing.

Limits. Nothing writes a label, and nothing refuses work: `pnpm issue:claim`
still claims an incompletely groomed issue, so manual work stays possible.
GitHub issue forms cannot apply labels from answers, so the form carries a note
rather than a control. `issue:board sync` is an ad hoc command with no scheduled
runner, so the report reaches whoever runs it.

**Merge sequencing.** No CI job runs `issue:board sync`, so no required check
changes. The operator-owned label backfill already landed on 2026-09-02: all 27
open `agent-ready` issues carry exactly one `risk:*` and at least one `pkg:*`, so
the new finding fires on 0 of them today.

Two scheduled producers will still create non-compliant issues when they next
fire, so merge issue 2215 before or soon after this PR. `issue:board sync` then
exits nonzero and names that issue until someone relabels it. It is a report,
not a stop: the check runs after each issue's own projection, per-issue failures
do not stop later issues, and every issue still reaches the Project. The finding
was not weakened to fit that window.

## Details

- `agentReadyRoutingGaps(issue)` in `scripts/pr/issue-board-state.mjs` returns
  the missing routing labels; `incompleteGroomingFinding(issue)` turns them into
  one message and returns `null` for anything that is not an open `agent-ready`
  issue. Both are pure and exported through `scripts/pr/agent-issue-board.mjs`.
- The finding rides `sync`'s existing repo-wide enumeration and lands in the
  same `IssueBoardSyncError` aggregate as the conflicting-queue-label finding:
  one per-issue entry, later issues unaffected, one nonzero exit at the end.
- Placement differs from the conflicting-label check on purpose. That check runs
  before projection because a conflicted issue has no state to project. Grooming
  gaps leave the state unambiguous, so the check runs *after* the issue's own
  projection and a thinly labeled issue still reaches the Project.
- The enumeration snapshot is stale by the time an issue's sync finishes, and
  the surrounding code already reconciles that drift. The snapshot therefore
  only decides whether a read is worth spending: the reported finding comes from
  a fresh `getIssue`, so a mid-run claim cannot produce a false failure. A
  `needs-grooming` issue promoted to a bare `agent-ready` mid-run is reported by
  the next run rather than guessed at. A failed confirming read is itself
  reported, so the check never silently drops an issue it flagged.
- A per-issue sync failure suppresses that issue's grooming finding for the run,
  so no issue number appears twice in one aggregate. The next run reports it.
- `hasSweepRouting` and the new classifier now share one `labelsWithPrefix`
  helper. The sweep's own narrowing to exactly one `pkg:*` is unchanged and
  stays the sweep's rule; a correctly labeled multi-package issue is never
  sweep-eligible.
- The sync report covers the `agent-ready` rule only: exactly one `risk:*` and
  at least one `pkg:*`. `kind:*` stays a filing rule with no machine check, and
  the workflow doc and the issue form both say so, so nobody reads the report as
  covering it.
- Seven existing sync fixtures carried a bare `agent-ready` label. They now
  carry `risk:low` and `pkg:tooling`, which is what a real `agent-ready` issue
  must look like, so each test still exercises the sync mechanic it was written
  for.

## Validation

- `pnpm issue:board:test` — 257 passed, up from 245. New cases cover missing
  risk, two risk labels, missing pkg, a fully labeled issue, a `needs-grooming`
  issue with no routing labels, a closed `agent-ready` issue, the finding
  reaching the sync failure aggregate, and a snapshot the confirming read
  disproves. Two negative controls: forcing `incompleteGroomingFinding` to
  return `null` failed exactly 3 of the new tests, and reverting the confirming
  read to the stale snapshot failed exactly the drift test. Both prove the tests
  run against live code. They prove the classifier over the label shapes listed;
  they do not prove behavior against live GitHub, which no offline suite reaches.
- `pnpm agent:autoreview` (codex engine, against `origin/main`) — run three
  times. Pass one raised one P2: the check read the stale enumeration snapshot.
  Fixed by the confirming read described above, with the drift test and its
  negative control as evidence. Pass two raised one P2: the issue form claimed
  the sync reports a missing `kind:*`, which it does not. Fixed in the form and
  the workflow doc rather than by widening the check, because the check's scope
  is the `agent-ready` rule. Pass three was clean. Three passes are not proof of
  no other defect.
- `pnpm agent:context-check` — passed, 170 managed files.
- `pnpm agent:context-budget --strict` — exit 0.
- `pnpm docs:index --check` — exit 0; no catalog entry changed, since this PR
  adds no document.
- `node scripts/docs/docs-navigation-eval.mjs --check-fixtures --json` —
  `valid: true`. The added prose spends 2,578 bytes of the suite's total unique
  reserve surplus, which drops from 7,815 to 5,237 bytes. This proves the suite
  still fits its floor today; it does not prove headroom for the next docs PR.
- `pnpm lint:scripts`, `node scripts/repo-health/check-guardrail-prose.mjs`,
  `pnpm docs:navigation-eval:test`, `pnpm tf:test`, and
  `./tools/trunk check --ci` over the changed files — all exit 0.
- The operator authorized a local quality-gate bypass on 2026-09-02, because the
  gate on this host fails closed in legacy owner recovery and Darwin lineage
  recovery (issues
  https://github.com/mento-protocol/monitoring-monorepo/issues/2216 and
  https://github.com/mento-protocol/monitoring-monorepo/issues/2224). It covers
  these exact heads:
  - `627249e18c229685d0908c2b52be9a320672d528` — the initial push. Three
    `pnpm agent:autoreview` passes on the codex engine, the last clean, and
    every mapped command above run directly at that head preceded it.
  - `02a1f51ea36c7a1cde45e818ecefcbf05d3b387e` — the review fix for the codex
    control-list finding. The gate was run first and exited 2 in Darwin lineage
    recovery with `Nothing has been executed`, so the failure was host state and
    not this diff; all nine mapped commands were then run directly at that head
    with exit 0.

  Each push used `--no-verify` once. No gate control changed. Exact-head GitHub
  CI is the authoritative replacement and remains required. Precedent: PR 2147,
  PR 2225.
- Running the mapped commands directly is weaker evidence than a gate run: it
  skips the scheduler, the freshness stamp, and the plan derivation the gate
  performs. It does not prove the gate would pass on a healthy host.
- `pnpm issue:review --pr 2234 --issue 2210` failed with
  `Issue #2210 mutex ref refs/mento-issue-board-locks/v1/ae536812f701c22d5f62a12ee502bacb8e3cf1f0ed139893d0b1541283dd3bc7 was absent after 3 compare-and-swap attempts`.
  That is the known tooling defect in
  https://github.com/mento-protocol/monitoring-monorepo/issues/2226, where
  GraphQL cannot read the custom mutex-ref namespace, so `issue:review` always
  fails on a claimed issue. It was not retried. Issue 2210 therefore stays
  `agent-active` rather than moving to `in-pr`; the `Closes` reference below
  still closes it on merge.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2215 — two
  scheduled producers create `agent-ready` issues without a full routing label
  set, so the new report fires on their output until they are fixed. The Sentry
  local projection applies only `agent-ready`; the file-size watchlist applies
  no `pkg:*`. Fixing them is out of scope here.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2235 — the
  backlog ranking entry points still treat every `agent-ready` issue as
  selectable, so a ranking run can recommend exactly the issue this rule holds
  back. Raised by codex on this PR. The fix lives in the `rank-backlog` skill
  and `docs/notes/backlog-ranking.md`, which this PR's scope excludes.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable. This states an existing label
      contract and reports on it; it constrains no future subsystem shape.

Closes #2210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN
