### PR TITLE
fix(review-eval): show the calibration judge the defect detail

### DIFF
--- a/docs/evals/review-skill-judge-calibration.json
+++ b/docs/evals/review-skill-judge-calibration.json
@@ -10,7 +10,7 @@
   "prompt": "scripts/review/prompts/judge-match.md"
  },
  "limits": {
-  "agreement_amber_below": 35
+  "agreement_amber_below": 37
  },
  "counts": {
   "total": 40,
@@ -836,14 +836,12 @@
  "measured_blind_baseline": {
   "model": "claude-fable-5",
   "effort": "max",
-  "measured_at": "2026-08-28",
-  "agreement": 37,
+  "measured_at": "2026-09-09",
+  "agreement": 39,
   "total": 40,
   "misses": [
-   "pr1982-3827655676-unmatched",
-   "pr1982-3827655684-unmatched",
-   "pr1995-3830695396-unmatched"
+   "pr1982-3827647420-matched"
   ],
-  "note": "Blind excerpt-only replay of the contract judge against the audited labels; the three misses are the same-file trap pairs recorded in provenance as a systematic blind over-matching bias. The verdict floor is anchored at this baseline minus 2."
+  "note": "Blind replay of the contract judge against the audited labels through the renderer fixed for issue 2332, which shows the judge each record's title plus its body detail. Two independent replays on 2026-09-09 both scored 39/40 with the same single miss. The 2026-08-28 baseline of 37/40 was measured on a title-only rendering, the defect that issue fixed: its three misses were the same-file trap pairs pr1982-3827655676-unmatched, pr1982-3827655684-unmatched and pr1995-3830695396-unmatched, and all three now judge correctly. The one miss left is new. pr1982-3827647420-matched is an under-match: the judge holds that the review names a different flaw in the same verification code, a false verification failure when a competing claim lands after a successful write, while the defect is stale claim data written when the competing claim lands before or during the write batch. Both replays gave that reasoning. The label is a matched pair from the audited set and is a candidate for the next re-audit, not a change made here. The verdict floor is anchored at this baseline minus 2."
  }
 }

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -726,7 +726,7 @@ generalization.
 | verdict        | it means                                                                                                                                                                                                                      | do this                                                                   |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | **GREEN**      | nothing below fired                                                                                                                                                                                                           | merge the ledger PR                                                       |
-| **AMBER**      | recall below baseline but McNemar not significant; or fewer than three paired defects, which never ranks; or the run did not complete; or judge calibration under 35/40; or a leak signal; or `control` moved with `pipeline` | merge the row, do not rank on it, read the reason                         |
+| **AMBER**      | recall below baseline but McNemar not significant; or fewer than three paired defects, which never ranks; or the run did not complete; or judge calibration under 37/40; or a leak signal; or `control` moved with `pipeline` | merge the row, do not rank on it, read the reason                         |
 | **RED**        | `b − c ≥ 6` net flips; or pooled P1 recall under 0.60 where P1 was measured; or wrong claims at twice the baseline rate, the baseline floored at one; or a condition found nothing on two or more PRs                         | open a priority issue naming the flipped defects before changing anything |
 | **PROMOTE**    | `c − b ≥ 6` and the change was intentional                                                                                                                                                                                    | re-anchor the baseline in a PR that says what changed and why             |
 | **INCOMPLETE** | the run failed, or a canary did not finish                                                                                                                                                                                    | fix the harness and re-run; the row stays as a trace                      |
@@ -894,22 +894,28 @@ older one is refused; pass `--contract` with the archived contract to read it.
 
 **Judge calibration runs before every scoring pass.** Forty frozen
 `(claim, defect, verdict)` pairs replay through the current judge. Agreement
-under 35/40 marks the run AMBER (floor = the contract judge's measured 37/40 blind baseline on the audited set minus a two-pair drift margin; re-anchor on any judge or set change), excludes the row from baseline comparison, and
-keeps it off the full-run freshness clock. It costs about $2 and it is the only
-mechanism that separates "the review skill regressed" from "the judge alias now
-points at different weights and the scorer got stricter". It fired on the very
-first baseline run (2026-08-28): the original labels — the frozen 2026-08
-judge's own decisions — scored 29/40 against two independent modern judges,
-which agreed with each other on 36/40. The set was re-audited against the modern
-consensus, which held for all six matched -> unmatched flips. All three
-unmatched -> matched flips it proposed were declined on full context: each cited
-the same file while describing a different problem, so both blind modern judges
-share an over-matching bias on file overlap and that direction has to be
-adjudicated, not trusted. Six records were then replaced with fresh matched
-pairs so the set still clears the balance guard at 18 matched / 22 unmatched
-(provenance in the calibration file). The contract judge is now
+under 37/40 marks the run AMBER (floor = the contract judge's measured 39/40
+blind baseline on the audited set minus a two-pair drift margin; re-anchor on
+any judge, set, or calibration-renderer change), excludes the row from baseline
+comparison, and keeps it off the full-run freshness clock. It costs about $2 and
+it is the only mechanism that separates "the review skill regressed" from "the
+judge alias now points at different weights and the scorer got stricter". It
+fired on the very first baseline run (2026-08-28): the original labels — the
+frozen 2026-08 judge's own decisions — scored 29/40 against two independent
+modern judges, which agreed with each other on 36/40. The set was re-audited
+against the modern consensus, which held for all six matched -> unmatched flips.
+All three unmatched -> matched flips it proposed were declined on full context:
+each cited the same file while describing a different problem, so both blind
+modern judges share an over-matching bias on file overlap and that direction has
+to be adjudicated, not trusted. Six records were then replaced with fresh
+matched pairs so the set still clears the balance guard at 18 matched / 22
+unmatched (provenance in the calibration file). The contract judge is now
 `claude-fable-5` at max effort, the judge whose full-context adjudication
-settled the contested labels.
+settled the contested labels. Until the issue 2332 fix the replay rendered an
+empty `detail:` line for every record, so the judge saw each defect's title and
+nothing else. The 2026-08-28 baseline of 37/40 was measured that way. A blind
+replay through the fixed renderer measures 39/40 on 2026-09-09, and the three
+same-file trap pairs that baseline missed now judge correctly.
 
 The forty outcomes are written to `calibration.json` in the run's detail
 directory. `--validate` re-derives `agreement` and `total` from them and checks

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -3,7 +3,7 @@ title: Review Skill Evaluation
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-30
+last_verified: 2026-09-09
 doc_type: runbook
 scope: ci/process
 review_interval_days: 90

--- a/scripts/review/review-eval-report.mjs
+++ b/scripts/review/review-eval-report.mjs
@@ -29,14 +29,17 @@ export const REVIEW_EVAL_ISSUE_LABELS = [
 ];
 
 export const REPORT_MAX_LINES = 40;
-// Anchored empirically 2026-08-28: the contract judge (claude-fable-5 max)
-// measures 37/40 blind against the audited labels — its only misses are the
-// three same-file trap pairs every blind judge over-matches. The floor sits
-// two below that measured baseline so it fires on drift, not on the known
-// ceiling. Re-measure and re-anchor whenever the calibration set or the
-// contract judge changes; the measured baseline lives in the calibration
-// file's measured_blind_baseline field.
-const CALIBRATION_FLOOR_RATIO = 35 / 40;
+// Anchored empirically 2026-09-09: the contract judge (claude-fable-5 max)
+// measures 39/40 blind against the audited labels — its one miss is an
+// under-match on a matched pair, and the three same-file trap pairs it used to
+// over-match now judge correctly. The floor sits two below that measured
+// baseline so it fires on drift, not on the known ceiling. Re-measure and
+// re-anchor whenever the calibration set, the contract judge, or the
+// calibration prompt renderer changes: the earlier 37/40 anchor (2026-08-28)
+// was measured through a renderer that showed the judge the defect title
+// alone. The measured baseline lives in the calibration file's
+// measured_blind_baseline field.
+const CALIBRATION_FLOOR_RATIO = 37 / 40;
 const HEADLINE_ORDER = ["pipeline", "replay", "control"];
 const MAX_FLIP_LINES = 12;
 const MAX_TITLE_CHARS = 88;
@@ -55,10 +58,9 @@ const LEAK_NOTE_PATTERN = /leak[ _]suspected/i;
 /**
  * Whether a row's judge calibration is good enough for its numbers to mean
  * anything. Every recorded bit comes from the judge, so a judge that falls
- * more than two pairs below its measured 37/40 blind baseline produces a
- * matrix nothing may rank on. The runbook: agreement under 35/40 marks the
- * run AMBER and excludes
- * it from baseline comparison.
+ * more than two pairs below its measured 39/40 blind baseline produces a
+ * matrix nothing may rank on. The runbook: agreement under 37/40 marks the
+ * run AMBER and excludes it from baseline comparison.
  */
 export function judgeCalibrationPasses(row) {
   const calibration = row?.judge_calibration;
@@ -75,7 +77,7 @@ function calibrationReason(row) {
   if (!isObject(calibration)) {
     return "row carries no judge_calibration; the score is not usable evidence";
   }
-  return `judge calibration ${calibration.agreement}/${calibration.total} is below 35/40`;
+  return `judge calibration ${calibration.agreement}/${calibration.total} is below 37/40`;
 }
 
 /** A rate is null when the condition had no opportunity to score it. */

--- a/scripts/review/review-eval-report.test.mjs
+++ b/scripts/review/review-eval-report.test.mjs
@@ -289,7 +289,7 @@ test("verdict applies the pre-registered rule to every branch", () => {
       row: row({ judge_calibration: { agreement: 33, total: 40 } }),
       baseline: baseline(),
       expect: "AMBER",
-      reason: /below 35\/40/,
+      reason: /below 37\/40/,
     },
     {
       // The scorer writes this note verbatim; see scorePlan in
@@ -422,7 +422,7 @@ test("a suspected leak is AMBER before any RED condition is read", () => {
 
 test("an uncalibrated baseline is refused before it ranks anything", () => {
   // The baseline supplies baseHeadline, every flip, and the wrong-claim
-  // denominator. Below 35/40 those numbers are unusable, so they may not turn a
+  // denominator. Below 37/40 those numbers are unusable, so they may not turn a
   // calibrated candidate RED or PROMOTE.
   const unusable = baseline({
     judge_calibration: { agreement: 33, total: 40 },
@@ -435,7 +435,7 @@ test("an uncalibrated baseline is refused before it ranks anything", () => {
   assert.equal(regressed.verdict, "AMBER", JSON.stringify(regressed.reasons));
   assert.match(
     regressed.reasons.join("\n"),
-    /baseline judge calibration 33\/40 is below 35\/40/,
+    /baseline judge calibration 33\/40 is below 37\/40/,
   );
   const promoted = verdict({
     contract,
@@ -606,7 +606,7 @@ test("a judge below its calibration floor gates every score verdict", () => {
   });
   assert.equal(belowP1.verdict, "AMBER");
   assert.ok(
-    belowP1.reasons.some((reason) => /below 35\/40/.test(reason)),
+    belowP1.reasons.some((reason) => /below 37\/40/.test(reason)),
     belowP1.reasons.join(" | "),
   );
   assert.ok(!belowP1.reasons.some((reason) => /p1_recall_floor/.test(reason)));
@@ -642,7 +642,7 @@ test("a judge below its calibration floor gates every score verdict", () => {
     }),
   });
   assert.equal(canary.verdict, "AMBER");
-  assert.match(canary.reasons[0], /below 35\/40/);
+  assert.match(canary.reasons[0], /below 37\/40/);
 
   // A failed run is still INCOMPLETE: it has no matrix for a judge to read.
   assert.equal(

--- a/scripts/review/review-eval-result-shape.mjs
+++ b/scripts/review/review-eval-result-shape.mjs
@@ -397,7 +397,7 @@ function recomputeScoringUsd(dir) {
  * Re-derive `judge_calibration` from the outcomes the scoring pass wrote.
  *
  * `judge_calibration` gates every other number on the row: `verdict()` caps a
- * run below the 35/40 floor at AMBER, `resolveBaseline` refuses to anchor on it, and the
+ * run below the 37/40 floor at AMBER, `resolveBaseline` refuses to anchor on it, and the
  * freshness clock refuses to count it as a full run. Taken from the row itself
  * it was the one gate an edit could lift by retyping two integers, so it is
  * recomputed here from `calibration.json` exactly as the bits are recomputed

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -458,7 +458,11 @@ function calibrationFinding(defect) {
   const [firstLine, ...rest] = detail.split("\n");
   const title = normalizeTitleLine(String(defect.title ?? ""));
   const repeatsTitle = title !== "" && normalizeTitleLine(firstLine) === title;
-  return { ...defect, body: (repeatsTitle ? rest.join("\n") : detail).trim() };
+  const stripped = repeatsTitle ? rest.join("\n").trim() : "";
+  // A record whose whole detail is the title line strips to nothing, and an
+  // empty `detail:` is the defect this maps around. Keep the title then: a
+  // repeated title tells the judge more than a blank line does.
+  return { ...defect, body: stripped || detail.trim() };
 }
 
 function selectScorable(truthFindings, scorableIds) {

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -454,7 +454,10 @@ function normalizeTitleLine(text) {
  * because no committed calibration record carries `body`.
  */
 function calibrationFinding(defect) {
-  const detail = String(defect.detail ?? defect.body ?? "");
+  // `??` would keep an empty `detail`, which is the blank line this maps
+  // around; fall back to the compatibility `body` whenever `detail` is blank.
+  const recorded = String(defect.detail ?? "");
+  const detail = recorded.trim() === "" ? String(defect.body ?? "") : recorded;
   const [firstLine, ...rest] = detail.split("\n");
   const title = normalizeTitleLine(String(defect.title ?? ""));
   const repeatsTitle = title !== "" && normalizeTitleLine(firstLine) === title;

--- a/scripts/review/review-eval-score.mjs
+++ b/scripts/review/review-eval-score.mjs
@@ -434,6 +434,33 @@ function defectBlock(findings) {
     .join("\n");
 }
 
+// A calibration record stores the defect body under `detail`, and every
+// `detail` opens by repeating the title, sometimes wrapped in the markdown the
+// source bot used (a severity prefix, a badge image, italics, a heading).
+// Normalizing both sides lets the repeat be recognized and dropped.
+const TITLE_DECORATION_PATTERN =
+  /!\[[^\]]*\]\([^)]*\)|^#+\s+|^\[[^\]]+\]\s+|[*_`]/g;
+
+function normalizeTitleLine(text) {
+  return text
+    .replace(TITLE_DECORATION_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Map a calibration record's defect into the truth-shaped finding
+ * `defectBlock()` renders. Without this the judge sees an empty `detail:`,
+ * because no committed calibration record carries `body`.
+ */
+function calibrationFinding(defect) {
+  const detail = String(defect.detail ?? defect.body ?? "");
+  const [firstLine, ...rest] = detail.split("\n");
+  const title = normalizeTitleLine(String(defect.title ?? ""));
+  const repeatsTitle = title !== "" && normalizeTitleLine(firstLine) === title;
+  return { ...defect, body: (repeatsTitle ? rest.join("\n") : detail).trim() };
+}
+
 function selectScorable(truthFindings, scorableIds) {
   const wanted = new Set(scorableIds);
   const selected = truthFindings.filter((finding) => wanted.has(finding.id));
@@ -853,7 +880,7 @@ export async function runCalibration({
     Math.max(1, concurrency),
     async (record) => {
       const prompt = renderPrompt(loadPrompt("judge-match"), {
-        DEFECTS: defectBlock([record.defect]),
+        DEFECTS: defectBlock([calibrationFinding(record.defect)]),
         REVIEW: String(record.claim_excerpt).slice(0, MAX_JUDGE_REVIEW_CHARS),
       });
       const parsed = await callJudge(

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -813,6 +813,22 @@ test("runCalibration preserves record order under concurrency", async () => {
   );
 });
 
+// The rendered detail, read out of the DEFECTS fence. Scoping matters: the
+// REVIEW block carries the claim excerpt, which may quote the defect title.
+function renderedDetail(prompt) {
+  const block = prompt.split("<<<DEFECTS\n")[1].split("\nDEFECTS\n")[0];
+  return block.split("detail: ").slice(1).join("detail: ");
+}
+
+// Independent of the module's own normalizer, so a change there cannot mutate
+// both sides of the comparison and keep this green.
+function plainText(text) {
+  return text
+    .replace(/[*_`#]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 test("runCalibration shows the judge the record's defect detail", async () => {
   const record = calibration.records.find(
     (row) => row.record_id === "pr1982-3827636772-matched",
@@ -835,7 +851,59 @@ test("runCalibration shows the judge the record's defect detail", async () => {
   );
   // The title is rendered once, by the header line. The stripped detail must
   // not repeat it.
-  assert.equal(prompt.split(record.defect.title).length - 1, 1);
+  assert.equal(renderedDetail(prompt).split(record.defect.title).length - 1, 0);
+});
+
+test("runCalibration renders every committed record with a detail and no repeated title", async () => {
+  const exec = stubExec(() =>
+    JSON.stringify({ matches: [1], reasoning: { 1: "stub" } }),
+  );
+  await runCalibration({
+    calibrationSet: calibration,
+    exec,
+    concurrency: 1,
+  });
+  assert.equal(exec.calls.length, calibration.records.length);
+  // Only five of the forty details open with the title verbatim; the rest wrap
+  // it in the source bot's markdown — a badge image, a heading, italics. Every
+  // one of them must lose the repeat and keep its body.
+  for (const [index, record] of calibration.records.entries()) {
+    const detail = renderedDetail(exec.calls[index].prompt);
+    assert.ok(
+      detail.trim() !== "",
+      `${record.record_id} rendered an empty detail`,
+    );
+    assert.ok(
+      !plainText(detail).includes(plainText(record.defect.title)),
+      `${record.record_id} repeats its title inside the detail`,
+    );
+  }
+});
+
+test("runCalibration keeps a title-only detail rather than rendering nothing", async () => {
+  const defect = {
+    ...truthFindings[0],
+    detail: `[P1] ${truthFindings[0].title}`,
+  };
+  const exec = stubExec([
+    JSON.stringify({ matches: [1], reasoning: { 1: "stub" } }),
+  ]);
+  await runCalibration({
+    calibrationSet: {
+      records: [
+        {
+          record_id: "title-only",
+          defect_id: defect.id,
+          expected_verdict: "matched",
+          claim_excerpt: "a claim",
+          defect,
+        },
+      ],
+    },
+    exec,
+    concurrency: 1,
+  });
+  assert.equal(renderedDetail(exec.calls[0].prompt).trim(), defect.detail);
 });
 
 test("runCalibration refuses an empty set", async () => {

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -813,6 +813,31 @@ test("runCalibration preserves record order under concurrency", async () => {
   );
 });
 
+test("runCalibration shows the judge the record's defect detail", async () => {
+  const record = calibration.records.find(
+    (row) => row.record_id === "pr1982-3827636772-matched",
+  );
+  const exec = stubExec([
+    JSON.stringify({ matches: [1], reasoning: { 1: "stub" } }),
+  ]);
+  await runCalibration({
+    calibrationSet: { records: [record] },
+    exec,
+    concurrency: 1,
+  });
+  const { prompt } = exec.calls[0];
+  // The body sits after the title line inside `defect.detail`. The renderer
+  // used to read `defect.body`, which no committed record carries, so every
+  // calibration replay judged on the title alone with `detail:` empty.
+  assert.match(
+    prompt,
+    /buildClaimComment \(scripts\/pr\/issue-board-commands\.mjs:74\) only emits a Branch: line/,
+  );
+  // The title is rendered once, by the header line. The stripped detail must
+  // not repeat it.
+  assert.equal(prompt.split(record.defect.title).length - 1, 1);
+});
+
 test("runCalibration refuses an empty set", async () => {
   await assert.rejects(
     runCalibration({ calibrationSet: { records: [] }, exec: stubExec([]) }),

--- a/scripts/review/review-eval-score.test.mjs
+++ b/scripts/review/review-eval-score.test.mjs
@@ -873,9 +873,12 @@ test("runCalibration renders every committed record with a detail and no repeate
       detail.trim() !== "",
       `${record.record_id} rendered an empty detail`,
     );
+    // The renderer only drops a leading title repeat, so only the first line
+    // is checked. A body that refers back to its own title later is valid.
+    const [firstDetailLine = ""] = detail.trim().split("\n");
     assert.ok(
-      !plainText(detail).includes(plainText(record.defect.title)),
-      `${record.record_id} repeats its title inside the detail`,
+      !plainText(firstDetailLine).includes(plainText(record.defect.title)),
+      `${record.record_id} repeats its title on the first detail line`,
     );
   }
 });
@@ -904,6 +907,33 @@ test("runCalibration keeps a title-only detail rather than rendering nothing", a
     concurrency: 1,
   });
   assert.equal(renderedDetail(exec.calls[0].prompt).trim(), defect.detail);
+});
+
+test("runCalibration falls back to body when detail is empty", async () => {
+  const defect = {
+    ...truthFindings[0],
+    detail: "   ",
+    body: "the compatibility body",
+  };
+  const exec = stubExec([
+    JSON.stringify({ matches: [1], reasoning: { 1: "stub" } }),
+  ]);
+  await runCalibration({
+    calibrationSet: {
+      records: [
+        {
+          record_id: "empty-detail",
+          defect_id: defect.id,
+          expected_verdict: "matched",
+          claim_excerpt: "a claim",
+          defect,
+        },
+      ],
+    },
+    exec,
+    concurrency: 1,
+  });
+  assert.equal(renderedDetail(exec.calls[0].prompt).trim(), defect.body);
 });
 
 test("runCalibration refuses an empty set", async () => {


### PR DESCRIPTION
## The Problem

- `runCalibration` handed each calibration record's raw `defect` to `defectBlock()`, which renders the `detail:` line from `finding.body`. All 40 records in `docs/evals/review-skill-judge-calibration.json` carry `detail`; none carries `body`.
- Every calibration replay therefore judged on the title line alone with `detail:` empty, including the `measured_blind_baseline` of 37/40 recorded on 2026-08-28.
- The calibration gate that decides whether a scoring run's numbers may be ranked was measured on a weaker prompt than the one it guards, and the runbook's claim that calibration replays "the current judge" was untrue of the prompt content.

## The Solution

At the calibration call site, a new `calibrationFinding(defect)` maps each record into the truth-shaped finding the renderer expects: `body` comes from `detail`, and the leading repeat of the title is dropped. The calibration judge now reads the same defect detail the per-cell scoring pass shows it. `defectDetail()` is untouched and still strict on `body`, so the scoring path is unchanged.

The blind baseline was then re-measured through the fixed renderer with the contract judge (`claude-fable-5` at `max`) and rose from 37/40 to 39/40. The three same-file trap pairs the old baseline missed now judge correctly. Applying the runbook rule of "measured baseline minus two", the floor moved: `limits.agreement_amber_below` goes 35 to 37 and `CALIBRATION_FLOOR_RATIO` goes 35/40 to 37/40. The gate now sits two pairs under a baseline measured on the prompt it actually guards, so a real judge regression has to fall only two pairs to show up instead of four.

Three limits are worth stating up front. One miss remains, `pr1982-3827647420-matched`, and it is a new under-match on an audited _matched_ pair rather than a leftover over-match; it is recorded in the calibration note as a candidate for the next human re-audit, and no label was changed here. The calibration prompt is now close to the scoring prompt but not identical: 28 of the 56 committed truth findings have a `body` whose first line repeats the decorated title, and the scoring path renders that repeat, while calibration strips it — the trade-off is explained under Details. Separately, the `DEFECTS:` header still prints `[severity]` next to titles that already carry their own severity prefix, which renders a double severity for some records; that predates this change, is visible on the scoring path too, and is out of scope for a call-site fix.

## Details

**How the title is stripped.** The original sketch assumed every `detail` opens with `"[<severity>] " + title`. Measured over the committed set, only 5 of 40 do. The other 35 wrap the same title in the source bot's markdown: a shields.io badge image, a `###` heading, or `_italics_`. A literal "strip severity prefix plus title" would have left 35 records rendering their title twice, which the issue's first acceptance criterion rules out. So `calibrationFinding()` normalizes both sides first (drops a leading `![...](...)`, `#+ `, `[sev] ` and any `*_` or backtick, then collapses whitespace) and drops the first line only when it then equals the normalized title. `calibrationFinding()` also falls back to `defect.body` when `detail` is missing or blank, so a record already shaped like a truth finding keeps its body instead of being blanked, and a record whose whole detail is just the title line keeps that line rather than rendering nothing. `MAX_DETAIL_CHARS`, `MARKUP_PATTERN` and `validateCalibrationSet` are unchanged.

**Digests that move.** Recomputed at this head with `comparabilityKey()` in `review-eval-run-plan.mjs`, against `origin/main` at b8efaa75:

| Input                     | `origin/main`             | this head                 |
| ------------------------- | ------------------------- | ------------------------- |
| `contract_digest`         | `26f5909640…`             | `26f5909640…` (unchanged) |
| `calibration_digest`      | `aa930bb14f…`             | `f61deb67b7…`             |
| `matcher_digest` (scorer) | `cc443aa4a8…`             | `4197ae9b54…`             |
| `orchestrator_digest`     | `e7fe24ecf4…`             | `e7fe24ecf4…` (unchanged) |
| `comparability_key`       | `578480fc4c…`             | `cf79cf4e42…`             |

The scorer digest moves for two independent reasons: `scorerDigest()` hashes its own `scriptPath` first, so editing `review-eval-score.mjs` moves it even though that file is not itself a `SCORING_MODULES` entry, and this PR also edits `review-eval-report.mjs` and `review-eval-result-shape.mjs`, which are entries. The calibration digest moves because `measured_blind_baseline` and `limits` were rewritten. Both feed `comparabilityKey()`, so the key changes.

**Nothing is orphaned.** `docs/evals/review-skill-ledger.jsonl` holds 6 rows on two keys: one `complete` on `76c7cde728…` and five `failed` on `ec451b1fe7…`. Neither equals the pre-change key `578480fc4c…` or the post-change key `cf79cf4e42…`, so no complete row was comparable to the current key before this change and none is orphaned by it. `pnpm review:eval -- --check-ledger` reports `comparable_rows: 0` at this head, which is what it reported before. There is no cache to invalidate: the key is recomputed from the files on every plan and every score, and a stale plan is refused with a re-plan error rather than silently paired.

**Re-anchor trigger widened.** The `CALIBRATION_FLOOR_RATIO` comment previously said to re-measure "whenever the calibration set or the contract judge changes". This class of defect changed neither, which is why it stayed invisible. The comment now names the calibration prompt renderer as a third trigger and cites the 2026-09-09 39/40 measurement; `docs/evals/review-skill.md` records that the pre-fix 2026-08-28 baseline was measured title-only, and its AMBER row follows the new floor.

**Declined review findings.**

- _[P2, independent-family closeout review at 550627b8] Preserve the production prompt shape in calibration (`review-eval-score.mjs:463-464`)._ The premise checks out: 28 of the 56 findings across `docs/evals/review-skill-truth/*.json` have a `body` whose first line repeats the decorated title, and the scoring path renders that body unchanged, so calibration and scoring now differ by one leading line and by how much description survives the 400-character `MAX_DETAIL_CHARS` cut. Won't fix here for two reasons. The strip is the issue's first acceptance criterion, worded as "shows `record.defect.detail` as the defect's detail, without repeating the title line the detail begins with", so passing `detail` through unchanged would fail the issue it closes. And the reviewer's alternative — normalize both paths — rewrites the prompt the scoring path sends, which moves `matcher_digest` for every scoring cell and invalidates the 39/40 baseline this PR just measured, requiring a second paid re-measure with the contract judge. Measured against the defect being fixed, the divergence shrinks from "calibration sees no detail at all" to "calibration sees the same detail without a duplicated title line", and the header line still shows the judge that title either way. The residual divergence is stated as a limit in the opening rather than hidden.
- _[P2, independent-family closeout review, raised at 739280ea and re-raised at f0371a00 and 550627b8] Extract the new renderer from the over-cap scorer (`review-eval-score.mjs:437-442`)._ Won't fix here. The change takes the file from 896 to 930 lines, which `scripts/repo-health/file-size-watchlist.mjs` scores as 663 to 679 rough — the same `soft cap` band it already occupied, with no status change. The cited rule in `docs/pr-checklists/recurring-review-patterns.md` is a drift guard keyed on crossing a cap; `scripts/` sets no `max-lines`, and the watchlist is an issue-only monthly workflow against `main`, so nothing gates. Against that, a split would add a module to `SCORING_MODULES` and move `matcher_digest` a second time on a PR that is already explaining a comparability-key move, at many times the size of the bug. Sibling modules sit in the same band (`review-eval-fixtures.mjs` 819 rough, `review-eval-ledger.mjs` 783); a split belongs in its own PR. `docs/notes/file-size-watch.md` is left alone for the same reason — it is passive guidance a monthly workflow refreshes against `main`, not a PR gate.
- _[P3, acceptance lens] Widen the floor's re-anchor trigger list to name the calibration prompt renderer._ Declined during the implementation phase because that phase's scope forbade touching the floor comment. It is now **done** in this PR, in the same commit that rewrites the baseline, the runbook sentence and the comment together.
- _[implementer's open question] The `DEFECTS:` header renders a double severity, `1. [P1] path:119 — [P1] <title>`, when a record title carries its own prefix._ Won't fix: it comes from `defectBlock()` printing `[severity]` beside a title the source bot already prefixed, it reproduces in the pre-fix run, and normalizing the header would change the prompt for the scoring path as well as calibration.

**Base integration.** `origin/main` advanced three times during this PR — to 7b49e201 (#2334), c9d83973 (#2335) and b8efaa75 (#2336). Each was merged in, never rebased. All three merges were clean, and `git diff origin/main HEAD` over every path those commits touched is empty, so the merged tree is byte-identical to `main` outside the seven files this PR owns.

## Validation

Scope baseline: merge base b8efaa754ea206269e6ccb978efbf2e8bf0fa13d, head d09c7091e9d15d530445bfee2bbad35747b45721, 7 changed files, 206 added and 43 deleted lines, of which 78 added lines are non-test and 128 are test.

`pnpm agent:quality-gate --run --base origin/main` — **not run**: it waited 1800s for the gate run lock held by another session's PR group (pid 17586) and exited 2 without running a mapped command. The contention is unrelated to this branch. The gate printed the commands it had mapped for this change set, and all ten were run directly at head d09c7091:

- `./tools/trunk fmt` on the six formatter-eligible changed files — passed, "Checked 6 files, No issues".
- `./tools/trunk check --ci` on all seven changed files — passed, "No issues". `docs/evals/review-skill-judge-calibration.json` is reported as ignored by `trunk.yaml` for every linter; it is a byte-frozen eval input, so it was hand-edited in the file's existing 1-space-indent style, and it parses and passes `validateCalibrationSet`.
- `pnpm review:eval:test` — passed. tests 405, pass 405, fail 0.
- `pnpm review:eval -- --check-fixtures --offline` — passed, `{"ok":true,…,"problems":[]}`.
- `pnpm review:eval -- --check-ledger --require-base --revalidate-appended` — passed, `{"ok":true,"rows":6,"comparable_rows":0,…,"problems":[]}`.
- `pnpm docs:index --check` — passed.
- `pnpm docs:navigation-eval:test` — passed. tests 34, pass 34, fail 0.
- `pnpm docs:navigation-eval -- --check-fixtures` — passed.
- `pnpm agent:context-check` — passed.
- `pnpm lint:scripts` — passed, no diagnostics.
- `pnpm tf:test` — passed.
- `CI=true pnpm install --frozen-lockfile` — passed, selected by the lockfile the base merges brought in.

No shell file changed, so `bash -n` and `shellcheck -x` do not apply. No ADR is added, so `pnpm adr:check` does not apply. The dashboard rows that the base merges would otherwise select were not run: `git diff origin/main HEAD` over `ui-dashboard/**`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` and `docs/notes/dashboard-verification.md` is empty, so the merged tree carries `main`'s reviewed bytes for those paths and this branch changes no dashboard input.

Closeout review: `pnpm agent:closeout-review --no-fetch --base origin/main` at head d09c7091 — **clean** (exit 0). Report: `.reviews/closeout-review-20260909T173206-d09c709-69082.md` (codex-cli 0.153.4, gpt-5.6-sol, high effort, read-only sandbox, base b8efaa75, dirty: no), verdict "clean", "Reviewed HEAD d09c7091 against b8efaa75 across seven files." Two earlier runs on the same branch content are recorded here because their findings are answered above and not because they passed: `.reviews/closeout-review-20260909T160214-f0371a0-12790.md` (exit 1, the scorer-split P2) and `.reviews/closeout-review-20260909T172433-550627b-85788.md` (aborted at exit 2 because `origin/main` moved mid-run, raising the prompt-shape P2 and re-raising the scorer split).

Re-measurement evidence: the 39/40 baseline comes from two independent blind replays of `runCalibration` on 2026-09-09 with `claude-fable-5` at `max` against the audited labels. Both scored 39/40 with the same single miss and the same reasoning for it.

Mutation evidence that the new tests bite, each mutation applied to the working file and then restored:

- Removing the badge alternative from `TITLE_DECORATION_PATTERN` gives 5 pass, 1 fail: "renders every committed record with a detail and no repeated title" fails with `pr1982-3827647420-matched repeats its title inside the detail`. The pre-existing single-record test stayed green, which is the gap this test closes.
- Removing the empty-detail fallback gives 5 pass, 1 fail: "keeps a title-only detail rather than rendering nothing" fails with `actual: '', expected: '[P1] Split the growing ready-state core'`.

**Nearest stronger claims this evidence does not support.** The 39/40 figure is the judge's agreement on these 40 audited pairs on one day with one model at one effort; it is not a measure of the judge on unseen defects, and two replays on the same day do not bound run-to-run variance. The committed test proves the renderer emits a non-empty, non-duplicated detail for all 40 records currently in the set; it does not prove the normalizing strip is correct for record shapes the set does not contain. A clean closeout review is one independent model's read of this diff, not proof of absence of defects — an earlier run on the same content raised two findings. The direct author checks cover the rows the gate mapped for this change set; they are not a substitute for the full quality gate, and required CI remains the merge authority.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyXYSWFBZaJu9vxdWjQrei
