### PR TITLE
docs(sweep): refine the grooming pass skip key, cap, path resolution, and shared surfaces

### DIFF
--- a/.agents/skills/backlog-sweep/SKILL.md
+++ b/.agents/skills/backlog-sweep/SKILL.md
@@ -181,7 +181,9 @@ Take the top N — default 2 — that satisfy **all** of:
   such issues both pass and then edit the same package. Multiple package areas
   are ambiguous and make the same independence check unreliable. Treat a
   missing or ambiguous package area as ineligible rather than as independence.
-- **Mutually independent.** No two issues in one batch share a `pkg:*` label —
+- **Mutually independent.** Two tests, in order: the label-independent
+  docs-catalog test below, then the label test. No two issues in one batch
+  share a `pkg:*` label —
   `pkg:dashboard`, `pkg:indexer`, `pkg:alerts`, `pkg:terraform`, `pkg:tooling`,
   listed in
   [`agent-issue-workflow.md`](../../../docs/notes/agent-issue-workflow.md).
@@ -189,7 +191,8 @@ Take the top N — default 2 — that satisfy **all** of:
   by lookup rather than per-batch judgement. Two workers editing one package
   produce PRs whose diffs conflict and whose reviewers see a base moving under
   them, and the second PR then pays for a merge, a re-gate, and a fresh review
-  round it did not need. `pkg:tooling` gets a path test instead, below.
+  round it did not need. `pkg:tooling` gets a path test instead of the label
+  test, below.
 - **Outside its own grooming veto window.** A candidate whose newest _trusted_
   `sweep-groomed:` marker comment is less than 12 hours old waits for the
   next run, whatever version that marker carries — the window asks whether a
@@ -224,6 +227,26 @@ Take the top N — default 2 — that satisfy **all** of:
   gh api "repos/$repo/collaborators/<login>/permission" --jq '.role_name'
   ```
 
+**The docs catalog is a pairwise conflict in every package.** Run this test
+before the label test, on every pair, whatever labels the two candidates carry.
+A candidate carries the catalog when its work adds, moves, or removes a
+Markdown surface, changes any front matter of an existing one, or adds or
+removes an internal link, because the catalog lists broken internal links
+beside an entry per file. Only a body-prose edit that leaves the front matter
+and every link alone is exempt, and a body whose documentation effect cannot be
+read carries the catalog: nothing to compare is not evidence of no conflict.
+Two candidates that both carry it are never independent.
+[`context-standards.md`](../../../docs/context-standards.md) requires that
+generated catalog to index every Markdown file and `pnpm docs:index --check`
+fails while it is stale, so both workers regenerate `docs/README.md` and their
+PRs conflict on that one file even when they share no package and no other
+path. Scoping the rule to `pkg:tooling` would miss exactly that pair: a
+`pkg:dashboard` issue adding a README beside a `pkg:indexer` issue adding one
+passes the label test and then produces two PRs regenerating one catalog. Do
+not restate which fields the catalog renders: `classifyDocumentation` and
+`catalogEntry` in `scripts/context/docs-index-helpers.mjs` decide that, and any
+list written here rots against them in silence.
+
 **`pkg:tooling` takes a path test, not a label test.** That one label covers
 `scripts/`, `docs/`, `.agents/`, `.claude/`, and the root tooling files, so two
 candidates that touch nothing in common still share it and the batch loses a
@@ -240,19 +263,9 @@ a path whose first two segments are `.claude/skills` is read with those replaced
 by `.agents/skills`, whatever follows and whether or not it ends in a slash. The
 two are one collision surface, so an issue naming one and an issue naming the
 other would otherwise pass a literal containment test and then produce two PRs
-touching the same files. Then add `docs/README.md` to the compared path set of
-any candidate whose named paths add, move, or remove a Markdown surface.
-[`context-standards.md`](../../../docs/context-standards.md) requires that
-catalog to index every Markdown file and `pnpm docs:index --check` fails while
-it is stale, so both workers regenerate the one file and their PRs conflict on
-it. Two Markdown-adding candidates are therefore never independent. A candidate
-that changes any front matter of an existing Markdown surface carries the
-catalog too, and so does one that adds or removes an internal link, because the
-catalog also lists broken internal links. Only a body-prose edit that leaves the
-front matter and every link alone is exempt. Do not restate which fields the
-catalog renders: `classifyDocumentation` and `catalogEntry` in
-`scripts/context/docs-index-helpers.mjs` decide that, and any list written here
-rots against them in silence.
+touching the same files. A candidate that carries the docs catalog above brings
+`docs/README.md` into this comparison too, so it also conflicts with a
+candidate that names that file outright.
 A candidate with no path list conflicts with every other `pkg:tooling`
 candidate: nothing to compare is not evidence that the paths are disjoint. Name
 the independence basis in the printed batch for every pair that relied on this,
@@ -721,14 +734,23 @@ The full procedure is
    Preflight's, and the marker records it.
 
    ```bash
-   git fetch origin main
+   git fetch "$(git remote get-url --push origin)" main
    oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
    git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
    ```
 
-   Pin `FETCH_HEAD`, not `origin/main`: a clone made with `--single-branch` on
-   another branch has no `refs/remotes/origin/main` for the fetch to update, so
-   `git rev-parse origin/main` there fails after the batch is already claimed.
+   Fetch the validated push URL, not the remote name. Preflight grades
+   `git remote get-url --push origin`, and a remote carrying a `pushurl`
+   fetches from a different URL than it pushes to, so `git fetch origin main`
+   would resolve every path in this pass against a URL no check ever read.
+   Naming that URL here binds the read to the repository Preflight approved and
+   leaves Preflight one check on one URL, which is the check the fork stop
+   needs.
+
+   Pin `FETCH_HEAD`, not `origin/main`: a fetch by URL updates no
+   remote-tracking ref at all, and a clone made with `--single-branch` on
+   another branch has no `refs/remotes/origin/main` to read either, so
+   `git rev-parse origin/main` fails after the batch is already claimed.
    Address each path as `<oid>:<path>`, not with `git ls-tree`: a body may name
    a directory with a trailing slash, and `git ls-tree "$oid" -- docs/notes/`
    lists that directory's children rather than its one tree id, while

--- a/.agents/skills/backlog-sweep/SKILL.md
+++ b/.agents/skills/backlog-sweep/SKILL.md
@@ -722,9 +722,18 @@ The full procedure is
 
    ```bash
    git fetch origin main
-   oid="$(git rev-parse origin/main)"
-   git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+   oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
+   git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
    ```
+
+   Pin `FETCH_HEAD`, not `origin/main`: a clone made with `--single-branch` on
+   another branch has no `refs/remotes/origin/main` for the fetch to update, so
+   `git rev-parse origin/main` there fails after the batch is already claimed.
+   Address each path as `<oid>:<path>`, not with `git ls-tree`: a body may name
+   a directory with a trailing slash, and `git ls-tree "$oid" -- docs/notes/`
+   lists that directory's children rather than its one tree id, while
+   `git rev-parse "$oid:<path>"` returns one id for a file, a directory, and a
+   directory with a trailing slash, and exits non-zero when the path is absent.
 
    Order by `rank-backlog` score, highest first, then by issue number, newest
    first; the
@@ -769,8 +778,8 @@ The full procedure is
    issue groomed under `v1` re-grooms once.
 
 2. **Read the body, then read the paths it names against the OID pinned in
-   step 1.** Read every path with `git ls-tree` or `git cat-file` against that
-   OID, never from the session checkout. Labels are repository-wide state and
+   step 1.** Read every path as `<oid>:<path>` against that OID, never from the
+   session checkout. Labels are repository-wide state and
    the checkout is session-local:
    a sweep started from a clean feature branch would otherwise classify live
    issues against that branch's tree, and since the pass never removes or
@@ -821,7 +830,8 @@ The full procedure is
 
    `ref` and `oid` name the tree the paths were resolved against. `body` is the
    SHA-256 of the issue body this pass read. `paths` maps each named path that
-   resolved at that OID to its `git ls-tree` blob or tree SHA, so a file whose
+   resolved at that OID to the one id `git rev-parse "<oid>:<path>"` returns,
+   so a file whose
    contents changed under a stable name invalidates the marker; only paths the
    body names are covered. `labels` snapshots the issue's `risk:*`, `pkg:*`,
    `kind:*`, and queue-state labels as read, before this pass writes anything —

--- a/.agents/skills/backlog-sweep/SKILL.md
+++ b/.agents/skills/backlog-sweep/SKILL.md
@@ -100,7 +100,7 @@ implementation. **Refuse a batch size above 4.** Say that plainly and stop
 rather than clamping silently — an operator who asked for 6 needs to know they
 got a refusal, not a quiet 4. The grooming pass below is outside that model: it
 costs issue reads, label writes, and one comment each, opens no PR, and buys no
-review round. Keep its cap at 10 candidates a run.
+review round. Keep its cap at 10 grooming attempts a run.
 
 ## Rank And Pick The Batch
 
@@ -191,8 +191,12 @@ Take the top N — default 2 — that satisfy **all** of:
   them, and the second PR then pays for a merge, a re-gate, and a fresh review
   round it did not need. `pkg:tooling` gets a path test instead, below.
 - **Outside its own grooming veto window.** A candidate whose newest _trusted_
-  `sweep-groomed:v1` marker comment is less than 12 hours old waits for the
-  next run; the report names when that window closes. The window is a bounded
+  `sweep-groomed:` marker comment is less than 12 hours old waits for the
+  next run, whatever version that marker carries — the window asks whether a
+  human has seen the labels, which does not depend on the payload shape, so
+  matching `v2` only here would un-veto every issue the last run groomed. The
+  skip key below does match `v2` only. The report names when that window
+  closes. The window is a bounded
   chance for a human to disagree with a label an agent applied, before that
   label selects work for another agent. An issue a human labeled by hand
   carries no marker and is never delayed. An operator who wants to fast-track a
@@ -213,7 +217,7 @@ Take the top N — default 2 — that satisfy **all** of:
   gh issue view <n> --repo mento-protocol/monitoring-monorepo \
     --json comments \
     --jq '.comments[]
-          | select(.body | startswith("<!-- sweep-groomed:v1"))
+          | select(.body | startswith("<!-- sweep-groomed:"))
           | {login: .author.login, created: .createdAt}'
 
   repo=mento-protocol/monitoring-monorepo
@@ -236,7 +240,19 @@ a path whose first two segments are `.claude/skills` is read with those replaced
 by `.agents/skills`, whatever follows and whether or not it ends in a slash. The
 two are one collision surface, so an issue naming one and an issue naming the
 other would otherwise pass a literal containment test and then produce two PRs
-touching the same files.
+touching the same files. Then add `docs/README.md` to the compared path set of
+any candidate whose named paths add, move, or remove a Markdown surface.
+[`context-standards.md`](../../../docs/context-standards.md) requires that
+catalog to index every Markdown file and `pnpm docs:index --check` fails while
+it is stale, so both workers regenerate the one file and their PRs conflict on
+it. Two Markdown-adding candidates are therefore never independent. A candidate
+that changes any front matter of an existing Markdown surface carries the
+catalog too, and so does one that adds or removes an internal link, because the
+catalog also lists broken internal links. Only a body-prose edit that leaves the
+front matter and every link alone is exempt. Do not restate which fields the
+catalog renders: `classifyDocumentation` and `catalogEntry` in
+`scripts/context/docs-index-helpers.mjs` decide that, and any list written here
+rots against them in silence.
 A candidate with no path list conflicts with every other `pkg:tooling`
 candidate: nothing to compare is not evidence that the paths are disjoint. Name
 the independence basis in the printed batch for every pair that relied on this,
@@ -698,25 +714,70 @@ control that blocks your own work, one run later. Narrowing is free.
 The full procedure is
 [`backlog-sweep.md`](../../../docs/notes/backlog-sweep.md). The operative steps:
 
-1. **Take at most 10 candidates**, ordered by `rank-backlog` score, highest
-   first, then by issue number, newest first — the outside-the-queue set carries
-   no score and so sits behind every scored candidate. Two sets qualify:
-   `agent-ready` issues lacking exactly one `risk:*` or exactly one `pkg:*`, and
-   issues with no queue-state label read from the roster the ranking already
-   fetched. Drop every bot record — anything authored by `app/github-actions`
-   or carrying `drift-detection`, `sentry-triage`, a `sentry:*` label,
-   `dependencies`, `security-advisories`, or `file-size-watchlist`. Skip a
-   candidate only when its body digest still matches its newest trusted marker,
-   the marker's resolved path set still matches, and the issue carries every
-   label in that marker's `applied` list. All three are needed: the verdict
-   comes from the body and from what the tree holds, so a named path that did
-   not exist then and does now must be read again; and missing `applied` labels
-   mean a write failed after the comment landed, so retry rather than skip for
-   ever. Compare the body, never `updatedAt` — posting the marker updates the
-   issue, so a timestamp test would compare the pass against its own write.
-   Count the skip in the report.
-2. **Read the body, then read the paths it names.** The labels come from what
-   the checkout holds, not from what the body claims.
+1. **Pin the tree, then order, filter, and cap at 10.** Fetch `origin/main` and
+   pin one OID for the whole pass before any candidate is read; every path read
+   below, the skip key's digests included, uses that one tree. The pass runs
+   long after Preflight, so it pins its own OID rather than inheriting
+   Preflight's, and the marker records it.
+
+   ```bash
+   git fetch origin main
+   oid="$(git rev-parse origin/main)"
+   git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+   ```
+
+   Order by `rank-backlog` score, highest first, then by issue number, newest
+   first; the
+   outside-the-queue set carries no score and so sits behind every scored
+   candidate. Two sets qualify: `agent-ready` issues lacking exactly one
+   `risk:*` or exactly one `pkg:*`, and issues with no queue-state label read
+   from the roster the ranking already fetched. Drop every bot record —
+   anything authored by `app/github-actions` or carrying `drift-detection`,
+   `sentry-triage`, a `sentry:*` label, `dependencies`,
+   `security-advisories`, or `file-size-watchlist`. Then walk that order and
+   test the skip key below as you reach each candidate, stopping at the first 10
+   survivors; the test costs one comment read each, so walk it lazily rather
+   than pre-filtering the whole queue. The cap bounds grooming attempts, not
+   candidates examined: capping first would let ten unchanged high scorers hold
+   every slot run after run and starve the rest of the queue. The read cost is
+   therefore bounded by the candidate set rather than by the cap, so report how
+   many candidates the walk examined beside how many it groomed. Do not add a
+   fixed ceiling on candidates examined: the walk order is stable, so a hard
+   stop at the same depth every run never reaches the tail. Count every skipped
+   candidate in the report.
+
+   **The skip key has four parts**, read from the candidate's newest trusted
+   `sweep-groomed:v2` marker. Skip only when all four hold: the body digest
+   still matches; the marker's `paths` map still matches, path for path and
+   digest for digest, at the OID pinned above; the issue carries every label in
+   the marker's `applied` list; and the issue's current `risk:*`,
+   `pkg:*`, `kind:*`, and queue-state labels equal the marker's `labels`
+   snapshot plus its `applied` list — the same four label classes on both sides,
+   because those are every class the pass writes into `applied`, and a class
+   present on one side only makes the test fail for ever. Each guards a
+   different way the verdict goes stale. The body is what the pass read. The `paths` map is the rest of it — a named path that was
+   absent then and exists now, one since deleted, and one whose contents changed
+   under a stable name all change the answer. Missing `applied` labels mean a
+   write failed after the comment landed, so retry rather than skip for ever.
+   The `labels` snapshot is what makes a human's correction reopen the issue:
+   a pass that stopped on two `risk:*` labels writes `applied: []`, and without
+   the snapshot the empty-subset check would succeed vacuously and strand the
+   issue after a human removed one of them. Compare the body, never `updatedAt`
+   — posting the marker updates the issue, so a timestamp test would compare
+   the pass against its own write. A `v1` marker never satisfies the key: it
+   carries no `labels`, no per-path digest, and no resolution ref, so every
+   issue groomed under `v1` re-grooms once.
+
+2. **Read the body, then read the paths it names against the OID pinned in
+   step 1.** Read every path with `git ls-tree` or `git cat-file` against that
+   OID, never from the session checkout. Labels are repository-wide state and
+   the checkout is session-local:
+   a sweep started from a clean feature branch would otherwise classify live
+   issues against that branch's tree, and since the pass never removes or
+   downgrades a label, a wrong `pkg:*` cannot be retracted later. The marker
+   records the ref and the OID, so a reader can tell what a verdict was based
+   on. The labels come from what that tree holds, not from what the body claims.
+
 3. **Decide the labels.**
    - `pkg:*` — every area the named paths fall in. Several labels when the
      issue genuinely spans packages, which keeps it correctly labeled and
@@ -755,13 +816,17 @@ The full procedure is
    posted, write no label for that issue.
 
    ```text
-   <!-- sweep-groomed:v1 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","body":"<sha256>","paths":[...],"applied":[...],"proposed":[...]} -->
+   <!-- sweep-groomed:v2 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","ref":"origin/main","oid":"<40-hex>","body":"<sha256>","paths":{"<path>":"<blob or tree sha>"},"labels":[...],"applied":[...],"proposed":[...]} -->
    ```
 
-   `body` is the SHA-256 of the issue body this pass read and `paths` the named
-   paths that existed in the checkout when it read them; the next run skips the
-   candidate only while both still match and its `applied` labels are present. `applied` lists the labels the
-   next call writes; `proposed` lists everything
+   `ref` and `oid` name the tree the paths were resolved against. `body` is the
+   SHA-256 of the issue body this pass read. `paths` maps each named path that
+   resolved at that OID to its `git ls-tree` blob or tree SHA, so a file whose
+   contents changed under a stable name invalidates the marker; only paths the
+   body names are covered. `labels` snapshots the issue's `risk:*`, `pkg:*`,
+   `kind:*`, and queue-state labels as read, before this pass writes anything —
+   every class the pass can write, so the skip key compares like with like.
+   `applied` lists the labels the next call writes; `proposed` lists everything
    the pass judged right and will not write itself — a `risk:low`, the state
    label the mutex owns, the `agent-ready` promotion, workboard enrollment, and
    a risk label withheld from a contradicted or double-labeled issue. `at`
@@ -937,18 +1002,26 @@ board.
    that something is still sitting there.
 6. **Anything needing the operator's decision** — a blocked control, a
    misgroomed issue, a finding the worker could not adjudicate.
-7. **Groomed for the next run**, a table of `Issue | Labels applied | Proposed
-for a human | Rule basis | Veto ends`. `Proposed for a human` is the column
-   an operator acts on — a `risk:low` the pass may not write, the state label
-   the mutex owns, workboard enrollment, an `agent-ready` promotion the body
-   already deserves. `Veto ends` says when the window closes, not when the
-   issue becomes selectable: an unapplied proposal, a `risk:medium`, or several
-   `pkg:*` labels keep it ineligible whatever the clock says. Name the
+7. **Groomed for the next run.** State two run-wide facts above the table: the
+   `origin/main` OID every path was read against, the same value the marker
+   carries, so a verdict is reproducible from a named ref; and how many
+   candidates the walk examined. Each is one value a run, so neither is a
+   column. The table is
+   `Issue | Labels applied | Proposed for a human | Rule basis | Veto ends`.
+   `Proposed for a human` is the column an operator acts on — a `risk:low` the pass may not write, the
+   state label the mutex owns, workboard enrollment, an `agent-ready` promotion
+   the body already deserves. `Rule basis` names the Low-risk rule clause behind
+   the risk verdict, and on a skipped or re-groomed row it carries the reason
+   instead. `Veto ends` says when the window closes, not
+   when the issue becomes selectable: an unapplied proposal, a `risk:medium`, or
+   several `pkg:*` labels keep it ineligible whatever the clock says. Name the
    remaining requirement beside the time whenever one applies. List candidates
-   skipped as unchanged since their last marker, so a stuck issue is visible.
-   Write the section with a `none` row when the pass groomed nothing — an empty
-   candidate set and a pass that never ran read identically once the section is
-   missing.
+   skipped against their last marker with the reason, and candidates re-groomed
+   because the key broke with what broke it — the changed path, the label a
+   human moved, or a `v1` marker. A stuck issue and a re-read one are both
+   visible that way. Write the section with a `none` row when the pass groomed
+   nothing — an empty candidate set and a pass that never ran read identically
+   once the section is missing.
 
 Print the same summary to the terminal; the file is the artifact, the terminal
 output is its summary.

--- a/.claude/skills/backlog-sweep/SKILL.md
+++ b/.claude/skills/backlog-sweep/SKILL.md
@@ -181,7 +181,9 @@ Take the top N — default 2 — that satisfy **all** of:
   such issues both pass and then edit the same package. Multiple package areas
   are ambiguous and make the same independence check unreliable. Treat a
   missing or ambiguous package area as ineligible rather than as independence.
-- **Mutually independent.** No two issues in one batch share a `pkg:*` label —
+- **Mutually independent.** Two tests, in order: the label-independent
+  docs-catalog test below, then the label test. No two issues in one batch
+  share a `pkg:*` label —
   `pkg:dashboard`, `pkg:indexer`, `pkg:alerts`, `pkg:terraform`, `pkg:tooling`,
   listed in
   [`agent-issue-workflow.md`](../../../docs/notes/agent-issue-workflow.md).
@@ -189,7 +191,8 @@ Take the top N — default 2 — that satisfy **all** of:
   by lookup rather than per-batch judgement. Two workers editing one package
   produce PRs whose diffs conflict and whose reviewers see a base moving under
   them, and the second PR then pays for a merge, a re-gate, and a fresh review
-  round it did not need. `pkg:tooling` gets a path test instead, below.
+  round it did not need. `pkg:tooling` gets a path test instead of the label
+  test, below.
 - **Outside its own grooming veto window.** A candidate whose newest _trusted_
   `sweep-groomed:` marker comment is less than 12 hours old waits for the
   next run, whatever version that marker carries — the window asks whether a
@@ -224,6 +227,26 @@ Take the top N — default 2 — that satisfy **all** of:
   gh api "repos/$repo/collaborators/<login>/permission" --jq '.role_name'
   ```
 
+**The docs catalog is a pairwise conflict in every package.** Run this test
+before the label test, on every pair, whatever labels the two candidates carry.
+A candidate carries the catalog when its work adds, moves, or removes a
+Markdown surface, changes any front matter of an existing one, or adds or
+removes an internal link, because the catalog lists broken internal links
+beside an entry per file. Only a body-prose edit that leaves the front matter
+and every link alone is exempt, and a body whose documentation effect cannot be
+read carries the catalog: nothing to compare is not evidence of no conflict.
+Two candidates that both carry it are never independent.
+[`context-standards.md`](../../../docs/context-standards.md) requires that
+generated catalog to index every Markdown file and `pnpm docs:index --check`
+fails while it is stale, so both workers regenerate `docs/README.md` and their
+PRs conflict on that one file even when they share no package and no other
+path. Scoping the rule to `pkg:tooling` would miss exactly that pair: a
+`pkg:dashboard` issue adding a README beside a `pkg:indexer` issue adding one
+passes the label test and then produces two PRs regenerating one catalog. Do
+not restate which fields the catalog renders: `classifyDocumentation` and
+`catalogEntry` in `scripts/context/docs-index-helpers.mjs` decide that, and any
+list written here rots against them in silence.
+
 **`pkg:tooling` takes a path test, not a label test.** That one label covers
 `scripts/`, `docs/`, `.agents/`, `.claude/`, and the root tooling files, so two
 candidates that touch nothing in common still share it and the batch loses a
@@ -240,19 +263,9 @@ a path whose first two segments are `.claude/skills` is read with those replaced
 by `.agents/skills`, whatever follows and whether or not it ends in a slash. The
 two are one collision surface, so an issue naming one and an issue naming the
 other would otherwise pass a literal containment test and then produce two PRs
-touching the same files. Then add `docs/README.md` to the compared path set of
-any candidate whose named paths add, move, or remove a Markdown surface.
-[`context-standards.md`](../../../docs/context-standards.md) requires that
-catalog to index every Markdown file and `pnpm docs:index --check` fails while
-it is stale, so both workers regenerate the one file and their PRs conflict on
-it. Two Markdown-adding candidates are therefore never independent. A candidate
-that changes any front matter of an existing Markdown surface carries the
-catalog too, and so does one that adds or removes an internal link, because the
-catalog also lists broken internal links. Only a body-prose edit that leaves the
-front matter and every link alone is exempt. Do not restate which fields the
-catalog renders: `classifyDocumentation` and `catalogEntry` in
-`scripts/context/docs-index-helpers.mjs` decide that, and any list written here
-rots against them in silence.
+touching the same files. A candidate that carries the docs catalog above brings
+`docs/README.md` into this comparison too, so it also conflicts with a
+candidate that names that file outright.
 A candidate with no path list conflicts with every other `pkg:tooling`
 candidate: nothing to compare is not evidence that the paths are disjoint. Name
 the independence basis in the printed batch for every pair that relied on this,
@@ -721,14 +734,23 @@ The full procedure is
    Preflight's, and the marker records it.
 
    ```bash
-   git fetch origin main
+   git fetch "$(git remote get-url --push origin)" main
    oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
    git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
    ```
 
-   Pin `FETCH_HEAD`, not `origin/main`: a clone made with `--single-branch` on
-   another branch has no `refs/remotes/origin/main` for the fetch to update, so
-   `git rev-parse origin/main` there fails after the batch is already claimed.
+   Fetch the validated push URL, not the remote name. Preflight grades
+   `git remote get-url --push origin`, and a remote carrying a `pushurl`
+   fetches from a different URL than it pushes to, so `git fetch origin main`
+   would resolve every path in this pass against a URL no check ever read.
+   Naming that URL here binds the read to the repository Preflight approved and
+   leaves Preflight one check on one URL, which is the check the fork stop
+   needs.
+
+   Pin `FETCH_HEAD`, not `origin/main`: a fetch by URL updates no
+   remote-tracking ref at all, and a clone made with `--single-branch` on
+   another branch has no `refs/remotes/origin/main` to read either, so
+   `git rev-parse origin/main` fails after the batch is already claimed.
    Address each path as `<oid>:<path>`, not with `git ls-tree`: a body may name
    a directory with a trailing slash, and `git ls-tree "$oid" -- docs/notes/`
    lists that directory's children rather than its one tree id, while

--- a/.claude/skills/backlog-sweep/SKILL.md
+++ b/.claude/skills/backlog-sweep/SKILL.md
@@ -722,9 +722,18 @@ The full procedure is
 
    ```bash
    git fetch origin main
-   oid="$(git rev-parse origin/main)"
-   git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+   oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
+   git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
    ```
+
+   Pin `FETCH_HEAD`, not `origin/main`: a clone made with `--single-branch` on
+   another branch has no `refs/remotes/origin/main` for the fetch to update, so
+   `git rev-parse origin/main` there fails after the batch is already claimed.
+   Address each path as `<oid>:<path>`, not with `git ls-tree`: a body may name
+   a directory with a trailing slash, and `git ls-tree "$oid" -- docs/notes/`
+   lists that directory's children rather than its one tree id, while
+   `git rev-parse "$oid:<path>"` returns one id for a file, a directory, and a
+   directory with a trailing slash, and exits non-zero when the path is absent.
 
    Order by `rank-backlog` score, highest first, then by issue number, newest
    first; the
@@ -769,8 +778,8 @@ The full procedure is
    issue groomed under `v1` re-grooms once.
 
 2. **Read the body, then read the paths it names against the OID pinned in
-   step 1.** Read every path with `git ls-tree` or `git cat-file` against that
-   OID, never from the session checkout. Labels are repository-wide state and
+   step 1.** Read every path as `<oid>:<path>` against that OID, never from the
+   session checkout. Labels are repository-wide state and
    the checkout is session-local:
    a sweep started from a clean feature branch would otherwise classify live
    issues against that branch's tree, and since the pass never removes or
@@ -821,7 +830,8 @@ The full procedure is
 
    `ref` and `oid` name the tree the paths were resolved against. `body` is the
    SHA-256 of the issue body this pass read. `paths` maps each named path that
-   resolved at that OID to its `git ls-tree` blob or tree SHA, so a file whose
+   resolved at that OID to the one id `git rev-parse "<oid>:<path>"` returns,
+   so a file whose
    contents changed under a stable name invalidates the marker; only paths the
    body names are covered. `labels` snapshots the issue's `risk:*`, `pkg:*`,
    `kind:*`, and queue-state labels as read, before this pass writes anything —

--- a/.claude/skills/backlog-sweep/SKILL.md
+++ b/.claude/skills/backlog-sweep/SKILL.md
@@ -100,7 +100,7 @@ implementation. **Refuse a batch size above 4.** Say that plainly and stop
 rather than clamping silently — an operator who asked for 6 needs to know they
 got a refusal, not a quiet 4. The grooming pass below is outside that model: it
 costs issue reads, label writes, and one comment each, opens no PR, and buys no
-review round. Keep its cap at 10 candidates a run.
+review round. Keep its cap at 10 grooming attempts a run.
 
 ## Rank And Pick The Batch
 
@@ -191,8 +191,12 @@ Take the top N — default 2 — that satisfy **all** of:
   them, and the second PR then pays for a merge, a re-gate, and a fresh review
   round it did not need. `pkg:tooling` gets a path test instead, below.
 - **Outside its own grooming veto window.** A candidate whose newest _trusted_
-  `sweep-groomed:v1` marker comment is less than 12 hours old waits for the
-  next run; the report names when that window closes. The window is a bounded
+  `sweep-groomed:` marker comment is less than 12 hours old waits for the
+  next run, whatever version that marker carries — the window asks whether a
+  human has seen the labels, which does not depend on the payload shape, so
+  matching `v2` only here would un-veto every issue the last run groomed. The
+  skip key below does match `v2` only. The report names when that window
+  closes. The window is a bounded
   chance for a human to disagree with a label an agent applied, before that
   label selects work for another agent. An issue a human labeled by hand
   carries no marker and is never delayed. An operator who wants to fast-track a
@@ -213,7 +217,7 @@ Take the top N — default 2 — that satisfy **all** of:
   gh issue view <n> --repo mento-protocol/monitoring-monorepo \
     --json comments \
     --jq '.comments[]
-          | select(.body | startswith("<!-- sweep-groomed:v1"))
+          | select(.body | startswith("<!-- sweep-groomed:"))
           | {login: .author.login, created: .createdAt}'
 
   repo=mento-protocol/monitoring-monorepo
@@ -236,7 +240,19 @@ a path whose first two segments are `.claude/skills` is read with those replaced
 by `.agents/skills`, whatever follows and whether or not it ends in a slash. The
 two are one collision surface, so an issue naming one and an issue naming the
 other would otherwise pass a literal containment test and then produce two PRs
-touching the same files.
+touching the same files. Then add `docs/README.md` to the compared path set of
+any candidate whose named paths add, move, or remove a Markdown surface.
+[`context-standards.md`](../../../docs/context-standards.md) requires that
+catalog to index every Markdown file and `pnpm docs:index --check` fails while
+it is stale, so both workers regenerate the one file and their PRs conflict on
+it. Two Markdown-adding candidates are therefore never independent. A candidate
+that changes any front matter of an existing Markdown surface carries the
+catalog too, and so does one that adds or removes an internal link, because the
+catalog also lists broken internal links. Only a body-prose edit that leaves the
+front matter and every link alone is exempt. Do not restate which fields the
+catalog renders: `classifyDocumentation` and `catalogEntry` in
+`scripts/context/docs-index-helpers.mjs` decide that, and any list written here
+rots against them in silence.
 A candidate with no path list conflicts with every other `pkg:tooling`
 candidate: nothing to compare is not evidence that the paths are disjoint. Name
 the independence basis in the printed batch for every pair that relied on this,
@@ -698,25 +714,70 @@ control that blocks your own work, one run later. Narrowing is free.
 The full procedure is
 [`backlog-sweep.md`](../../../docs/notes/backlog-sweep.md). The operative steps:
 
-1. **Take at most 10 candidates**, ordered by `rank-backlog` score, highest
-   first, then by issue number, newest first — the outside-the-queue set carries
-   no score and so sits behind every scored candidate. Two sets qualify:
-   `agent-ready` issues lacking exactly one `risk:*` or exactly one `pkg:*`, and
-   issues with no queue-state label read from the roster the ranking already
-   fetched. Drop every bot record — anything authored by `app/github-actions`
-   or carrying `drift-detection`, `sentry-triage`, a `sentry:*` label,
-   `dependencies`, `security-advisories`, or `file-size-watchlist`. Skip a
-   candidate only when its body digest still matches its newest trusted marker,
-   the marker's resolved path set still matches, and the issue carries every
-   label in that marker's `applied` list. All three are needed: the verdict
-   comes from the body and from what the tree holds, so a named path that did
-   not exist then and does now must be read again; and missing `applied` labels
-   mean a write failed after the comment landed, so retry rather than skip for
-   ever. Compare the body, never `updatedAt` — posting the marker updates the
-   issue, so a timestamp test would compare the pass against its own write.
-   Count the skip in the report.
-2. **Read the body, then read the paths it names.** The labels come from what
-   the checkout holds, not from what the body claims.
+1. **Pin the tree, then order, filter, and cap at 10.** Fetch `origin/main` and
+   pin one OID for the whole pass before any candidate is read; every path read
+   below, the skip key's digests included, uses that one tree. The pass runs
+   long after Preflight, so it pins its own OID rather than inheriting
+   Preflight's, and the marker records it.
+
+   ```bash
+   git fetch origin main
+   oid="$(git rev-parse origin/main)"
+   git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+   ```
+
+   Order by `rank-backlog` score, highest first, then by issue number, newest
+   first; the
+   outside-the-queue set carries no score and so sits behind every scored
+   candidate. Two sets qualify: `agent-ready` issues lacking exactly one
+   `risk:*` or exactly one `pkg:*`, and issues with no queue-state label read
+   from the roster the ranking already fetched. Drop every bot record —
+   anything authored by `app/github-actions` or carrying `drift-detection`,
+   `sentry-triage`, a `sentry:*` label, `dependencies`,
+   `security-advisories`, or `file-size-watchlist`. Then walk that order and
+   test the skip key below as you reach each candidate, stopping at the first 10
+   survivors; the test costs one comment read each, so walk it lazily rather
+   than pre-filtering the whole queue. The cap bounds grooming attempts, not
+   candidates examined: capping first would let ten unchanged high scorers hold
+   every slot run after run and starve the rest of the queue. The read cost is
+   therefore bounded by the candidate set rather than by the cap, so report how
+   many candidates the walk examined beside how many it groomed. Do not add a
+   fixed ceiling on candidates examined: the walk order is stable, so a hard
+   stop at the same depth every run never reaches the tail. Count every skipped
+   candidate in the report.
+
+   **The skip key has four parts**, read from the candidate's newest trusted
+   `sweep-groomed:v2` marker. Skip only when all four hold: the body digest
+   still matches; the marker's `paths` map still matches, path for path and
+   digest for digest, at the OID pinned above; the issue carries every label in
+   the marker's `applied` list; and the issue's current `risk:*`,
+   `pkg:*`, `kind:*`, and queue-state labels equal the marker's `labels`
+   snapshot plus its `applied` list — the same four label classes on both sides,
+   because those are every class the pass writes into `applied`, and a class
+   present on one side only makes the test fail for ever. Each guards a
+   different way the verdict goes stale. The body is what the pass read. The `paths` map is the rest of it — a named path that was
+   absent then and exists now, one since deleted, and one whose contents changed
+   under a stable name all change the answer. Missing `applied` labels mean a
+   write failed after the comment landed, so retry rather than skip for ever.
+   The `labels` snapshot is what makes a human's correction reopen the issue:
+   a pass that stopped on two `risk:*` labels writes `applied: []`, and without
+   the snapshot the empty-subset check would succeed vacuously and strand the
+   issue after a human removed one of them. Compare the body, never `updatedAt`
+   — posting the marker updates the issue, so a timestamp test would compare
+   the pass against its own write. A `v1` marker never satisfies the key: it
+   carries no `labels`, no per-path digest, and no resolution ref, so every
+   issue groomed under `v1` re-grooms once.
+
+2. **Read the body, then read the paths it names against the OID pinned in
+   step 1.** Read every path with `git ls-tree` or `git cat-file` against that
+   OID, never from the session checkout. Labels are repository-wide state and
+   the checkout is session-local:
+   a sweep started from a clean feature branch would otherwise classify live
+   issues against that branch's tree, and since the pass never removes or
+   downgrades a label, a wrong `pkg:*` cannot be retracted later. The marker
+   records the ref and the OID, so a reader can tell what a verdict was based
+   on. The labels come from what that tree holds, not from what the body claims.
+
 3. **Decide the labels.**
    - `pkg:*` — every area the named paths fall in. Several labels when the
      issue genuinely spans packages, which keeps it correctly labeled and
@@ -755,13 +816,17 @@ The full procedure is
    posted, write no label for that issue.
 
    ```text
-   <!-- sweep-groomed:v1 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","body":"<sha256>","paths":[...],"applied":[...],"proposed":[...]} -->
+   <!-- sweep-groomed:v2 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","ref":"origin/main","oid":"<40-hex>","body":"<sha256>","paths":{"<path>":"<blob or tree sha>"},"labels":[...],"applied":[...],"proposed":[...]} -->
    ```
 
-   `body` is the SHA-256 of the issue body this pass read and `paths` the named
-   paths that existed in the checkout when it read them; the next run skips the
-   candidate only while both still match and its `applied` labels are present. `applied` lists the labels the
-   next call writes; `proposed` lists everything
+   `ref` and `oid` name the tree the paths were resolved against. `body` is the
+   SHA-256 of the issue body this pass read. `paths` maps each named path that
+   resolved at that OID to its `git ls-tree` blob or tree SHA, so a file whose
+   contents changed under a stable name invalidates the marker; only paths the
+   body names are covered. `labels` snapshots the issue's `risk:*`, `pkg:*`,
+   `kind:*`, and queue-state labels as read, before this pass writes anything —
+   every class the pass can write, so the skip key compares like with like.
+   `applied` lists the labels the next call writes; `proposed` lists everything
    the pass judged right and will not write itself — a `risk:low`, the state
    label the mutex owns, the `agent-ready` promotion, workboard enrollment, and
    a risk label withheld from a contradicted or double-labeled issue. `at`
@@ -937,18 +1002,26 @@ board.
    that something is still sitting there.
 6. **Anything needing the operator's decision** — a blocked control, a
    misgroomed issue, a finding the worker could not adjudicate.
-7. **Groomed for the next run**, a table of `Issue | Labels applied | Proposed
-for a human | Rule basis | Veto ends`. `Proposed for a human` is the column
-   an operator acts on — a `risk:low` the pass may not write, the state label
-   the mutex owns, workboard enrollment, an `agent-ready` promotion the body
-   already deserves. `Veto ends` says when the window closes, not when the
-   issue becomes selectable: an unapplied proposal, a `risk:medium`, or several
-   `pkg:*` labels keep it ineligible whatever the clock says. Name the
+7. **Groomed for the next run.** State two run-wide facts above the table: the
+   `origin/main` OID every path was read against, the same value the marker
+   carries, so a verdict is reproducible from a named ref; and how many
+   candidates the walk examined. Each is one value a run, so neither is a
+   column. The table is
+   `Issue | Labels applied | Proposed for a human | Rule basis | Veto ends`.
+   `Proposed for a human` is the column an operator acts on — a `risk:low` the pass may not write, the
+   state label the mutex owns, workboard enrollment, an `agent-ready` promotion
+   the body already deserves. `Rule basis` names the Low-risk rule clause behind
+   the risk verdict, and on a skipped or re-groomed row it carries the reason
+   instead. `Veto ends` says when the window closes, not
+   when the issue becomes selectable: an unapplied proposal, a `risk:medium`, or
+   several `pkg:*` labels keep it ineligible whatever the clock says. Name the
    remaining requirement beside the time whenever one applies. List candidates
-   skipped as unchanged since their last marker, so a stuck issue is visible.
-   Write the section with a `none` row when the pass groomed nothing — an empty
-   candidate set and a pass that never ran read identically once the section is
-   missing.
+   skipped against their last marker with the reason, and candidates re-groomed
+   because the key broke with what broke it — the changed path, the label a
+   human moved, or a `v1` marker. A stuck issue and a re-read one are both
+   visible that way. Write the section with a `none` row when the pass groomed
+   nothing — an empty candidate set and a pass that never ran read identically
+   once the section is missing.
 
 Print the same summary to the terminal; the file is the artifact, the terminal
 output is its summary.

