### PR TITLE
docs(rank-backlog): hold out incompletely groomed agent-ready issues

### DIFF
--- a/.agents/skills/rank-backlog/SKILL.md
+++ b/.agents/skills/rank-backlog/SKILL.md
@@ -213,6 +213,19 @@ their own merits, and seeing where they land is the point. Never Select one:
 recommend the top `agent-ready` candidate instead, and say in the Selected
 section when a higher-scoring issue was passed over for that reason.
 
+**`agent-ready` requires exactly one `risk:*` and at least one `pkg:*`. An
+`agent-ready` issue that fails either requirement ranks like a `needs-grooming`
+issue.** `agent-issue-workflow.md` calls that
+[incompletely groomed](../../../docs/notes/agent-issue-workflow.md#labels), and
+consumers treat it as `needs-grooming` until it is repaired. Score it, rank it,
+and never Select it or stand it as the runner-up. Name each one in Method with
+its routing gap: no `risk:*`, conflicting `risk:*`, or no `pkg:*`. An issue that
+also carries `needs-grooming` is counted under the conflicting queue-state rule
+above and not here, so the two Method counts stay disjoint. Ranking does not
+repair it: adding a label is a grooming decision, and which `risk:*` fits is the
+[low-risk rule](../../../docs/notes/agent-issue-workflow.md#low-risk-rule)'s
+call.
+
 ## Score Each Candidate
 
 Four factors, 0-25 each, 100 total. Break ties alphabetically by title.
@@ -246,13 +259,14 @@ rest from the list line. A reason must come from a body actually read; an issue
 whose reason rests on its title alone does not belong in the table.
 
 **Read the eventual Selected issue and its runner-up in full whatever their
-rank.** Top 15 is not the right cutoff for that pair, because only `agent-ready`
-issues can be Selected while `needs-grooming` issues are ranked alongside them.
-Fifteen higher-scoring grooming issues would push the best ready candidate and
-its runner-up off the table, and the Selected section still has to name a first
-concrete step and say why one beats the other — neither of which a list line
-supports. Read both before writing that section, even when the table never shows
-them.
+rank.** Top 15 is not the right cutoff for that pair, because only a fully
+groomed `agent-ready` issue can be Selected while `needs-grooming` and
+incompletely groomed issues are ranked alongside it. Fifteen higher-scoring
+grooming issues would push the best ready candidate
+and its runner-up off the table, and the Selected section still has to name a
+first concrete step and say why one beats the other — neither of which a list
+line supports. Read both before writing that section, even when the table never
+shows them.
 
 **Rescore from those reads, then re-check the order.** A body read exists to
 change a score, and a changed score can change which ready issue leads, so
@@ -264,7 +278,9 @@ top — but neither name the Selected section prints may rest on a list-line sco
 
 **One surviving candidate has no runner-up.** Write `Runner-up: none` and skip
 the comparison, the same way an empty ready queue writes `Selected: none`. The
-empty-queue rule covers zero candidates; this covers one.
+empty-queue rule covers zero candidates; this covers one. A candidate the rules
+bar from the runner-up slot does not count toward that one, so a roster whose
+only other survivor is incompletely groomed also writes `Runner-up: none`.
 
 ## Write The Receipt
 
@@ -290,10 +306,11 @@ Three sections:
 
 1. **Method** — fetch timestamp, open-issue count, how many of those sat outside
    the queue, roster count, the per-reason drop counts, how many bodies were read
-   in full, how many issues were scored from the list line, how many candidates
-   were held out — truncated timelines that could not be resolved, and issues
-   carrying conflicting queue-state labels, named — and any cap that applied to a
-   whole class of issues.
+   in full, how many issues were scored from the list line, how many `agent-ready`
+   candidates were incompletely groomed, each named with its routing gap, how
+   many candidates were held out — truncated timelines that could not be
+   resolved, and issues carrying conflicting queue-state labels, named — and any
+   cap that applied to a whole class of issues.
 2. **Top 15** — one table with the columns `Rank | Issue | Score | Reason`. The
    reason is one line: what the issue is, why it scores where it does, and the
    cap when one applied.
@@ -301,10 +318,10 @@ Three sections:
    runner-up. State the first concrete step and what would make it stop.
 
 **An empty ready queue is a result, not a failure.** When no `agent-ready`
-candidate survives the drops — every one claimed, parked, or awaiting grooming —
-write `Selected: none` with the reason, and skip the runner-up comparison there
-is nothing to make. Method and the table still carry the run. Never groom, claim,
-or invent a candidate to fill the section.
+candidate survives the drops — every one claimed, parked, awaiting grooming, or
+incompletely groomed — write `Selected: none` with the reason, and skip the
+runner-up comparison there is nothing to make. Method and the table still carry
+the run. Never groom, claim, or invent a candidate to fill the section.
 
 Print the Selected section, the top five rows, and the receipt path to the
 terminal. The receipt is the artifact; the terminal output is its summary.

--- a/.claude/skills/rank-backlog/SKILL.md
+++ b/.claude/skills/rank-backlog/SKILL.md
@@ -213,6 +213,19 @@ their own merits, and seeing where they land is the point. Never Select one:
 recommend the top `agent-ready` candidate instead, and say in the Selected
 section when a higher-scoring issue was passed over for that reason.
 
+**`agent-ready` requires exactly one `risk:*` and at least one `pkg:*`. An
+`agent-ready` issue that fails either requirement ranks like a `needs-grooming`
+issue.** `agent-issue-workflow.md` calls that
+[incompletely groomed](../../../docs/notes/agent-issue-workflow.md#labels), and
+consumers treat it as `needs-grooming` until it is repaired. Score it, rank it,
+and never Select it or stand it as the runner-up. Name each one in Method with
+its routing gap: no `risk:*`, conflicting `risk:*`, or no `pkg:*`. An issue that
+also carries `needs-grooming` is counted under the conflicting queue-state rule
+above and not here, so the two Method counts stay disjoint. Ranking does not
+repair it: adding a label is a grooming decision, and which `risk:*` fits is the
+[low-risk rule](../../../docs/notes/agent-issue-workflow.md#low-risk-rule)'s
+call.
+
 ## Score Each Candidate
 
 Four factors, 0-25 each, 100 total. Break ties alphabetically by title.
@@ -246,13 +259,14 @@ rest from the list line. A reason must come from a body actually read; an issue
 whose reason rests on its title alone does not belong in the table.
 
 **Read the eventual Selected issue and its runner-up in full whatever their
-rank.** Top 15 is not the right cutoff for that pair, because only `agent-ready`
-issues can be Selected while `needs-grooming` issues are ranked alongside them.
-Fifteen higher-scoring grooming issues would push the best ready candidate and
-its runner-up off the table, and the Selected section still has to name a first
-concrete step and say why one beats the other — neither of which a list line
-supports. Read both before writing that section, even when the table never shows
-them.
+rank.** Top 15 is not the right cutoff for that pair, because only a fully
+groomed `agent-ready` issue can be Selected while `needs-grooming` and
+incompletely groomed issues are ranked alongside it. Fifteen higher-scoring
+grooming issues would push the best ready candidate
+and its runner-up off the table, and the Selected section still has to name a
+first concrete step and say why one beats the other — neither of which a list
+line supports. Read both before writing that section, even when the table never
+shows them.
 
 **Rescore from those reads, then re-check the order.** A body read exists to
 change a score, and a changed score can change which ready issue leads, so
@@ -264,7 +278,9 @@ top — but neither name the Selected section prints may rest on a list-line sco
 
 **One surviving candidate has no runner-up.** Write `Runner-up: none` and skip
 the comparison, the same way an empty ready queue writes `Selected: none`. The
-empty-queue rule covers zero candidates; this covers one.
+empty-queue rule covers zero candidates; this covers one. A candidate the rules
+bar from the runner-up slot does not count toward that one, so a roster whose
+only other survivor is incompletely groomed also writes `Runner-up: none`.
 
 ## Write The Receipt
 
@@ -290,10 +306,11 @@ Three sections:
 
 1. **Method** — fetch timestamp, open-issue count, how many of those sat outside
    the queue, roster count, the per-reason drop counts, how many bodies were read
-   in full, how many issues were scored from the list line, how many candidates
-   were held out — truncated timelines that could not be resolved, and issues
-   carrying conflicting queue-state labels, named — and any cap that applied to a
-   whole class of issues.
+   in full, how many issues were scored from the list line, how many `agent-ready`
+   candidates were incompletely groomed, each named with its routing gap, how
+   many candidates were held out — truncated timelines that could not be
+   resolved, and issues carrying conflicting queue-state labels, named — and any
+   cap that applied to a whole class of issues.
 2. **Top 15** — one table with the columns `Rank | Issue | Score | Reason`. The
    reason is one line: what the issue is, why it scores where it does, and the
    cap when one applied.
@@ -301,10 +318,10 @@ Three sections:
    runner-up. State the first concrete step and what would make it stop.
 
 **An empty ready queue is a result, not a failure.** When no `agent-ready`
-candidate survives the drops — every one claimed, parked, or awaiting grooming —
-write `Selected: none` with the reason, and skip the runner-up comparison there
-is nothing to make. Method and the table still carry the run. Never groom, claim,
-or invent a candidate to fill the section.
+candidate survives the drops — every one claimed, parked, awaiting grooming, or
+incompletely groomed — write `Selected: none` with the reason, and skip the
+runner-up comparison there is nothing to make. Method and the table still carry
+the run. Never groom, claim, or invent a candidate to fill the section.
 
 Print the Selected section, the top five rows, and the receipt path to the
 terminal. The receipt is the artifact; the terminal output is its summary.

--- a/docs/notes/backlog-ranking.md
+++ b/docs/notes/backlog-ranking.md
@@ -39,7 +39,7 @@ The loop reuses the workflow's terms and adds none:
 - `needs-grooming` — scored and ranked, never Selected. A high-scoring
   `needs-grooming` issue is a grooming prompt, and the receipt says so.
 - **incompletely groomed** — an `agent-ready` issue that carries no `risk:*`,
-  two conflicting `risk:*`, or no `pkg:*`, as
+  more than one `risk:*`, or no `pkg:*`, as
   [`agent-issue-workflow.md`](agent-issue-workflow.md#labels) defines it.
   Consumers treat it as `needs-grooming`, so the loop scores and ranks it but
   never Selects it and never stands it as the runner-up. Method names it and its

--- a/docs/notes/backlog-ranking.md
+++ b/docs/notes/backlog-ranking.md
@@ -35,9 +35,16 @@ disagree with the pick.
 
 The loop reuses the workflow's terms and adds none:
 
-- `agent-ready` — eligible to be Selected.
+- `agent-ready` — eligible to be Selected once its routing labels are complete.
 - `needs-grooming` — scored and ranked, never Selected. A high-scoring
   `needs-grooming` issue is a grooming prompt, and the receipt says so.
+- **incompletely groomed** — an `agent-ready` issue that carries no `risk:*`,
+  two conflicting `risk:*`, or no `pkg:*`, as
+  [`agent-issue-workflow.md`](agent-issue-workflow.md#labels) defines it.
+  Consumers treat it as `needs-grooming`, so the loop scores and ranks it but
+  never Selects it and never stands it as the runner-up. Method names it and its
+  routing gap; which `risk:*` fits is the
+  [low-risk rule](agent-issue-workflow.md#low-risk-rule)'s call, not the loop's.
 - `agent-active` and `in-pr` — already owned, so dropped from the roster. This
   repo claims through labels and Project fields rather than assignees, so
   neither state shows up in an assignee check — and the reverse holds too: an


### PR DESCRIPTION
## The Problem

The backlog ranking loop could recommend an `agent-ready` issue that the repo's
own label rule holds back. `docs/notes/agent-issue-workflow.md` requires exactly
one `risk:*` and at least one `pkg:*` on any `agent-ready` issue and calls one
that fails either requirement **incompletely groomed**; consumers treat it as
`needs-grooming` until it is repaired.

- `.agents/skills/rank-backlog/SKILL.md` recommended the top `agent-ready`
  candidate with no routing-label check, and `docs/notes/backlog-ranking.md`
  repeated that contract (`agent-ready` — eligible to be Selected).
- Two other consumers already refuse: `pnpm issue:board sync` reports the gap,
  and the backlog sweep's `--sweep-eligible` path demands `risk:low` plus exactly
  one `pkg:*` through `hasSweepRouting`.
- An operator who acted on a ranking receipt could therefore be handed an issue
  that the next consumer in the loop rejects.

## The Solution

The skill and the runbook now score and rank an incompletely groomed issue,
never Select it and never stand it as the runner-up, and name it in Method with
its routing gap. An operator reading a receipt can therefore trust that the
Selected issue is actually claimable. Ranking still does not repair anything: it
names the gap and leaves the label decision to grooming.

- `rank-backlog` now treats an incompletely groomed `agent-ready` issue the way
  it already treats a conflicting queue state: scored, ranked, named in Method,
  never Selected and never the runner-up.
- Method bullet 1 gained a count for the class, and each such issue is named with
  its routing gap, so the receipt states which repair the issue needs.
- The runbook's Vocabulary carries the same term, so the skill and the runbook
  agree on one definition.
- Material limit: this is a hold-out classification only. It does not change the
  scoring algorithm, the receipt table contract, or the Stop There boundary, and
  ranking still never edits a label.

## Details

- The hold-out sits with the existing `needs-grooming` and conflicting-queue-state
  rules in the roster section, so all three read as one class of held-out
  candidate.
- Precedence is stated: an issue that also carries `needs-grooming` is counted
  under the conflicting-queue-state rule and not under the new one. Without that,
  a mid-repair snapshot carrying `agent-ready`, `needs-grooming`, and no `pkg:*`
  matches both antecedents and Method double-counts it. The skill's ordered
  first-match language covers only the bulleted drop list, not these two bolded
  paragraphs.
- The receipt wording says "routing gap: no `risk:*`, conflicting `risk:*`, or no
  `pkg:*`" rather than "the label it lacks". `agentReadyRoutingGaps` in
  `scripts/pr/issue-board-state.mjs` emits three gaps, and the two-`risk:*` case
  has no lacking label to name, so "the label it lacks" could not express it.
- The rule text says "consumers treat it as `needs-grooming`", matching
  `agent-issue-workflow.md` verbatim. It does not say "every consumer":
  `pnpm issue:claim` still claims an incompletely groomed issue by design, and
  the Stop There section hands the operator exactly that command.
- The one-candidate runner-up paragraph now says a candidate the rules bar from
  the runner-up slot does not count toward the single survivor, so a roster of
  one groomed and one incompletely groomed candidate writes `Runner-up: none`.
- The rule links `agent-issue-workflow.md#labels` and `#low-risk-rule` instead of
  restating the label rule or the risk criteria. One definition, one owner.
- `.claude/skills/rank-backlog/SKILL.md` is a byte-identical copy of the
  `.agents/` file; both are real files, not symlinks.

## Validation

- The operator authorized a local quality-gate bypass for exact head
  `2d4c52a3345450cb2e9481916b88f39194cbd99d` on 2026-09-03 because the host gate
  fails closed in Darwin lineage recovery (issue 2224); the push used
  `--no-verify`; mapped commands run directly: `./tools/trunk check --ci` on the
  three changed files, `pnpm docs:index --check`,
  `pnpm docs:navigation-eval:test`, `pnpm agent:context-check`,
  `node scripts/repo-health/check-skills-mirror.test.mjs`,
  `node scripts/repo-health/check-skills-mirror.mjs`, `pnpm tf:test`,
  `pnpm docs:navigation-eval -- --check-fixtures`; no gate control changed;
  exact-head GitHub CI is the authoritative replacement.
- `pnpm agent:quality-gate` (inspect mode) exit 0. It mapped the eight commands
  above from the three changed paths, surfaces `docs` and `agent-context`.
- `./tools/trunk check --ci .agents/skills/rank-backlog/SKILL.md .claude/skills/rank-backlog/SKILL.md docs/notes/backlog-ranking.md` exit 0, "No issues".
  The first invocation aborted with a Trunk internal error (exit 2, daemon crash,
  no lint result produced); the recorded result is the rerun on the same files.
- `pnpm docs:index --check` exit 0. `pnpm docs:navigation-eval:test` exit 0, 34
  tests. `pnpm agent:context-check` exit 0, 170 managed files. `pnpm tf:test`
  exit 0. `pnpm agent:context-budget --strict` exit 0.
- `node scripts/repo-health/check-skills-mirror.test.mjs` exit 0, 17 tests, and
  `node scripts/repo-health/check-skills-mirror.mjs` exit 0, ".agents/skills and
  .claude/skills are identical".
- `pnpm docs:navigation-eval -- --check-fixtures` exit 0, `"valid":true`,
  `total_unique_reserve_surplus_bytes: 4251`, so the byte budget still has
  headroom after the added prose.
- `pnpm agent:autoreview` exit 0 against head
  `2d4c52a3345450cb2e9481916b88f39194cbd99d` on base `8e2753fc`: "autoreview
  clean: no accepted/actionable findings reported".
- An independent review of the first draft returned six findings; all six were
  verified against `scripts/pr/issue-board-state.mjs` and
  `docs/notes/agent-issue-workflow.md` and all six were applied.
- Nearest stronger claim the evidence does NOT support: these are prose and lint
  checks over documentation. No command executes the ranking loop, so nothing
  here proves a ranking run actually holds out an incompletely groomed issue. The
  skill is instructions read by an agent, and only a live ranking run against a
  backlog containing such an issue would demonstrate the behavior. The mirror
  check proves the two SKILL.md copies are byte-identical; it does not check that
  their content is correct.
- Host-state notes. Issue 2235 is NOT claimed. `pnpm issue:claim --issue 2235
  --agent claude --branch docs/rank-backlog-incomplete-grooming` failed five
  times across three sessions with `mutex ref
  refs/mento-issue-board-locks/v1/eb3d3d4c... was absent after 3
  compare-and-swap attempts` (exit 1), the same mutex-ref defect issue 2226
  records for `pnpm issue:review`. Issue 2226 names only the review path, so it
  understates the blast radius: the claim path fails the same way. Every attempt
  applied nothing, and no label was edited by hand, so issue 2235 still shows
  `agent-ready` with no owner.
- `pnpm issue:review --pr 2261 --issue 2235` was run once, exit 1: "review
  requires durable Claim ID, Agent, and Branch ownership". That is the downstream
  effect of the unlanded claim, not the issue 2226 mutex error itself. It was not
  retried, because no retry can succeed until the claim lands.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2259 — the skill
  bars an incompletely groomed issue from the runner-up slot but never says
  whether a `needs-grooming` issue may hold it, though it says the two classes
  rank alike. Resolving that needs a policy decision about what the runner-up
  slot is for, which is wider than this issue's scope.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable: this restates an existing rule from `docs/notes/agent-issue-workflow.md` in one consumer.

Closes #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN
