### PR TITLE
fix(evals): resume the review-eval judge pass per cell

### DIFF
--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -757,7 +757,10 @@ Scored evidence reaches the detail-dir root — `result-*.json` and
 row publish no scored evidence and a retry still resume: the two needs are one
 layout rather than a trade. Editing the scorer moves `scorer_digest`, so the
 next run plans a new directory name; seed it by copying the previous run's
-`cells/` across, as with any superseded run.
+`cells/` across, as with any superseded run. A retry that crosses UTC midnight
+needs the same copy for the same reason: the directory base carries the date, so
+`resolve_detail_dir` finds no earlier run to resume from and the paid cells stay
+in yesterday's directory until they are moved.
 
 `--score --against` requires the baseline to carry the plan's
 `comparability_key`. It refuses a cross-key pair before model work. `--report`

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -811,9 +811,13 @@ directory. `--validate` re-derives `agreement` and `total` from them and checks
 each `expected` against the frozen pair, so the gate that caps a run at AMBER is
 evidence on disk rather than two integers the row states about itself. A detail
 directory holding cell results but no `calibration.json` fails validation. The
-replay is also cached beside the cell verdicts, at `cells/calibration.json`, and
-reused when the plan's calibration digest and the contract judge both still
-match, so a resumed pass does not replay the forty pairs again.
+replay is also cached beside the cell verdicts, at `cells/calibration.json`,
+under the same resume identity those verdicts carry — the comparability key, the
+contract digest, the matcher digest, the calibration digest and the cell
+fingerprint — with the contract judge standing in for the per-cell transcript
+digest. A resumed pass reuses it only when every one of those still matches, so
+an edit to a scoring module, which moves `matcher_digest`, replays the forty
+pairs again rather than reusing a replay the edit could have changed.
 
 **Model retirement needs a bridge run.** Pinned models get retired and history
 cannot be re-run. When that happens, run the retiring model and its replacement

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -285,10 +285,11 @@ and CI check both records against the plan. Changing only the row and plan
 inputs cannot relabel a candidate as an installed run. The run directory
 carries the kind and the skill digest in its name, so an
 aborted run followed by a skill edit re-runs instead of scoring the old skill
-under the new digest. A run that ends before it scores keeps its cells on disk
-for that retry — publishing strips them from the commit with an exclude
-pathspec rather than deleting them — and only a run that reached a score
-removes them, having nothing left to resume. The directory belongs to one
+under the new digest. A run that never published a score keeps its cells on
+disk for that retry — publishing strips them from the commit with an exclude
+pathspec rather than deleting them — and only a run that published one removes
+them, having nothing left to resume. `cells/` carries the judge pass's per-cell
+verdicts as well as the paid transcripts, so a retry resumes the scoring too. The directory belongs to one
 execution: a run killed before it recorded anything is retried into it, but once
 a ledger row points at it the next execution takes the next name and copies
 those cells across, because a second run writing there would overwrite the plan,
@@ -405,7 +406,10 @@ changes, and nothing reaches the freshness workflow. A scored row wedges it the
 same way. The installed job uses the non-publishing mode, so both endings follow
 one rule: the run prints recovery commands and exits non-zero until an operator
 finishes the helper and `ship` workflow. launchd therefore records that a human
-still has to finish the job.
+still has to finish the job. Writing that row clears the scored artifacts at the
+run-directory root, because `--revalidate-appended` would otherwise read them as
+the failure row's own numbers; it leaves `cells/` alone, so the judge verdicts a
+stopped pass already earned survive for the retry.
 
 A run that failed with `novel judge returned no parseable JSON object` before
 the scorer read balanced JSON spans hit the greedy slice, which ran from the
@@ -710,7 +714,8 @@ against the anchor with the version drift named beside it.
 `review-eval-score.mjs` owns the `SCORING_MODULES` inventory and computes
 `scorer_digest`. The digest covers every file that can move a recorded number
 or verdict. This includes the CLI, the run facade, plan construction, scoring
-process execution, cell identity and leak checks, condition folding, row
+process execution, cell identity, judge-verdict reuse and leak checks,
+condition folding, row
 assembly, the recompute, timestamp validation, and verdict rules. It also
 covers the two fixture helpers:
 `review-eval-fixtures.mjs` picks the matrix, the truth file and the recall
@@ -734,6 +739,25 @@ first calibration call. A later checkout edit cannot change one cell's
 scoring. `--check-fixtures` covers the inputs once, before the matrix starts;
 under `--skill-ref` the spec worktree is the live checkout for the two hours in
 between, and the contract digest alone would not notice.
+
+**The judge pass resumes per cell.** Judging one cell costs about $4 and nine
+minutes, so 39 cells run about six hours and do not fit inside one usage window:
+the 2026-09-05 attempt scored nineteen cells, hit a usage limit, and re-spent
+them on the retry. `--score` writes each verdict to `cells/<cell_id>/score.json`
+as it earns it, under a resume identity carrying the plan's comparability key,
+contract digest, matcher digest and calibration digest, the cell fingerprint, and
+the digest of the `result.json` that verdict was formed on. A later pass reuses a
+record only when every one of those matches; a mismatched or unparsable record
+is ignored and re-judged, which costs one cell. The `--json` output reports
+`judge_pass.judged`, `judge_pass.reused` and `judge_pass.calibration_reused`, so
+the run log says what the pass paid for.
+
+Scored evidence reaches the detail-dir root — `result-*.json` and
+`calibration.json` — only once the pass has finished. That is what lets a failed
+row publish no scored evidence and a retry still resume: the two needs are one
+layout rather than a trade. Editing the scorer moves `scorer_digest`, so the
+next run plans a new directory name; seed it by copying the previous run's
+`cells/` across, as with any superseded run.
 
 `--score --against` requires the baseline to carry the plan's
 `comparability_key`. It refuses a cross-key pair before model work. `--report`
@@ -786,7 +810,10 @@ The forty outcomes are written to `calibration.json` in the run's detail
 directory. `--validate` re-derives `agreement` and `total` from them and checks
 each `expected` against the frozen pair, so the gate that caps a run at AMBER is
 evidence on disk rather than two integers the row states about itself. A detail
-directory holding cell results but no `calibration.json` fails validation.
+directory holding cell results but no `calibration.json` fails validation. The
+replay is also cached beside the cell verdicts, at `cells/calibration.json`, and
+reused when the plan's calibration digest and the contract judge both still
+match, so a resumed pass does not replay the forty pairs again.
 
 **Model retirement needs a bridge run.** Pinned models get retired and history
 cannot be re-run. When that happens, run the retiring model and its replacement

--- a/scripts/review/review-eval-run-cell.mjs
+++ b/scripts/review/review-eval-run-cell.mjs
@@ -1,6 +1,7 @@
-// Cell identity, cache reuse, and answer-key leak signals.
+// Cell identity, raw and judge cache reuse, and answer-key leak signals.
 
-import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { defaultRunGit } from "./review-eval-fixtures.mjs";
@@ -304,4 +305,124 @@ export function cellReuseDecision({ plan, resultPath, result = null }) {
       ? "the cached cell matches this run through the recorded reviewed orchestrator transition"
       : "the cached cell matches this run",
   };
+}
+
+/** Where the orchestrator wrote one cell's raw contestant transcript. */
+export function cellResultPath(planDir, cell) {
+  return path.join(planDir, "cells", cell.cell_id, "result.json");
+}
+
+/**
+ * One cell's raw result plus the digest of the exact bytes scoring reads, or
+ * null when the cell never completed. The digest is what ties a cached judge
+ * verdict to the transcript that verdict was formed on.
+ */
+export function readCellResult(planDir, cell) {
+  const file = cellResultPath(planDir, cell);
+  if (!existsSync(file)) return null;
+  const bytes = readFileSync(file);
+  let result;
+  try {
+    result = JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    throw new Error(`could not read valid JSON from ${file}`, { cause: error });
+  }
+  if (result?.ok !== true || typeof result.output !== "string") return null;
+  return { result, digest: createHash("sha256").update(bytes).digest("hex") };
+}
+
+/**
+ * What a cached judge verdict must have been produced under.
+ *
+ * The judge pass costs about four dollars and nine minutes a cell, so a 39-cell
+ * pass outlasts one usage window: it has to resume rather than re-spend from
+ * zero. These fields are every input that can move a scored number - the
+ * comparability key the row is filed under, the contract, the scorer and
+ * calibration bytes that key is derived from, the execution fingerprint the raw
+ * cell already carries, and, per cell, the transcript itself. A record matching
+ * all of them is the same judge call, so replaying it changes nothing. Anything
+ * else is ignored and re-judged, which costs one cell and never scores one
+ * pipeline's output under another pipeline's identity.
+ */
+function judgeResumeIdentity({ plan, resultDigest = null, judge = null }) {
+  return {
+    comparability_key: plan?.comparability_key ?? null,
+    contract_digest: plan?.contract_digest ?? null,
+    matcher_digest: plan?.matcher_digest ?? null,
+    calibration_digest: plan?.calibration_digest ?? null,
+    fingerprint: cellFingerprint({ plan }),
+    ...(resultDigest === null ? {} : { result_digest: resultDigest }),
+    ...(judge === null ? {} : { judge }),
+  };
+}
+
+/** The record a resume file holds, or null when it does not match or parse. */
+function readResume(file, identity) {
+  let stored;
+  try {
+    stored = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+  return JSON.stringify(stored?.resume_identity) === JSON.stringify(identity)
+    ? (stored.record ?? null)
+    : null;
+}
+
+function writeResume(file, identity, record) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(
+    file,
+    `${JSON.stringify({ resume_identity: identity, record }, null, 2)}\n`,
+  );
+}
+
+// The resume cache lives under `cells/`: the directory publication already
+// excludes with a pathspec and a failed run already keeps on disk. Scored
+// evidence at the detail-dir root is exactly what a failed row must not carry,
+// so the scorer writes nothing there until the pass has finished.
+function scoreResumePath(planDir, cellId) {
+  return path.join(planDir, "cells", cellId, "score.json");
+}
+
+function calibrationResumePath(planDir) {
+  return path.join(planDir, "cells", "calibration.json");
+}
+
+/** A judge verdict for this cell that this plan may reuse, or null. */
+export function readScoreResume({ planDir, plan, cell, resultDigest }) {
+  return readResume(
+    scoreResumePath(planDir, cell.cell_id),
+    judgeResumeIdentity({ plan, resultDigest }),
+  );
+}
+
+export function writeScoreResume({
+  planDir,
+  plan,
+  cell,
+  resultDigest,
+  record,
+}) {
+  writeResume(
+    scoreResumePath(planDir, cell.cell_id),
+    judgeResumeIdentity({ plan, resultDigest }),
+    record,
+  );
+}
+
+/** A calibration replay this plan and judge may reuse, or null. */
+export function readCalibrationResume({ planDir, plan, judge }) {
+  return readResume(
+    calibrationResumePath(planDir),
+    judgeResumeIdentity({ plan, judge }),
+  );
+}
+
+export function writeCalibrationResume({ planDir, plan, judge, calibration }) {
+  writeResume(
+    calibrationResumePath(planDir),
+    judgeResumeIdentity({ plan, judge }),
+    calibration,
+  );
 }

--- a/scripts/review/review-eval-run-cell.mjs
+++ b/scripts/review/review-eval-run-cell.mjs
@@ -389,12 +389,25 @@ function calibrationResumePath(planDir) {
   return path.join(planDir, "cells", "calibration.json");
 }
 
-/** A judge verdict for this cell that this plan may reuse, or null. */
+/**
+ * A judge verdict for this cell that this plan may reuse, or null.
+ *
+ * `treatment` stays out of the resume identity: the selection that named the
+ * run is display identity, not a judge input, so the same transcript under the
+ * same contract earns the same verdict either way. The record is published as
+ * `result-<pr>-<condition>-<draw>.json` though, and run evidence rejects one
+ * whose treatment is not this plan's, so a reused verdict is rebound to this
+ * run's selection - exactly what a fresh judge call stamps onto a cached raw
+ * cell.
+ */
 export function readScoreResume({ planDir, plan, cell, resultDigest }) {
-  return readResume(
+  const record = readResume(
     scoreResumePath(planDir, cell.cell_id),
     judgeResumeIdentity({ plan, resultDigest }),
   );
+  return record === null
+    ? null
+    : { ...record, treatment: treatmentIdentity({ plan }) };
 }
 
 export function writeScoreResume({

--- a/scripts/review/review-eval-run-cell.mjs
+++ b/scripts/review/review-eval-run-cell.mjs
@@ -393,23 +393,31 @@ function calibrationResumePath(planDir) {
  * Whether a stored record can stand in for a judge call.
  *
  * A resumed record is published verbatim as
- * `result-<pr>-<condition>-<draw>.json`, so it has to carry what run evidence
- * demands of one. Rejecting anything else here keeps a matching identity over a
- * record that is `{}`, an array or a scalar from reaching `record.leak` in the
- * scoring loop and aborting the pass at the one point the design promises a
- * re-judge - the same ending an unparsable file already gets, for the same
- * reason: one cell re-spent beats a dead six-hour pass.
+ * `result-<pr>-<condition>-<draw>.json` and folded into a condition on the way,
+ * so every field either consumer dereferences has to be there and has to have
+ * the right type. A partial record is worse than no record: it is not re-judged,
+ * it aborts the pass on the missing field, and it stays under `cells/` so the
+ * next retry aborts the same way. Rejecting it takes the ending an unparsable
+ * file already gets, for the same reason - one cell re-spent beats a dead
+ * six-hour pass.
  */
 function usableScoreRecord(record) {
+  if (typeof record !== "object" || record === null || Array.isArray(record)) {
+    return false;
+  }
+  const finite = (value) => typeof value === "number" && Number.isFinite(value);
   return (
-    typeof record === "object" &&
-    record !== null &&
-    !Array.isArray(record) &&
-    typeof record.scoring_usd === "number" &&
-    Number.isFinite(record.scoring_usd) &&
+    typeof record.cell_id === "string" &&
+    finite(record.scoring_usd) &&
     record.scoring_usd >= 0 &&
+    finite(record.seconds) &&
+    finite(record.usd) &&
+    Array.isArray(record.claims) &&
+    Array.isArray(record.matched_ids) &&
     typeof record.leak?.suspected === "boolean" &&
-    Array.isArray(record.leak?.hard)
+    Array.isArray(record.leak?.hard) &&
+    finite(record.novel?.novelReal) &&
+    finite(record.novel?.novelWrong)
   );
 }
 

--- a/scripts/review/review-eval-run-cell.mjs
+++ b/scripts/review/review-eval-run-cell.mjs
@@ -401,13 +401,16 @@ function calibrationResumePath(planDir) {
  * file already gets, for the same reason - one cell re-spent beats a dead
  * six-hour pass.
  */
-function usableScoreRecord(record) {
+function usableScoreRecord(record, cell) {
   if (typeof record !== "object" || record === null || Array.isArray(record)) {
     return false;
   }
   const finite = (value) => typeof value === "number" && Number.isFinite(value);
   return (
-    typeof record.cell_id === "string" &&
+    record.cell_id === cell.cell_id &&
+    record.pr === cell.pr &&
+    record.condition === cell.condition &&
+    record.draw === cell.draw &&
     finite(record.scoring_usd) &&
     record.scoring_usd >= 0 &&
     finite(record.seconds) &&
@@ -437,7 +440,7 @@ export function readScoreResume({ planDir, plan, cell, resultDigest }) {
     scoreResumePath(planDir, cell.cell_id),
     judgeResumeIdentity({ plan, resultDigest }),
   );
-  return usableScoreRecord(record)
+  return usableScoreRecord(record, cell)
     ? { ...record, treatment: treatmentIdentity({ plan }) }
     : null;
 }
@@ -456,12 +459,44 @@ export function writeScoreResume({
   );
 }
 
+/**
+ * Whether a stored calibration replay can stand in for running the forty pairs.
+ *
+ * It is published as `calibration.json`, and `--validate` re-derives
+ * `agreement` and `total` from `outcomes` to check the row's own numbers. A
+ * record that cannot support that re-derivation would be published as a reuse,
+ * fail validation, and - because the failed-run path keeps `cells/` - be reused
+ * by every retry after it. Replaying forty pairs once is the cheaper ending.
+ */
+function usableCalibrationRecord(calibration) {
+  if (
+    typeof calibration !== "object" ||
+    calibration === null ||
+    Array.isArray(calibration)
+  ) {
+    return false;
+  }
+  return (
+    Number.isInteger(calibration.total) &&
+    calibration.total > 0 &&
+    Number.isInteger(calibration.agreement) &&
+    calibration.agreement >= 0 &&
+    calibration.agreement <= calibration.total &&
+    Array.isArray(calibration.outcomes) &&
+    calibration.outcomes.length === calibration.total &&
+    typeof calibration.scoring_usd === "number" &&
+    Number.isFinite(calibration.scoring_usd) &&
+    calibration.scoring_usd >= 0
+  );
+}
+
 /** A calibration replay this plan and judge may reuse, or null. */
 export function readCalibrationResume({ planDir, plan, judge }) {
-  return readResume(
+  const calibration = readResume(
     calibrationResumePath(planDir),
     judgeResumeIdentity({ plan, judge }),
   );
+  return usableCalibrationRecord(calibration) ? calibration : null;
 }
 
 export function writeCalibrationResume({ planDir, plan, judge, calibration }) {

--- a/scripts/review/review-eval-run-cell.mjs
+++ b/scripts/review/review-eval-run-cell.mjs
@@ -390,6 +390,30 @@ function calibrationResumePath(planDir) {
 }
 
 /**
+ * Whether a stored record can stand in for a judge call.
+ *
+ * A resumed record is published verbatim as
+ * `result-<pr>-<condition>-<draw>.json`, so it has to carry what run evidence
+ * demands of one. Rejecting anything else here keeps a matching identity over a
+ * record that is `{}`, an array or a scalar from reaching `record.leak` in the
+ * scoring loop and aborting the pass at the one point the design promises a
+ * re-judge - the same ending an unparsable file already gets, for the same
+ * reason: one cell re-spent beats a dead six-hour pass.
+ */
+function usableScoreRecord(record) {
+  return (
+    typeof record === "object" &&
+    record !== null &&
+    !Array.isArray(record) &&
+    typeof record.scoring_usd === "number" &&
+    Number.isFinite(record.scoring_usd) &&
+    record.scoring_usd >= 0 &&
+    typeof record.leak?.suspected === "boolean" &&
+    Array.isArray(record.leak?.hard)
+  );
+}
+
+/**
  * A judge verdict for this cell that this plan may reuse, or null.
  *
  * `treatment` stays out of the resume identity: the selection that named the
@@ -405,9 +429,9 @@ export function readScoreResume({ planDir, plan, cell, resultDigest }) {
     scoreResumePath(planDir, cell.cell_id),
     judgeResumeIdentity({ plan, resultDigest }),
   );
-  return record === null
-    ? null
-    : { ...record, treatment: treatmentIdentity({ plan }) };
+  return usableScoreRecord(record)
+    ? { ...record, treatment: treatmentIdentity({ plan }) }
+    : null;
 }
 
 export function writeScoreResume({

--- a/scripts/review/review-eval-run-score.mjs
+++ b/scripts/review/review-eval-run-score.mjs
@@ -1,7 +1,7 @@
 // Cell scoring, condition folding, row assembly, and freshness planning.
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -25,22 +25,20 @@ import {
 } from "./review-eval-score.mjs";
 import {
   cellFingerprint,
+  cellResultPath,
   cellReuseDecision,
   leakSignals,
   loginsInFixtureTree,
+  readCalibrationResume,
+  readCellResult,
+  readScoreResume,
   reviewerLogins,
   treatmentIdentity,
+  writeCalibrationResume,
+  writeScoreResume,
 } from "./review-eval-run-cell.mjs";
 import { resetFixture } from "./review-eval-run-execution.mjs";
 import { baselinePlanIdentity, planCells } from "./review-eval-run-plan.mjs";
-
-function readJson(file) {
-  try {
-    return JSON.parse(readFileSync(file, "utf8"));
-  } catch (error) {
-    throw new Error(`could not read valid JSON from ${file}`, { cause: error });
-  }
-}
 
 /** Read, verify, and parse the same truth bytes that scoring will retain. */
 function readPinnedTruth(repoRoot, fixture) {
@@ -59,18 +57,6 @@ function readPinnedTruth(repoRoot, fixture) {
   }
 }
 
-function cellResultPath(planDir, cell) {
-  return path.join(planDir, "cells", cell.cell_id, "result.json");
-}
-
-function readCellResult(planDir, cell) {
-  const file = cellResultPath(planDir, cell);
-  if (!existsSync(file)) return null;
-  const result = readJson(file);
-  return result?.ok === true && typeof result.output === "string"
-    ? result
-    : null;
-}
 async function scoreOneCell({
   cell,
   cellResult,
@@ -338,20 +324,20 @@ export async function scorePlan({
   const treatment = treatmentIdentity({ plan });
   const missing = [];
   for (const cell of plan.cells) {
-    const cellResult = readCellResult(planDir, cell);
-    if (!cellResult) {
+    const completed = readCellResult(planDir, cell);
+    if (!completed) {
       missing.push(cell.cell_id);
       continue;
     }
     const reuse = cellReuseDecision({
       plan,
       resultPath: cellResultPath(planDir, cell),
-      result: cellResult,
+      result: completed.result,
     });
     if (!reuse.reuse) {
       throw new Error(`cell ${cell.cell_id} cannot be scored: ${reuse.reason}`);
     }
-    completedCellResults.set(cell.cell_id, cellResult);
+    completedCellResults.set(cell.cell_id, completed);
   }
   if (completedCellResults.size === 0) {
     throw new Error(
@@ -369,13 +355,64 @@ export async function scorePlan({
   );
   const scoringCost = { usd: 0 };
   const metered = meterExec(exec, scoringCost);
-  const calibrationCost = { usd: 0 };
-  const calibration = await runCalibration({
-    calibrationSet,
-    exec: meterExec(metered, calibrationCost),
-    model: contract.judge.model,
-    effort: contract.judge.effort,
-  });
+  const judge = { model: contract.judge.model, effort: contract.judge.effort };
+  let calibration = readCalibrationResume({ planDir, plan, judge });
+  const calibrationReused = calibration !== null;
+  if (calibrationReused) {
+    scoringCost.usd += Number(calibration.scoring_usd ?? 0);
+  } else {
+    const calibrationCost = { usd: 0 };
+    calibration = {
+      ...(await runCalibration({
+        calibrationSet,
+        exec: meterExec(metered, calibrationCost),
+        ...judge,
+      })),
+      // The replay's share of `scoring_usd`. With the per-cell shares it makes
+      // the row's scoring cost re-derivable from the detail, and a resumed pass
+      // adds the recorded share back so the row still states what the evidence
+      // beside it cost to produce.
+      scoring_usd: calibrationCost.usd,
+    };
+    if (write) writeCalibrationResume({ planDir, plan, judge, calibration });
+  }
+  const scored = new Map();
+  const leaked = [];
+  let reusedCells = 0;
+  let judgedCells = 0;
+  for (const cell of plan.cells) {
+    const completed = completedCellResults.get(cell.cell_id);
+    if (!completed) continue;
+    const resultDigest = completed.digest;
+    let record = readScoreResume({ planDir, plan, cell, resultDigest });
+    if (record) {
+      reusedCells += 1;
+      scoringCost.usd += Number(record.scoring_usd ?? 0);
+    } else {
+      record = await scoreOneCell({
+        cell,
+        cellResult: completed.result,
+        fingerprint,
+        treatment,
+        contract,
+        repoRoot,
+        truth: truthByPr.get(cell.pr),
+        exec: metered,
+        runGit,
+      });
+      judgedCells += 1;
+      if (write) {
+        writeScoreResume({ planDir, plan, cell, resultDigest, record });
+      }
+    }
+    scored.set(cell.cell_id, record);
+    if (record.leak.suspected) leaked.push(...record.leak.hard);
+  }
+  // The scored evidence reaches the detail-dir root only here, once every cell
+  // the matrix collected has a verdict. A judge that dies mid-pass therefore
+  // leaves the root clean, which is what a `status: failed` row must publish,
+  // while the per-cell verdicts above stay under `cells/` for the retry.
+  //
   // The calibration replay is the only recorded number with no other trace on
   // disk, so `--validate` had to take `judge_calibration` on the row's own say
   // so. Writing the forty outcomes beside the cell results makes the agreement
@@ -391,35 +428,16 @@ export async function scorePlan({
           fingerprint,
           treatment,
           completed_cell_ids: [...completedCellResults.keys()],
-          // The replay's share of `scoring_usd`. With the per-cell shares it
-          // makes the row's scoring cost re-derivable from the detail.
-          scoring_usd: calibrationCost.usd,
+          scoring_usd: calibration.scoring_usd,
           outcomes: calibration.outcomes ?? [],
         },
         null,
         2,
       )}\n`,
     );
-  }
-  const scored = new Map();
-  const leaked = [];
-  for (const cell of plan.cells) {
-    const cellResult = completedCellResults.get(cell.cell_id);
-    if (!cellResult) continue;
-    const record = await scoreOneCell({
-      cell,
-      cellResult,
-      fingerprint,
-      treatment,
-      contract,
-      repoRoot,
-      truth: truthByPr.get(cell.pr),
-      exec: metered,
-      runGit,
-    });
-    scored.set(cell.cell_id, record);
-    if (record.leak.suspected) leaked.push(...record.leak.hard);
-    if (write) {
+    for (const cell of plan.cells) {
+      const record = scored.get(cell.cell_id);
+      if (!record) continue;
       writeFileSync(
         path.join(
           planDir,
@@ -504,6 +522,9 @@ export async function scorePlan({
     missing,
     baselineRow: baseline,
     scored: [...scored.values()],
+    reused: reusedCells,
+    judged: judgedCells,
+    calibrationReused,
   };
 }
 

--- a/scripts/review/review-eval.mjs
+++ b/scripts/review/review-eval.mjs
@@ -622,6 +622,14 @@ async function modeScore(options, context) {
       status: scored.row.status,
       missing: scored.missing,
       judge_calibration: scored.row.judge_calibration,
+      // What this pass paid for and what it read back from the resume cache a
+      // stopped pass left under `cells/`. A retry that says it judged nothing
+      // and reused everything is the run log saying the judge was free.
+      judge_pass: {
+        judged: scored.judged,
+        reused: scored.reused,
+        calibration_reused: scored.calibrationReused,
+      },
       reasons: scored.reasons,
     },
     options.json,

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5326,7 +5326,14 @@ test("a resume record whose shape cannot be published is re-judged", async () =>
     await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
 
     const broken = plan.cells.slice(0, 3);
-    const shapes = [{}, [], 7];
+    // The last one is the shape that survives a shallow guard: it carries the
+    // cost and the leak signals, and `foldCondition` then aborts on the `novel`
+    // counts it does not carry.
+    const shapes = [
+      {},
+      [],
+      { scoring_usd: 0, leak: { suspected: false, hard: [] } },
+    ];
     broken.forEach((cell, index) => {
       const stored = JSON.parse(readFileSync(scoreResume(plan, cell), "utf8"));
       stored.record = shapes[index % shapes.length];

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5314,6 +5314,38 @@ test("a resume record that does not match this plan is re-judged", async () => {
   }
 });
 
+test("a resume record whose shape cannot be published is re-judged", async () => {
+  // The identity matches, so the file is this plan's, but the record is not a
+  // verdict. It is published verbatim as result-<pr>-<condition>-<draw>.json,
+  // so folding one in would either abort the pass on `record.leak` or write
+  // evidence `--validate` rejects. Re-judging costs one cell instead.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
+
+    const broken = plan.cells.slice(0, 3);
+    const shapes = [{}, [], 7];
+    broken.forEach((cell, index) => {
+      const stored = JSON.parse(readFileSync(scoreResume(plan, cell), "utf8"));
+      stored.record = shapes[index % shapes.length];
+      writeFileSync(scoreResume(plan, cell), JSON.stringify(stored));
+    });
+
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.equal(again.judged, broken.length);
+    assert.equal(again.reused, plan.cells.length - broken.length);
+    assert.deepEqual(validateLedgerRow(again.row), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a calibration replay is reused only for the judge that produced it", async () => {
   const root = makeRoot();
   try {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -4446,7 +4446,14 @@ test("scoring resets each fixture, uses the contract judge, and totals its cost"
     }
 
     // A reset that does not land on the pinned head fails scoring rather than
-    // scoring the contestant's tree.
+    // scoring the contestant's tree. A reused judge verdict never touches the
+    // fixture, so clear the resume records the pass above wrote: the drift is
+    // only reachable on a cell this pass actually judges.
+    for (const cell of plan.cells) {
+      rmSync(path.join(plan.plan_dir, "cells", cell.cell_id, "score.json"), {
+        force: true,
+      });
+    }
     const drifting = stubGit();
     const driftGit = ({ args, cwd }) => {
       const answer = drifting.runGit({ args, cwd });
@@ -5148,6 +5155,226 @@ test("the spec worktree is not created where a cell can list it", () => {
   const cleanup = shellFunction("cleanup");
   assert.match(cleanup, /worktree remove --force "\$SPEC"/);
   assert.match(cleanup, /rm -rf "\$SPEC"/);
+});
+
+/**
+ * One canary plan whose cells all carry a stubbed contestant transcript, ready
+ * for a judge pass. The resume cases below score it more than once.
+ */
+function planWithCollectedCells(root) {
+  const plan = buildPlan({
+    contract,
+    contractDigest,
+    kind: "canary",
+    repoRoot: root,
+    outDir: path.join(root, "run"),
+    env: planEnv,
+  });
+  for (const cell of plan.cells) {
+    const dir = path.join(plan.plan_dir, "cells", cell.cell_id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "result.json"),
+      JSON.stringify({
+        ok: true,
+        fingerprint: cellFingerprint({ plan }),
+        output: "scripts/pr/pr-ready-state-core.mjs:750 is too long.",
+        seconds: 300,
+        cost_usd: 3.5,
+        fixture_path: root,
+      }),
+    );
+  }
+  return plan;
+}
+
+/** The arguments every resume case passes to `scorePlan` but `exec`. */
+function scoreArgs({ plan, root }) {
+  return {
+    plan,
+    contract,
+    contractDigest,
+    repoRoot: root,
+    planDir: plan.plan_dir,
+    runGit: stubGit().runGit,
+    calibrationSet: JSON.parse(
+      readFileSync(
+        path.join(root, "docs/evals/review-skill-judge-calibration.json"),
+        "utf8",
+      ),
+    ),
+    now: new Date("2026-09-05T00:00:00Z"),
+  };
+}
+
+function scoreResume(plan, cell) {
+  return path.join(plan.plan_dir, "cells", cell.cell_id, "score.json");
+}
+
+test("a second judge pass reuses every verdict it already paid for", async () => {
+  // The judge costs about $4 and nine minutes a cell, so a 39-cell pass does
+  // not fit inside one usage window. Re-running the same command must resume
+  // from the verdicts on disk rather than re-spend the whole pass.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    const scored = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: first.exec,
+    });
+    assert.ok(first.calls.length > 0, "the first pass never called the judge");
+    assert.equal(scored.judged, plan.cells.length);
+    assert.equal(scored.reused, 0);
+    assert.equal(scored.calibrationReused, false);
+
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.deepEqual(second.calls, [], "the resumed pass called the judge");
+    assert.equal(again.judged, 0);
+    assert.equal(again.reused, plan.cells.length);
+    assert.equal(again.calibrationReused, true);
+    // Same row, down to the scoring dollars: the reused shares are added back
+    // so `scoring_usd` still states what the evidence beside it cost.
+    assert.deepEqual(again.row, scored.row);
+    assert.deepEqual(validateLedgerRow(again.row), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a resume record that does not match this plan is re-judged", async () => {
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
+
+    // One record produced under a different skill, and one that cannot be
+    // parsed at all. Neither may be folded into this run.
+    const [mismatched, corrupt] = plan.cells;
+    const stored = JSON.parse(
+      readFileSync(scoreResume(plan, mismatched), "utf8"),
+    );
+    stored.resume_identity.fingerprint.skill_digest = "0".repeat(64);
+    writeFileSync(scoreResume(plan, mismatched), JSON.stringify(stored));
+    writeFileSync(scoreResume(plan, corrupt), "{ this is not json");
+
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.equal(again.judged, 2);
+    assert.equal(again.reused, plan.cells.length - 2);
+    assert.ok(second.calls.length > 0);
+    // Re-judging restores a matching record, so the next pass is free again.
+    const third = stubExec();
+    assert.equal(
+      (await scorePlan({ ...scoreArgs({ plan, root }), exec: third.exec }))
+        .judged,
+      0,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a calibration replay is reused only for the judge that produced it", async () => {
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: stubExec().exec });
+    const resume = path.join(plan.plan_dir, "cells", "calibration.json");
+    const stored = JSON.parse(readFileSync(resume, "utf8"));
+    assert.equal(stored.resume_identity.judge.model, contract.judge.model);
+    assert.equal(
+      stored.resume_identity.calibration_digest,
+      plan.calibration_digest,
+    );
+
+    stored.resume_identity.judge.effort = "low";
+    writeFileSync(resume, JSON.stringify(stored));
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.equal(again.calibrationReused, false);
+    assert.equal(again.judged, 0, "only the calibration had to re-run");
+    assert.ok(second.calls.length > 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed run keeps the judge verdicts its retry resumes from", async () => {
+  // `write_failed_row` clears the scored artifacts because
+  // `--revalidate-appended` would otherwise read them as the failure row's own
+  // numbers. It clears the run-directory root, and the judge pass keeps its
+  // verdicts under `cells/`, which publication excludes and `abort` keeps on
+  // disk — so the clearing a failed row needs and the resume a retry needs are
+  // the same layout, not a trade.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const scored = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: stubExec().exec,
+    });
+
+    const harness = [
+      "set -uo pipefail",
+      `RUN_DIR=${JSON.stringify(plan.plan_dir)}`,
+      shellFunction("clear_scoring_artifacts"),
+      "clear_scoring_artifacts",
+    ].join("\n");
+    const cleared = spawnSync("bash", ["-c", harness], { encoding: "utf8" });
+    assert.equal(cleared.status, 0, cleared.stderr);
+    assert.deepEqual(
+      readdirSync(plan.plan_dir)
+        .filter(
+          (name) =>
+            name === "calibration.json" ||
+            (name.startsWith("result-") && name.endsWith(".json")),
+        )
+        .sort(),
+      [],
+      "the failed row would publish scored evidence",
+    );
+
+    const retry = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: async () => {
+        throw new Error("a retry must not call the judge again");
+      },
+    });
+    assert.equal(retry.judged, 0);
+    assert.equal(retry.reused, plan.cells.length);
+    assert.equal(retry.calibrationReused, true);
+    assert.deepEqual(retry.row, scored.row);
+    // And the retry rebuilds exactly the evidence the failed row cleared.
+    assert.equal(
+      existsSync(path.join(plan.plan_dir, "calibration.json")),
+      true,
+    );
+    for (const cell of plan.cells) {
+      assert.equal(
+        existsSync(
+          path.join(
+            plan.plan_dir,
+            `result-${cell.pr}-${cell.condition}-${cell.draw}.json`,
+          ),
+        ),
+        true,
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("a failed run publishes no partial scoring artifacts", () => {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5246,6 +5246,37 @@ test("a second judge pass reuses every verdict it already paid for", async () =>
   }
 });
 
+test("a reused verdict is rebound to this run's treatment", async () => {
+  // The selection that names a run does not change what the judge saw, so
+  // `treatment` stays out of the resume identity and a changed one still
+  // reuses. But the record is published as `result-<pr>-<condition>-<draw>.json`
+  // and run evidence rejects one whose treatment is not this plan's, so the
+  // reused verdict has to carry the current selection.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
+
+    const moved = {
+      ...plan,
+      inputs: { ...plan.inputs, dirty: !plan.inputs.dirty },
+    };
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan: moved, root }),
+      exec: second.exec,
+    });
+    assert.deepEqual(second.calls, [], "the resumed pass called the judge");
+    assert.equal(again.reused, plan.cells.length);
+    for (const record of again.scored) {
+      assert.deepEqual(record.treatment, treatmentIdentity({ plan: moved }));
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a resume record that does not match this plan is re-judged", async () => {
   const root = makeRoot();
   try {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5353,6 +5353,65 @@ test("a resume record whose shape cannot be published is re-judged", async () =>
   }
 });
 
+test("a cached verdict filed under the wrong cell is re-judged", async () => {
+  // The identity matches and every type is right, but the record describes a
+  // different cell. Publishing it would put one cell's verdict in another's
+  // result file, which run evidence rejects - and the bad record stays under
+  // `cells/`, so every retry would fail the same way.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
+
+    const [target, other] = plan.cells;
+    const stored = JSON.parse(readFileSync(scoreResume(plan, target), "utf8"));
+    stored.record.pr = other.pr;
+    stored.record.cell_id = other.cell_id;
+    writeFileSync(scoreResume(plan, target), JSON.stringify(stored));
+
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.equal(again.judged, 1);
+    assert.equal(again.reused, plan.cells.length - 1);
+    assert.deepEqual(validateLedgerRow(again.row), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a cached calibration replay that cannot be validated is replayed", async () => {
+  // `--validate` re-derives agreement and total from `outcomes`, so a replay
+  // that cannot support that must not be published as a reuse. It survives
+  // under `cells/` too, so accepting it would wedge every retry.
+  const root = makeRoot();
+  try {
+    const plan = planWithCollectedCells(root);
+    const first = stubExec();
+    await scorePlan({ ...scoreArgs({ plan, root }), exec: first.exec });
+
+    const file = path.join(plan.plan_dir, "cells", "calibration.json");
+    const stored = JSON.parse(readFileSync(file, "utf8"));
+    stored.record = {};
+    writeFileSync(file, JSON.stringify(stored));
+
+    const second = stubExec();
+    const again = await scorePlan({
+      ...scoreArgs({ plan, root }),
+      exec: second.exec,
+    });
+    assert.equal(again.calibrationReused, false);
+    assert.equal(again.reused, plan.cells.length);
+    assert.ok(second.calls.length > 0, "the replay was not re-run");
+    assert.deepEqual(validateLedgerRow(again.row), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a calibration replay is reused only for the judge that produced it", async () => {
   const root = makeRoot();
   try {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -5378,11 +5378,11 @@ test("a failed run keeps the judge verdicts its retry resumes from", async () =>
 });
 
 test("a failed run publishes no partial scoring artifacts", () => {
-  // `--score` writes calibration.json before the first cell and one result
-  // file per cell it scores. A judge that dies mid-pass, or a scored row that
-  // fails `--validate`, leaves those beside the zero placeholders `failedRow`
-  // publishes, and `--revalidate-appended` recomputes the row from exactly
-  // those files and rejects the failure PR. The paid `cells/` cache stays.
+  // `--score` writes calibration.json and one result file per cell only once
+  // the whole pass has finished, so a scored row that then fails `--validate`
+  // is what leaves those beside the zero placeholders `failedRow` publishes,
+  // and `--revalidate-appended` recomputes the row from exactly those files
+  // and rejects the failure PR. The paid `cells/` cache stays.
   const dir = mkdtempSync(path.join(tmpdir(), "review-eval-partial-"));
   try {
     const run = path.join(dir, "run");


### PR DESCRIPTION
## The Problem

- The review-eval matrix is cached per cell, but the judge pass behind `--score` was all-or-nothing. `scorePlan` wrote `result-<pr>-<condition>-<draw>.json` after every cell and never read one back, so a retry re-paid for every judge call it had already made.
- `write_failed_row` calls `clear_scoring_artifacts`, which deletes those partial `result-*.json` files and `calibration.json`. A failed run therefore destroyed the only record of the scoring it had already paid for.
- Judging one cell costs about $4 and nine minutes, so 39 cells run about six hours and do not fit inside one Claude usage window. On 2026-09-05 the run scored nineteen cells in three hours, hit a usage limit, and the lifecycle deleted all nineteen results (run dirs `docs/evals/review-skill-runs/2026-09-04-cde7103e-full-96edaa2a` and `2026-09-05-15330f32-full-96edaa2a`, both local-only).

## The Solution

`--score` now treats its own verdicts as a resume cache. Each cell's judge output is written to `cells/<cell_id>/score.json` as it is earned, stamped with a resume identity: the plan's comparability key, contract digest, matcher digest and calibration digest, the cell fingerprint from `cellFingerprint`, and the sha256 of the exact `result.json` bytes that verdict was formed on. A later pass reuses a record only when every one of those matches. A record that does not match, cannot be parsed, or does not carry the shape run evidence demands of a published result is ignored and re-judged, which costs one cell and never folds one pipeline's verdict into another's row. `treatment` — the `skill_ref`/`dirty` selection that named the run — is deliberately not part of that identity, because it does not change what the judge saw; `readScoreResume` instead stamps this run's selection onto the record it returns, exactly as a fresh judge call does with a cached raw cell. The calibration replay is cached the same way at `cells/calibration.json`, under that same resume identity with the contract judge standing in for the per-cell transcript digest, so an edit to a scoring module moves `matcher_digest` and replays the forty pairs rather than reusing a replay the edit could have changed. The `--json` output reports `judge_pass.judged`, `judge_pass.reused` and `judge_pass.calibration_reused`, so the run log states what the pass paid for.

Scored evidence reaches the detail-directory root — `result-*.json` and `calibration.json` — only once the pass has finished. That is the placement choice: a judge that dies mid-pass now leaves the root clean, which is exactly what a `status: failed` row must publish, while the verdicts stay under `cells/`, which publication already excludes with a `:(exclude)$detail/cells` pathspec and which `abort` already keeps on disk via `KEEP_CELLS=1`. Clearing what a failed row must not carry and resuming what a retry needs became one layout instead of a trade.

Limits and non-goals. The retry path is unchanged: the same `pnpm review:eval:run --kind full`. This PR edits three modules inside `SCORING_MODULES`, so `scorer_digest` moves from `73b60b69` to `e224ae67`; the comparability key moves with it and the next run plans a new directory name, whose `cells/` must be seeded by copying the previous run's across, as with any superseded run. Seeded raw cells stay reusable — `orchestrator_digest` is unchanged, so the paid contestant transcripts are not invalidated — but seeded `score.json` records carry the old comparability key and will be re-judged once. This does not make a partial judge pass cheaper on its first attempt, and it does not shorten the six-hour deadline that bounds the pass.

## Details

**Placement: option (b), and why not (a).** Option (a) — keep writing `result-*.json` at the root and make `clear_scoring_artifacts` move them into `cells/` — requires editing `scripts/review/run-eval-lifecycle.sh`. That file is in `ORCHESTRATOR_FILES` (`review-eval-run-plan.mjs:52-59`), so any byte change to it, comment included, moves `orchestrator_digest`. `orchestrator_digest` is a field of `cellFingerprint`, so every cached paid contestant cell would be refused and the whole matrix would have to re-run — several hundred dollars to fix a scoring bug. Option (b) needs no orchestrator edit at all: `run-eval-lifecycle.sh` is byte-identical on this branch, and the measured `orchestrator_digest` is unchanged (`dda25054…` before and after). `clear_scoring_artifacts` keeps working as written, because it targets only the run-directory root. Its own comment now over-describes the case it handles — it still says a judge dying mid-pass leaves scored files at the root, which after this PR it does not; the surviving reason to clear is a completed score that then fails `--validate`. Correcting that comment is exactly the byte change this section refuses, so it waits for a change that already has to move `orchestrator_digest`.

**Evidence rules stay true.** `runEvidenceProblems` reads the detail directory non-recursively. For `row.status === "failed"` it demands no `calibration.json` and no `result-*.json` at the root (`review-eval-run-evidence.mjs:43-54`) — satisfied by construction now, not by a deletion that has to run. For a complete row it demands one `result-<pr>-<condition>-<draw>.json` per planned cell (lines 306-328) and that `calibration.json`'s `completed_cell_ids` match the result files exactly (lines 86-137) — both are written together at the end of a finished pass, from the same `completedCellResults` map as before. The published record shape is unchanged: the resume identity lives in the `score.json` wrapper (`{resume_identity, record}`), never in the `result-*.json` the ledger validates and `runEvidenceDigest` hashes.

**Cost accounting.** A condition's `usd` is still the contestant's. `row.scoring_usd` still equals the sum of `calibration.json`'s share and every result record's `scoring_usd`, because a reused record adds its recorded share back into the run tally. A resumed row therefore states what the evidence beside it cost to produce, not only what this attempt spent.

**Where the code went.** The resume primitives, plus `cellResultPath` and `readCellResult`, live in `review-eval-run-cell.mjs`, whose stated job is already cell identity and cache reuse. That keeps `review-eval-run-score.mjs` at 599 raw lines, under ADR 0065's 600-line soft cap and under the 600 this repo pins for it in `review-eval.test.mjs`'s `validationModuleLineLimits`. `review-eval-run-cell.mjs` is 508. `review-eval.mjs` grew by the 8 lines of the new `judge_pass` field; it was already at 865, above the generic 600 soft cap but within the 900 the same pinned map allows it.

**Docs.** `docs/evals/review-skill.md` gains a `--score` resume paragraph, a sentence each on calibration reuse and on what a failed row clears versus keeps, and a corrected sentence in the orchestration paragraph (`cells/` now carries verdicts as well as transcripts). `docs/notes/quick-commands.md` is unchanged: it carries no `review:eval:run`, `--score` or retry entry.

## Validation

Head SHA `8627c9d077356e0361b3ac7335a39909fdd0edd3`. All commands run from a clean clone at that head.

- `pnpm --silent review:eval:test` — 387 tests, 387 pass, 0 fail. Four are new, in `scripts/review/review-eval.test.mjs`: a second pass reuses every verdict and calls the judge zero times; a record with a tampered fingerprint and a record that is not JSON are both re-judged while the rest are reused; a calibration replay is reused only for the judge that produced it; and a failed run keeps the verdicts its retry resumes from. That last one runs the real `clear_scoring_artifacts` out of `run-eval-lifecycle.sh` through the existing `shellFunction` harness, then re-scores with an `exec` that throws if called.
- Fail-before / pass-after. With the three changed source modules restored to `origin/main` and the new tests kept, all four fail (`node --test --test-name-pattern …`): `tests 4, pass 0, fail 4`. The failed-run case fails with `Error [JudgeOutputError]: calibration pr1982-3827636772-matched call failed: a retry must not call the judge again` — the judge was called on the retry because the only scored records had been deleted. With the fixed modules restored, `tests 4, pass 4, fail 0`.
- One pre-existing test needed a change, not a relaxation. `scoring resets each fixture, uses the contract judge, and totals its cost` re-scores the same plan directory with a drifting `git` to prove a reset that misses the pinned head fails scoring. A reused verdict never touches the fixture, so the test now clears the resume records before that sub-assertion; the drift assertion itself is unchanged.
- `pnpm --silent lint:scripts` — clean. `pnpm --silent docs:index --check` — clean. `CI=true ./tools/trunk check --no-fix` over the five changed files — `Checked 5 files, ✔ No issues`.
- Digests measured, not assumed: `scorerDigest()` `73b60b69…` → `e224ae67…`; `orchestratorSourceDigest()` `dda25054…` unchanged.
- There is no `scripts/review/*.test.sh`; `run-eval-lifecycle.sh` is covered only from `review-eval.test.mjs`, which the run above includes.
- Review round two (`8fe13328`) changed prose only: the calibration paragraph in `docs/evals/review-skill.md` now names every field the reuse gate compares, and the `a failed run publishes no partial scoring artifacts` comment in `review-eval.test.mjs` now describes the post-resume write order. No assertion, no source module and no digest moved. Re-ran `pnpm --silent review:eval:test` (387 tests, 387 pass, 0 fail), `pnpm --silent docs:index --check` (clean), and `CI=true ./tools/trunk check --no-fix` over both files (`Checked 2 files, ✔ No issues`).
- Review round three (`26127996`) answers a review finding with one behaviour change: a reused verdict is rebound to this run's `treatment`. New test `a reused verdict is rebound to this run's treatment` re-scores one plan whose `dirty` flag flipped; with the rebind removed it fails with `actual { skill_ref: 'installed', dirty: false }` against `expected { … dirty: true }` — the record run evidence would have rejected — and passes with it. Full suite `pnpm --silent review:eval:test`: 388 tests, 388 pass, 0 fail. The rebind went into `review-eval-run-cell.mjs` rather than the reuse branch because placing it inline pushed `review-eval-run-score.mjs` to 607 lines and failed `review-eval validation modules retain split headroom`; the pinned 600 was not raised. `pnpm --silent lint:scripts`, `pnpm --silent docs:index --check` and `CI=true ./tools/trunk check --no-fix` over the four changed files are clean. Re-measured: `scorer_digest` `cbbce46f…`, `orchestrator_digest` `dda25054…` still unchanged.
- Review round four (`884e079e`) answers a review finding: a `score.json` whose identity matched but whose `record` was `{}`, `[]` or a scalar reached `record.leak.suspected` and aborted the pass. `readScoreResume` now requires a finite nonnegative `scoring_usd` and a `leak` carrying a boolean `suspected` and an array `hard` — what run evidence demands of the `result-*.json` the record becomes — and re-judges anything else. New test `a resume record whose shape cannot be published is re-judged` stores all three shapes against matching identities and asserts the judge runs for exactly those cells and that the row still validates; with the guard removed it fails with `TypeError: Cannot read properties of undefined (reading 'suspected')`. Full suite: 389 tests, 389 pass, 0 fail. `pnpm --silent lint:scripts`, `pnpm --silent docs:index --check` and `CI=true ./tools/trunk check --no-fix` clean. `scorer_digest` `e594b7e0…`; `orchestrator_digest` `dda25054…` still unchanged.
- Review round five (`480dbaa2`) widens that guard, which was too narrow. A record carrying only `scoring_usd` and `leak` passed it and `foldCondition` then aborted on the `novel` counts; because the record stays under `cells/`, every retry died the same way. `usableScoreRecord` now checks every field the fold and the published record dereference — `cell_id`, finite `scoring_usd`/`seconds`/`usd`, array `claims`/`matched_ids`, the `leak` pair, and finite `novel.novelReal`/`novel.novelWrong`. The test's third malformed shape is now exactly that record; with the narrow guard restored it fails with `TypeError: Cannot read properties of undefined (reading 'novelReal')`. Full suite: 389 tests, 389 pass, 0 fail. Lint, docs index and trunk clean. `scorer_digest` `cbe3bb8f…`; `orchestrator_digest` `dda25054…` still unchanged.
- Review round six (`8627c9d0`) closes the last two ways a parseable cache still wedged a retry. A score record is now bound to the cell it is filed under (`cell_id`, `pr`, `condition`, `draw`), and `readCalibrationResume`, which had no shape check at all, now requires a positive integer `total`, an `agreement` within it, an `outcomes` array of that length, and a nonnegative finite `scoring_usd`. Both bad records survive under `cells/`, so each failed every retry after it rather than once. Two new tests cover them; with each guard removed the matching test fails. Full suite: 391 tests, 391 pass, 0 fail. Lint, docs index and trunk clean. `scorer_digest` `e224ae67…`; `orchestrator_digest` `dda25054…` still unchanged.
- Pushes used `git push --no-verify` at `4b17a893`, `8fe13328`, `26127996`, `884e079e`, `480dbaa2` and `8627c9d0`. The local quality-gate coordinator is wedged and the operator directed skipping it for this branch; CI on this PR is the gate that ran.

What this evidence does not support: it does not prove a real six-hour judge pass resumes correctly against live model output. Every case runs with a stubbed `exec` and a stubbed `git`, so it proves the reuse decision, the identity comparison, the write placement and the row equality — not the behaviour of the Claude CLI under a usage limit. It also does not prove that no other consumer reads `result-*.json` during a pass; it proves that the checks in `review-eval-run-evidence.mjs`, `review-eval-plan-evidence.mjs` and `review-eval-ledger.mjs` that the suite exercises still pass.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable: this restores the resume behaviour the runbook already describes and changes no constraint an ADR records.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation runs can resume after interruptions or failures by reusing valid prior judgments and calibration results.
  * Cached results are validated for consistency; invalid, outdated, or mismatched results are automatically reprocessed.
  * Evaluation reports now show judged cases, reused judgments, and results reused from calibration.
  * Failed runs preserve reusable judgment data, while publishing retains per-case evidence.
  * Retries across UTC midnight can continue using preserved case results.

* **Documentation**
  * Updated the evaluation runbook with guidance for resumable judge passes and calibration replay caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