--- a/docs/adr/0077-operator-triggered-backlog-sweep.md
+++ b/docs/adr/0077-operator-triggered-backlog-sweep.md
@@ -3,7 +3,7 @@ title: Operator-triggered backlog sweep with isolated workers
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-02
+last_verified: 2026-09-03
 scope: process
 date: 2026-08
 doc_type: adr
@@ -96,8 +96,9 @@ every clause it had, the sweep still stops at READY, and it still never merges.
 every worker is spawned, and before the report — including on an empty batch,
 which is the case it exists for. It reads each candidate's body and the paths
 that body names, applies `pkg:*`, `kind:*`, and a narrowing `risk:*` from what
-the tree holds, posts one `sweep-groomed:v1` marker comment per issue, and is
-capped at 10 candidates a run. Its position in the loop is one safety property:
+the tree holds, posts one `sweep-groomed:v2` marker comment per issue, and is
+capped at 10 grooming attempts a run. Its position in the loop is one safety
+property:
 this run's eligibility step has already finished, so no label the pass writes
 can select work for this run. Grooming first and then selecting was the
 alternative, and it is one night faster; it was rejected because it lets one
@@ -168,6 +169,30 @@ one label; every other area keeps the label test. `pnpm issue:claim
 issue's own labels and never sees the batch, so batch independence stays the
 orchestrator's judgement in both shapes.
 
+**The `sweep-groomed:v2` marker contract.** Five findings from reviewing the
+pass refine it without changing the decision above. The skip key now runs before
+the 10-candidate cap, so the cap bounds grooming attempts and unchanged high
+scorers cannot hold every slot; the cap bounds no reads, so the report records
+how many candidates the walk examined, and no ceiling was put on that number
+because a stable walk order plus a fixed depth never reaches the tail of the
+queue. `docs/README.md` joins the compared path set of any `pkg:tooling`
+candidate that adds, moves, or removes a Markdown surface, that changes the
+front matter of one, or that adds or removes an internal link, because
+`pnpm docs:index --check` makes the generated catalog a file both workers
+regenerate and `scripts/context/docs-index-helpers.mjs` renders it from front
+matter and link state alike. Paths resolve against `origin/main` at one pinned OID rather
+than the session checkout, since labels are repository-wide state and the pass
+may not retract a wrong one. The marker gains a `labels` snapshot, so a human
+who fixes the labels a stop asked about reopens the candidate without editing
+the body, and a per-path blob digest, so a named file whose contents changed
+under a stable name is read again. The snapshot and the skip test read the same
+four label classes — `risk:*`, `pkg:*`, `kind:*`, and queue state — because a
+class the pass writes but the snapshot omits would make the test fail for every
+issue carrying one. Those fields are a new payload shape, so the
+marker is `sweep-groomed:v2` and the skip key matches that prefix literally:
+every `v1` marker is invalid by construction and re-grooms once. The veto window
+alone still reads any version, because it asks whether a human saw the labels.
+
 ## Alternatives considered
 
 **Shared checkout for all workers.** Cheaper to set up and avoids repeated
@@ -229,7 +254,9 @@ PR it opens.
 - Issue
   [#2209](https://github.com/mento-protocol/monitoring-monorepo/issues/2209)
   carries the 2026-09 amendment: the grooming pass, its veto window, and the
-  `pkg:tooling` path test, all documented in the two files above.
+  `pkg:tooling` path test, all documented in the two files above. Issues 2240,
+  2242, 2246, 2247, and 2256 carry the `sweep-groomed:v2` marker contract that
+  followed from reviewing it.
 - The concurrency bound is the gate coordinator's own capacity, default 3,
   recorded in [ADR 0076](0076-fair-quality-gate-coordinator.md) and
   [`docs/notes/agent-quality-gate-mechanics.md`](../notes/agent-quality-gate-mechanics.md).

--- a/docs/adr/0077-operator-triggered-backlog-sweep.md
+++ b/docs/adr/0077-operator-triggered-backlog-sweep.md
@@ -175,14 +175,20 @@ the 10-candidate cap, so the cap bounds grooming attempts and unchanged high
 scorers cannot hold every slot; the cap bounds no reads, so the report records
 how many candidates the walk examined, and no ceiling was put on that number
 because a stable walk order plus a fixed depth never reaches the tail of the
-queue. `docs/README.md` joins the compared path set of any `pkg:tooling`
-candidate that adds, moves, or removes a Markdown surface, that changes the
-front matter of one, or that adds or removes an internal link, because
-`pnpm docs:index --check` makes the generated catalog a file both workers
-regenerate and `scripts/context/docs-index-helpers.mjs` renders it from front
-matter and link state alike. Paths resolve against `origin/main` at one pinned OID rather
-than the session checkout, since labels are repository-wide state and the pass
-may not retract a wrong one. The marker gains a `labels` snapshot, so a human
+queue. Two candidates that both regenerate `docs/README.md` conflict whatever
+`pkg:*` labels they carry, and a candidate carries that catalog when it adds,
+moves, or removes a Markdown surface, when it changes the front matter of one,
+or when it adds or removes an internal link, because `pnpm docs:index --check`
+makes the generated catalog a file both workers regenerate and
+`scripts/context/docs-index-helpers.mjs` renders it from front matter and link
+state alike. That test is pairwise and label-independent, so it runs before the
+label test rather than inside the `pkg:tooling` path test, which would read a
+cross-package pair of Markdown-adding issues as independent. Paths resolve
+against `origin/main` at one pinned OID rather than the session checkout, since
+labels are repository-wide state and the pass may not retract a wrong one; the
+pass fetches that ref from the push URL Preflight validates, so the tree it
+reads and the fork stop grade one URL. The marker gains a `labels` snapshot,
+so a human
 who fixes the labels a stop asked about reopens the candidate without editing
 the body, and a per-path blob digest, so a named file whose contents changed
 under a stable name is read again. The snapshot and the skip test read the same

--- a/docs/notes/backlog-sweep.md
+++ b/docs/notes/backlog-sweep.md
@@ -447,9 +447,22 @@ verdict reproducible.
 
 ```bash
 git fetch origin main
-oid="$(git rev-parse origin/main)"
-git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
+git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
 ```
+
+Pin `FETCH_HEAD`, not `origin/main`. `git fetch origin main` always writes the
+commit it fetched there, while a clone made with `--single-branch` on another
+branch has no `refs/remotes/origin/main` for that fetch to update, and
+`git rev-parse origin/main` in it fails after the batch is already claimed. The
+marker's `ref` still records `origin/main`, which is what was fetched.
+
+Address each path as `<oid>:<path>`, not with `git ls-tree`. A body may name a
+directory, with or without a trailing slash, and `git ls-tree "$oid" -- docs/notes/`
+lists that directory's children instead of returning its one tree id.
+`git rev-parse "$oid:<path>"` returns exactly one id for a file, for a directory,
+and for a directory written with a trailing slash, and exits non-zero when the
+path is absent — the case the marker's map omits.
 
 Order, then filter, then cap at 10. Ordering is by `rank-backlog` score,
 highest first, then by issue number, newest first. The outside-the-queue set
@@ -544,7 +557,7 @@ of the pass. Every label below comes from what that tree holds, not from what
 the body claims.
 
 **The resolution basis is the shared ref, not the session checkout.** Read every
-path with `git ls-tree` or `git cat-file` against that one pinned OID. Preflight
+path as `<oid>:<path>` against that one pinned OID. Preflight
 fetches `origin/main`
 and requires a clean worktree, but never requires the checkout to be _at_
 `origin/main`, so a sweep started from a clean feature branch would classify live
@@ -643,7 +656,8 @@ One comment per groomed issue, opening with a machine-readable marker:
 `ref` and `oid` name the tree the paths were resolved against, so a later reader
 can tell what a verdict was based on and reproduce it. `body` is the SHA-256 of
 the issue body this pass read. `paths` maps each named path that resolved at
-that OID to its `git ls-tree` blob or tree SHA; a path the body names and the
+that OID to the one blob or tree id `git rev-parse "<oid>:<path>"` returns; a
+path the body names and the
 tree does not hold is absent from the map. `labels` snapshots the issue's
 `risk:*`, `pkg:*`, `kind:*`, and queue-state labels as read, before this pass
 writes anything — every class the pass can write, so the skip key compares like

--- a/docs/notes/backlog-sweep.md
+++ b/docs/notes/backlog-sweep.md
@@ -212,7 +212,10 @@ An issue enters a batch only when all of the following hold:
 - **Carries exactly one `pkg:*` label** — no package area makes the independence
   test vacuous, while several areas make ownership ambiguous. The
   `--sweep-eligible` claim path enforces the same rule.
-- **Mutually independent** — no two issues in one batch share a `pkg:*` label.
+- **Mutually independent** — two tests, in order. The docs-catalog test runs
+  first and ignores labels: two candidates that both regenerate
+  `docs/README.md` conflict whatever packages they sit in, below. Then the
+  label test — no two issues in one batch share a `pkg:*` label.
   That label is the repo's existing ownership area
   ([`agent-issue-workflow.md`](agent-issue-workflow.md)), so "same subsystem" is
   a lookup rather than a per-batch judgement. Otherwise the second PR pays for
@@ -278,6 +281,31 @@ the sweep did not groom itself; honouring an unverified marker costs the queue.
 The sweep's own marker never depends on the lookup, so the case the veto is for
 never turns on a failed API call.
 
+### Docs-catalog independence
+
+This test runs before the label test, on every pair, whatever labels the two
+candidates carry. A candidate carries the catalog when its work adds, moves, or
+removes a Markdown surface, changes any front matter of an existing one, or
+adds or removes an internal link, because the catalog lists broken internal
+links beside an entry per file. Only a body-prose edit that leaves the front
+matter and every link alone is exempt, and a body whose documentation effect
+cannot be read carries the catalog: nothing to compare is not evidence of no
+conflict. Two candidates that both carry it are never independent.
+
+[`context-standards.md`](../context-standards.md) requires that generated
+catalog to index every Markdown file, and `pnpm docs:index --check` fails while
+it is stale, so both workers regenerate `docs/README.md` and their PRs conflict
+on that one file even when they share no package and no other named path.
+Scoping the rule to `pkg:tooling` would miss the pair the label test cannot
+see: a `pkg:dashboard` issue adding a README beside a `pkg:indexer` issue
+adding one shares no label and no path, and still produces two PRs that
+regenerate one catalog.
+
+Do not restate which fields the catalog renders: `classifyDocumentation` and
+`catalogEntry` in `scripts/context/docs-index-helpers.mjs` decide that, they
+already read `canonical` and `doc_type` beyond the fields an earlier draft of
+this rule listed, and any list written here rots against them in silence.
+
 ### `pkg:tooling` independence
 
 The label test assumes a `pkg:*` label maps to a collision surface. It does for
@@ -297,20 +325,9 @@ Two `pkg:tooling` candidates are independent when all three hold:
   `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.trunk/**`, `.github/workflows/**`,
   `scripts/agent-quality-gate.sh`, or `scripts/gate/**`.
 
-A candidate whose named paths add, move, or remove a Markdown surface carries
-`docs/README.md` into that comparison as well.
-[`context-standards.md`](../context-standards.md) requires the generated catalog
-to index every Markdown file, and `pnpm docs:index --check` fails while it is
-stale, so both workers must regenerate the same file and their PRs conflict on
-it even when every path they named was disjoint. Two Markdown-adding candidates
-are therefore never independent. A candidate that changes any front matter of an
-existing Markdown surface carries the catalog too, and so does one that adds or
-removes an internal link, because the catalog also lists broken internal links.
-Only a body-prose edit that leaves the front matter and every link alone is
-exempt. Do not restate which fields the catalog renders: `classifyDocumentation`
-and `catalogEntry` in `scripts/context/docs-index-helpers.mjs` decide that, they
-already read `canonical` and `doc_type` beyond the fields an earlier draft of
-this rule listed, and any list written here rots against them in silence.
+A candidate that carries the docs catalog above brings `docs/README.md` into
+this comparison as well, so it also conflicts with a candidate that names that
+file outright.
 
 Normalize the mirrored skill trees before comparing, by path segments rather
 than by text: any path whose first two segments are `.claude/skills` is read
@@ -446,16 +463,25 @@ and the marker records the ref and OID it used. That record is what makes a
 verdict reproducible.
 
 ```bash
-git fetch origin main
+git fetch "$(git remote get-url --push origin)" main
 oid="$(git rev-parse FETCH_HEAD)"   # the commit this fetch just wrote
 git rev-parse "$oid:<path>"         # one blob or tree id; non-zero when absent
 ```
 
-Pin `FETCH_HEAD`, not `origin/main`. `git fetch origin main` always writes the
-commit it fetched there, while a clone made with `--single-branch` on another
-branch has no `refs/remotes/origin/main` for that fetch to update, and
-`git rev-parse origin/main` in it fails after the batch is already claimed. The
-marker's `ref` still records `origin/main`, which is what was fetched.
+Fetch the validated push URL, not the remote name. Preflight grades
+`git remote get-url --push origin`, and a remote that carries a `pushurl`
+fetches from a different URL than it pushes to, so `git fetch origin main`
+would resolve every path in the pass against a URL no check ever read. Naming
+the validated URL binds the read to the repository Preflight approved, and it
+leaves Preflight one check on one URL — the check the fork stop needs — rather
+than a second check whose only reader is this pass.
+
+Pin `FETCH_HEAD`, not `origin/main`. Every fetch writes the commit it fetched
+there, while a fetch by URL updates no remote-tracking ref at all and a clone
+made with `--single-branch` on another branch has no `refs/remotes/origin/main`
+to read either, so `git rev-parse origin/main` fails after the batch is already
+claimed. The marker's `ref` still records `origin/main`: the remote and branch
+that was fetched.
 
 Address each path as `<oid>:<path>`, not with `git ls-tree`. A body may name a
 directory, with or without a trailing slash, and `git ls-tree "$oid" -- docs/notes/`

--- a/docs/notes/backlog-sweep.md
+++ b/docs/notes/backlog-sweep.md
@@ -3,7 +3,7 @@ title: Backlog Sweep
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-02
+last_verified: 2026-09-03
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -219,14 +219,14 @@ An issue enters a batch only when all of the following hold:
   a merge, a re-gate, and a fresh review round caused only by its sibling.
   `pkg:tooling` is the one area where a path test replaces that lookup, below.
 - **Outside its own grooming veto window** — a candidate whose newest
-  _trusted_ `sweep-groomed:v1` marker comment is less than 12 hours old waits
-  for the next run, and the report names when that window closes. The window
-  gives a human a bounded chance to disagree with a label an agent applied,
-  before that label selects work for another agent. An issue a human labeled by
-  hand carries no marker and is never delayed. An operator who wants to
-  fast-track a groomed issue waits the window out or deletes the marker
-  comment: a window its caller can waive is not a window. What makes a marker
-  trusted is below.
+  _trusted_ `sweep-groomed:` marker comment is less than 12 hours old waits
+  for the next run, whatever version that marker carries, and the report names
+  when that window closes. The window gives a human a bounded chance to
+  disagree with a label an agent applied, before that label selects work for
+  another agent. An issue a human labeled by hand carries no marker and is
+  never delayed. An operator who wants to fast-track a groomed issue waits the
+  window out or deletes the marker comment: a window its caller can waive is
+  not a window. What makes a marker trusted is below.
 
 Fewer qualifying issues than the batch size is a normal result: take fewer and
 say so. Zero is also a result — write the report with an empty table rather
@@ -260,7 +260,7 @@ timing.
 gh issue view <n> --repo mento-protocol/monitoring-monorepo \
   --json comments \
   --jq '.comments[]
-        | select(.body | startswith("<!-- sweep-groomed:v1"))
+        | select(.body | startswith("<!-- sweep-groomed:"))
         | {login: .author.login, created: .createdAt}'
 
 repo=mento-protocol/monitoring-monorepo
@@ -296,6 +296,21 @@ Two `pkg:tooling` candidates are independent when all three hold:
 - neither names a shared root file or a control root: `package.json`,
   `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.trunk/**`, `.github/workflows/**`,
   `scripts/agent-quality-gate.sh`, or `scripts/gate/**`.
+
+A candidate whose named paths add, move, or remove a Markdown surface carries
+`docs/README.md` into that comparison as well.
+[`context-standards.md`](../context-standards.md) requires the generated catalog
+to index every Markdown file, and `pnpm docs:index --check` fails while it is
+stale, so both workers must regenerate the same file and their PRs conflict on
+it even when every path they named was disjoint. Two Markdown-adding candidates
+are therefore never independent. A candidate that changes any front matter of an
+existing Markdown surface carries the catalog too, and so does one that adds or
+removes an internal link, because the catalog also lists broken internal links.
+Only a body-prose edit that leaves the front matter and every link alone is
+exempt. Do not restate which fields the catalog renders: `classifyDocumentation`
+and `catalogEntry` in `scripts/context/docs-index-helpers.mjs` decide that, they
+already read `canonical` and `doc_type` beyond the fields an earlier draft of
+this rule listed, and any list written here rots against them in silence.
 
 Normalize the mirrored skill trees before comparing, by path segments rather
 than by text: any path whose first two segments are `.claude/skills` is read
@@ -422,9 +437,24 @@ re-run selection after it.
 
 ### Candidates
 
-At most 10 a run, ordered by `rank-backlog` score, highest first, then by issue
-number, newest first. The outside-the-queue set carries no score, so it orders
-by age alone and sits behind every scored candidate. Two sets qualify:
+**Pin the tree before the walk.** Fetch `origin/main` and pin one OID for the
+whole pass, before any candidate is read, because the skip key below compares
+per-path digests at that OID and every later read in the pass must use the same
+tree. The pass runs long after Preflight — after the batch is claimed and every
+worker is spawned — so it pins its own OID rather than inheriting Preflight's,
+and the marker records the ref and OID it used. That record is what makes a
+verdict reproducible.
+
+```bash
+git fetch origin main
+oid="$(git rev-parse origin/main)"
+git ls-tree "$oid" -- <path>      # blob or tree SHA, empty when absent
+```
+
+Order, then filter, then cap at 10. Ordering is by `rank-backlog` score,
+highest first, then by issue number, newest first. The outside-the-queue set
+carries no score, so it orders by age alone and sits behind every scored
+candidate. Two sets qualify:
 
 - `agent-ready` issues that lack exactly one `risk:*` or exactly one `pkg:*`
   label. Eligibility cannot admit one of these as written, whether or not this
@@ -443,33 +473,89 @@ by age alone and sits behind every scored candidate. Two sets qualify:
 never earn a `pkg:*` label, and ten of them would hold the cap every run and
 starve everything below.
 
-Every marker records the SHA-256 of the issue body the pass read and, beside it,
-which of the paths that body named existed in the checkout at that moment. Skip
-a candidate only when three things hold: the body digest still matches, that
-resolved path set still matches, and every label in the marker's `applied` list
-is on the issue.
+**The skip runs before the cap.** The cap bounds grooming attempts, not
+candidates examined. Capping first and skipping second gives the same ten
+unchanged high scorers every slot on every run, and no lower-ranked candidate is
+ever reached — the starvation the skip rule was written to prevent, moved one
+step up. So order the candidates, drop the bot records, then walk that order and
+test the skip key as you reach each one, stopping at the first 10 survivors. The
+test costs one comment read per candidate examined, so walk it lazily rather
+than pre-filtering the whole queue.
+
+That cost is bounded by the candidate set, not by the cap: a run in which every
+candidate skips reads every candidate's comments and grooms nothing. Record the
+number of candidates examined in the report beside the number groomed, so the
+read cost is measured rather than assumed. A fixed ceiling on candidates
+examined was rejected: the walk order is stable, so a hard stop at the same
+depth every run never reaches the tail of the queue, which is the starvation
+this ordering exists to remove.
+
+**The skip key has four parts**, read from the candidate's newest trusted
+`sweep-groomed:v2` marker. Skip only when all four hold:
+
+- the SHA-256 of the issue body still matches the marker's `body`;
+- the marker's `paths` map still matches, path for path and digest for digest,
+  resolved at this run's pinned `origin/main` OID;
+- every label in the marker's `applied` list is on the issue;
+- the issue's current `risk:*`, `pkg:*`, `kind:*`, and queue-state labels equal
+  the marker's `labels` snapshot plus its `applied` list.
+
+The fourth condition compares two sets that must cover the same label classes.
+The snapshot and this test both read `risk:*`, `pkg:*`, `kind:*`, and
+queue-state because those are every class the pass can write into `applied`. A
+class the pass writes but the snapshot omits would sit on the right side and
+never on the left, and the test would fail for every issue that carries one.
+Any future label class the pass writes joins both sides together.
 
 Each guards a different way the verdict can go stale. The body is what the pass
-reads. The resolved path set is the rest of it — a named path that was absent
-then and exists now changes the answer, and one that has since been deleted
-changes it too, so comparing the set catches both. The `applied` labels prove
-the previous run finished: a marker whose labels are missing records a write
-that failed after the comment landed, and skipping on the digest that failed run
+reads. The `paths` map is the rest of it — a named path that was absent then and
+exists now changes the answer, one since deleted changes it too, and one whose
+contents changed under a stable name changes it as well: a helper that becomes a
+production-data writer flips the Low-risk rule without touching the body or the
+path list. Comparing the map catches all three. The `applied` labels prove the
+previous run finished: a marker whose labels are missing records a write that
+failed after the comment landed, and skipping on the digest that failed run
 wrote would strand the issue permanently.
 
+The `labels` snapshot is what makes a human's correction reopen the candidate.
+The pass stops without writing on an issue carrying two `risk:*` labels and on a
+`risk:low` its verified paths contradict, and both stops write `applied: []`.
+Against an empty list the third condition succeeds vacuously, so a human who
+removes one of the two risk labels — the fix the stop was asking for — leaves
+the body and the path map unchanged and the issue skipped for ever. The snapshot
+is compared as a set against `labels` plus `applied`, because the pass's own
+write lands after the marker and must not invalidate it.
+
 Count every skip in the report, so a stuck issue is visible rather than silent.
+A candidate re-groomed because the key broke gets its reason named too: which
+path changed, which label a human moved, or that the marker was `v1`.
 
 Compare the body, not `updatedAt`: posting the marker updates the issue, so a
 timestamp test would compare the pass against its own write and never skip
 anything. The digest is the same primitive `pnpm issue:claim --body-sha256`
-already pins a sweep claim with. It also states the limit — a body edit reopens
-the candidate, and so does deleting the marker, but a verdict that would change
-only because the tree changed underneath it does not.
+already pins a sweep claim with. The limit is worth stating: only paths the body
+names are covered, so a verdict that would change because some file the body
+never mentions changed is not caught.
 
 ### What the pass applies
 
-Read the body, then read the paths it names in the checkout. Every label below
-comes from what the tree holds, not from what the body claims.
+Read the body, then read the paths it names against the OID pinned at the start
+of the pass. Every label below comes from what that tree holds, not from what
+the body claims.
+
+**The resolution basis is the shared ref, not the session checkout.** Read every
+path with `git ls-tree` or `git cat-file` against that one pinned OID. Preflight
+fetches `origin/main`
+and requires a clean worktree, but never requires the checkout to be _at_
+`origin/main`, so a sweep started from a clean feature branch would classify live
+issues against that branch's tree. A path that exists only on the branch produces
+a `pkg:*` the issue should not have, and one deleted on the branch produces the
+wrong risk verdict. The labels are repository-wide state while the checkout is
+session-local, and the pass never removes or downgrades a label, so a later
+correct run can add a label beside the wrong one but cannot retract it and the
+issue is left ambiguously routed and permanently sweep-ineligible. That rule
+stays; the resolution basis is the thing that moves. The fetch and the pin
+happen once, at the start of the pass, under Candidates above.
 
 **The pass never writes a label that leaves an issue sweep-eligible.** Work out
 the label set the write would produce; when that set satisfies the sweep
@@ -551,13 +637,19 @@ field, and it never touches the state label of an owned issue — one carrying
 One comment per groomed issue, opening with a machine-readable marker:
 
 ```text
-<!-- sweep-groomed:v1 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","body":"<sha256>","paths":[...],"applied":[...],"proposed":[...]} -->
+<!-- sweep-groomed:v2 {"sweep":"<sweep_id>","at":"<ISO-8601 UTC>","ref":"origin/main","oid":"<40-hex>","body":"<sha256>","paths":{"<path>":"<blob or tree sha>"},"labels":[...],"applied":[...],"proposed":[...]} -->
 ```
 
-`body` is the SHA-256 of the issue body this pass read and `paths` the named
-paths that existed in the checkout when it read them; the next run skips the
-candidate only while both still match and its `applied` labels are present. `applied` lists the labels the pass writes
-immediately after posting this comment; the comment is written first, so the field names an intent that the
+`ref` and `oid` name the tree the paths were resolved against, so a later reader
+can tell what a verdict was based on and reproduce it. `body` is the SHA-256 of
+the issue body this pass read. `paths` maps each named path that resolved at
+that OID to its `git ls-tree` blob or tree SHA; a path the body names and the
+tree does not hold is absent from the map. `labels` snapshots the issue's
+`risk:*`, `pkg:*`, `kind:*`, and queue-state labels as read, before this pass
+writes anything — every class the pass can write, so the skip key compares like
+with like. Together with `applied` those four fields are the skip key above.
+`applied` lists the labels the pass writes immediately after posting this
+comment; the comment is written first, so the field names an intent that the
 label call then carries out. `proposed` lists everything the pass judged right
 and will not write itself: a `risk:low` it is not allowed to apply, the state
 label the mutex owns, the `agent-ready` promotion only an operator can make,
@@ -568,6 +660,16 @@ two or contradicted by its own paths.
 is measured from GitHub's `createdAt` on the comment instead, and only on a
 comment from a trusted author, both settled under Eligibility above.
 
+**The version in the prefix is what retires an old contract.** `v2` added `ref`,
+`oid`, `labels`, and per-path digests, so the skip key matches the literal
+`sweep-groomed:v2` prefix and every `v1` marker is ignored by construction:
+issues groomed under `v1` re-groom once, on a tree the marker never named.
+The veto window is the exception and reads any `sweep-groomed:` version, because
+it asks whether a human has had a chance to see the labels and that question
+does not depend on the payload shape. Reading `v2` only there would un-veto
+every issue the last run groomed. The next contract change bumps to `v3` on the
+same terms.
+
 Under it, in prose: the labels applied, the paths checked, the Low-risk rule
 clause that decided the risk label, and — for an unlabeled issue — whether the
 body meets the agent-ready bar. The marker's timestamp is what the veto window
@@ -575,7 +677,7 @@ reads; the prose is what a human reads before promoting the issue.
 
 ### The veto window
 
-A candidate whose newest `sweep-groomed:v1` marker is younger than 12 hours is
+A candidate whose newest `sweep-groomed:` marker is younger than 12 hours is
 ineligible, and the eligibility step above enforces it. The window is a bounded
 chance for a human to disagree with an agent's label before that label picks
 work for another agent. Only a sweep writes this marker, so an issue a human
@@ -682,19 +784,30 @@ Two properties make the table worth reading:
   the ready queue, `--needs-grooming` takes it out of reach until a human
   settles something.
 
-The grooming section is its own table, `Issue | Labels applied | Proposed for a
-human | Rule basis | Veto ends`. `Proposed for a human` is the column an
-operator acts on: a `risk:low` the pass may not write, the state label the mutex
-owns, workboard enrollment, an `agent-ready` promotion the body already
-deserves. `Rule basis` names the Low-risk rule clause behind the risk verdict.
+The grooming section states two run-wide facts above its table: the
+`origin/main` OID every path was read against, the same value the marker
+carries, so a verdict in the report is reproducible from a named ref rather than
+from whatever tree the session happened to hold; and how many candidates the
+walk examined to reach the groomed set. Both are one value a run, so neither is
+a column.
+
+The table itself is `Issue | Labels applied | Proposed for a human | Rule basis
+| Veto ends`. `Proposed for a human` is the
+column an operator acts on: a `risk:low` the pass may not write, the state label
+the mutex owns, workboard enrollment, an `agent-ready` promotion the body already
+deserves. `Rule basis` names the Low-risk rule clause behind the risk verdict,
+and on a skipped or re-groomed row it carries the reason instead.
 `Veto ends` is the end of that issue's 12-hour window, and it says when the
 window closes rather than when the issue becomes selectable — a proposal nobody
 has applied, a `risk:medium`, or several `pkg:*` labels all keep it ineligible
 whatever the clock says. Name the remaining requirement beside the time whenever
 one applies. Zero groomed issues is a valid line and gets written rather than
 omitted — an empty candidate set and a pass that never ran read identically once
-the section is missing. Candidates skipped as unchanged since their last marker
-get a line too, so a permanently stuck issue is visible.
+the section is missing. Candidates skipped against their last marker get a row
+too, so a permanently stuck issue is visible, and so do candidates the key sent
+back for re-grooming. Both put their reason in `Rule basis`: for a skip, that
+the key held; for a re-groom, what broke it — the path whose digest moved, the
+label a human changed, or a `v1` marker.
 
 The report ends with one URL for each READY PR. A human can open each link and
 merge in the GitHub UI. Listing a link is not merge approval. The sweep never


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The sweep's grooming pass took its ten candidates first and applied its
  unchanged-marker skip second, so ten unchanged high scorers held every slot on
  every run and no lower-ranked issue was ever groomed.
- It resolved the paths an issue body names against whatever tree the session
  had checked out, so a sweep started from a feature branch labeled live issues
  from that branch. The pass never removes or downgrades a label, so a wrong
  `pkg:*` could not be retracted.
- Its marker recorded neither the label state it read nor the contents of the
  files it read, so a human's relabel and a changed file both left a stale
  verdict in place; and the `pkg:tooling` independence test missed
  `docs/README.md`, which two workers that each add a Markdown file must both
  regenerate.

## The Solution

The pass now walks candidates in rank order, tests the skip key as it reaches
each one, and stops at the first ten survivors, so the cap bounds grooming
attempts and the queue below the top ten is reachable again. It fetches `main`
from the push URL Preflight validates, pins one OID before the walk starts,
addresses every path as `<oid>:<path>` against that OID, and records the ref and
OID in the marker, so a verdict names the tree it was made on and a later reader
can reproduce it. The marker gains a `labels` snapshot and a per-path blob
digest, so a human's correction or a changed file reopens the candidate. The
docs catalog becomes a pairwise conflict test that runs before the `pkg:*` label
test and ignores labels: two candidates that both add, move, or remove a
Markdown surface, that both change the front matter of one, or that both add or
remove an internal link, regenerate `docs/README.md` and are never independent,
whatever packages they sit in.

The operator benefit is a grooming pass whose verdicts are reproducible from a
named ref, whose skips expire when the facts change, and whose cap no longer
starves the backlog.

Two limits. The skip key covers only the paths the body names, so a verdict that
would change because some unmentioned file changed is not caught. The cap bounds
grooming attempts and not comment reads, so a run where every candidate skips
still reads every candidate's comments; the pass now reports how many candidates
it examined, and a starvation-safe bound on that number is deferred to issue
2265.

This PR changes documentation and skill prose only. No script, workflow, or
control behavior changes.

## Details

The five refinements change one payload, so the marker moves to
`sweep-groomed:v2` once and the skip key matches that prefix literally: every
`v1` marker is invalid by construction and re-grooms once, on a tree the marker
never named. The veto window is the exception and still reads any
`sweep-groomed:` version, because it asks whether a human has had a chance to see
the labels, which does not depend on the payload shape. Matching `v2` there would
un-veto every issue the last run groomed.

The skip key has four parts: the body digest, the `paths` map path-for-path and
digest-for-digest at the pinned OID, every label in `applied` still present, and
the issue's current labels equal to the `labels` snapshot plus `applied`. That
last test compares two sets, so both sides read the same four label classes —
`risk:*`, `pkg:*`, `kind:*`, and queue state — which are every class the pass
writes into `applied`. A class on one side only would make the test fail for
every issue carrying one, and the skip would never fire.

The OID is pinned at the start of the pass, ahead of the candidate walk, because
the walk's own skip key compares digests at it. The pass runs after the batch is
claimed and every worker is spawned, an arbitrarily long gap after Preflight, so
it fetches and pins its own OID rather than inheriting Preflight's, and there is
exactly one fetch and one basis in the text.

The independence rule states a structural test rather than a list of catalog
fields, and names `classifyDocumentation` and `catalogEntry` in
`scripts/context/docs-index-helpers.mjs` as the source of truth. An enumeration
under-covered the generator: the catalog groups entries by `garden_lane` and by
an authority derived from `canonical:`, renders an ADR title only when
`doc_type` is `adr`, and emits a `## Broken internal links` section, so
`canonical:`, `doc_type:`, and a prose-only edit that breaks a link all move
`docs/README.md`. This narrows independence further and widens nothing.

Corrected premise: issue 2242's third acceptance criterion says an in-place
Markdown edit is unaffected "since the committed catalog holds no per-document
volatile fields". It does hold them, per the generator above. In-place edits that
touch neither front matter nor links are still exempt, so the criterion's intent
holds with a narrower carve-out than its stated reason.

The grooming report drops the `Resolved at` column and states the resolution OID
and the examined-candidate count once above the table, because both are one value
a run. Skipped and re-groomed rows carry their reason in `Rule basis`.

Rejected in review: a fixed ceiling on candidates examined (stop at ten survivors
or forty examined). The walk order is stable, so a hard stop at the same depth
every run never reaches the tail of the queue, which is the starvation class this
PR removes, moved one step down. The read cost is reported and measured instead,
and issue 2265 carries the bound.

The path recipe pins `git rev-parse FETCH_HEAD` rather than
`git rev-parse origin/main`, because a clone made with `--single-branch` on
another branch has no `refs/remotes/origin/main` for the fetch to update and the
pin would fail after the batch is already claimed. Each path is addressed as
`git rev-parse "$oid:<path>"` rather than read with `git ls-tree`, because a body
may name a directory with a trailing slash: `git ls-tree HEAD -- docs/notes/`
lists 32 child entries in this repository, while
`git rev-parse HEAD:docs/notes` and `git rev-parse HEAD:docs/notes/` both return
the one tree id the marker's map can hold. Both came from codex review of this
PR and landed in 5e59ab7b.

Two further codex findings landed in e5df87ca. The pass fetched `origin`, whose
fetch URL nothing grades: Preflight validates only
`git remote get-url --push origin`, and a remote carrying a `pushurl` fetches
from a different URL than it pushes to, so the pass could pin its whole tree
from an unread URL. It now fetches `main` from that validated push URL by name.
Fixing the pass rather than adding a fetch-URL check to Preflight keeps
Preflight's paragraph consistent — it argues one check on one URL for one
purpose, the fork stop — and binds the read to the URL that check already
grades. Separately, the docs-catalog rule sat inside the `pkg:tooling` path
test, so a `pkg:dashboard` issue and a `pkg:indexer` issue that both add a
Markdown file shared no label and no path and read as independent. The catalog
test is now pairwise and label-independent and runs before the label test; the
`pkg:tooling` path test keeps only the clause that a carried `docs/README.md`
joins its compared path set, which still catches a candidate that names the
generated file outright.

`docs/notes/backlog-sweep.md`, both skill mirrors, and ADR 0077's 2026-09
amendment carry the same contract; the mirrors are byte-identical.

## Validation

Host state: the local quality gate cannot dispatch on this machine (issue 2224:
Darwin lineage recovery fails closed), so `pnpm agent:quality-gate` was run bare
for its command mapping and every mapped command was then run directly in the
clone. The full set was run at `8b9b9f0bb6ee16f7c9d580e869496fd99429d8a7`, at
`5e59ab7b1c756fca619e52799e50273c44d0b996`, and again at exact head
`e5df87ca5314de97d551f5f5e9166dfd511736d8` after that head was rebased onto
`9931cef9`.

- `./tools/trunk check --ci` on the four changed files — exit 0.
- `pnpm docs:index --check` — exit 0. The generated catalog is not stale.
- `pnpm docs:navigation-eval:test` — exit 0.
- `pnpm docs:navigation-eval -- --check-fixtures` — exit 0, `"valid":true`, 18
  questions, total unique reserve surplus 4,251 bytes.
- `pnpm agent:context-check` — exit 0, 170 managed files.
- `pnpm agent:context-budget --strict` — exit 0.
- `node scripts/repo-health/check-skills-mirror.test.mjs` — exit 0.
- `node scripts/repo-health/check-skills-mirror.mjs` — exit 0,
  `.agents/skills and .claude/skills are identical`.
- `pnpm tf:test` — exit 0.
- `pnpm agent:autoreview` — the review itself reported `autoreview clean: no
  accepted/actionable findings reported` and `overall: patch is correct (0.92)`.
  The wrapper then exited 125 on the same Darwin containment contract as issue
  2224 (`cannot settle the Darwin contained helper lineage`), after the review
  had finished.
- The operator authorized a local quality-gate bypass for exact head
  `5e59ab7b1c756fca619e52799e50273c44d0b996` on 2026-09-03 because the host gate
  fails closed in Darwin lineage recovery (issue 2224); the push used
  `--no-verify`; mapped commands run directly: `./tools/trunk check --ci` (4
  changed files), `pnpm docs:index --check`, `pnpm docs:navigation-eval:test`,
  `pnpm agent:context-check`, `node
  scripts/repo-health/check-skills-mirror.test.mjs`, `node
  scripts/repo-health/check-skills-mirror.mjs`, `pnpm tf:test`, `pnpm
  docs:navigation-eval -- --check-fixtures`, `pnpm agent:context-budget
  --strict`; no gate control changed; exact-head GitHub CI is the authoritative
  replacement.
- The operator authorized a local quality-gate bypass for exact head
  `e5df87ca5314de97d551f5f5e9166dfd511736d8` on 2026-09-03 because the host gate
  fails closed in Darwin lineage recovery (issue 2224); the push used
  `--no-verify`; mapped commands run directly: `./tools/trunk check --ci` (4
  changed files), `pnpm docs:index --check`, `pnpm docs:navigation-eval:test`,
  `pnpm docs:navigation-eval -- --check-fixtures`, `pnpm agent:context-check`,
  `pnpm agent:context-budget --strict`, `node
  scripts/repo-health/check-skills-mirror.test.mjs`, `node
  scripts/repo-health/check-skills-mirror.mjs`, `pnpm tf:test` — every one exit
  0; `cmp` on the two `SKILL.md` copies reports them identical; no gate control
  changed; exact-head GitHub CI is the authoritative replacement.

What this evidence does not support: these commands prove the four files parse,
format, mirror byte-identically, and keep the catalog and navigation budgets
consistent. They do not execute the grooming pass, because no code implements it
— the pass is a procedure an agent follows from this prose. The claim that the
skip key can now fire was established by reading the generator and the label
classes, not by a run.

Board state: `pnpm issue:claim` fails on issues 2240, 2242, 2246 and 2247 with
the issue 2226 mutex defect (`mutex ref refs/mento-issue-board-locks/v1/… was
absent after 3 compare-and-swap attempts`), while `git ls-remote` shows that ref
present. It was retried once at this head with the same result. Those four are
therefore unclaimed on the board; each carries a comment recording the head, the
mapped-command results, and the generated claim id. Issue 2256 is claimed
(`claim-95b91800-4d9b-4112-949b-66b68e30d3b9`).

`pnpm issue:review --pr 2266 --issue <n>` was run once for each of the five
issues at this head. On 2256 it fails with the issue 2226 mutex defect (`mutex
ref refs/mento-issue-board-locks/v1/… was absent after 3 compare-and-swap
attempts`). On 2240, 2242, 2246 and 2247 it fails with `review requires durable
Claim ID, Agent, and Branch ownership`, which is the downstream effect of the
same defect blocking the claim. Neither was retried.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2265 — bound the
  grooming pass's comment-read cost without reintroducing tail starvation.
- https://github.com/mento-protocol/monitoring-monorepo/issues/2268 — decide
  whether sweep eligibility should revalidate a groomed issue's marker evidence
  before claiming it. Raised by codex on this PR; deferred because the human
  label is the acknowledgement the design asks for, and because an evidence test
  in the eligibility predicate changes what `pnpm issue:claim --sweep-eligible`
  enforces, which is a control surface a prose-only PR should not redefine.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? ADR 0077's 2026-09 amendment records the `sweep-groomed:v2` contract in this PR.

Closes #2240
Closes #2242
Closes #2246
Closes #2247
Closes #2256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN

