### PR TITLE
fix(alerts): render pool recovery transitions green

### DIFF
--- a/alerts/rules/contact-points.tf
+++ b/alerts/rules/contact-points.tf
@@ -120,7 +120,7 @@ resource "grafana_contact_point" "slack_pools_transition" {
     token                   = var.slack_bot_token
     recipient               = var.slack_channel_pools
     disable_resolve_message = true
-    title                   = "{{ if eq .Status \"firing\" }}🟡{{ else }}✅{{ end }}"
+    title                   = "{{ if eq (index .CommonAnnotations \"transition_reason\") \"recovered\" }}✅{{ else if eq .Status \"firing\" }}🟡{{ else }}✅{{ end }}"
     text                    = local.slack_body_template
   }
 }

--- a/alerts/rules/rules-fpmms-deviation-transitions.tf
+++ b/alerts/rules/rules-fpmms-deviation-transitions.tf
@@ -12,11 +12,12 @@ resource "grafana_rule_group" "fpmms_deviation_transitions" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = local.deviation_transition_summary_annotation
-      current_reserves = local.deviation_current_reserves_annotation
-      breach_duration  = local.deviation_transition_breach_duration_annotation
-      breach_started   = local.deviation_transition_breach_started_annotation
-      breach_ended     = local.deviation_transition_breach_ended_annotation
+      summary           = local.deviation_transition_summary_annotation
+      transition_reason = "{{ index $values.Info.Labels \"reason\" }}"
+      current_reserves  = local.deviation_current_reserves_annotation
+      breach_duration   = local.deviation_transition_breach_duration_annotation
+      breach_started    = local.deviation_transition_breach_started_annotation
+      breach_ended      = local.deviation_transition_breach_ended_annotation
     }
 
     labels = {
@@ -116,11 +117,12 @@ resource "grafana_rule_group" "fpmms_deviation_transitions" {
     no_data_state  = "OK"
 
     annotations = {
-      summary          = local.deviation_transition_summary_annotation
-      current_reserves = local.deviation_current_reserves_annotation
-      breach_duration  = local.deviation_transition_breach_duration_annotation
-      breach_started   = local.deviation_transition_breach_started_annotation
-      breach_ended     = local.deviation_transition_breach_ended_annotation
+      summary           = local.deviation_transition_summary_annotation
+      transition_reason = "{{ index $values.Info.Labels \"reason\" }}"
+      current_reserves  = local.deviation_current_reserves_annotation
+      breach_duration   = local.deviation_transition_breach_duration_annotation
+      breach_started    = local.deviation_transition_breach_started_annotation
+      breach_ended      = local.deviation_transition_breach_ended_annotation
     }
 
     labels = {

--- a/alerts/rules/rules-fpmms-deviation-transitions.tf
+++ b/alerts/rules/rules-fpmms-deviation-transitions.tf
@@ -13,7 +13,7 @@ resource "grafana_rule_group" "fpmms_deviation_transitions" {
 
     annotations = {
       summary           = local.deviation_transition_summary_annotation
-      transition_reason = "{{ index $values.Info.Labels \"reason\" }}"
+      transition_reason = "{{- if $values.Info -}}{{ index $values.Info.Labels \"reason\" }}{{- end -}}"
       current_reserves  = local.deviation_current_reserves_annotation
       breach_duration   = local.deviation_transition_breach_duration_annotation
       breach_started    = local.deviation_transition_breach_started_annotation
@@ -118,7 +118,7 @@ resource "grafana_rule_group" "fpmms_deviation_transitions" {
 
     annotations = {
       summary           = local.deviation_transition_summary_annotation
-      transition_reason = "{{ index $values.Info.Labels \"reason\" }}"
+      transition_reason = "{{- if $values.Info -}}{{ index $values.Info.Labels \"reason\" }}{{- end -}}"
       current_reserves  = local.deviation_current_reserves_annotation
       breach_duration   = local.deviation_transition_breach_duration_annotation
       breach_started    = local.deviation_transition_breach_started_annotation

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1931,6 +1931,49 @@ test("flap-prone criticals keep incidents open across short recoveries", () => {
   }
 });
 
+test("pool transition Slack titles render recovery events as resolved", () => {
+  const transitionRules = readFileSync(
+    path.resolve(repoRoot, "alerts/rules/rules-fpmms-deviation-transitions.tf"),
+    "utf8",
+  );
+  for (const namePattern of [
+    /\bname\s*=\s*"Deviation Breach State Changed"/,
+    /\bname\s*=\s*"Deviation Breach Critical State Changed"/,
+  ]) {
+    assert(
+      /\btransition_reason\s*=\s*"\{\{ index \$values\.Info\.Labels \\"reason\\" \}\}"/.test(
+        ruleBlockNamed(transitionRules, namePattern),
+      ),
+      `${namePattern} must expose the bounded transition reason to the notification template`,
+    );
+  }
+
+  const contactPoints = stripComments(
+    readFileSync(
+      path.resolve(repoRoot, "alerts/rules/contact-points.tf"),
+      "utf8",
+    ),
+  );
+  const [poolTransitionContactPoint] = blocksFor(
+    contactPoints,
+    'resource "grafana_contact_point" "slack_pools_transition"',
+  );
+  assert(
+    poolTransitionContactPoint,
+    "grafana_contact_point.slack_pools_transition should exist",
+  );
+  assert(
+    /\bdisable_resolve_message\s*=\s*true/.test(poolTransitionContactPoint),
+    "transition delivery must remain one-shot rather than sending a second resolve message",
+  );
+  assert(
+    /\btitle\s*=\s*"\{\{ if eq \(index \.CommonAnnotations \\"transition_reason\\"\) \\"recovered\\" \}\}✅\{\{ else if eq \.Status \\"firing\\" \}\}🟡\{\{ else \}\}✅\{\{ end \}\}"/.test(
+      poolTransitionContactPoint,
+    ),
+    "a recovered firing transition must render green while other firing transitions stay yellow",
+  );
+});
+
 // A token-count share is the exchange rate, not depletion: a balanced
 // JPYm/USDm pool reads 0.4% / 99.6% by count and would page forever. PR #1940
 // shipped exactly that and was corrected in #1944 before the production apply.

--- a/scripts/alerts/alert-rules-lint.test.mjs
+++ b/scripts/alerts/alert-rules-lint.test.mjs
@@ -1941,7 +1941,7 @@ test("pool transition Slack titles render recovery events as resolved", () => {
     /\bname\s*=\s*"Deviation Breach Critical State Changed"/,
   ]) {
     assert(
-      /\btransition_reason\s*=\s*"\{\{ index \$values\.Info\.Labels \\"reason\\" \}\}"/.test(
+      /\btransition_reason\s*=\s*"\{\{- if \$values\.Info -\}\}\{\{ index \$values\.Info\.Labels \\"reason\\" \}\}\{\{- end -\}\}"/.test(
         ruleBlockNamed(transitionRules, namePattern),
       ),
       `${namePattern} must expose the bounded transition reason to the notification template`,


### PR DESCRIPTION
## The Problem

- Grafana emits one-shot pool recovery transitions with `.Status == "firing"` and `reason == "recovered"`, so the shared firing-status title rendered a yellow indicator for messages that said the pool was back within tolerance.
- Operators therefore saw contradictory recovery notifications in `#alerts-pools`; this PR changes only the pool-transition contact point and does not enable resolve messages or alter alert evaluation.

## The Solution

Expose the bounded transition reason as a rule annotation and render `reason == "recovered"` with the existing green resolved indicator. Other firing transition reasons remain yellow, resolved-status fallback remains green, and delivery stays one-shot.

## Details

- Adds `transition_reason` to both deviation transition rules from the existing `Info` query's `reason` label.
- Makes `grafana_contact_point.slack_pools_transition` prefer the recovery reason before falling back to the existing status-based title.
- Adds a focused regression covering both transition rules, the active pool-transition contact point, the exact recovered/firing/fallback title contract, and `disable_resolve_message = true`.
- Leaves the unused legacy warning-transition contact point unchanged.

## Validation

- Red-before: `node scripts/alerts/alert-rules-lint.test.mjs` failed the new regression with 51 passing tests and 1 failure because the transition rules did not expose `transition_reason`.
- Green-after: `node scripts/alerts/alert-rules-lint.test.mjs` passed all 52 tests.
- `./tools/trunk check alerts/rules/contact-points.tf alerts/rules/rules-fpmms-deviation-transitions.tf scripts/alerts/alert-rules-lint.test.mjs` passed with no issues.
- Disposable-copy `terraform init -backend=false -input=false` and `terraform validate` passed. This proves the configuration parses and validates; it does not prove live Grafana rendering or Slack delivery.
- `pnpm agent:quality-gate --run` ran all eight mapped checks successfully three times (targeted Trunk, Terraform fmt/init/validate, alert lint, Terraform tests, script lint, and alert-rule tests). The coordinator exited 2 after each run because Terraform init added a platform checksum to the tracked lockfile before terminal-result publication; that generated-only change was removed and is not in this PR.
- Initial manual full-diff/history review, deterministic local autoreview, and a fresh-context adversarial review found no actionable issues. The remote Claude review then found one valid P2: guard `$values.Info` before indexing `reason`. Commit `92297dbf` fixes both rule instances and strengthens the regression; deterministic and fresh-context follow-up reviews are clean (0.98 confidence).
- Review baseline: 3 changed files and 24 non-test changed lines against `6324add2343a66f167379bb1d4b5346ee222abbc`.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states the material non-goals.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and nearest stronger unsupported claim where applicable.
- [x] No findings or knowingly deferred work require a follow-up issue.
- [x] No architecture decision is introduced; an ADR is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alert transition handling when transition metadata is unavailable.
  - Recovered pool transitions now display a green check mark in Slack titles.
  - Other firing transitions continue to display the existing alert indicator.
  - Separate resolve messages are no longer generated for pool deviation transition alerts.

- **Tests**
  - Added coverage for conditional transition details and recovered transition formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->