### PR TITLE
fix(review-eval): slice judge JSON by balanced spans, not a greedy regex

### DIFF
--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -407,6 +407,13 @@ one rule: the run prints recovery commands and exits non-zero until an operator
 finishes the helper and `ship` workflow. launchd therefore records that a human
 still has to finish the job.
 
+A run that failed with `novel judge returned no parseable JSON object` before
+the scorer read balanced JSON spans hit the greedy slice, which ran from the
+first brace in the judge's reply to the last: a brace in the prose ahead of the
+fenced answer — an awk snippet, say — swallowed the JSON. The logged stderr
+tail is the only record of it, because `run-eval.sh` deletes the score stderr
+file as soon as it prints that tail.
+
 The freshness workflow also routes a new staleness issue through
 `review-eval-freshness-publication.mjs`. The wrapper keeps the hash-covered
 issue planner unchanged, replaces its legacy PR instruction at the GitHub

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -217,10 +217,67 @@ function repairJson(text) {
     .replace(/,(\s*[}\]])/g, "$1");
 }
 
+// The span of `text` from the bracket at `start` to its matching close, or
+// null when nothing closes it. Quotes and their backslash escapes are tracked,
+// because a bracket inside a JSON string is text, not structure.
+function balancedSpan(text, start, open, close) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i += 1) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === open) depth += 1;
+    else if (char === close && --depth === 0) return text.slice(start, i + 1);
+  }
+  return null;
+}
+
+// Candidate spans, best signal first: the contents of each fenced block, then
+// each top-level balanced span of the wanted shape in order. A span that fails
+// to parse is not descended into, so a nested `{}` never stands in for the
+// object that contains it.
+function* jsonCandidates(text, shape) {
+  const [open, close] = shape === "array" ? ["[", "]"] : ["{", "}"];
+  for (const fence of text.matchAll(/```[a-z]*\n([\s\S]*?)```/gi)) {
+    yield fence[1];
+  }
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] !== open) continue;
+    const span = balancedSpan(text, i, open, close);
+    if (!span) continue;
+    yield span;
+    i += span.length - 1;
+  }
+}
+
+// The first candidate that parses to the wanted shape. This used to be one
+// greedy regex from the first opening bracket to the last closing one, which a
+// judge broke by writing prose before its fenced answer: a brace in the prose
+// — an awk snippet such as `open != "" { next }` — started the slice, and every
+// canonical run since the judge became agentic died on "no parseable JSON".
+// The limit is unchanged from the greedy form: a prose span that itself parses
+// to the wanted shape still wins, so the fenced block is tried first.
 function sliceJson(text, shape) {
-  const pattern = shape === "array" ? /\[[\s\S]*\]/ : /\{[\s\S]*\}/;
-  const match = text.match(pattern);
-  return match ? match[0] : null;
+  for (const candidate of jsonCandidates(text, shape)) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (shape === "array" ? Array.isArray(parsed) : isObject(parsed)) {
+        return trimmed;
+      }
+    } catch {
+      // Not this span. The next candidate, then the repaired text, then throw.
+    }
+  }
+  return null;
 }
 
 export function parseJudgeJson(

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -224,6 +224,58 @@ test("parseJudgeJson throws JudgeOutputError rather than defaulting to empty", (
   );
 });
 
+// A trimmed excerpt of the novel-judge reply that failed the 2026-09-05
+// canonical run. The greedy slice started at the brace in the awk snippet and
+// ran to the last brace in the file, so `JSON.parse` reported "Expected
+// property name" and the whole scoring pass threw.
+const PROSE_BEFORE_FENCE = [
+  "Verification complete. Both claims describe mechanics that check out.",
+  "",
+  "**Claim 2 — real and distinct.** The awk in `verify_gate_family_partition`",
+  "(test.sh:497-565) enforces the marker placement, but skips every line",
+  'inside an open family (`open != "" { next }`) — it never checks for the',
+  "`arm_suite_abort_trap` call the file's own comment declares mandatory.",
+  "",
+  "```json",
+  '{"verdicts": {"1": {"class": "known", "why": "restates test.sh:628"},',
+  '"2": {"class": "real", "why": "distinct from test.sh:572"}}}',
+  "```",
+].join("\n");
+
+test("parseJudgeJson reads the fenced object past a brace in the prose", () => {
+  const parsed = parseJudgeJson(PROSE_BEFORE_FENCE, { shape: "object" });
+  assert.deepEqual(Object.keys(parsed.verdicts), ["1", "2"]);
+  assert.equal(parsed.verdicts["2"].class, "real");
+});
+
+test("parseJudgeJson reads an unfenced object past a brace in the prose", () => {
+  const parsed = parseJudgeJson(
+    'The awk skips family lines (`open != "" { next }`), so the rule is\n' +
+      'unenforced.\n{"verdicts": {"1": {"class": "real", "why": "distinct"}}}',
+    { shape: "object" },
+  );
+  assert.deepEqual(parsed.verdicts["1"], { class: "real", why: "distinct" });
+});
+
+test("parseJudgeJson reads an array past a stray bracket in the prose", () => {
+  const parsed = parseJudgeJson(
+    "I read the gate [scripts/agent-quality-gate.sh:1616-1618] first.\n" +
+      '["the focus refusal keys only on the lock env var", "the awk skips"]',
+    { shape: "array" },
+  );
+  assert.deepEqual(parsed, [
+    "the focus refusal keys only on the lock env var",
+    "the awk skips",
+  ]);
+});
+
+test("parseJudgeJson still throws when a brace in prose is all there is", () => {
+  assert.throws(
+    () => parseJudgeJson('the awk skips `open != "" { next }` and stops there'),
+    JudgeOutputError,
+  );
+});
+
 test("renderPrompt refuses a template with an unfilled placeholder", () => {
   assert.throws(
     () => renderPrompt(loadPrompt("judge-match"), { DEFECTS: "1. x" }),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The scorer cut the judge's JSON out of its reply with one greedy regex —
  `/\{[\s\S]*\}/`, the first opening brace through the last closing one. That
  worked while the judge answered with JSON and nothing else.
- The novel judge (Fable at max effort, agentic with Bash) writes prose first
  and fences its JSON after it. A brace anywhere in that prose — an awk snippet
  such as `` `open != "" { next }` `` — started the slice, so `JSON.parse` saw
  prose and failed with "Expected property name".
- `--score` then threw `novel judge returned no parseable JSON object` and the
  whole run aborted after paying for every cell. The ledger holds five
  `status: failed` rows between 2026-08-29 and 2026-08-31, each recording only
  `run failed: scoring failed` because the score stderr file that named the
  cause is deleted; the captured final message from the 2026-09-05 run
  reproduces the parse failure exactly. A judge reply that named two verdicts
  correctly was discarded over a brace in a sentence.

## The Solution

`parseJudgeJson` now picks its slice by structure instead of by first-and-last
bracket. It tries the contents of each fenced block first — the judge marks its
answer, so that mark is the strongest signal — then walks each top-level
balanced span of the wanted shape, tracking quotes and backslash escapes so a
bracket inside a JSON string is text rather than structure, and returns the
first span that parses to that shape. The captured 2026-09-05 reply now yields
its two verdicts.

The benefit is that a canonical full run survives a chatty judge instead of
throwing away six hours of paid cells over prose punctuation.

Two limits. Nothing new counts as valid output: the single `repairJson` retry,
the shape check, and the `JudgeOutputError` are unchanged, and a reply with no
JSON in it still throws. And the first-match rule keeps one weakness of the
greedy form — a prose span that itself parses to the wanted shape (a bare `[1]`
before the real array) still wins. Trying fenced blocks first covers the shape
this judge actually produces; it is not a guarantee against every prose bracket.

## Details

`sliceJson` is replaced by two helpers plus a rewritten `sliceJson`, all
private to `scripts/review/review-eval-score.mjs`:

- `balancedSpan(text, start, open, close)` returns the span from the bracket at
  `start` to its match, or `null` when nothing closes it. It is string-aware:
  inside a `"…"` run, brackets and quotes are counted only after a backslash
  escape resolves.
- `jsonCandidates(text, shape)` yields fenced-block contents first, then each
  top-level balanced span in order. A span that fails to parse is **not**
  descended into, so a nested `{}` never stands in for the object containing
  it. That is what keeps the existing fenced/trailing-comma repair test passing.
- `sliceJson` returns the first candidate that both parses and matches the
  requested shape.

The prompts are untouched; they already say "Reply with ONLY JSON".

`scorerDigest()` hashes this module, so it changes:
`4ad762d1…` → `73b60b69…`. Rows scored after this merge carry a new
`comparability_key` and will not pair with rows scored before it. No test or
fixture pinned the literal digest, so no pin needed updating.

The module is not split. It was already past the 600-line watchlist soft cap
from ADR 0065 before this change (839 raw / 623 rough), and is 896 raw / 663
rough after — moving `sliceJson` out would not bring it back under 600, and
both numbers stay well under the 950 near-hard and 1,000 hard caps.

`docs/evals/review-skill.md` gains one paragraph, in the failed-run section,
recording that this error string in an older run's log means the greedy slice,
and that the logged stderr tail is the only record because `run-eval.sh` deletes
the score stderr file right after printing it.

## Validation

Head SHA `ce870ab687975f866fd0d6d95917ca133a15432d`. All commands run in a clean
clone at that head.

- **Fail before, pass after.** The three new positive tests were run against the
  pre-fix `review-eval-score.mjs` (restored from a file copy, not a stash) with
  `node --test --test-name-pattern 'parseJudgeJson'`: 6 tests, 3 pass, 3 fail,
  each failing with `JudgeOutputError: judge returned no parseable JSON
  object`/`array`. With the fixed source: 6 tests, 6 pass, 0 fail.
- **Real reproduction.** The captured failing final message from the 2026-09-05
  run (2,275 chars; first `{` at offset 1154 inside prose, the fenced `json`
  block at offset 1640) parses under the new code to a `verdicts` object with
  entries `1` and `2`, classes `known` and `real`. The first committed test is a
  trimmed excerpt of that message, keeping the `{ next }` prose and the fence.
- **Suites.** `node --test scripts/review/review-eval-score.test.mjs`: 46 tests,
  46 pass, 0 fail (42 before). `pnpm review:eval:test`: 383 tests, 383 pass,
  0 fail. `node --test scripts/review/review-eval.test.mjs`: 162 pass.
  `node --test scripts/context/docs-index.test.mjs`: 30 pass, covering the doc
  edit's links and catalog.
- **Lint and format.** `pnpm lint:scripts` clean.
  `CI=true ./tools/trunk check --no-fix` on the three changed files: 3 files
  checked, no issues (one Prettier quote-style autofix was applied first via
  `trunk fmt`).
- **Push.** Pushed with `git push --no-verify`. The local quality-gate
  coordinator on this host is wedged and the operator directed skipping it for
  this session; CI on this PR is the gate that actually ran.

What this evidence does not support: the suites prove the parser handles these
four shapes plus the one captured real reply, and that no existing scorer test
regressed. They do not prove it recovers every prose-plus-JSON reply a judge can
emit, and no full `--score` run against a live judge was executed here — the
next canonical run is the first end-to-end confirmation.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation result parsing when explanatory text contains stray braces or brackets before valid JSON.
  - Added support for reliably identifying structured results in fenced JSON blocks.
  - Preserved clear errors when no valid result is available.

- **Tests**
  - Added regression coverage for JSON objects and arrays preceded by prose, including fenced responses and invalid output scenarios.

- **Documentation**
  - Documented a failure mode and recovery guidance for evaluation results that cannot be parsed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->