### PR TITLE
docs(card): drop the stale note about the global review skill's tooling reference

### DIFF
--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -268,9 +268,7 @@ If root `package.json` changed, first run
 
    `~/.claude/bin/codex-review.sh` is a different operator tool with a
    different CLI and different exit codes. In this repo the closeout is
-   `pnpm agent:closeout-review`. The global `review` skill's tooling
-   reference still names a retired repo command; that file lives outside this
-   repository and fixing it is a separate follow-up.
+   `pnpm agent:closeout-review`.
 
 5. **Ship.** Open the PR through the `ship` skill on every surface, including
    hosted sessions — do not hand-roll PR creation. The description follows the


### PR DESCRIPTION
## The Problem

- Operating card step 4 told readers that the global `review` skill's tooling reference still names a retired repo command and that fixing it is a separate follow-up.
- That follow-up landed in chapati23/agent-skills PR 2 on 2026-09-05, so the note now misdirects a reader toward a fix that already exists.

## The Solution

The two-sentence note is removed. The preceding sentences stay: `codex-review.sh` is a different operator tool with a different CLI and exit codes, and this repo's closeout is `pnpm agent:closeout-review`. Nothing else in step 4 changes.

## Details

Prose-only deletion in `docs/notes/pr-operating-card.md`. The card is a pinned guardrail document; none of its pinned sentences are touched.

## Validation

- `./tools/trunk fmt docs/notes/pr-operating-card.md`: no issues.
- `pnpm docs:index --check`: passes (the catalog entry is unchanged).
- `node scripts/repo-health/check-guardrail-prose.mjs`: 64 pinned sentences present across 11 files.
- `pnpm agent:context-check`: passed, 171 managed files.
- These prove the deletion leaves the catalog, the pinned prose, and the agent context budget intact. They do not prove anything about the closeout flow itself, which this PR does not change.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable.

Closes #2304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBBUKZdqzHewn44dEzu1hh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated closeout-review guidance to document the repository-local `pnpm agent:closeout-review` command.
  - Removed the outdated reference to the retired global review-skill command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->