### PR TITLE
docs(pr): set a bar for deferring bot review findings

### DIFF
--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -337,7 +337,10 @@ even when you never open an authority.
    and `git fetch` before every push because reviewers push mid-session. Check
    new additions against the scope baseline frozen at step 4; classify each as
    in-scope, follow-up, or stop; **file a labeled GitHub issue before deferring
-   any valid follow-up** and link it from the PR's `## Deferrals` section. Warn
+   any valid follow-up** and link it from the PR's `## Deferrals` section. A
+   bot finding is a valid follow-up only when the defect is observed, the wrong
+   outcome is operator-visible, and the fix is small; otherwise answer it as an
+   evidence-backed won't-fix, which needs no issue. Warn
    as the diff approaches twice the baseline. Do not pause solely for cycle count
    before five review-triggered patch cycles are complete; pause for
    reclassification before starting a sixth. Authority:
@@ -517,7 +520,8 @@ These bind regardless of which step you are on:
   `## Deferrals`. Every issue an agent files carries a state label, a `kind:*`,
   at least one `pkg:*`, and exactly one `risk:*` set by the
   [Low-risk rule](agent-issue-workflow.md#low-risk-rule). An evidence-backed
-  won't-fix is not a deferral.
+  won't-fix is not a deferral, and it is the default for a bot finding that is
+  hypothetical, cosmetic, or would need a new mechanism to close.
 - **Never weaken a control that is blocking your own work.** Do not widen,
   disable, or soften the quality gate, the sandbox or permission config, branch
   protection, or a safety-boundary rule to unblock the change you are making

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -520,8 +520,8 @@ These bind regardless of which step you are on:
   `## Deferrals`. Every issue an agent files carries a state label, a `kind:*`,
   at least one `pkg:*`, and exactly one `risk:*` set by the
   [Low-risk rule](agent-issue-workflow.md#low-risk-rule). An evidence-backed
-  won't-fix is not a deferral, and it is the default for a bot finding that is
-  hypothetical, cosmetic, or would need a new mechanism to close.
+  won't-fix is not a deferral, and it is the default for any bot finding that
+  fails one or more of the three follow-up conditions above.
 - **Never weaken a control that is blocking your own work.** Do not widen,
   disable, or soften the quality gate, the sandbox or permission config, branch
   protection, or a safety-boundary rule to unblock the change you are making


### PR DESCRIPTION
## The Problem

- `docs/notes/pr-operating-card.md` told an agent to file a labeled GitHub issue before deferring **any** valid follow-up, with no test for what counts as valid.
- Review bots (codex, CodeRabbit) and worker subagents treated every hypothetical race, cosmetic asymmetry, and edge case as a valid follow-up. Nine backlog-sweep tooling issues were filed in 48 hours from PR reviews; a two-judge triage under the operator's minimalism rule kept one (PR 2283, a 2-line allowlist entry) and closed eight as not planned.
- Each deferral costs an issue, a claim, a PR, and a review round, and the sweep skill grew to 64 KB absorbing them.

## The Solution

The card now states the bar in both places it names deferrals: a bot finding is a valid follow-up only when the defect is observed, the wrong outcome is operator-visible, and the fix is small. Otherwise it is answered as an evidence-backed won't-fix, which needs no issue. Two sentences added, one clause extended; no new mechanism, checklist, or command.

Limit: the bar is prose guidance for agents reading the card. It does not change `check-pr-description.mjs` or any helper, so a deferral filed against it is still accepted by tooling.

## Details

- `docs/notes/pr-operating-card.md` step 6 (babysit): the "file a labeled GitHub issue before deferring any valid follow-up" sentence gains the three-part test and the won't-fix default.
- `docs/notes/pr-operating-card.md` Hard Boundaries: the "Knowingly deferred work needs a GitHub issue first" bullet's closing sentence now names when a won't-fix is the default.
- +6/−2 lines, one file.

## Validation

Mapped commands from `pnpm agent:quality-gate` (inspect) run directly at head 171e419471b469d030794a380d3abcf915add09e, all exit 0:

- `./tools/trunk check --ci docs/notes/pr-operating-card.md` — no issues
- `pnpm docs:index --check`
- `pnpm docs:navigation-eval:test`
- `pnpm docs:navigation-eval -- --check-fixtures` — `valid: true`
- `node scripts/repo-health/check-guardrail-prose.mjs` — 12 pinned sentences present
- `pnpm agent:context-check`
- `pnpm agent:context-budget --strict`
- `pnpm tf:test`

The operator authorized a local quality-gate bypass for exact head 171e419471b469d030794a380d3abcf915add09e on 2026-09-04 because the host gate fails closed in Darwin lineage recovery (issue 2224); the push used `--no-verify`; mapped commands run directly as listed; no gate control changed; exact-head GitHub CI is the authoritative replacement.

The same authorization covered exact head dfe2f1887f6bf59f40be0bbd5e2ec406c7094726 (CodeRabbit follow-up, one sentence in the same file); `./tools/trunk check --ci`, `node scripts/repo-health/check-guardrail-prose.mjs`, and `pnpm docs:navigation-eval -- --check-fixtures` (`valid: true`) exited 0 at that head before the push. The first Code Quality run on 171e4194 failed at the governance-watchdog audit step with "pnpm audit … exited 1 without advisory data" (advisory endpoint unreachable from the runner, no advisory named); this PR touches no manifest or lockfile.

Head 7b9fd70e217263814fb0f94fa5ca98942054e6b8 is an empty retrigger commit (no content change) pushed under the same authorization after the CI and Trunk runs on dfe2f188 were cancelled. Root cause, verified across both open PRs on the morning of 2026-09-04: Blacksmith runners could not reach the npm registry, so every `pnpm-install` composite step hung ~5 minutes until its own timeout cancelled the job, Trunk's `setup-ci` hung, and the governance-watchdog audit returned no advisory data (the gate fails closed on that by design). Four Trunk attempts on 7b9fd70e were cancelled inside the pnpm audit steps (attempt 4 passed three of the four lockfile audits in seconds and stalled on the last); CI, Sentry suites, and both Vercel checks are green on the same head. On 2026-09-04 the operator waived the pnpm audit requirement for this PR because the npm advisory endpoint was unavailable from the runners; `Code Quality` therefore stays cancelled for this head and the merge needs the operator's bypass of that required check. No gate or workflow was changed.

## Deferrals

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that valid follow-ups require filing and linking a labeled GitHub issue.
  * Classified hypothetical, cosmetic, or mechanism-dependent bot findings as evidence-backed won’t-fix responses rather than deferrals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


