### PR TITLE
fix(pr): recognize ruleset fallback on protection 404

### DIFF
--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -3,7 +3,7 @@ title: PR Ready State
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-03
+last_verified: 2026-09-08
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -47,8 +47,8 @@ Required blockers:
 - Branch-protection context lookup failures caused by unreadable or
   unauthorized protection data; the probe fails closed rather than guessing
   required-vs-optional status. If the classic branch-protection endpoint returns
-  GitHub's `Branch not protected (HTTP 404)` response, the probe reads active
-  branch rulesets and derives required status contexts from any
+  HTTP 404, whether `gh` renders it as `Not Found` or `Branch not protected`,
+  the probe reads active branch rulesets and derives required status contexts from any
   `required_status_checks` and named `workflows` rule before using the fallback
   split.
 - Required GitHub review state, including requested changes or required review

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -50,7 +50,9 @@ Required blockers:
   HTTP 404, whether `gh` renders it as `Not Found` or `Branch not protected`,
   the probe reads active branch rulesets and derives required status contexts from any
   `required_status_checks` and named `workflows` rule before using the fallback
-  split.
+  split. A ruleset result that is empty or defines no required status checks or
+  workflows stays unavailable and blocking because the 404 may mask missing
+  permission to read classic protection rather than prove its absence.
 - Required GitHub review state, including requested changes or required review
   still pending.
 - Unreplied review comments that repo policy requires agents to answer. A

