### PR TITLE
docs(adr): mark ADR 0083's fixed 24-cell count as historical

### DIFF
--- a/docs/adr/0083-non-ledger-review-eval-experiments.md
+++ b/docs/adr/0083-non-ledger-review-eval-experiments.md
@@ -18,7 +18,10 @@ garden_lane: adrs-architecture
 
 ## Context
 
-The canonical review-skill evaluation has 24 model cells. It supplies the
+The canonical review-skill evaluation had 24 model cells when this ADR was
+written; since [ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md) the
+count is derived from the contract grid (`pnpm review:eval -- --plan --kind
+full --json` prints it). It supplies the
 ledger verdict, baseline, and freshness evidence. This matrix is too slow and
 costly for early prompt experiments.
 
@@ -58,7 +61,8 @@ Add a small staged experiment lane with these rules:
   plan binds the contract digest, fixture head and base SHAs, truth,
   finder-report and prompt digests, skill digests, model and effort settings,
   provider CLI versions, scorer, the six-module experiment harness digest,
-  complete lane set, treatment order, and a canonical 24-cell rerun manifest.
+  complete lane set, treatment order, and a canonical rerun manifest (24 cells
+  when written; the count is derived since ADR 0086).
 - The screen uses the first frozen finder report for each of the three grid
   fixtures. The holdout uses each complementary report. The optional
   `live-paired` stage generates one current finder output per fixture and gives
@@ -106,7 +110,8 @@ Add a small staged experiment lane with these rules:
   not an unattended service or an adversarial containment boundary.
 - The canonical rerun manifest is planning data only. No canonical importer
   exists, and the manifest disables experiment-artifact reuse. A selected
-  candidate must rerun all 24 canonical cells.
+  candidate must rerun every canonical cell (24 when written; the count is
+  derived since ADR 0086).
 - The current fixtures are development data. A broad generalization claim
   needs a new holdout whose truth did not guide the candidate change.
 

--- a/docs/adr/0083-non-ledger-review-eval-experiments.md
+++ b/docs/adr/0083-non-ledger-review-eval-experiments.md
@@ -3,7 +3,7 @@ title: Review-skill experiments use a separate staged non-ledger lane
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-01
+last_verified: 2026-09-06
 scope: ci/process
 date: 2026-09
 doc_type: adr

--- a/docs/adr/0083-non-ledger-review-eval-experiments.md
+++ b/docs/adr/0083-non-ledger-review-eval-experiments.md
@@ -20,8 +20,9 @@ garden_lane: adrs-architecture
 
 The canonical review-skill evaluation had 24 model cells when this ADR was
 written; since [ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md) the
-count is derived from the contract grid (`pnpm review:eval -- --plan --kind
-full --json` prints it). It supplies the
+count is derived from the contract's full run matrix — pipeline and control
+cells for every fixture, replay cells per finder report for grid fixtures —
+and `pnpm review:eval -- --plan --kind full --json` prints it. It supplies the
 ledger verdict, baseline, and freshness evidence. This matrix is too slow and
 costly for early prompt experiments.
 

--- a/docs/adr/0083-non-ledger-review-eval-experiments.md
+++ b/docs/adr/0083-non-ledger-review-eval-experiments.md
@@ -35,8 +35,8 @@ experiment cannot replace canonical qualification.
 [ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md) supersedes this
 decision on the panel: the grid is every contract fixture marked `grid: true`,
 `--draws N` repeats each fixture, and every number written below as a count —
-the fixed PR list, the three-lane panel, 12 P1 opportunities, the 24-cell
-manifest, and the promote and reject bars — is derived from the grid and the
+the fixed PR list, the three-lane panel, 12 P1 opportunities, the historical
+24-cell manifest, and the promote and reject bars — is derived from the grid and the
 draws instead. The harness digest binds every module listed in
 `EXPERIMENT_SOURCE_FILES`, which is no longer six. Everything else here stands.
 

--- a/docs/adr/0083-non-ledger-review-eval-experiments.md
+++ b/docs/adr/0083-non-ledger-review-eval-experiments.md
@@ -36,9 +36,10 @@ experiment cannot replace canonical qualification.
 [ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md) supersedes this
 decision on the panel: the grid is every contract fixture marked `grid: true`,
 `--draws N` repeats each fixture, and every number written below as a count —
-the fixed PR list, the three-lane panel, 12 P1 opportunities, the historical
-24-cell manifest, and the promote and reject bars — is derived from the grid and the
-draws instead. The harness digest binds every module listed in
+the fixed PR list, the three-lane panel, 12 P1 opportunities, and the promote
+and reject bars — is derived from the grid and the draws instead, while the
+historical 24-cell manifest is derived from the contract's full run matrix as
+the Context above describes. The harness digest binds every module listed in
 `EXPERIMENT_SOURCE_FILES`, which is no longer six. Everything else here stands.
 
 ADR 0085 supersedes this decision on one point: the plan records provider CLI


### PR DESCRIPTION
## The Problem

- ADR 0083 stated the canonical review-skill evaluation as a fixed 24 cells in three places: its context, the plan-binding bullet, and the qualification bullet.
- ADR 0086 derives the count from the contract grid, and the planner prints 39 today, so an operator reading ADR 0083 underestimated the paid qualification run by more than a third.

## The Solution

The three sentences now say the count was 24 when the ADR was written and is derived since ADR 0086 from the contract's full run matrix (pipeline and control cells for every fixture, replay cells per finder report for grid fixtures), and the context paragraph names the planner command that prints it (`pnpm review:eval -- --plan --kind full --json`). No count is pinned in the ADR, so it cannot drift again. `docs/notes/quick-commands.md` already reads "reruns every canonical cell" on `main`, so that half of #2298 needed no change.

## Details

Prose-only edit to `docs/adr/0083-non-ledger-review-eval-experiments.md`; the ADR keeps `status: active` per its own note on partial supersession. The remaining "24" mentions in `docs/adr`, `docs/notes`, and `docs/evals` are the three historical phrasings this PR writes plus ADR 0083's ADR 0086 supersession paragraph, which now calls it the historical 24-cell manifest. Out of scope, noted only: `docs/evals/review-skill.md` says the 39-cell run takes about 3 h at line 215 and about six hours at line 744.

## Validation

- `pnpm review:eval -- --plan --kind full --json`: 39 cells (the derived count the text now points at).
- `grep -rn "24 cells\|24-cell\|24 canonical\|24 model cells" docs/adr docs/notes docs/evals`: three hits, all historical text that says so. CodeRabbit asked for an explicit qualifier on the supersession paragraph's own mention; e0485192 adds "historical" there.
- Codex on e0485192 asked that the count source name the full run matrix rather than the grid alone, matching `planCells` in `scripts/review/review-eval-run-plan.mjs`; fixed in 04e40b74.
- Codex on 04e40b74 flagged the same derivation in the ADR 0086 supersession clause, which still grouped the manifest with grid-and-draws values; the clause now points the manifest at the Context paragraph's full-matrix derivation; fixed in ae0245f9.
- Codex on ae0245f9 asked for `last_verified` to move to the date of this re-verification per `docs/context-standards.md`; set to 2026-09-06 in the next commit.
- `./tools/trunk fmt` on the ADR: clean. `pnpm docs:index --check`: passes. `pnpm adr:check`: passes. `pnpm review:eval:test`: 391 pass, 0 fail.
- These prove the catalog, ADR index, and eval suite are unaffected by a prose change. They do not prove the qualification run itself, which this PR does not touch.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this annotates an existing ADR.

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBBUKZdqzHewn44dEzu1hh
