### PR TITLE
fix(tooling): give Sentry projection and watchlist issues their routing labels

### DIFF
--- a/docs/adr/0038-sentry-central-plane-verdict-projection.md
+++ b/docs/adr/0038-sentry-central-plane-verdict-projection.md
@@ -77,10 +77,13 @@ deterministic step.**
   job — the matrix jobs hosting the LLM agent never see it. For a `code-fix` /
   `config-fix` verdict whose destination is `external`, it files an issue in
   that repo. For `local-config`, it files a local work issue with
-  `agent-ready` using the ambient workflow token. Before a local create, the
-  route ensures only the canonical shared `agent-ready` definition. Before a
-  closed-match repair, it ensures all four canonical lifecycle label definitions
-  named by the edit. Neither path force-edits existing metadata. Both routes label the stub
+  `agent-ready`, `kind:bug`, `pkg:dashboard`, and `risk:medium` using the
+  ambient workflow token; `agent-ready` needs exactly one `risk:*` and at least
+  one `pkg:*` beside it, and the projected body names no verification command,
+  which holds the risk at medium. Before a local create, the route ensures every
+  one of those four definitions, because `gh issue create` fails on a label the
+  repository does not carry. Before a closed-match repair, it ensures all four
+  canonical lifecycle label definitions named by the edit. Neither path force-edits existing metadata. Both routes label the stub
   `sentry:projected`, comment the projected URL, and close the stub. A closed
   local match restores `agent-ready`, removes `agent-active`, `in-pr`, and
   `needs-grooming`, and then reopens. A failed repair stays retryable; an open

--- a/docs/adr/0059-repo-owned-file-size-watchlist-scheduler.md
+++ b/docs/adr/0059-repo-owned-file-size-watchlist-scheduler.md
@@ -45,6 +45,14 @@ The repository owns one monthly, issue-only file-size schedule:
   determine cap status; raw counts describe growth only.
 - The durable `file-size-watchlist` label narrows lookup, and an immutable body
   marker identifies the owned issue. Multiple marked issues fail closed.
+- An actionable issue carries `agent-ready`, `kind:refactor`, `priority:p2`, one
+  `pkg:*` per package area its actionable rows touch, and one `risk:*`. Risk is
+  `risk:medium` unless the issue already carries a stricter label, which the
+  upsert keeps. The job never writes `risk:low`: `agent-ready` plus one
+  `risk:low` plus one `pkg:*` is the sweep predicate, and
+  [`docs/notes/backlog-sweep.md`](../notes/backlog-sweep.md) reserves that last
+  label for a human, so an unattended job cannot route its own issue into the
+  unattended sweep.
 - Reruns never overwrite an issue carrying `agent-active`, `in-pr`, or
   `needs-grooming`. An unclaimed issue closes when the actionable rows clear and
   reopens if drift returns.

--- a/docs/notes/sentry-triage-pipeline.md
+++ b/docs/notes/sentry-triage-pipeline.md
@@ -100,7 +100,7 @@ Adding a project means adding it to the allowlist, not only to Sentry.
 | Verdict              | `analytics-mento-org` (local)                                                                                                                                                                                                                     | Every other project (external)                        |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `code-fix`           | `fix_scope: mechanical` → **autofix-eligible**, closed ledger entry — the only path that writes code. `fix_scope: architectural` → **stays OPEN** under `sentry:fix-scope-architectural` (human design work, excluded from autofix at query time) | Projects an issue into the owning repo. Never autofix |
-| `config-fix`         | Projects a local work issue with `agent-ready`; no autofix                                                                                                                                                                                        | Projects an issue into the owning repo                |
+| `config-fix`         | Projects a local work issue with `agent-ready`, `kind:bug`, `pkg:dashboard`, and `risk:medium`; no autofix                                                                                                                                        | Projects an issue into the owning repo                |
 | `upstream-transient` | Closes. Nothing downstream                                                                                                                                                                                                                        | Same                                                  |
 | `needs-human`        | Stays open with a decision-ready brief                                                                                                                                                                                                            | Same                                                  |
 
@@ -942,7 +942,7 @@ the label and transition below:
 | `code-fix` (mechanical/external) | `sentry:verdict-code-fix`                                    | Close as completed                | Project to an allowlisted external repo, or leave a visible projection-skipped note; eligible local mechanical issues may later enter autofix |
 | `code-fix` (local architectural) | `sentry:verdict-code-fix` + `sentry:fix-scope-architectural` | **Keep open** (human design work) | Excluded from autofix at query time; re-triage to clear (#1812)                                                                               |
 | `config-fix` (external)          | `sentry:verdict-config-fix`                                  | Close as completed                | Project to an allowlisted external repo, or leave a visible projection-skipped note                                                           |
-| `config-fix` (local)             | `sentry:verdict-config-fix`                                  | Close after projection            | Create or reuse a local work issue with `agent-ready`; no projection PAT required                                                             |
+| `config-fix` (local)             | `sentry:verdict-config-fix`                                  | Close after projection            | Create or reuse a local work issue with `agent-ready`, `kind:bug`, `pkg:dashboard`, and `risk:medium`; no projection PAT required             |
 | `upstream-transient`             | `sentry:verdict-upstream`                                    | Close as completed                | None                                                                                                                                          |
 | `needs-human`                    | `sentry:verdict-needs-human`                                 | Keep open                         | Human answers the recorded question and decides the next action                                                                               |
 
@@ -1041,11 +1041,15 @@ reuse and must be treated as a migration. A local config route uses the
 ambient workflow token. It only matches local issues whose `gh issue list`
 author is `app/github-actions`, while marker comments use the trusted
 `github-actions` or `github-actions[bot]` comment fence. Before it creates a
-local issue, it ensures only the canonical shared `agent-ready` definition.
+local issue, it ensures every routing label definition it applies:
+`agent-ready`, `kind:bug`, `pkg:dashboard`, and `risk:medium`.
 Before it repairs a closed match, it ensures all four canonical lifecycle label
 definitions named by the edit. Neither path force-edits existing metadata. It
-creates a new issue with `agent-ready`. For a closed match, it restores that
-label and removes
+creates a new issue with that routing set: `agent-ready` needs exactly one
+`risk:*` and at least one `pkg:*` (docs/notes/agent-issue-workflow.md), the
+dashboard is the only local project's package, and the projected body names no
+verification command, which keeps the risk at medium. For a closed match, it
+restores `agent-ready` and removes
 `agent-active`, `in-pr`, and `needs-grooming` before reopening it, so a failed
 repair stays retryable. It leaves an open match's lifecycle unchanged. On
 `main`, an absent `SENTRY_PROJECTION_TOKEN` makes only external projection a

--- a/scripts/gate/routing-table/arms-agent-modules.mjs
+++ b/scripts/gate/routing-table/arms-agent-modules.mjs
@@ -537,6 +537,12 @@ export const AGENT_MODULE_ARMS = [
         command: "pnpm issue:board:test",
         reason: "agent issue board helper changed",
       },
+      {
+        why: "file-size-watchlist.test.mjs asserts the labels the monthly filer writes through agentReadyRoutingGaps, the state module's own incomplete-grooming predicate. Without this arm a change to that predicate can invalidate the filer's contract and stay unrun until an unrelated watchlist edit.",
+        command: "node --test scripts/repo-health/file-size-watchlist.test.mjs",
+        reason:
+          "issue-board state predicate backs the file-size watchlist label contract",
+      },
     ],
   },
 ];