--- a/scripts/pr/pr-ready-state.mjs
+++ b/scripts/pr/pr-ready-state.mjs
@@ -697,12 +697,24 @@ export async function fetchRequiredStatusContexts({
         ? await fetchWorkflowNames(repo, rulesResult.value ?? [])
         : { byPath: new Map(), error: null };
 
-      return requiredStatusContextsFromRulesResult(rulesResult.value ?? [], {
-        workflowNameByPath: workflowNameByPath.byPath,
-        workflowNameLookupError: workflowNameByPath.error,
-        fallbackRepoPath: repoPath(repo),
-        statusCheckRollup,
-      });
+      const rulesContexts = requiredStatusContextsFromRulesResult(
+        rulesResult.value ?? [],
+        {
+          workflowNameByPath: workflowNameByPath.byPath,
+          workflowNameLookupError: workflowNameByPath.error,
+          fallbackRepoPath: repoPath(repo),
+          statusCheckRollup,
+        },
+      );
+      if (rulesContexts.error === null && rulesContexts.contexts.length === 0) {
+        return {
+          contexts: [],
+          error:
+            "Required status contexts unavailable: classic branch protection returned HTTP 404 and branch rulesets did not define required status checks or workflows",
+        };
+      }
+
+      return rulesContexts;
     }
 
     return {

--- a/scripts/pr/pr-ready-state.mjs
+++ b/scripts/pr/pr-ready-state.mjs
@@ -662,19 +662,26 @@ async function attachCodexRequestReactions({ repo, issueComments }) {
   );
 }
 
-async function fetchRequiredStatusContexts({
+function isHttpNotFoundError(error) {
+  return /\bHTTP 404\b/i.test(String(error));
+}
+
+export async function fetchRequiredStatusContexts({
   repo,
   baseRef,
   statusCheckRollup = [],
+  fetchProtection = ghApiJsonResult,
+  fetchRules = ghApiJsonPagesResult,
+  fetchWorkflowNames = fetchWorkflowNamesForRules,
 }) {
   const encodedBaseRef = encodeURIComponent(baseRef);
-  const result = await ghApiJsonResult(repo, [
+  const result = await fetchProtection(repo, [
     `repos/${repoPath(repo)}/branches/${encodedBaseRef}/protection/required_status_checks`,
   ]);
 
   if (!result.ok) {
-    if (result.error.includes("Branch not protected (HTTP 404)")) {
-      const rulesResult = await ghApiJsonPagesResult(repo, [
+    if (isHttpNotFoundError(result.error)) {
+      const rulesResult = await fetchRules(repo, [
         `repos/${repoPath(repo)}/rules/branches/${encodedBaseRef}`,
       ]);
 
@@ -687,7 +694,7 @@ async function fetchRequiredStatusContexts({
 
       const workflowNameByPath = workflowPathsFromRules(rulesResult.value ?? [])
         .length
-        ? await fetchWorkflowNamesForRules(repo, rulesResult.value ?? [])
+        ? await fetchWorkflowNames(repo, rulesResult.value ?? [])
         : { byPath: new Map(), error: null };
 
       return requiredStatusContextsFromRulesResult(rulesResult.value ?? [], {

--- a/scripts/pr/pr-ready-state.test.mjs
+++ b/scripts/pr/pr-ready-state.test.mjs
@@ -368,6 +368,24 @@ test("fails closed when branch protection is absent and rulesets are unavailable
   });
 });
 
+test("fails closed when a protection 404 yields no ruleset-required contexts", async () => {
+  const result = await fetchRequiredStatusContexts({
+    repo: { owner: "mento-protocol", name: "monitoring-monorepo", host: null },
+    baseRef: "main",
+    fetchProtection: async () => ({
+      ok: false,
+      error: "gh: Not Found (HTTP 404)",
+    }),
+    fetchRules: async () => ({ ok: true, value: [{ type: "deletion" }] }),
+  });
+
+  assertDeepEqual(result, {
+    contexts: [],
+    error:
+      "Required status contexts unavailable: classic branch protection returned HTTP 404 and branch rulesets did not define required status checks or workflows",
+  });
+});
+
 test("fails closed without reading rulesets for non-404 protection errors", async () => {
   let rulesCalls = 0;
   const result = await fetchRequiredStatusContexts({

--- a/scripts/pr/pr-ready-state.test.mjs
+++ b/scripts/pr/pr-ready-state.test.mjs
@@ -47,10 +47,15 @@ import {
 
 let passed = 0;
 let failed = 0;
+const tests = [];
 
 function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+async function runTest(name, fn) {
   try {
-    fn();
+    await fn();
     process.stdout.write(`ok ${name}\n`);
     passed += 1;
   } catch (err) {
@@ -3105,6 +3110,10 @@ test("a passing CodeRabbit check does not clear a real required blocker", () => 
     "CodeRabbit must never appear as a required blocker by default",
   );
 });
+
+for (const { name, fn } of tests) {
+  await runTest(name, fn);
+}
 
 if (failed > 0) {
   process.stderr.write(`\n${failed} failed, ${passed} passed\n`);

--- a/scripts/pr/pr-ready-state.test.mjs
+++ b/scripts/pr/pr-ready-state.test.mjs
@@ -31,6 +31,7 @@ import {
 import { formatCompact, formatHuman } from "./pr-ready-state-format.mjs";
 import {
   annotateStatusCheckSources,
+  fetchRequiredStatusContexts,
   fetchHeadUpdatedAt,
   headUpdatedAtFromTimeline,
   parseArgs,
@@ -281,6 +282,107 @@ test("falls back to bare branch protection contexts when check details are absen
       { context: "Vercel", integrationId: null },
     ],
   );
+});
+
+test("uses classic branch protection required status contexts when available", async () => {
+  let rulesCalls = 0;
+  const result = await fetchRequiredStatusContexts({
+    repo: { owner: "mento-protocol", name: "monitoring-monorepo", host: null },
+    baseRef: "main",
+    fetchProtection: async () => ({
+      ok: true,
+      value: { contexts: ["ci", "Vercel"] },
+    }),
+    fetchRules: async () => {
+      rulesCalls += 1;
+      return { ok: true, value: [] };
+    },
+  });
+
+  assertDeepEqual(result, {
+    contexts: [
+      { context: "ci", integrationId: null },
+      { context: "Vercel", integrationId: null },
+    ],
+    error: null,
+  });
+  assertEqual(rulesCalls, 0, "rulesets must not be read when protection works");
+});
+
+test("falls back to rulesets for the current gh branch-protection 404", async () => {
+  const result = await fetchRequiredStatusContexts({
+    repo: { owner: "mento-protocol", name: "monitoring-monorepo", host: null },
+    baseRef: "main",
+    fetchProtection: async () => ({
+      ok: false,
+      error:
+        "gh api repos/mento-protocol/monitoring-monorepo/branches/main/protection/required_status_checks failed with exit 1:\ngh: Not Found (HTTP 404)\n",
+    }),
+    fetchRules: async () => ({
+      ok: true,
+      value: [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [
+              { context: "ci" },
+              { context: "Code Quality" },
+            ],
+          },
+        },
+      ],
+    }),
+  });
+
+  assertDeepEqual(result, {
+    contexts: [
+      { context: "ci", integrationId: null },
+      { context: "Code Quality", integrationId: null },
+    ],
+    error: null,
+  });
+});
+
+test("fails closed when branch protection is absent and rulesets are unavailable", async () => {
+  const result = await fetchRequiredStatusContexts({
+    repo: { owner: "mento-protocol", name: "monitoring-monorepo", host: null },
+    baseRef: "main",
+    fetchProtection: async () => ({
+      ok: false,
+      error: "gh: Not Found (HTTP 404)",
+    }),
+    fetchRules: async () => ({
+      ok: false,
+      error: "gh: Resource not accessible by integration (HTTP 403)",
+    }),
+  });
+
+  assertDeepEqual(result, {
+    contexts: [],
+    error: "gh: Resource not accessible by integration (HTTP 403)",
+  });
+});
+
+test("fails closed without reading rulesets for non-404 protection errors", async () => {
+  let rulesCalls = 0;
+  const result = await fetchRequiredStatusContexts({
+    repo: { owner: "mento-protocol", name: "monitoring-monorepo", host: null },
+    baseRef: "main",
+    fetchProtection: async () => ({
+      ok: false,
+      error: "gh: Resource not accessible by integration (HTTP 403)",
+    }),
+    fetchRules: async () => {
+      rulesCalls += 1;
+      return { ok: true, value: [] };
+    },
+  });
+
+  assertDeepEqual(result, {
+    contexts: [],
+    error: "gh: Resource not accessible by integration (HTTP 403)",
+  });
+  assertEqual(rulesCalls, 0, "non-404 errors must not trigger a fallback");
 });
 
 test("extracts required workflow contexts from branch rulesets", () => {


### PR DESCRIPTION
## The Problem

- `pr:ready-state` only recognized GitHub's old `Branch not protected (HTTP 404)` text when classic branch protection was absent.
- Current `gh` renders that endpoint response as `Not Found (HTTP 404)`, so the existing ruleset fallback never ran.
- Repositories protected by rulesets were therefore reported as having unavailable required status contexts even when every required check was visible and passing.

## The Solution

Treat an HTTP 404 from the classic required-status-checks endpoint as a signal to query active branch rulesets, but accept the fallback only when those rulesets explicitly define required status checks or workflows. This restores the intended required-check projection while remaining fail-closed when the 404 could be masking missing permission to read classic protection. It does not change which checks the ruleset requires.

## Details

- Recognize the HTTP status independently of `gh`'s human-readable error wording.
- Keep classic branch protection as the primary source when it is available.
- Keep an empty ruleset response, or one without required checks/workflows, blocking.
- Add injectable API seams so the legacy, ruleset, and unavailable paths are covered without live GitHub calls.
- Queue and await test callbacks so async regression failures affect the suite verdict.
- Update the canonical ready-state runbook to document both known 404 renderings and the fail-closed fallback condition.

## Validation

- `pnpm pr:ready-state:test` — 99/99 cases passed, including classic protection, current-`gh` ruleset fallback, ruleset-unavailable fail-closed, ambiguous-empty-policy fail-closed, and non-404 fail-closed paths. These fixtures prove the modeled response paths; they do not prove every future `gh` error rendering.
- Async harness mutation probe with `NODE_OPTIONS=--unhandled-rejections=warn` — before the review fix, an intentional async assertion failure exited 0 after printing 98 passed; after the fix, the same probe exited 1 with 1 failed / 97 passed. This proves async assertion failures affect the suite verdict; it does not prove all possible asynchronous resource leaks are detected.
- `pnpm agent:quality-gate --run` — all 8 mapped commands passed on `a361ae9bad1e8eafd9ed5fee7d8525b666ba8841`: targeted Trunk, docs index, docs navigation tests and fixtures, context check, scripts lint, the 99-case readiness suite, and Terraform contract tests. This proves the repository's mapped local checks; it does not replace GitHub's required CI.
- Independent adversarial review — the initial P3 async-harness finding was fixed in `6862fd1b`; the final pass on `a361ae9b` found no actionable findings across 3 files and confirmed the documentation matches the fail-closed behavior. Source review does not replace runtime or CI evidence.
- Live Codex review — the P1 finding that generic 404s can mask missing classic-protection permission was fixed in `a361ae9b` with the ambiguous-policy regression above. The finding still requires an exact-head reply/resolution and fresh reviewer/CI confirmation before readiness.
- `pnpm agent:closeout-review --base origin/main` was attempted three times but refused by design inside the active Codex session because nested `codex exec` is unavailable. The independent reviewer provided the documented single-source fallback; no second-model closeout report was produced.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this repairs the existing classic-protection-to-ruleset fallback without changing the readiness model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request readiness checks when branch protection is unavailable by falling back to active repository rules.
  * Readiness checks now remain blocked when rules are unavailable or define no required status checks or workflows.
  * Preserved failure behavior for protection errors unrelated to missing configuration.

* **Tests**
  * Added coverage for successful protection checks, rules-based fallback, unavailable requirements, and non-fallback errors.

* **Documentation**
  * Updated readiness-check verification notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
