### PR TITLE
fix(ci): report lint and audit failures in one run

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -33,18 +33,11 @@ jobs:
         run: node scripts/workflows/check-github-action-pins.mjs
       - uses: ./.trunk/setup-ci
       - name: PR validation boundary suite
+        id: validation-boundary
         # This required workflow always runs, including when a PR changes only
         # .trunk/setup-ci. The suite rejects implicit PR cache saves before
         # setup-node's post action can publish one from a successful job.
         run: node scripts/workflows/check-pr-validation-boundary.test.mjs
-      - name: pnpm audit high gate self-tests
-        run: node scripts/supply-chain/pnpm-audit-high-gate.test.mjs
-      - name: pnpm audit governance-watchdog deploy lockfile (high+ only)
-        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir governance-watchdog --label governance-watchdog
-      - name: pnpm audit on-call announcer deploy lockfile (high+ only)
-        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir alerts/infra/oncall-announcer --label alerts/infra/oncall-announcer
-      - name: pnpm audit handler deploy lockfile (high+ only)
-        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir alerts/infra/onchain-event-handler --label alerts/infra/onchain-event-handler
       - name: Restore Trunk artifacts
         id: trunk-cache
         continue-on-error: true
@@ -61,6 +54,20 @@ jobs:
           node -e 'const { rmSync } = require("node:fs"); const { homedir } = require("node:os"); const { join } = require("node:path"); rmSync(join(homedir(), ".cache", "trunk"), { force: true, recursive: true });'
       - name: Run Trunk
         run: ./tools/trunk check --ci --all
+      # Report every audit even if lint or another audit fails. Setup and
+      # validation failures still stop candidate tooling; cancellation stops work.
+      - name: pnpm audit high gate self-tests
+        if: ${{ !cancelled() && steps.validation-boundary.outcome == 'success' }}
+        run: node scripts/supply-chain/pnpm-audit-high-gate.test.mjs
+      - name: pnpm audit governance-watchdog deploy lockfile (high+ only)
+        if: ${{ !cancelled() && steps.validation-boundary.outcome == 'success' }}
+        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir governance-watchdog --label governance-watchdog
+      - name: pnpm audit on-call announcer deploy lockfile (high+ only)
+        if: ${{ !cancelled() && steps.validation-boundary.outcome == 'success' }}
+        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir alerts/infra/oncall-announcer --label alerts/infra/oncall-announcer
+      - name: pnpm audit handler deploy lockfile (high+ only)
+        if: ${{ !cancelled() && steps.validation-boundary.outcome == 'success' }}
+        run: node scripts/supply-chain/pnpm-audit-high-gate.mjs --dir alerts/infra/onchain-event-handler --label alerts/infra/onchain-event-handler
       - name: Save Trunk artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.trunk-cache.outputs.cache-hit != 'true'
         continue-on-error: true

--- a/scripts/workflows/check-pr-validation-boundary.test.mjs
+++ b/scripts/workflows/check-pr-validation-boundary.test.mjs
@@ -54,6 +54,44 @@ test("the repository satisfies the M2 structural boundary", () => {
   assert.deepEqual(checkStructuralRepository(ROOT), []);
 });
 
+test("Code Quality reports lint and all audits without bypassing prerequisites", () => {
+  const { jobs } = load(
+    readFileSync(join(ROOT, ".github/workflows/trunk.yml"), "utf8"),
+  );
+  const { steps } = jobs.trunk;
+  assert.equal(jobs.trunk.name, "Code Quality");
+  assert.notEqual(jobs.trunk["continue-on-error"], true);
+  const lint = steps.findIndex(
+    (step) => step.run === "./tools/trunk check --ci --all",
+  );
+  const boundary = steps.findIndex((step) => step.id === "validation-boundary");
+  const setup = steps.findIndex((step) => step.uses === "./.trunk/setup-ci");
+  const pins = steps.findIndex(
+    (step) => step.name === "Check GitHub Actions pins",
+  );
+  assert(pins >= 0 && pins < setup && setup < boundary && boundary < lint);
+  // Default success() semantics keep setup, trust checks, and cache cleanup
+  // failures fatal to lint. Only independent audits override failure short-circuiting.
+  for (const index of [pins, setup, boundary, lint]) {
+    assert.equal(steps[index].if, undefined);
+    assert.notEqual(steps[index]["continue-on-error"], true);
+  }
+  const audits = steps.filter((step) => step.name?.startsWith("pnpm audit "));
+  assert.equal(audits.length, 4);
+  for (const audit of audits) {
+    assert(steps.indexOf(audit) > lint, `${audit.name} cannot suppress lint`);
+    assert.equal(
+      audit.if,
+      "${{ !cancelled() && steps.validation-boundary.outcome == 'success' }}",
+    );
+    assert.notEqual(
+      audit["continue-on-error"],
+      true,
+      `${audit.name} must fail the job`,
+    );
+  }
+});
+
 test("a HOME override cannot put the pnpm cache inside the checkout", () => {
   const root = structuralFixture();
   const action = load(


### PR DESCRIPTION
## The Problem

Supply-chain audit failures in `Code Quality` skipped Trunk, so lint regressions remained hidden until the audit failures were fixed.

## The Solution

Run Trunk before the audits. Run each audit even when lint or another audit fails. Every failure still makes the existing required `Code Quality` job fail.

Checkout, action-pin validation, dependency setup, and the PR validation boundary must succeed first. Cancellation still stops the work. These prerequisites can intentionally prevent lint and audit execution.

## Details

- Move the four audit steps after Trunk and guard them with the validation-boundary outcome and `!cancelled()`.
- Keep the required context, permissions, cache policy, and ten-minute job timeout unchanged.
- Add a contract test for ordering, prerequisites, cancellation guard, and fatal audit failures.
- Architecture decision: none. This fixes step ordering inside the existing job without changing the CI architecture.

Closes #2253.

## Validation

- Passed: changed-file Trunk formatting and checks, including workflow lint.
- Passed: `pnpm ci:contract:test` — 178 tests.
- Passed: `node scripts/workflows/check-github-action-pins.mjs`.
- Passed: `node scripts/workflows/check-autofix-ci-trust.mjs`.
- Passed: `pnpm lint:scripts` and `git diff --check`.
- Audited current documentation for stale audit-before-lint instructions; none found.
- The local contract tests verify the workflow structure. They do not execute GitHub Actions or inject a live hosted audit failure. Hosted CI remains the runtime check.
- `pnpm agent:closeout-review --base origin/main`: not run successfully; exit 2 because nested Codex execution is unavailable. Independent subagent source review used as the disclosed fallback.
- Claude Security scan: skipped (not available in this Codex session; workflow trust covered by focused contracts and source review).
- Scope baseline: issue #2253; owner Codex; merge base `7285899eadefb6f2702e7878a6711fbd91775b92`; two changed files; 15 added non-test lines (23 added plus deleted). Dirty diff SHA-256 `9e358e592a3339affee8c677a7f77f8fcd860a5483c0407f8df6ad68f9a1b794`. Review growth threshold: 100 added non-test lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation workflow sequencing so supply-chain audits run after Trunk execution and only following successful validation.
  * Preserved audit failures instead of suppressing them.

* **Tests**
  * Added workflow checks covering job naming, validation order, failure handling, and audit-step conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->