### PR TITLE
docs(sweep): make workers name the simplest version before coding

### DIFF
--- a/.agents/skills/backlog-sweep/SKILL.md
+++ b/.agents/skills/backlog-sweep/SKILL.md
@@ -533,6 +533,14 @@ Then spawn one worker subagent per issue. Give each a brief containing:
 - **The loop:** [`pr-operating-card.md`](../../../docs/notes/pr-operating-card.md)
   steps 2-7, end to end. Implement surgically — touch only what the issue
   needs, and read the scoped `AGENTS.md` for the package first.
+
+  **Name the simplest version before you write code.** On every issue, answer
+  two questions: what is the simplest change that satisfies the issue's Done
+  means, and what could be removed instead of added. Record both answers in one
+  or two lines in the PR body's `## Details`. They matter most when the work
+  adds a new module, a new script, or a new file that other tooling has to
+  register, because each one is a surface every later change must carry.
+
 - **Formatting before the commit:** `./tools/trunk fmt <changed files>`. The
   retained pre-commit hook formats staged files, and the required Code Quality
   check enforces formatting in CI.

--- a/.claude/skills/backlog-sweep/SKILL.md
+++ b/.claude/skills/backlog-sweep/SKILL.md
@@ -533,6 +533,14 @@ Then spawn one worker subagent per issue. Give each a brief containing:
 - **The loop:** [`pr-operating-card.md`](../../../docs/notes/pr-operating-card.md)
   steps 2-7, end to end. Implement surgically — touch only what the issue
   needs, and read the scoped `AGENTS.md` for the package first.
+
+  **Name the simplest version before you write code.** On every issue, answer
+  two questions: what is the simplest change that satisfies the issue's Done
+  means, and what could be removed instead of added. Record both answers in one
+  or two lines in the PR body's `## Details`. They matter most when the work
+  adds a new module, a new script, or a new file that other tooling has to
+  register, because each one is a surface every later change must carry.
+
 - **Formatting before the commit:** `./tools/trunk fmt <changed files>`. The
   retained pre-commit hook formats staged files, and the required Code Quality
   check enforces formatting in CI.


### PR DESCRIPTION
## The Problem

- The `backlog-sweep` worker brief told each worker to "implement surgically —
  touch only what the issue needs", which constrains how wide a change spreads
  but never asks whether a smaller shape would do at all.
- A worker could therefore satisfy an issue by adding a new module, a new
  script, or a new file that other tooling must register, without ever having
  considered a version that added less or removed something instead.
- Nothing in the PR body recorded that the alternative was weighed, so a
  reviewer could not tell a deliberate choice from an unexamined default.

## The Solution

The worker brief now makes every worker answer two questions before writing
code: what is the simplest change that satisfies the issue's Done means, and
what could be removed instead of added. Both answers go into the PR body's
`## Details` in one or two lines, so the reviewer sees the alternative the
worker rejected and can push back on it.

The rule applies on every issue, and the brief says it matters most when the
work adds a new module, a new script, or a new file that other tooling has to
register, because each of those is a surface every later change must carry.

Material limit: this is prose in an agent brief, not an enforced check. No CI
gate reads the two lines or verifies that the simplest version was actually
chosen. It changes what workers are asked to do and what they must write down;
it does not measure the outcome.

## Details

Simplest version that satisfies this change: eight added lines in one brief
bullet, mirrored. Removed instead of added: nothing removed, and no new file,
script, or registration — the paragraph attaches to the existing
`- **The loop:**` bullet rather than opening a new brief section, so the brief
gains no new structure to keep aligned.

- `.agents/skills/backlog-sweep/SKILL.md` — one paragraph added under the
  `- **The loop:**` bullet in the worker-brief list (around line 536).
- `.claude/skills/backlog-sweep/SKILL.md` — the byte-identical mirror, verified
  by `node scripts/repo-health/check-skills-mirror.mjs`.
- `docs/notes/backlog-sweep.md` was checked and left alone. It never restated
  the brief's per-item contracts — it carries no formatting rule, no closeout
  command, no PR-template rule, no reply forms, and no report-back list — so it
  teaches no sequence this change makes stale.
- Wording uses the repo's canonical term "Done means"
  (`docs/notes/agent-issue-workflow.md`).

## Validation

Scope baseline, frozen before review: merge base
`7a9e0db6a750f48d9efa2c265974b6efbe48b2c4`, tree
`d4ffb044dfb4064f7d1af56b05770dff358215bf`, 2 changed files, 16 non-test added
lines (8 per file), 0 deleted. Stop threshold 100 lines (baseline under 50).

Author checks, per operating-card step 3, run directly on the committed tree.
The operator directed this PR to skip the legacy `pnpm agent:quality-gate --run`
and run the matching direct checks instead:

- `./tools/trunk fmt .agents/skills/backlog-sweep/SKILL.md .claude/skills/backlog-sweep/SKILL.md` — passed ("Checked 2 files, No issues"). It reflowed the paragraph and added one blank line, which is why the diff is 8 lines per file rather than 7.
- `pnpm docs:index --check` — passed (no catalog or link drift).
- `node scripts/repo-health/check-skills-mirror.mjs` — passed (".agents/skills and .claude/skills are identical").
- `node scripts/repo-health/check-skills-mirror.test.mjs` — passed (0 fail).
- `node scripts/repo-health/check-guardrail-prose.mjs` — passed ("64 pinned sentences present across 11 files"). No pinned sentence sits in the edited region.
- `node scripts/repo-health/check-guardrail-prose.test.mjs` — passed (0 fail).
- `pnpm agent:context-check` — passed (171 managed files).
- `pnpm agent:context-budget --strict` — exit 0. The two `[WARNING]` routes it prints, `scripts/AGENTS.md` (99.3%) and `terraform/AGENTS.md` (99.7%), are present on `origin/main` and are untouched here; the budget covers `AGENTS.md` instruction files, and no `SKILL.md` is budgeted.
- `pnpm agent:context-budget:test` — passed (17/17).

Closeout review: `pnpm agent:closeout-review --no-fetch --base origin/main`,
one round, exit 1 (findings), report
`.reviews/closeout-review-20260904T153529-7a9e0db-55086.md`, merge base
`7a9e0db`, `target_fingerprint`
`b205520279a70d2e4c7d98764d8d127e71f12a94328688f63f5369faec85bfbb`. It raised
one P2: update `docs/notes/backlog-sweep.md` because the skill declares that
note canonical for the loop. Declined with evidence — see `## Details`: the
note carries none of the brief's seven per-item contracts, so it is not a live
entry point that this change makes stale, and adding only this one would leave
the note inconsistent with the six it still omits. The second-model tooling of
the `review` skill was not run, on the operator's instruction for this PR.

What this evidence does not establish: the checks prove the two files stay
byte-identical, keep every pinned guardrail sentence, keep the docs catalog and
context budgets within limits, and are formatted. They do not prove that
workers will follow the new instruction, that the two recorded lines will be
truthful, or that any sweep PR gets smaller. No behavior is executed by this
change.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development workflow guidance to require documenting the simplest implementation approach and removable alternatives in pull request details.
  - Added additional guidance for changes involving new modules, scripts, or tooling registration.

- **User Impact**
  - No changes to end-user functionality, public interfaces, or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->