--- a/scripts/lib/gh-issue-lifecycle.mjs
+++ b/scripts/lib/gh-issue-lifecycle.mjs
@@ -10,8 +10,10 @@
  * `scripts/` — and copied the rest. Both now read them from here.
  *
  * The local Sentry projection route also reads the canonical issue-state label
- * definitions. It uses the narrowed `agent-ready` definition before create and
- * the full set before closed repair. Callers own their markers, metadata
+ * definitions. Before create it ensures its own routing set — the narrowed
+ * `agent-ready` definition, the shared `risk:medium` definition, and two labels
+ * this module does not carry — and before a closed repair it ensures the full
+ * set. Callers own their markers, metadata
  * validation, and decision branches. This module owns the shared lifecycle
  * label definitions and the mechanisms that were byte-identical between the
  * documentation jobs.

--- a/scripts/repo-health/file-size-watchlist-issue.mjs
+++ b/scripts/repo-health/file-size-watchlist-issue.mjs
@@ -12,21 +12,115 @@ const ACTIVE_QUEUE_LABELS = new Set([
   "in-pr",
   "needs-grooming",
 ]);
-const MANAGED_LABELS = new Set([
+
+/**
+ * `pkg:*` label for each watchlist scope (`SOURCE_SCOPES` in
+ * file-size-watchlist.mjs). Every scope but `scripts` names its package
+ * directly; `scripts/` is repository tooling. An `agent-ready` issue needs at
+ * least one `pkg:*` (docs/notes/agent-issue-workflow.md), and the drift issue
+ * spans whatever its actionable rows span, so the map is applied per row rather
+ * than collapsed to one package. The issue body embeds the whole scan report,
+ * so it names rows outside these package areas; `formatIssueBody` says which
+ * set the labels describe. `scopePackageLabel` throws on an unmapped
+ * scope: filing a groomed-incomplete issue silently is the failure this map
+ * exists to prevent, and a test pins the map against the scope list.
+ */
+const SCOPE_PACKAGE_LABELS = {
+  aegis: "pkg:aegis",
+  dashboard: "pkg:dashboard",
+  indexer: "pkg:indexer",
+  "integration-probes": "pkg:integration-probes",
+  "metrics-bridge": "pkg:metrics-bridge",
+  scripts: "pkg:tooling",
+  "shared-config": "pkg:shared-config",
+};
+
+const ACTIONABLE_BASE_LABELS = [
   "file-size-watchlist",
   "agent-ready",
-  ...ACTIVE_QUEUE_LABELS,
   "kind:refactor",
   "priority:p2",
-  "risk:low",
-]);
-const ACTIONABLE_LABELS = [
-  "file-size-watchlist",
-  "agent-ready",
-  "kind:refactor",
-  "priority:p2",
-  "risk:low",
 ];
+
+/**
+ * The risk label this job may write, and the order it ranks them in.
+ *
+ * The floor is `risk:medium` and this job never writes `risk:low`. The sweep
+ * predicate is `agent-ready` plus exactly one `risk:*` equal to `risk:low` plus
+ * exactly one `pkg:*` (`hasSweepRouting`, scripts/pr/issue-board-state.mjs), so
+ * a `risk:low` write here would let a monthly unattended job hand its own issue
+ * to the unattended sweep. docs/notes/backlog-sweep.md forbids exactly that for
+ * the automated grooming pass: `risk:low` is proposed and a human applies it.
+ * That rule binds every unattended writer of the predicate, not only the pass.
+ *
+ * Deciding the floor per row was the alternative, and it needs a list of the
+ * control surfaces a row can reach. Such a list under-scans: it missed the
+ * low-risk rule's credential clause and its production-data clause, so
+ * `scripts/sentry/triage/sentry-triage-archive.mjs`, a live actionable row that
+ * writes production Sentry state, classified as low risk. A constant floor
+ * cannot rot that way, and a human who reads the issue can still apply
+ * `risk:low`.
+ */
+const RISK_FLOOR = "risk:medium";
+const RISK_RANK = new Map([
+  ["risk:low", 0],
+  ["risk:medium", 1],
+  ["risk:high", 2],
+]);
+
+const MANAGED_LABELS = new Set([
+  ...ACTIONABLE_BASE_LABELS,
+  ...ACTIVE_QUEUE_LABELS,
+  ...Object.values(SCOPE_PACKAGE_LABELS),
+]);
+
+function isRiskLabel(label) {
+  return label.startsWith("risk:");
+}
+
+export function scopePackageLabel(scope) {
+  const label = SCOPE_PACKAGE_LABELS[scope];
+  if (label === undefined) {
+    throw new Error(
+      `file-size watchlist scope '${scope}' has no pkg:* label; add it to SCOPE_PACKAGE_LABELS`,
+    );
+  }
+  return label;
+}
+
+export function packageLabelsForRows(rows) {
+  return [...new Set(rows.map((row) => scopePackageLabel(row.package)))].sort();
+}
+
+/**
+ * The one `risk:*` the issue carries after the write.
+ *
+ * Risk is managed by prefix, not by an enumeration of the labels this job may
+ * own. Preserving a `risk:*` the job does not recognise and appending its own
+ * leaves two risk labels, which `agentReadyRoutingGaps` reports as conflicting
+ * — the incomplete-grooming finding this whole change exists to remove.
+ *
+ * The result is the stricter of the floor and whatever the issue already
+ * carries, so an operator who escalates a repeated drift issue to `risk:high`
+ * keeps that escalation across the next monthly upsert. The job may narrow
+ * risk, never widen it. A `risk:*` outside the three ranked labels is dropped
+ * and replaced by the floor; it routes nothing and cannot be ordered.
+ */
+export function riskLabelForIssue(existingLabels = []) {
+  const ranks = existingLabels
+    .filter((label) => RISK_RANK.has(label))
+    .map((label) => RISK_RANK.get(label));
+  const rank = Math.max(RISK_RANK.get(RISK_FLOOR), ...ranks);
+  return [...RISK_RANK].find(([, value]) => value === rank)[0];
+}
+
+export function actionableLabels(rows, existingLabels = []) {
+  return [
+    ...ACTIONABLE_BASE_LABELS,
+    ...packageLabelsForRows(rows),
+    riskLabelForIssue(existingLabels),
+  ];
+}
 
 function parseBoolean(value, name) {
   if (value === undefined || value === null || value === "") return false;
@@ -41,8 +135,19 @@ function labelsForIssue(issue) {
   );
 }
 
+/**
+ * Labels the write carries through untouched.
+ *
+ * Every `risk:*` drops, because the write appends exactly one and
+ * `riskLabelForIssue` has already folded the existing ones into it. A `pkg:*`
+ * outside `SCOPE_PACKAGE_LABELS` stays: an extra package area is legal on an
+ * `agent-ready` issue and only narrows sweep eligibility, so a job that did not
+ * apply it should not remove it.
+ */
 function preserveUnmanagedLabels(labels) {
-  return labels.filter((label) => !MANAGED_LABELS.has(label));
+  return labels.filter(
+    (label) => !MANAGED_LABELS.has(label) && !isRiskLabel(label),
+  );
 }
 
 function resolvedLabels(labels) {
@@ -87,7 +192,7 @@ export function planIssueSync({ issues, rows, publishReport }) {
       issue,
       labels: [
         ...preserveUnmanagedLabels(existingLabels),
-        ...ACTIONABLE_LABELS,
+        ...actionableLabels(actionableRows, existingLabels),
       ],
     };
   }
@@ -202,6 +307,8 @@ function formatIssueBody({ report, actionableRows, repo, runUrl }) {
     `**Current main:** [\`${report.mainSha}\`](${commitUrl})`,
     runUrl ? `**Workflow run:** [${runUrl}](${runUrl})` : null,
     `**Actionable files:** ${actionableRows.length}`,
+    "",
+    "The `pkg:*` labels name the package areas of the actionable files only. Current Report below lists every watchlist row, including rows this issue does not ask anyone to touch.",
     "",
     report.issueBody,
     "",

--- a/scripts/repo-health/file-size-watchlist.mjs
+++ b/scripts/repo-health/file-size-watchlist.mjs
@@ -51,7 +51,8 @@ export function exemptionReason(path) {
   return null;
 }
 
-const SOURCE_SCOPES = [
+// Exported so the issue filer's pkg:* map can be pinned against the scope list.
+export const SOURCE_SCOPES = [
   {
     label: "dashboard",
     prefix: "ui-dashboard/src/",

--- a/scripts/repo-health/file-size-watchlist.test.mjs
+++ b/scripts/repo-health/file-size-watchlist.test.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 import {
   _private,
   SCRIPTS_EXEMPTIONS,
+  SOURCE_SCOPES,
   countLines,
   exemptionReason,
   formatIssue,
@@ -28,11 +29,21 @@ import {
 import {
   ISSUE_MARKER,
   actionableFileSizeRows,
+  actionableLabels,
+  packageLabelsForRows,
   planIssueSync,
+  riskLabelForIssue,
+  scopePackageLabel,
 } from "./file-size-watchlist-issue.mjs";
+// The consumer that reports incomplete grooming. Asserting through it, rather
+// than restating its rule here, is what pins the label set to the finding.
+import { agentReadyRoutingGaps } from "../pr/issue-board-state.mjs";
 
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(scriptPath), "../..");
+
+// `agentReadyRoutingGaps` reads `labels[].name`; the planner returns bare names.
+const asIssue = (labels) => ({ labels: labels.map((name) => ({ name })) });
 
 test("scopeForPath excludes generated files, non-Aegis tests, and dashboard types", () => {
   assert.equal(scopeForPath("indexer-envio/.envio/types.d.ts"), null);
@@ -204,7 +215,7 @@ test("actionable drift keeps cap status separate from raw growth", () => {
 
 test("issue sync creates, resolves, and force-publishes one marked issue", () => {
   const actionableRows = [
-    { path: "near.ts", status: "near-hard", rawDelta: 0 },
+    { path: "near.ts", package: "dashboard", status: "near-hard", rawDelta: 0 },
   ];
   const marked = {
     number: 44,
@@ -213,11 +224,20 @@ test("issue sync creates, resolves, and force-publishes one marked issue", () =>
     labels: [{ name: "agent-ready" }, { name: "custom" }],
   };
 
-  assert.equal(
-    planIssueSync({ issues: [], rows: actionableRows, publishReport: false })
-      .action,
-    "create",
-  );
+  const created = planIssueSync({
+    issues: [],
+    rows: actionableRows,
+    publishReport: false,
+  });
+  assert.equal(created.action, "create");
+  assert.deepEqual(created.labels, [
+    "file-size-watchlist",
+    "agent-ready",
+    "kind:refactor",
+    "priority:p2",
+    "pkg:dashboard",
+    "risk:medium",
+  ]);
 
   const resolved = planIssueSync({
     issues: [marked],
@@ -254,6 +274,145 @@ test("issue sync never overwrites a claimed packet and fails on duplicates", () 
       }),
     /expected at most one/,
   );
+});
+
+test("every watchlist scope maps to a pkg:* label", () => {
+  for (const scope of SOURCE_SCOPES) {
+    assert.match(scopePackageLabel(scope.label), /^pkg:/);
+  }
+  assert.throws(() => scopePackageLabel("terraform"), /has no pkg:\* label/);
+});
+
+test("actionable labels span every package the rows touch", () => {
+  const rows = [
+    {
+      path: "scripts/sentry/triage/sentry-triage-project.mjs",
+      package: "scripts",
+    },
+    { path: "ui-dashboard/src/app/page.tsx", package: "dashboard" },
+    { path: "aegis/src/server.ts", package: "aegis" },
+  ];
+  assert.deepEqual(packageLabelsForRows(rows), [
+    "pkg:aegis",
+    "pkg:dashboard",
+    "pkg:tooling",
+  ]);
+  assert.deepEqual(actionableLabels(rows), [
+    "file-size-watchlist",
+    "agent-ready",
+    "kind:refactor",
+    "priority:p2",
+    "pkg:aegis",
+    "pkg:dashboard",
+    "pkg:tooling",
+    "risk:medium",
+  ]);
+});
+
+test("the live scan never produces a sweep-claimable label set", () => {
+  const report = JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["scripts/repo-health/file-size-watchlist.mjs", "--format", "json"],
+      { cwd: repoRoot, encoding: "utf8", maxBuffer: 5 * 1024 * 1024 },
+    ),
+  );
+  const actionable = actionableFileSizeRows(report.rows);
+  assert.ok(
+    actionable.length > 0,
+    "no actionable row today; this assertion needs a real row to mean anything",
+  );
+  const labels = actionableLabels(actionable);
+  // The sweep predicate is `agent-ready` plus exactly one `risk:*` equal to
+  // `risk:low` plus exactly one `pkg:*` (`hasSweepRouting`,
+  // scripts/pr/issue-board-state.mjs). This job writes `agent-ready`, so the
+  // risk label is the only thing keeping its own issue out of the unattended
+  // sweep. docs/notes/backlog-sweep.md reserves that `risk:low` for a human.
+  assert.ok(labels.includes("agent-ready"));
+  assert.deepEqual(
+    labels.filter((label) => label.startsWith("risk:")),
+    ["risk:medium"],
+  );
+  assert.deepEqual(agentReadyRoutingGaps(asIssue(labels)), []);
+});
+
+test("a lone production-data writer still files at the risk floor", () => {
+  // sentry-triage-archive.mjs is a live actionable row and it archives the
+  // underlying Sentry issue under a write-scoped token. Any per-row risk rule
+  // that misses the low-risk rule's production-data clause reads this single
+  // scripts/ row as `risk:low` and hands the issue to the unattended sweep.
+  const rows = [
+    {
+      path: "scripts/sentry/triage/sentry-triage-archive.mjs",
+      package: "scripts",
+    },
+  ];
+  assert.deepEqual(packageLabelsForRows(rows), ["pkg:tooling"]);
+  assert.equal(riskLabelForIssue([]), "risk:medium");
+  assert.ok(!actionableLabels(rows).includes("risk:low"));
+});
+
+test("an operator risk escalation survives the next upsert as the only risk label", () => {
+  const marked = {
+    number: 44,
+    state: "open",
+    body: ISSUE_MARKER,
+    labels: [
+      { name: "agent-ready" },
+      { name: "risk:high" },
+      { name: "pkg:alerts" },
+      { name: "file-size-watchlist" },
+    ],
+  };
+  const plan = planIssueSync({
+    issues: [marked],
+    rows: [
+      {
+        path: "ui-dashboard/src/app/page.tsx",
+        package: "dashboard",
+        status: "hard",
+        rawDelta: 0,
+      },
+    ],
+    publishReport: false,
+  });
+  assert.equal(plan.action, "upsert-open");
+  assert.deepEqual(
+    plan.labels.filter((label) => label.startsWith("risk:")),
+    ["risk:high"],
+    "the write must never leave two risk labels, and must never lower one",
+  );
+  // A package area this job did not apply only narrows eligibility, so it stays.
+  assert.ok(plan.labels.includes("pkg:alerts"));
+  assert.ok(plan.labels.includes("pkg:dashboard"));
+  assert.deepEqual(agentReadyRoutingGaps(asIssue(plan.labels)), []);
+});
+
+test("the risk floor holds and an unrankable risk label is repaired", () => {
+  assert.equal(riskLabelForIssue(["risk:low"]), "risk:medium");
+  assert.equal(riskLabelForIssue(["risk:medium"]), "risk:medium");
+  assert.equal(riskLabelForIssue(["risk:high"]), "risk:high");
+  assert.equal(riskLabelForIssue(["risk:unknown"]), "risk:medium");
+  assert.equal(riskLabelForIssue(["risk:low", "risk:high"]), "risk:high");
+});
+
+test("the resolved label set keeps managed routing labels off a closed report", () => {
+  const marked = {
+    number: 47,
+    state: "open",
+    body: ISSUE_MARKER,
+    labels: [
+      { name: "pkg:tooling" },
+      { name: "risk:medium" },
+      { name: "custom" },
+    ],
+  };
+  const resolved = planIssueSync({
+    issues: [marked],
+    rows: [],
+    publishReport: false,
+  });
+  assert.deepEqual(resolved.labels, ["custom", "file-size-watchlist"]);
 });
 
 const BIG_SOURCE = Array.from(

--- a/scripts/repo-health/file-size-watchlist.test.mjs
+++ b/scripts/repo-health/file-size-watchlist.test.mjs
@@ -318,10 +318,18 @@ test("the live scan never produces a sweep-claimable label set", () => {
     ),
   );
   const actionable = actionableFileSizeRows(report.rows);
-  assert.ok(
-    actionable.length > 0,
-    "no actionable row today; this assertion needs a real row to mean anything",
-  );
+  if (actionable.length === 0) {
+    // Drift cleared, which is the state the automation exists to reach. The
+    // filer opens nothing, so there is no label set to check; assert that
+    // instead of failing the suite for the healthy tree.
+    const plan = planIssueSync({
+      issues: [],
+      rows: report.rows,
+      publishReport: false,
+    });
+    assert.equal(plan.action, "noop");
+    return;
+  }
   const labels = actionableLabels(actionable);
   // The sweep predicate is `agent-ready` plus exactly one `risk:*` equal to
   // `risk:low` plus exactly one `pkg:*` (`hasSweepRouting`,
@@ -347,9 +355,18 @@ test("a lone production-data writer still files at the risk floor", () => {
       package: "scripts",
     },
   ];
+  const labels = actionableLabels(rows);
   assert.deepEqual(packageLabelsForRows(rows), ["pkg:tooling"]);
   assert.equal(riskLabelForIssue([]), "risk:medium");
-  assert.ok(!actionableLabels(rows).includes("risk:low"));
+  // The fixture, not the live scan, is what pins the contract: one package, one
+  // risk label, and never the `risk:low` that would complete the sweep
+  // predicate. This holds whether or not the tree has drift today.
+  assert.ok(labels.includes("agent-ready"));
+  assert.deepEqual(
+    labels.filter((label) => label.startsWith("risk:")),
+    ["risk:medium"],
+  );
+  assert.deepEqual(agentReadyRoutingGaps(asIssue(labels)), []);
 });
 
 test("an operator risk escalation survives the next upsert as the only risk label", () => {

--- a/scripts/sentry/triage/sentry-triage-project-route.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-route.mjs
@@ -11,6 +11,7 @@ import {
   AGENT_READY_LABEL_DEFINITION,
   ensureLabelsExist,
   ISSUE_STATE_LABEL_DEFINITIONS,
+  LABEL_DEFINITIONS,
 } from "../../lib/gh-issue-lifecycle.mjs";
 import { PROJECTED_LABEL } from "./sentry-triage-project-core.mjs";
 import {
@@ -40,10 +41,22 @@ export const AGENT_READY_LABEL = AGENT_READY_LABEL_DEFINITION.name;
  *   honest floor is medium.
  *
  * Definitions, not names, because the ensure below creates a missing label from
- * the same shared shape it applies. Each color and description copies the live
- * repository label, so a create lands identical metadata; an existing label is
- * never edited.
+ * the same shared shape it applies. `agent-ready` and `risk:medium` come from
+ * the shared lifecycle definitions rather than being restated here, so the
+ * repository keeps one source of truth per label; `ensureLabelsExist` never
+ * edits an existing label, so a second shape would silently be decided by
+ * whichever scheduled producer created the label first. `kind:bug` and
+ * `pkg:dashboard` are not in the shared set, and their color and description
+ * copy this repository's live labels.
  */
+function sharedLabelDefinition(name) {
+  const definition = LABEL_DEFINITIONS.find((label) => label.name === name);
+  if (definition === undefined) {
+    throw new Error(`no shared definition for label '${name}'`);
+  }
+  return definition;
+}
+
 export const LOCAL_PROJECTION_LABEL_DEFINITIONS = [
   AGENT_READY_LABEL_DEFINITION,
   {
@@ -56,11 +69,7 @@ export const LOCAL_PROJECTION_LABEL_DEFINITIONS = [
     color: "1d76db",
     description: "Dashboard package or UI workflow",
   },
-  {
-    name: "risk:medium",
-    color: "fbca04",
-    description: "Medium-risk change requiring focused verification",
-  },
+  sharedLabelDefinition("risk:medium"),
 ];
 
 export const LOCAL_PROJECTION_LABELS = LOCAL_PROJECTION_LABEL_DEFINITIONS.map(

--- a/scripts/sentry/triage/sentry-triage-project-route.mjs
+++ b/scripts/sentry/triage/sentry-triage-project-route.mjs
@@ -21,6 +21,52 @@ import {
 
 export const AGENT_READY_LABEL = AGENT_READY_LABEL_DEFINITION.name;
 
+/**
+ * The routing labels a LOCAL projected work issue is created with.
+ * `agent-ready` alone made every projection read as incompletely groomed:
+ * docs/notes/agent-issue-workflow.md requires exactly one `risk:*` and at least
+ * one `pkg:*` beside it, and `pnpm issue:board sync` reports the gap.
+ *
+ * - `pkg:dashboard`: the local route is reached only when the verdict names
+ *   THIS repo, and `analytics-mento-org` — `ui-dashboard/` — is the only Sentry
+ *   project whose source lives here (docs/notes/sentry-triage-pipeline.md), so
+ *   the dashboard is the owning package the routing already resolved.
+ * - `kind:bug`: the projection exists because a production error fired. A
+ *   `config-fix` verdict says where the fix goes, not that the error was
+ *   intended.
+ * - `risk:medium`: the low-risk rule needs the body to name a verification
+ *   path, and the projected body renders verdict fields and links only. Adding
+ *   a command the pipeline cannot derive would invent an untrusted fact, so the
+ *   honest floor is medium.
+ *
+ * Definitions, not names, because the ensure below creates a missing label from
+ * the same shared shape it applies. Each color and description copies the live
+ * repository label, so a create lands identical metadata; an existing label is
+ * never edited.
+ */
+export const LOCAL_PROJECTION_LABEL_DEFINITIONS = [
+  AGENT_READY_LABEL_DEFINITION,
+  {
+    name: "kind:bug",
+    color: "d73a4a",
+    description: "Bug fix work item",
+  },
+  {
+    name: "pkg:dashboard",
+    color: "1d76db",
+    description: "Dashboard package or UI workflow",
+  },
+  {
+    name: "risk:medium",
+    color: "fbca04",
+    description: "Medium-risk change requiring focused verification",
+  },
+];
+
+export const LOCAL_PROJECTION_LABELS = LOCAL_PROJECTION_LABEL_DEFINITIONS.map(
+  (definition) => definition.name,
+);
+
 // `projectable` remains the external-write capability. This closed routing
 // enum adds one exact local destination without widening that capability.
 export const PROJECTION_DESTINATIONS = {
@@ -192,22 +238,23 @@ const REPROJECTION_REOPEN_COMMENT =
   "Reopened by the Mento Sentry triage pipeline: the underlying Sentry issue " +
   "regressed and was re-triaged as actionable.";
 
-// Local create consumes only the agent-ready lifecycle label. It creates a
-// missing label from the shared canonical definition and never force-edits
-// existing shared metadata. The ensure is best-effort. The issue mutation
-// remains authoritative and fails loudly if the label is still absent.
-export async function ensureAgentReadyLabel(owningRun, owningRepo) {
+// Local create consumes the routing label set above. It creates a missing label
+// from the shared canonical definition and never force-edits existing shared
+// metadata. The ensure is best-effort. The issue mutation remains authoritative
+// and fails loudly if a label is still absent, which is why the ensure covers
+// every label the create passes, not only `agent-ready`.
+export async function ensureLocalProjectionLabels(owningRun, owningRepo) {
   try {
     await ensureLabelsExist(
       { repo: owningRepo },
       {
         runner: owningRun,
-        definitions: [AGENT_READY_LABEL_DEFINITION],
+        definitions: LOCAL_PROJECTION_LABEL_DEFINITIONS,
       },
     );
   } catch (error) {
     process.stderr.write(
-      `warning: could not ensure label ${AGENT_READY_LABEL}: ${error.message}\n`,
+      `warning: could not ensure local projection labels (${LOCAL_PROJECTION_LABELS.join(", ")}): ${error.message}\n`,
     );
   }
 }

--- a/scripts/sentry/triage/sentry-triage-project.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.mjs
@@ -116,10 +116,10 @@ import { parseArgs, usage } from "./sentry-triage-project-cli.mjs";
 // (the workflow restores needs-triage instead of closing).
 import { clearBriefComments } from "./sentry-triage-brief.mjs";
 import {
-  AGENT_READY_LABEL,
   createProjectedIssue,
   defaultRunGh,
-  ensureAgentReadyLabel,
+  ensureLocalProjectionLabels,
+  LOCAL_PROJECTION_LABELS,
   fetchProjectorLogin,
   findExistingProjection,
   markStubProjected,
@@ -535,10 +535,10 @@ export async function runProjection(options, deps = {}) {
   });
 
   if (localConfig) {
-    await ensureAgentReadyLabel(owningRun, owningRepo);
+    await ensureLocalProjectionLabels(owningRun, owningRepo);
   }
   const url = await createProjectedIssue(owningRun, owningRepo, title, body, {
-    labels: localConfig ? [AGENT_READY_LABEL] : [],
+    labels: localConfig ? LOCAL_PROJECTION_LABELS : [],
   });
   registerFamily({ number: Number(url.split("/").pop()), url });
   await markStubProjected(

--- a/scripts/sentry/triage/sentry-triage-project.test.mjs
+++ b/scripts/sentry/triage/sentry-triage-project.test.mjs
@@ -62,6 +62,8 @@ import {
 } from "./sentry-triage-project.mjs";
 import {
   isWorkflowCreatedIssue,
+  LOCAL_PROJECTION_LABEL_DEFINITIONS,
+  LOCAL_PROJECTION_LABELS,
   WORKFLOW_ISSUE_AUTHOR,
 } from "./sentry-triage-project-route.mjs";
 import { BRIEF_COMMENT_MARKER } from "./sentry-triage-brief.mjs";
@@ -1750,7 +1752,7 @@ await test("runProjection projects config-fix as well", async () => {
   );
 });
 
-await test("runProjection creates local config work with the ambient token and agent-ready", async () => {
+await test("runProjection creates local config work with the ambient token and the full routing label set", async () => {
   const issue = queueIssue({
     comments: [
       botComment(
@@ -1783,7 +1785,7 @@ await test("runProjection creates local config work with the ambient token and a
   );
   const [labelCreate] = assertLabelDefinitionsCreatedBefore(
     calls,
-    [AGENT_READY_LABEL_DEFINITION],
+    LOCAL_PROJECTION_LABEL_DEFINITIONS,
     create,
   );
   assertEqual(labelCreate.token, null);
@@ -1792,17 +1794,27 @@ await test("runProjection creates local config work with the ambient token and a
     create.args[create.args.indexOf("-R") + 1],
     "mento-protocol/monitoring-monorepo",
   );
-  assert(
-    create.args.includes("agent-ready"),
-    "expected local work issue ready",
+  // `agent-ready` needs exactly one risk:* and at least one pkg:* beside it, or
+  // `issue:board sync` reports the projection as incompletely groomed.
+  assertDeepEqual(
+    create.args.flatMap((arg, index) =>
+      create.args[index - 1] === "--label" ? [arg] : [],
+    ),
+    ["agent-ready", "kind:bug", "pkg:dashboard", "risk:medium"],
   );
+  assertDeepEqual(LOCAL_PROJECTION_LABELS, [
+    "agent-ready",
+    "kind:bug",
+    "pkg:dashboard",
+    "risk:medium",
+  ]);
   assert(
     !calls.some((c) => c.token),
     "every local projection call must use the ambient token, never the PAT",
   );
 });
 
-await test("runProjection does not recreate an existing local agent-ready label", async () => {
+await test("runProjection does not recreate existing local routing labels", async () => {
   const issue = queueIssue({
     comments: [
       botComment(
@@ -1816,6 +1828,7 @@ await test("runProjection does not recreate an existing local agent-ready label"
   });
   const { runGh, calls } = makeRunGh({
     issue,
+    existingLabels: LOCAL_PROJECTION_LABELS,
     createdUrl:
       "https://github.com/mento-protocol/monitoring-monorepo/issues/999",
   });


### PR DESCRIPTION
## The Problem

- Two scheduled jobs filed `agent-ready` issues that the board immediately reported as incompletely groomed. The Sentry local projection created its work issue with `agent-ready` alone; the file-size watchlist filer carried no `pkg:*`. `agent-ready` requires exactly one `risk:*` and at least one `pkg:*`, so `pnpm issue:board sync` flagged every issue either job produced.
- An operator had to hand-label each new issue before anyone could route it, which is the grooming work `agent-ready` is supposed to promise is already done.

## The Solution

Both producers now apply a full routing set at creation, so a fresh issue from either job routes without a human touching it first.

- The Sentry local `config-fix` route creates with `agent-ready`, `kind:bug`, `pkg:dashboard`, and `risk:medium`, and ensures every one of those label definitions exists before the create.
- The file-size watchlist filer derives one `pkg:*` per package area its actionable rows touch, and writes exactly one `risk:*`.

Neither job ever writes `risk:low`. `agent-ready` plus exactly one `risk:low` plus exactly one `pkg:*` is the sweep predicate (`hasSweepRouting`, `scripts/pr/issue-board-state.mjs`), and `docs/notes/backlog-sweep.md` reserves that last label for a human so an unattended writer cannot complete sweep eligibility on its own. A monthly unattended job that could hand its own issue to the unattended sweep would widen unattended work with no human acknowledgement anywhere in the loop. A person who reads the issue can still apply `risk:low`.

Material limits. The risk floor is a constant, so a genuinely low-risk single-package drift issue is filed at `risk:medium` and waits for a human to lower it. Only the create path changed: an issue either job filed before this PR keeps its old labels, and a reopen of an older Sentry projection restores `agent-ready` alone (issue 2262). Backfilling those is an operator job, per the do-not-touch list on issue 2215.

## Details

`scripts/sentry/triage/sentry-triage-project-route.mjs` gains `LOCAL_PROJECTION_LABEL_DEFINITIONS` and `LOCAL_PROJECTION_LABELS`, and `ensureAgentReadyLabel` becomes `ensureLocalProjectionLabels`, which ensures every label the create passes. `gh issue create` fails when a passed label is absent, so ensuring only `agent-ready` would have broken the create. The definitions copy the live repository labels exactly; `ensureLabelsExist` never force-edits an existing label, so a description only matters on a create into a repo that lacks it.

The Sentry labels are a constant, not a per-project lookup. The local route fires on `projectionDestination(verdict, repoCheck)` when the verdict is `config-fix` and `repoCheck.reason` is `local-repo`. `validateAffectedRepo` reads only `affected_repo`; no Sentry project slug reaches `runProjection`. Per `docs/notes/sentry-triage-pipeline.md`, `analytics-mento-org` is the only project whose source lives here (`ui-dashboard/`), and every other project routes external with `labels: []`. A per-project map would have exactly one reachable entry.

Sentry risk is `risk:medium` because `buildProjectedBody` renders the marker, verdict fields, summary, root cause, proposed action, duplicate ids and links, and names no command, test file, or browser check. Condition 3 of the low-risk rule needs a verification path in the body, and inventing one would add an untrusted fact to a deterministic pipeline.

`scripts/repo-health/file-size-watchlist-issue.mjs` gains `SCOPE_PACKAGE_LABELS`, one `pkg:*` per watchlist scope. `scopePackageLabel` throws on an unmapped scope, because filing a silently ungroomed issue is the failure the map exists to prevent, and a test pins the map against the exported `SOURCE_SCOPES`. `packageLabelsForRows` returns the sorted distinct set, so a multi-package drift issue carries every package it spans.

Risk is managed by prefix, not by an enumeration of the labels the job may own. `preserveUnmanagedLabels` drops every `risk:*` and `riskLabelForIssue` folds the existing ones into the single label the write appends, returning the stricter of the floor and what the issue already carries. An operator escalation to `risk:high` therefore survives the next monthly upsert as the only risk label. Before this, an appended `risk:low` stood beside a preserved `risk:high` and `agentReadyRoutingGaps` reported "conflicting risk labels" — the exact finding issue 2215 exists to remove. A `pkg:*` the job did not apply stays, because an extra package area is legal on an `agent-ready` issue and only narrows sweep eligibility.

A per-row risk rule was the alternative and it was implemented first. It needed a list of the control surfaces a watchlist row can reach, and that list under-scanned: it missed the low-risk rule's credential clause and its production-data clause, so `scripts/sentry/triage/sentry-triage-archive.mjs`, a live actionable row that archives Sentry issues under a write-scoped token, classified as low risk. The list and its tests are gone. A constant floor cannot rot that way.

The issue body embeds the whole scan report while the labels describe the actionable rows alone, so the body now says which set the labels name.

ADR 0059 gains the label contract, since it enumerates what the filer does. ADR 0038 and the `scripts/lib/gh-issue-lifecycle.mjs` module comment both still described the projection as filing with `agent-ready` alone and ensuring only that definition; both now name the four-label set. The route reads `risk:medium` from the shared `LABEL_DEFINITIONS` rather than restating it, so one label has one shape in the codebase. The issue-board arm of the gate routing table now also runs the watchlist suite, because that suite asserts through `agentReadyRoutingGaps` and a change to the predicate would otherwise stay unrun.

## Validation

- The operator authorized a local quality-gate bypass for exact head `4e98e37aec8d443a076eadee908cdf2668c1fb9a` on 2026-09-03 because the host gate fails closed in Darwin lineage recovery (issue 2224); the push used `--no-verify`; mapped commands run directly: `./tools/trunk check --ci <the 8 changed files>`, `pnpm docs:index --check`, `pnpm docs:navigation-eval:test`, `pnpm agent:context-check`, `pnpm sentry:brief:test`, `pnpm lint:scripts`, `node --test scripts/repo-health/file-size-watchlist.test.mjs`, `pnpm sentry:project:test`, `node scripts/sentry/triage/sentry-triage-agent-comment.test.mjs`, `pnpm sentry:digest:test`, `pnpm sentry:archive:test`, `node scripts/sentry/ci-wiring/check-sentry-suites-in-ci.test.mjs`, `env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry/gate/sentry-suite-gate.test.mjs`, `env -u NODE_OPTIONS -u NODE_PATH node scripts/sentry/gate/sentry-suite-gate.mjs`, `pnpm tf:test`, `pnpm docs:navigation-eval -- --check-fixtures`; no gate control changed; exact-head GitHub CI is the authoritative replacement.
- Every one of those sixteen commands exited 0. `node --test scripts/repo-health/file-size-watchlist.test.mjs` reports 29 pass, 0 fail. `pnpm sentry:project:test` reports 142 passed. Those runs establish that the mapped checks for this diff pass on this host. They do not establish that the full gate passes, because the gate could not dispatch here.
- `node scripts/repo-health/file-size-watchlist.mjs --format json` today lists 14 actionable rows spanning `metrics-bridge` and `scripts`. The new test drives `actionableLabels` from that live scan and asserts the label set through `agentReadyRoutingGaps`, the consumer that reports the finding. That proves the live rows produce a compliant, non-sweep-claimable set; it does not prove every future row set does, which is why the risk floor is a constant rather than a computed value.
- The `risk:high` case is pinned by a test over `planIssueSync`, asserting exactly one `risk:*` after the upsert and that it is the stricter label. That test covers the three ranked labels and an unrankable `risk:*`; it does not cover a label vocabulary change, which would need the ranking map updated.
- `pnpm agent:autoreview` produced one P2 and then failed with `error: Darwin lineage recovery stayed fail-closed because no coherent snapshot was available before its deadline` (exit 125), the same host state as issue 2224. The review output was captured before the failure. Its finding is answered under Deferrals.
- `pnpm issue:claim --issue 2215` failed with the issue 2226 mutex-ref error ("absent after 3 compare-and-swap attempts"), so the board holds no claim for this issue. Verified afterwards that issue 2215 carries no `agent-active` and no other session holds it. `pnpm issue:review --pr 2264 --issue 2215` was run once and failed downstream of that: "Issue #2215 review requires durable Claim ID, Agent, and Branch ownership". The board records no claim to transition, which is issue 2226, not a second defect.
- After the review round, every mapped command was re-run against the wider diff and exited 0, including `pnpm gate:routing-table:test`, `pnpm issue:board:test`, `pnpm docs:garden:test`, and `pnpm review:eval:test`. The one exception is `pnpm agent:quality-gate:test`, which fails on this host inside the Darwin settlement-watcher tests. It named a different test on each of two runs ("converts a post-arm cancel action into settlement", "reacts when its controller dies but launcher remains"), while `node --test scripts/gate/darwin-process-lineage.test.mjs` passes 57 of 57 on this branch. That is the issue 2224 host state. The diff's only gate change is six lines of routing-table data and `pnpm gate:routing-table:test` passes, so nothing here can reach a process-lineage watcher. CI settles it.
- Not validated: no live Sentry projection or watchlist run was executed against GitHub. Both producers are exercised through their offline suites with mocked `gh` only.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2267 — review asked the watchlist filer to ensure every label it sends, as the Sentry route does. The exposure predates this PR: the filer already sent four labels through an unensured `gh issue create`, and this PR added `pkg:*` to that same create. Closing it needs definitions for the seven `pkg:*` labels, and `pkg:tooling` and `risk:medium` disagree between `LABEL_DEFINITIONS` and this repository's live labels, so writing them here would silently pick a winner for repository metadata. The issue carries both halves.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2262 — the closeout review asked the Sentry reuse and reopen paths to apply the routing set too. Issue 2215 forbids it directly ("Do not relabel issues these jobs already created; that is an operator backfill, not a producer change"), so the gap is recorded rather than fixed here. No open local projection is in that state today: issue 2025, the one open local `config-fix` projection, already carries a full routing set from an earlier operator backfill.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? No new decision; ADR 0059 is updated with the label contract it already owns.

Closes #2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN

