### PR TITLE
fix(sweep): register issue:groom in the gate's tooling-script allowlist

### DIFF
--- a/scripts/gate/mapping/engine.test.mjs
+++ b/scripts/gate/mapping/engine.test.mjs
@@ -1323,6 +1323,7 @@ test("the root manifest classifies into its four closed classes", () => {
   const cases = [
     // A tooling script pointer and nothing else.
     [(m) => (m.scripts["docs:index"] = "node b.mjs"), "root-tooling-scripts"],
+    [(m) => (m.scripts["issue:groom"] = "node b.mjs"), "root-tooling-scripts"],
     // A script that is not on the tooling list.
     [(m) => (m.scripts.build = "false"), "package-scripts"],
     // Descriptive metadata only.

--- a/scripts/gate/mapping/facts.mjs
+++ b/scripts/gate/mapping/facts.mjs
@@ -96,6 +96,7 @@ const TOOLING_SCRIPT_POINTERS = new Set(
     "issue:board",
     "issue:board:test",
     "issue:claim",
+    "issue:groom",
     "issue:review",
     "issue:release",
     "sentry:ingest",


### PR DESCRIPTION
## The Problem

- A root `package.json` edit touching only the `issue:groom` script classified as `package-scripts`, which fans the quality-gate plan out across the whole workspace: every package build, coverage floor, knip, dep-cruiser, react-doctor, size-limit and forge test.
- Every sibling in the family was already registered in `TOOLING_SCRIPT_POINTERS`, so the identical edit to `issue:board`, `issue:claim`, `issue:review` or `issue:release` stayed on the narrow `root-tooling-scripts` path. Only `issue:groom` was missing.
- These scripts have been edited repeatedly this week, so the mismatch lands on the pre-push gate path whose long runs operators already feel.

## The Solution

`issue:groom` now classifies like its siblings: a root manifest change touching only that script routes to `root-tooling-scripts` instead of the full workspace suite. The benefit is a narrow gate plan on the edit an operator is most likely to make next in this family.

The change is one string added to a list the repo already maintains. It adds no rule and no new mechanism. The material limit: the allowlist stays an enumeration, so a future `issue:*` script can be added without being registered. This allowlist has now been widened once for this family; a second miss is the trigger to replace the enumeration with a structural rule rather than to add another string.

## Details

`TOOLING_SCRIPT_POINTERS` in `scripts/gate/mapping/facts.mjs` is a `Set` of `/scripts/<name>` pointers that `classifyRootPackageJsonChanges` consults. The entry goes between `issue:claim` and `issue:review`; the array is mapped through `` .map((name) => `/scripts/${name}`) ``, so the bare script name is the whole code change.

`scripts/gate/mapping/engine.test.mjs` gains one row in the case table of "the root manifest classifies into its four closed classes", beside the existing `docs:index` row.

The narrowed class does not relax the manifest guard: a root `package.json` change still sets the
package-script risk flag, so `agent-quality-gate --run` keeps refusing until
`--allow-package-script-changes`, and `package.json` still gets a full-repo Trunk scan. What changes
is only which package suites the plan schedules.

Out of scope: replacing the enumeration with a structural `issue:*` predicate, and any refactor of the `Set`.

### Triage of the other eight follow-up issues

This branch is the output of a triage pass over nine follow-up issues filed in the last 48 hours by review bots and workers as PR deferrals. The operator set the disposition rule for that pass: "your goal is MINIMAL useful additions and fixes, i do NOT want you to add thousands of lines of code to catch every edge case imaginable and turn this into another process monster." Default disposition is discard; keep only a real, observed defect that would cause an outcome an operator notices, whose fix is small and removes or simplifies rather than adds. Duplicates are always discarded in favour of one survivor.

One issue survived, the fix in this PR. The other eight are closed, each with the full reasoning on the issue itself:

- issue 2274 — duplicate of 2273; the wider "any other `issue:*` script" sweep is empty, all five siblings are already registered. Closed as not planned.
- issue 2281 — file-size watchlist label write outside the issue-board mutex; grooming skips watchlist issues and the risk label can only narrow, so the race cannot fire. Closed as not planned.
- issue 2268 — revalidating grooming-marker evidence at claim time; the runbook already routes any label that would complete sweep eligibility to a human, so the marker is not the evidence. Closed as not planned.
- issue 2267 — labels passed without an ensure step; the cited writer creates through `gh api --method POST`, which does no client-side label validation, so the failure it describes cannot occur on that path. Closed as not planned.
- issue 2265 — unbounded grooming read cost; the candidate set is bounded by the 79-issue open roster, and the remaining ask is cross-run rotation state mirrored into four files. Closed as not planned.
- issue 2262 — reopened Sentry projections keep a bare `agent-ready` label; no issue is in that state, the gap fails closed against sweep eligibility, and grooming repairs it. Closed as not planned.
- issue 2259 — `rank-backlog` runner-up rule asymmetry; every downstream consumer revalidates, so the two outputs differ only in which advisory sentence a reader sees. Closed as not planned, with the one-clause unification named for whoever next opens that skill.
- issue 2208 — issue-board mutex false-absence diagnostics; PR 2257 fixed the cause (GraphQL `repository.ref` returns null outside `refs/heads`) and the terminal error already carries the diagnostics asked for. Closed as completed against PR 2257, not as not planned, so the fix stays discoverable from the issue.

## Validation

`pnpm agent:quality-gate` (inspect only — this host's dispatch fails closed, issue 2224) mapped 8 commands for this diff. Seven were run directly and passed; the eighth is the documented host hang, covered below.

- `./tools/trunk fmt` on the two changed files — exit 0
- `./tools/trunk check --ci scripts/gate/mapping/engine.test.mjs scripts/gate/mapping/facts.mjs` — exit 0
- `pnpm lint:scripts` — exit 0
- `node --test scripts/gate/mapping/shell-quote.test.mjs` — exit 0
- `node --test scripts/gate/mapping/engine.test.mjs` — exit 0
- `node scripts/gate/agent-prewarm.test.mjs` — exit 0
- `pnpm gate:routing-table:test` — exit 0
- `pnpm tf:test` — exit 0
- `pnpm docs:index --check` — exit 0
- `pnpm agent:context-check` — exit 0
- `pnpm agent:context-budget --strict` — exit 0
- `node scripts/check-agent-quality-gate-package-scripts.mjs` — exit 0
- `node --test scripts/sentry/ci-wiring/check-sentry-suites-in-ci-gate-probe.test.mjs` — exit 0 (the other importer of this allowlist)

- The operator authorized a local quality-gate bypass for exact head
  93f9d8fc5b934eadd1472536c2dd03867e818b48 on 2026-09-03 because the host gate
  fails closed in Darwin lineage recovery (issue 2224); the push used
  `--no-verify`; mapped commands run directly: (listed above); no gate control
  changed; exact-head GitHub CI is the authoritative replacement.
- The defect was reproduced before the fix, not inferred:
  `classifyRootPackageJsonChanges(["/scripts/issue:groom"])` returned
  `package-scripts` on origin/main (cd279d963) while `/scripts/issue:claim`
  returned `root-tooling-scripts`. After the fix it returns
  `root-tooling-scripts`.
- The new test case was run against a mutation of the code it covers: with
  `scripts/gate/mapping/facts.mjs` stashed back to origin/main, the case fails
  with `actual: 'package-scripts', expected: 'root-tooling-scripts'`. It does
  not pass vacuously.
- `pnpm agent:quality-gate:test` (`bash scripts/agent-quality-gate.test.sh`)
  was not completed: it reaches
  `scripts/gate/agent-quality-gate-scheduler.integration.test.mjs` and hangs on
  this host (issue 2224), the same behaviour recorded on PR 2276. The part of
  that suite this diff touches — the root package-script inventory — is covered
  by `node scripts/check-agent-quality-gate-package-scripts.mjs` and
  `node --test scripts/gate/mapping/engine.test.mjs`, both exit 0.
- The closeout review did not run, and no control was loosened to make it run.
  `pnpm agent:autoreview` (codex engine) reached the model and returned
  `You've hit your usage limit ... try again at Sep 7th, 2026`. The documented
  fallback `--engine claude` refused twice: first `claude not found in PATH`
  behind the cmux CLI shim, then, with `AUTOREVIEW_CLAUDE_BIN` set to the real
  binary, `AUTOREVIEW_CLAUDE_BIN does not point at a trusted absolute
  executable`. That is the autoreview trust policy doing its job, so it is
  reported rather than worked around. Coverage here is single-source: the
  author's own read of a two-line diff, plus the commands above. No
  second-model pass stands behind this diff.
- This establishes that `issue:groom` now classifies as `root-tooling-scripts`
  and that the mapping suite pins it. It does not establish that every other
  root script is classified correctly: the allowlist stays an enumeration and
  no check asserts the `issue:*` family is complete.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #2273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qMnHNftC9epVzng7JTwN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Classified the `issue:groom` tooling script as a root-level tooling change.
  * Added coverage to verify the script classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->