### PR TITLE
feat(review-eval): a PROMOTE needs replay corroboration to re-anchor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -217,6 +217,7 @@ Authority: canonical
 - [`docs/adr/0088-temporary-m6-canary-collection.md`](adr/0088-temporary-m6-canary-collection.md) — Temporary event-driven M6 canary collection
 - [`docs/adr/0089-review-eval-canonical-matrix-pr-groups.md`](adr/0089-review-eval-canonical-matrix-pr-groups.md) — The canonical review-eval matrix runs PR groups concurrently
 - [`docs/adr/0090-canonical-eval-matrix-freshness-floor.md`](adr/0090-canonical-eval-matrix-freshness-floor.md) — The canonical review-eval matrix is a freshness floor
+- [`docs/adr/0091-promote-needs-replay-corroboration.md`](adr/0091-promote-needs-replay-corroboration.md) — A PROMOTE needs replay corroboration before it re-anchors
 
 Authority: non-canonical
 

--- a/docs/adr/0090-canonical-eval-matrix-freshness-floor.md
+++ b/docs/adr/0090-canonical-eval-matrix-freshness-floor.md
@@ -95,11 +95,10 @@ today's cells, and it carries a different comparability key in any case.
   on one of the 12 defects from PRs 1982, 1984 and 2001 is unchecked rather than
   uncorroborated. The thresholds in
   `verdict_rules` are pre-registered and are deliberately not re-tuned here.
-- That reading is not enforced. A PROMOTE re-anchors the baseline on its own
-  and its verdict is recomputed from the row's numbers, so it cannot be lowered
-  by hand.
-  [Issue 2324](https://github.com/mento-protocol/monitoring-monorepo/issues/2324)
-  carries the rule change, which is its own pre-registered decision.
+- That reading is now enforced on the PROMOTE side.
+  [ADR 0091](0091-promote-needs-replay-corroboration.md) gates the PROMOTE
+  branch on a corroborating `replay` gain, so an uncorroborated `pipeline` gain
+  reads GREEN and does not re-anchor the baseline. RED is unchanged.
 - `control` recall is measured over the 39 grid defects while `pipeline` covers
   all 51. The two rates are over different denominators and must not be
   subtracted from each other within a run.

--- a/docs/adr/0091-promote-needs-replay-corroboration.md
+++ b/docs/adr/0091-promote-needs-replay-corroboration.md
@@ -84,6 +84,9 @@ silently moves the reference.
   ranking belongs ([ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md)).
 - An uncorroborated gain reads GREEN, so the report states it as a gain and says
   it did not re-anchor. Nothing is lost from the record.
+- The rule binds the contracts that carry the key. `--report --contract` with a
+  contract from before this change still prints the verdict that run saw, so
+  history does not move under a rule its runs never ran against.
 - Scaling the control-drift waiver threshold to control's 39-defect scope is a
   separate verdict-rule decision and stays open as
   [issue 2333](https://github.com/mento-protocol/monitoring-monorepo/issues/2333).

--- a/docs/adr/0091-promote-needs-replay-corroboration.md
+++ b/docs/adr/0091-promote-needs-replay-corroboration.md
@@ -1,0 +1,102 @@
+---
+title: A PROMOTE needs replay corroboration before it re-anchors
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-09-09
+scope: ci/process
+date: 2026-09
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0091 — A PROMOTE needs replay corroboration before it re-anchors
+
+**Status:** Accepted (Sep 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+A `PROMOTE` verdict moves the review-eval baseline by itself. `resolveBaseline`
+picks the newest `PROMOTE` row of the comparability key, and `revalidateRow`
+recomputes the verdict from the row's own numbers, so an operator cannot record
+a lower verdict by hand. From then on every run is paired against that row's
+bits.
+
+Since [ADR 0090](0090-canonical-eval-matrix-freshness-floor.md) the `pipeline`
+condition takes one live finder draw per PR instead of two. The finder samples:
+the 2026-09 programme watched one codex configuration draw 19 and then 10 known
+defects on identical diffs. Six net apparent gains on `pipeline` alone are
+therefore more likely to be sampling than they were with two OR-folded draws,
+and a spurious `PROMOTE` becomes the anchor every later run reads, with the bias
+invisible from that point on.
+
+ADR 0090 wrote down the reading — a `pipeline` flip `replay` does not
+corroborate is unproven — and recorded that the harness does not enforce it.
+
+## Decision
+
+A pre-registered rule `verdict_rules.promote_corroboration_net_flips: 3` gates
+the PROMOTE branch of `verdict()`. When the headline condition is `pipeline` and
+the pipeline flips would give PROMOTE, the row is PROMOTE only if `replay`
+corroborates: both rows carry a `replay` condition, the two share at least
+`noise_floor_defects` scored defects, and `replay` gained at least
+`promote_corroboration_net_flips` net defects. Uncorroborated, the verdict is
+GREEN and the reasons carry the pipeline gain plus one line naming why `replay`
+did not corroborate it and stating that the gain does not re-anchor the
+baseline.
+
+Three is half the PROMOTE threshold. `replay` replays frozen finder reports over
+the 39 grid defects with two OR-folded draws, so it carries no finder sampling
+and less verifier sampling than a single-draw `pipeline`. Asking it for half the
+threshold in the same direction, on at least the noise-floor number of shared
+defects, confirms the direction beyond noise without demanding that one verifier
+reproduce a PROMOTE-sized gain on 39 defects.
+
+The gate reads a `pipeline` headline only. When `replay` is the headline no live
+pipeline cell scored, and `replay`'s finder is frozen, so there is no finder
+sampling to corroborate away.
+
+RED is unchanged. A spurious RED costs an investigation; a spurious PROMOTE
+silently moves the reference.
+
+## Alternatives considered
+
+- **Refuse the anchor in `resolveBaseline` instead.** Rejected: the verdict
+  printed in the report and the ledger would still read PROMOTE while the
+  baseline quietly stayed put, so the reader and the harness would disagree.
+- **Raise `regression_net_flips`.** Rejected: it moves the RED line with the
+  PROMOTE line, and the cost of the two errors is not symmetric.
+- **Ask `replay` for the full six net flips.** Rejected: `replay` sees 39 of the
+  51 defects, so it would demand a larger effect from the narrower condition and
+  no real improvement would clear it.
+- **Leave it to the reviewer.** Rejected: `revalidateRow` recomputes the
+  verdict, so a reviewer who disagrees cannot record a lower one.
+
+## Consequences
+
+- The contract digest moves, and with it `matcher_digest` and the comparability
+  key, so the first run after this change resolves no baseline and re-anchors.
+  That was already true of ADR 0090's matrix change.
+- A real improvement that only `pipeline` shows now needs a second run, or the
+  experiment lane, to promote. The lane holds the finder fixed and is where
+  ranking belongs ([ADR 0086](0086-review-eval-lane-any-grid-multi-draw.md)).
+- An uncorroborated gain reads GREEN, so the report states it as a gain and says
+  it did not re-anchor. Nothing is lost from the record.
+- Scaling the control-drift waiver threshold to control's 39-defect scope is a
+  separate verdict-rule decision and stays open as
+  [issue 2333](https://github.com/mento-protocol/monitoring-monorepo/issues/2333).
+
+## Evidence
+
+- `scripts/review/review-eval-report.mjs` (`verdict`,
+  `promoteCorroborationGap`) holds the rule;
+  `scripts/review/review-eval-fixtures.mjs` validates the new key.
+- `docs/evals/review-skill-fixtures.json` pre-registers
+  `promote_corroboration_net_flips: 3`.
+- `scripts/review/review-eval-report.test.mjs` covers a corroborated PROMOTE, an
+  uncorroborated gain on every branch, an unchanged RED, and a `replay`
+  headline; `scripts/review/review-eval.test.mjs` proves the recorded PROMOTE
+  fails `revalidateRow` and never becomes the anchor.
+- Raised on [issue 2324](https://github.com/mento-protocol/monitoring-monorepo/issues/2324).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,6 +100,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0088](0088-temporary-m6-canary-collection.md)              | Collect temporary M6 canary evidence after CI without per-PR operator requests       |
 | [0089](0089-review-eval-canonical-matrix-pr-groups.md)      | The canonical review-eval matrix runs PR groups concurrently                         |
 | [0090](0090-canonical-eval-matrix-freshness-floor.md)       | Canonical full run drops to 27 cells; repeat draws live in the experiment lane       |
+| [0091](0091-promote-needs-replay-corroboration.md)          | A PROMOTE re-anchors only when `replay` corroborates the `pipeline` gain             |
 
 ### shared-config
 

--- a/docs/evals/review-skill-fixtures.json
+++ b/docs/evals/review-skill-fixtures.json
@@ -346,6 +346,7 @@
   "verdict_rules": {
     "noise_floor_defects": 3,
     "regression_net_flips": 6,
+    "promote_corroboration_net_flips": 3,
     "p1_recall_floor": 0.6,
     "wrong_claims_ratio_ceiling": 2,
     "canary_min_matched_grid": 16

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -134,7 +134,9 @@ a run where nothing changed, so **read a `pipeline` flip beside `replay`**:
 `replay` runs frozen reports, so it does not move with the finder — though its
 own verifier session is sampled fresh like any other, so it is quieter than
 `pipeline`, not silent. A `pipeline` flip it does not corroborate is unproven
-rather than a regression.
+rather than a regression. On the PROMOTE side the harness holds you to that:
+an uncorroborated `pipeline` gain is GREEN, so it never re-anchors the
+baseline.
 And `control` recall is now measured over the 39 grid defects while `pipeline`
 recall covers all 51, so the two rates are over different denominators: read
 `control` against the previous run's `control`, never as a within-run
@@ -728,7 +730,7 @@ generalization.
 | **GREEN**      | nothing below fired                                                                                                                                                                                                           | merge the ledger PR                                                       |
 | **AMBER**      | recall below baseline but McNemar not significant; or fewer than three paired defects, which never ranks; or the run did not complete; or judge calibration under 35/40; or a leak signal; or `control` moved with `pipeline` | merge the row, do not rank on it, read the reason                         |
 | **RED**        | `b − c ≥ 6` net flips; or pooled P1 recall under 0.60 where P1 was measured; or wrong claims at twice the baseline rate, the baseline floored at one; or a condition found nothing on two or more PRs                         | open a priority issue naming the flipped defects before changing anything |
-| **PROMOTE**    | `c − b ≥ 6` and the change was intentional                                                                                                                                                                                    | re-anchor the baseline in a PR that says what changed and why             |
+| **PROMOTE**    | `c − b ≥ 6` on the headline, the change was intentional, and where the headline is `pipeline` a net gain of at least 3 on `replay` corroborates it                                                                            | re-anchor the baseline in a PR that says what changed and why             |
 | **INCOMPLETE** | the run failed, or a canary did not finish                                                                                                                                                                                    | fix the harness and re-run; the row stays as a trace                      |
 
 **A `pipeline` flip `replay` contradicts is unproven; a flip on a defect
@@ -748,13 +750,25 @@ corroborating `replay` flip for what it is: two conditions moving together, each
 with its own verifier draw, which is weaker than a repeated measurement and
 stronger than one condition alone.
 
-The harness does not enforce that yet, and it is the one place this matters
-most: a PROMOTE re-anchors the baseline on its own, because `resolveBaseline()`
-picks the newest PROMOTE row of the same key and `--validate` recomputes the
-verdict from the row's own numbers, so it cannot be lowered by hand. Until
-[issue 2324](https://github.com/mento-protocol/monitoring-monorepo/issues/2324)
-gates re-anchoring on corroboration, read the next run against a PROMOTE anchor
-knowing the anchor may carry one draw of finder noise.
+The harness enforces that reading where it matters most. A PROMOTE re-anchors
+the baseline on its own — `resolveBaseline()` picks the newest PROMOTE row of
+the same key, and `--validate` recomputes the verdict from the row's own
+numbers, so it cannot be lowered by hand — so a `pipeline` gain past the flip
+threshold is PROMOTE only when `replay` gained at least
+`verdict_rules.promote_corroboration_net_flips` (3) net defects on at least
+`noise_floor_defects` defects both runs scored. Uncorroborated, the row is
+GREEN and the reason states the gain, why `replay` did not corroborate it, and
+that it does not re-anchor the baseline. Half the PROMOTE threshold is the bar
+because `replay` folds two frozen-report draws over the 39 grid defects: it
+confirms the direction beyond noise without asking one verifier to reproduce a
+PROMOTE-sized gain on the grid alone.
+
+The gate reads a `pipeline` headline only. A row whose headline is `replay`
+scored no live pipeline cell, and `replay`'s finder is frozen, so it has no
+finder sampling to corroborate away. RED is unchanged: a spurious RED costs an
+investigation, a spurious PROMOTE moves the reference every later run reads.
+[ADR 0091](../adr/0091-promote-needs-replay-corroboration.md) records the
+decision.
 
 The three AMBER gates — failed judge calibration, a leak signal, and a matrix
 that did not complete — are read before the RED lines, not after them. Each says
@@ -785,7 +799,10 @@ re-derives it after seeing a result they dislike.
 
 `verdict()` enforces the floor: when a candidate and its baseline share fewer
 than `noise_floor_defects` scored defects, the row is AMBER and the reason says
-the comparison was refused. It never reads as green, and it never promotes.
+the comparison was refused. It never reads as green, and it never promotes. The
+same floor bounds the PROMOTE corroboration check: `replay` corroborates only
+over defects both runs scored, and fewer than `noise_floor_defects` of them
+corroborate nothing.
 
 Do not use a two-proportion z-test on these numbers. The comparison is paired
 at the defect level, which is the whole point of freezing the fixtures.
@@ -960,7 +977,8 @@ paired comparison and only the absolute floors apply.
 Every later run pairs against that anchor, never against the run before it: a
 five-point slide repeated four times never trips the per-run flip threshold,
 but it does show against the anchor. The anchor moves only for a `PROMOTE`
-row, which is where the runbook already requires a reviewed PR; from then on
+row, which is where the runbook already requires a reviewed PR, and a
+`pipeline` PROMOTE needs `replay` to corroborate it; from then on
 that promoted row is the baseline of record. Baseline selection uses immutable
 ledger append order. A backdated row cannot move ahead of the established
 anchor because its machine clock was slow.

--- a/scripts/review/review-eval-fixtures.mjs
+++ b/scripts/review/review-eval-fixtures.mjs
@@ -18,6 +18,7 @@ export const FINDER_ARGV_ELEMENT = /^[A-Za-z0-9._="@/:-]+$/;
 const REQUIRED_VERDICT_RULES = [
   "noise_floor_defects",
   "regression_net_flips",
+  "promote_corroboration_net_flips",
   "p1_recall_floor",
   "wrong_claims_ratio_ceiling",
   "canary_min_matched_grid",
@@ -595,6 +596,26 @@ function checkShape({ contract, problems }) {
       problems.push(
         "verdict_rules.p1_recall_floor must be a rate at or below 1",
       );
+    }
+    // The corroboration rule counts defects, and it asks `replay` to move less
+    // than the flip rule asks of the headline. A value above
+    // `regression_net_flips` would demand more of the quieter condition than
+    // the verdict itself demands, which no PROMOTE could ever clear.
+    const corroboration = rules.promote_corroboration_net_flips;
+    if (Number.isFinite(corroboration)) {
+      if (!Number.isSafeInteger(corroboration)) {
+        problems.push(
+          "verdict_rules.promote_corroboration_net_flips must be a whole number of defects",
+        );
+      }
+      if (
+        Number.isFinite(rules.regression_net_flips) &&
+        corroboration > rules.regression_net_flips
+      ) {
+        problems.push(
+          "verdict_rules.promote_corroboration_net_flips must not exceed verdict_rules.regression_net_flips",
+        );
+      }
     }
   }
   const cadence = contract.cadence_days;

--- a/scripts/review/review-eval-fixtures.mjs
+++ b/scripts/review/review-eval-fixtures.mjs
@@ -599,8 +599,10 @@ function checkShape({ contract, problems }) {
     }
     // The corroboration rule counts defects, and it asks `replay` to move less
     // than the flip rule asks of the headline. A value above
-    // `regression_net_flips` would demand more of the quieter condition than
-    // the verdict itself demands, which no PROMOTE could ever clear.
+    // `regression_net_flips` would ask `replay`'s 39 grid defects for a larger
+    // move than the headline's 51 have to make. That is the asymmetry ADR 0091
+    // rejects under "Ask `replay` for the full six net flips"; such a value is
+    // still clearable, so the bound is policy, not arithmetic.
     const corroboration = rules.promote_corroboration_net_flips;
     if (Number.isFinite(corroboration)) {
       if (!Number.isSafeInteger(corroboration)) {

--- a/scripts/review/review-eval-fixtures.test.mjs
+++ b/scripts/review/review-eval-fixtures.test.mjs
@@ -542,6 +542,26 @@ test("every contract problem is collected, not just the first", () => {
   assert.match(joined, /regression_net_flips must be a positive number/);
 });
 
+test("the corroboration rule may not ask more than the flip rule", () => {
+  // `promote_corroboration_net_flips` asks `replay` to move in the same
+  // direction as a `pipeline` gain. Above `regression_net_flips` it would ask
+  // the quieter condition for more than the verdict itself needs, and no
+  // PROMOTE could clear it.
+  const contract = clone(committed.contract);
+  contract.verdict_rules.promote_corroboration_net_flips =
+    contract.verdict_rules.regression_net_flips + 1;
+  assert.match(
+    checkFixtures({ contract, repoRoot }).problems.join("\n"),
+    /promote_corroboration_net_flips must not exceed verdict_rules\.regression_net_flips/,
+  );
+  const fractional = clone(committed.contract);
+  fractional.verdict_rules.promote_corroboration_net_flips = 1.5;
+  assert.match(
+    checkFixtures({ contract: fractional, repoRoot }).problems.join("\n"),
+    /promote_corroboration_net_flips must be a whole number of defects/,
+  );
+});
+
 test("a contract that is not an object fails closed", () => {
   for (const bad of [null, [], "contract"]) {
     const result = checkFixtures({ contract: bad, repoRoot });

--- a/scripts/review/review-eval-fixtures.test.mjs
+++ b/scripts/review/review-eval-fixtures.test.mjs
@@ -545,8 +545,8 @@ test("every contract problem is collected, not just the first", () => {
 test("the corroboration rule may not ask more than the flip rule", () => {
   // `promote_corroboration_net_flips` asks `replay` to move in the same
   // direction as a `pipeline` gain. Above `regression_net_flips` it would ask
-  // the quieter condition for more than the verdict itself needs, and no
-  // PROMOTE could clear it.
+  // `replay`'s 39 grid defects for a larger move than the headline's 51 have
+  // to make. The contract refuses that as policy; such a value is clearable.
   const contract = clone(committed.contract);
   contract.verdict_rules.promote_corroboration_net_flips =
     contract.verdict_rules.regression_net_flips + 1;

--- a/scripts/review/review-eval-report.mjs
+++ b/scripts/review/review-eval-report.mjs
@@ -592,6 +592,22 @@ export function verdict({
 function promoteCorroborationGap({ rules, row, baseline, name }) {
   if (name !== "pipeline") return null;
   const tail = "the gain does not re-anchor the baseline";
+  // The gate is a pre-registered rule, so it binds the contracts that carry it
+  // and no others. A contract from before this rule never registered it, and
+  // `--report --contract <archived>` has to reproduce the verdict that run
+  // saw, so an absent key leaves the old semantics alone. Its series is its
+  // own: `comparabilityKey` hashes the contract digest, so a row scored under
+  // such a contract can only re-anchor rows scored under it too.
+  //
+  // A contract that names the rule and gives it a value the gate cannot read
+  // is the other case: it claims the gate and cannot run it, so it
+  // corroborates nothing.
+  const need = rules.promote_corroboration_net_flips;
+  const floor = rules.noise_floor_defects;
+  if (need === undefined) return null;
+  if (!Number.isFinite(need) || need <= 0 || !Number.isFinite(floor)) {
+    return `the contract names promote_corroboration_net_flips ${JSON.stringify(need)} against noise_floor_defects ${JSON.stringify(floor)}, which the gate cannot read, so nothing corroborates the pipeline gain; ${tail}`;
+  }
   const replay = row.conditions?.replay;
   const baseReplay = baseline?.conditions?.replay;
   if (!replay || !baseReplay) {
@@ -604,11 +620,11 @@ function promoteCorroborationGap({ rules, row, baseline, name }) {
     return `replay is absent on ${where}, so nothing corroborates the pipeline gain; ${tail}`;
   }
   const replayFlips = compareConditions(baseReplay, replay);
-  if (replayFlips.ids.length < (rules.noise_floor_defects ?? 0)) {
-    return `replay and the baseline share only ${replayFlips.ids.length} scored defect(s); noise_floor_defects ${rules.noise_floor_defects} refuses to corroborate the pipeline gain on that, so ${tail}`;
+  if (replayFlips.ids.length < floor) {
+    return `replay and the baseline share only ${replayFlips.ids.length} scored defect(s); noise_floor_defects ${floor} refuses to corroborate the pipeline gain on that, so ${tail}`;
   }
-  if (-replayFlips.delta < rules.promote_corroboration_net_flips) {
-    return `replay moved ${-replayFlips.delta} defects on ${replayFlips.ids.length} shared defects, and corroboration needs a net gain of at least ${rules.promote_corroboration_net_flips}, so ${tail}`;
+  if (-replayFlips.delta < need) {
+    return `replay moved ${-replayFlips.delta} defects on ${replayFlips.ids.length} shared defects, and corroboration needs a net gain of at least ${need}, so ${tail}`;
   }
   return null;
 }

--- a/scripts/review/review-eval-report.mjs
+++ b/scripts/review/review-eval-report.mjs
@@ -544,13 +544,17 @@ export function verdict({
     return { verdict: "AMBER", reasons: [...reasons, ...amber] };
 
   if (flips && rankable && -flips.delta >= rules.regression_net_flips) {
-    return {
-      verdict: "PROMOTE",
-      reasons: [
-        ...reasons,
-        `${name} gained a net ${-flips.delta} defects against the baseline (b=${flips.b}, c=${flips.c})`,
-      ],
-    };
+    const gain = `${name} gained a net ${-flips.delta} defects against the baseline (b=${flips.b}, c=${flips.c})`;
+    const uncorroborated = promoteCorroborationGap({
+      rules,
+      row,
+      baseline,
+      name,
+    });
+    if (uncorroborated) {
+      return { verdict: "GREEN", reasons: [...reasons, gain, uncorroborated] };
+    }
+    return { verdict: "PROMOTE", reasons: [...reasons, gain] };
   }
   return {
     verdict: "GREEN",
@@ -561,6 +565,52 @@ export function verdict({
         : `${name} recall ${rateText(condition.recall.rate)}, P1 ${rateText(condition.p1.rate)}`,
     ],
   };
+}
+
+/**
+ * Why `replay` does not corroborate a `pipeline` gain large enough to PROMOTE,
+ * or null when it does.
+ *
+ * A PROMOTE re-anchors the baseline: `resolveBaseline` picks the newest PROMOTE
+ * row of the key, and every later run is paired against its bits. Since
+ * [ADR 0090](../../docs/adr/0090-canonical-eval-matrix-freshness-floor.md)
+ * `pipeline` takes one live finder draw per PR, and the finder samples — one
+ * codex configuration drew 19 and then 10 known defects on identical diffs — so
+ * six net flips there can be the draw rather than the reviewer. `replay` runs
+ * frozen finder reports over the 39 grid defects with two OR-folded draws, so
+ * it is the quieter condition, and asking it for half the PROMOTE threshold in
+ * the same direction confirms the direction beyond noise without asking the
+ * verifier alone to reproduce a PROMOTE-sized gain on 39 defects.
+ *
+ * The gate applies to a `pipeline` headline only. When `replay` is the headline
+ * no live pipeline cell scored, and `replay`'s finder is frozen, so there is no
+ * finder sampling to corroborate away.
+ *
+ * RED is unchanged. A spurious RED costs an investigation; a spurious PROMOTE
+ * moves the reference every later run reads.
+ */
+function promoteCorroborationGap({ rules, row, baseline, name }) {
+  if (name !== "pipeline") return null;
+  const tail = "the gain does not re-anchor the baseline";
+  const replay = row.conditions?.replay;
+  const baseReplay = baseline?.conditions?.replay;
+  if (!replay || !baseReplay) {
+    const where =
+      !replay && !baseReplay
+        ? "this row or the baseline"
+        : !replay
+          ? "this row"
+          : "the baseline";
+    return `replay is absent on ${where}, so nothing corroborates the pipeline gain; ${tail}`;
+  }
+  const replayFlips = compareConditions(baseReplay, replay);
+  if (replayFlips.ids.length < (rules.noise_floor_defects ?? 0)) {
+    return `replay and the baseline share only ${replayFlips.ids.length} scored defect(s); noise_floor_defects ${rules.noise_floor_defects} refuses to corroborate the pipeline gain on that, so ${tail}`;
+  }
+  if (-replayFlips.delta < rules.promote_corroboration_net_flips) {
+    return `replay moved ${-replayFlips.delta} defects on ${replayFlips.ids.length} shared defects, and corroboration needs a net gain of at least ${rules.promote_corroboration_net_flips}, so ${tail}`;
+  }
+  return null;
 }
 
 /** One condition's per-defect vectors narrowed to a set of defect ids. */
@@ -597,7 +647,7 @@ function restrictCondition(condition, ids) {
  * while control's share of it stays under the bar. That direction is a RED that
  * should have been AMBER — an investigation, not a false pass — and scaling the
  * pre-registered threshold to the scope is a verdict-rule change with its own
- * decision to record. Issue 2324 carries it.
+ * decision to record. Issue 2333 carries it.
  */
 function controlMoved({ contract, row, baseline, flips, name }) {
   if (!baseline || !flips || flips.delta === 0) return null;

--- a/scripts/review/review-eval-report.test.mjs
+++ b/scripts/review/review-eval-report.test.mjs
@@ -118,6 +118,11 @@ function baseline(overrides = {}) {
   });
 }
 
+/** A `replay` condition: the grid defects only, both frozen reports replayed. */
+function replay(overrides = {}) {
+  return condition({ ids: gridIds, draws: 2, ...overrides });
+}
+
 test("the fixtures used by these assertions are themselves valid rows", () => {
   assert.deepEqual(validateLedgerRow(row()), []);
   assert.deepEqual(
@@ -345,9 +350,19 @@ test("verdict applies the pre-registered rule to every branch", () => {
       reason: /cannot be ranked against the given baseline/,
     },
     {
-      name: "PROMOTE on a net gain past the threshold",
-      row: row({ conditions: { pipeline: condition({ found: 26 }) } }),
-      baseline: baseline(),
+      name: "PROMOTE on a net gain past the threshold replay corroborates",
+      row: row({
+        conditions: {
+          pipeline: condition({ found: 26 }),
+          replay: replay({ found: 13 }),
+        },
+      }),
+      baseline: baseline({
+        conditions: {
+          pipeline: condition({ found: 20 }),
+          replay: replay({ found: 10 }),
+        },
+      }),
       expect: "PROMOTE",
       reason: /gained a net 6 defects/,
     },
@@ -507,6 +522,114 @@ test("verdict refuses to rank a pair sharing fewer than three defects", () => {
     }).verdict,
     "GREEN",
   );
+});
+
+test("a pipeline gain replay does not corroborate does not re-anchor", () => {
+  // A PROMOTE moves the baseline every later run is paired against, and since
+  // ADR 0090 `pipeline` takes one live finder draw per PR, so six net flips
+  // there can be the draw. `replay` replays frozen reports over the grid, so
+  // it is the condition that can tell the two apart.
+  const gain = { pipeline: condition({ found: 26 }) };
+  const base = { pipeline: condition({ found: 20 }) };
+  const cases = [
+    {
+      name: "replay held still",
+      row: row({ conditions: { ...gain, replay: replay({ found: 10 }) } }),
+      baseline: baseline({
+        conditions: { ...base, replay: replay({ found: 10 }) },
+      }),
+      reason:
+        /replay moved 0 defects on 39 shared defects, and corroboration needs a net gain of at least 3/,
+    },
+    {
+      name: "replay moved the other way",
+      row: row({ conditions: { ...gain, replay: replay({ found: 8 }) } }),
+      baseline: baseline({
+        conditions: { ...base, replay: replay({ found: 10 }) },
+      }),
+      reason: /replay moved -2 defects/,
+    },
+    {
+      name: "replay gained less than the corroboration threshold",
+      row: row({ conditions: { ...gain, replay: replay({ found: 12 }) } }),
+      baseline: baseline({
+        conditions: { ...base, replay: replay({ found: 10 }) },
+      }),
+      reason: /replay moved 2 defects/,
+    },
+    {
+      name: "replay absent on the row",
+      row: row({ conditions: gain }),
+      baseline: baseline({
+        conditions: { ...base, replay: replay({ found: 10 }) },
+      }),
+      reason: /replay is absent on this row/,
+    },
+    {
+      name: "replay absent on the baseline",
+      row: row({ conditions: { ...gain, replay: replay({ found: 13 }) } }),
+      baseline: baseline({ conditions: base }),
+      reason: /replay is absent on the baseline/,
+    },
+    {
+      name: "replay shares fewer defects than the noise floor",
+      row: row({
+        conditions: {
+          ...gain,
+          replay: condition({ ids: gridIds.slice(0, 2), found: 2 }),
+        },
+      }),
+      baseline: baseline({
+        conditions: {
+          ...base,
+          replay: condition({ ids: gridIds.slice(0, 2), found: 0 }),
+        },
+      }),
+      reason:
+        /replay and the baseline share only 2 scored defect\(s\); noise_floor_defects 3 refuses to corroborate/,
+    },
+  ];
+  for (const item of cases) {
+    const decision = verdict({
+      contract,
+      row: item.row,
+      baselineRow: item.baseline,
+    });
+    assert.equal(decision.verdict, "GREEN", item.name);
+    const joined = decision.reasons.join("\n");
+    // The gain is still stated: the reader sees what moved and why it is not
+    // enough to move the anchor.
+    assert.match(joined, /pipeline gained a net 6 defects/, item.name);
+    assert.match(joined, item.reason, `${item.name}: ${joined}`);
+    assert.match(joined, /does not re-anchor the baseline/, item.name);
+  }
+});
+
+test("corroboration gates PROMOTE only, and only a pipeline headline", () => {
+  // RED is unchanged: a spurious RED costs an investigation, a spurious
+  // PROMOTE silently moves the reference.
+  const red = verdict({
+    contract,
+    row: row({ conditions: { pipeline: condition({ found: 14 }) } }),
+    baselineRow: baseline({
+      conditions: { pipeline: condition({ found: 20 }) },
+    }),
+  });
+  assert.equal(red.verdict, "RED", JSON.stringify(red.reasons));
+  assert.match(red.reasons.join("\n"), /lost a net 6 defects/);
+  // A row whose headline is `replay` scored no live pipeline cell, and
+  // `replay`'s finder is frozen, so there is no finder sampling to corroborate.
+  const replayHeadline = verdict({
+    contract,
+    row: row({ conditions: { replay: replay({ found: 26 }) } }),
+    baselineRow: baseline({ conditions: { replay: replay({ found: 20 }) } }),
+  });
+  assert.equal(
+    replayHeadline.verdict,
+    "PROMOTE",
+    JSON.stringify(replayHeadline.reasons),
+  );
+  assert.match(replayHeadline.reasons.join("\n"), /replay gained a net 6/);
 });
 
 test("a condition that scored no P1 defect is not read as zero P1 recall", () => {

--- a/scripts/review/review-eval-report.test.mjs
+++ b/scripts/review/review-eval-report.test.mjs
@@ -632,6 +632,71 @@ test("corroboration gates PROMOTE only, and only a pipeline headline", () => {
   assert.match(replayHeadline.reasons.join("\n"), /replay gained a net 6/);
 });
 
+test("the gate binds the contracts that pre-register it", () => {
+  // A contract from before this rule never registered it, and
+  // `--report --contract <archived>` has to reproduce the verdict that run
+  // saw, so an absent key leaves the PROMOTE standing. A key the gate cannot
+  // read is the other case: the contract claims the gate and cannot run it.
+  const gain = row({
+    conditions: {
+      pipeline: condition({ found: 26 }),
+      replay: replay({ found: 16 }),
+    },
+  });
+  const base = baseline({
+    conditions: {
+      pipeline: condition({ found: 20 }),
+      replay: replay({ found: 10 }),
+    },
+  });
+  const corroborated = verdict({ contract, row: gain, baselineRow: base });
+  assert.equal(
+    corroborated.verdict,
+    "PROMOTE",
+    JSON.stringify(corroborated.reasons),
+  );
+  // An archived contract: the rule is absent, so the old verdict stands even
+  // when replay would not corroborate.
+  const archived = structuredClone(contract);
+  delete archived.verdict_rules.promote_corroboration_net_flips;
+  const flatReplay = {
+    pipeline: condition({ found: 26 }),
+    replay: replay({ found: 10 }),
+  };
+  const legacy = verdict({
+    contract: archived,
+    row: row({ conditions: flatReplay }),
+    baselineRow: base,
+  });
+  assert.equal(legacy.verdict, "PROMOTE", JSON.stringify(legacy.reasons));
+  // A value the gate cannot read corroborates nothing.
+  for (const value of [0, -3, "3", null]) {
+    const broken = structuredClone(contract);
+    broken.verdict_rules.promote_corroboration_net_flips = value;
+    const decision = verdict({
+      contract: broken,
+      row: row({ conditions: flatReplay }),
+      baselineRow: base,
+    });
+    assert.equal(decision.verdict, "GREEN", String(value));
+    assert.match(
+      decision.reasons.join("\n"),
+      /which the gate cannot read, so nothing corroborates the pipeline gain/,
+      String(value),
+    );
+  }
+  const noFloor = structuredClone(contract);
+  delete noFloor.verdict_rules.noise_floor_defects;
+  assert.equal(
+    verdict({
+      contract: noFloor,
+      row: row({ conditions: flatReplay }),
+      baselineRow: base,
+    }).verdict,
+    "GREEN",
+  );
+});
+
 test("a condition that scored no P1 defect is not read as zero P1 recall", () => {
   const noP1 = row({
     conditions: {

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -3214,6 +3214,60 @@ test("resolveBaseline uses the same eligibility rule as an explicit baseline", (
   );
 });
 
+test("an uncorroborated PROMOTE never becomes the anchor", () => {
+  // The gate lives in `verdict()`, and both baseline paths read it there:
+  // `revalidateRow` recomputes the verdict from the row's own numbers, so a
+  // hand-written PROMOTE is refused, and `resolveBaseline` re-anchors on the
+  // verdict a row actually carries.
+  const prs = contract.fixtures.map((fixture) => fixture.pr);
+  const allIds = scorableIdsFor(prs);
+  const nonGridIds = scorableIdsFor(
+    contract.fixtures
+      .filter((fixture) => fixture.grid !== true)
+      .map((fixture) => fixture.pr),
+  );
+  // Every gained defect sits on a PR `replay` never scores, so `pipeline`
+  // clears the flip threshold with nothing corroborating it.
+  const gained = new Set(
+    nonGridIds.slice(0, contract.verdict_rules.regression_net_flips),
+  );
+  const anchor = makeRow({
+    executedAt: "2026-09-08T10:41:07Z",
+    matchedIds: allIds.filter((id) => !gained.has(id)),
+    fullMatrix: true,
+  });
+  const claimed = makeRow({
+    executedAt: "2026-12-08T10:41:07Z",
+    matchedIds: allIds,
+    fullMatrix: true,
+    verdict: "PROMOTE",
+  });
+  const checked = revalidateRow({
+    contract,
+    row: claimed,
+    repoRoot,
+    ledgerRows: [anchor, claimed],
+  });
+  assert.equal(checked.verdict, "GREEN", JSON.stringify(checked.problems));
+  assert.equal(checked.ok, false);
+  assert.ok(
+    checked.problems.some((problem) =>
+      problem.startsWith(
+        "row.verdict is PROMOTE; the row's own numbers give GREEN",
+      ),
+    ),
+    JSON.stringify(checked.problems),
+  );
+  // The ledger therefore only ever holds the recomputed verdict, and that row
+  // leaves the anchor where it was.
+  const recorded = { ...claimed, verdict: checked.verdict };
+  const later = makeRow({ executedAt: "2027-01-08T10:41:07Z" });
+  assert.equal(
+    resolveBaseline({ rows: [anchor, recorded], row: later }).executed_at,
+    anchor.executed_at,
+  );
+});
+
 test("resolveBaseline anchors on the first full row until a PROMOTE re-anchors", () => {
   const anchor = makeRow({ executedAt: "2026-09-08T10:00:00Z" });
   const later = makeRow({ executedAt: "2026-10-08T10:00:00Z" });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- A `PROMOTE` verdict re-anchored the review-eval baseline by itself:
  `resolveBaseline` picks the newest `PROMOTE` row of the comparability key,
  and `revalidateRow` recomputes the verdict from the row's own numbers, so an
  operator could not record a lower verdict by hand.
- Since ADR 0090 the `pipeline` condition takes one live finder draw per PR
  instead of two OR-folded draws. The finder samples — the 2026-09 programme
  watched one codex configuration draw 19 and then 10 known defects on
  identical diffs — so six net gains on `pipeline` alone can be sampling.
- A spurious `PROMOTE` then became the anchor every later run is paired
  against, and the bias is invisible from that point on. ADR 0090 wrote the
  reading down and recorded that the harness did not enforce it.

## The Solution

A pre-registered rule, `verdict_rules.promote_corroboration_net_flips: 3` in
`docs/evals/review-skill-fixtures.json`, now gates the PROMOTE branch of
`verdict()`. When the headline condition is `pipeline` and the pipeline flips
would give PROMOTE, the row stays PROMOTE only if `replay` corroborates: both
rows carry a `replay` condition, the pair shares at least `noise_floor_defects`
scored defects, and `replay` gained at least 3 net defects in the same
direction. Uncorroborated, the verdict is GREEN, and the reasons keep the
pipeline gain line and add one line naming why `replay` did not corroborate it
and stating that the gain does not re-anchor the baseline.

The benefit: a single-draw sampling artifact can no longer move the reference
every later run reads. The threshold lives in the contract, so it is
pre-registered and versioned rather than a constant in code, and ADR 0091
records why 3 is the number — half the PROMOTE threshold, asked of the
condition whose finder is frozen and whose two draws are OR-folded over the 39
grid defects.

Material limits. RED is unchanged: a spurious RED costs an investigation, a
spurious PROMOTE silently moves the reference. A `replay` headline is exempt,
because no live pipeline cell scored and `replay`'s finder is frozen. The gate
binds only contracts that carry the key, so archived pre-ADR-0091 contracts
still report the verdict their runs saw.

## Details

**Where the gate lives.** New helper `promoteCorroborationGap({rules, row,
baseline, name})` in `scripts/review/review-eval-report.mjs` returns `null`
when `replay` corroborates and otherwise the reason it does not. It pairs
`baseline.conditions.replay` with `row.conditions.replay` through
`compareConditions`. Three refusal reasons name the branch that fired: `replay`
absent (naming which side), below the shared-defect floor, or below the
corroboration threshold. The gate sits in `verdict()`, not in `resolveBaseline`
or `baselineEligibility`, so the printed verdict and the anchor never disagree.

**Contract validation.** `checkContract` in
`scripts/review/review-eval-fixtures.mjs` adds the key to
`REQUIRED_VERDICT_RULES`, so it inherits the existing positive-number check,
plus two new checks: a whole number of defects, and not above
`regression_net_flips`.

**Archived contracts.** A contract from before this change never registered the
rule, so `--report --contract <archived>` still prints the verdict that run
saw; history does not move under a rule its runs never ran against. A contract
that names the key with a value the gate cannot read (0, a negative, a string)
refuses to corroborate instead of promoting unchecked. This shape came out of
the independent closeout review, which caught that a blanket fail-closed
reading breaks the documented archived-contract report path
(`docs/evals/review-skill.md`).

**Why `resolveBaseline` needed no change.** `revalidateRow` recomputes through
`verdict()`, so a row that records `PROMOTE` on an uncorroborated gain fails
with "row's own numbers give GREEN" and never enters the ledger;
`resolveBaseline` then never sees a `PROMOTE` to re-anchor on. A test asserts
both halves.

**Digests that move.** `docs/evals/review-skill-fixtures.json` changes, so
`contract_digest` moves. `review-eval-report.mjs` and `review-eval-fixtures.mjs`
are both in `SCORING_MODULES`, so `matcher_digest` moves too. `comparability_key`
therefore moves: the first canonical run after this merge resolves no baseline
and re-anchors, and rows under the old key become a separate series that still
validates and still reports. This is the same lineage break ADR 0090 took.

**No cache invalidation for the experiment lane.** `ORCHESTRATOR_FILES` is
unchanged, so the orchestrator digest is unchanged.

**Docs.** The runbook's "Read the verdict" PROMOTE row states the corroboration
requirement; the paragraph that said the harness does not enforce the reading
(and linked issue 2324) now states the enforced rule, the exemption, and the
ADR link; "The noise rule" notes the shared-defect floor also bounds
corroboration. New ADR 0091 records the decision; ADR 0090's "that reading is
not enforced" consequence is amended; `docs/adr/README.md` and `docs/README.md`
are regenerated.

**Left untouched.**
`scripts/review/testdata/review-eval-split-equivalence/contract.json.txt` is the
frozen pre-split contract whose digest `review-eval.test.mjs` asserts. It is
loaded, never validated, so adding the key there would only break that
assertion.

**Review findings declined here, with reasons.**

- _Split the growing over-cap review modules_ (closeout review round 2, P2):
  `review-eval-fixtures.mjs` grows 977 → 1,000 lines and `review-eval-report.mjs`
  921 → 987 against the merge base, both already over the 600-line soft cap.
  Declined, not deferred, so no issue tracks it. Splitting either module means
  adding files to `SCORING_MODULES`, which moves `matcher_digest` and the
  comparability key again on top of the break this PR already takes. The cap is
  advisory for this path: the root eslint config sets no `max-lines` for
  `scripts/`, and the watchlist is a monthly issue-only report. The whole
  review-eval family already sits over the cap on `main` (ledger 1,009, score
  896, `review-eval.mjs` 873), so the split is a family-wide refactor that
  belongs in its own PR.
- _The grooming comment on issue 2324 runs about 20 lines, not the five to eight
  the brief asked for_ (review lens 2, P3). Declined: the content is correct and
  matches the ADR, and editing an already-posted comment changes no behavior
  while risking the precise wording. Stating the deviation here instead.

## Validation

All commands ran at `71f8969e` — the merge of `origin/main` (`c9d83973`) into
the reviewed head `a566bec5` — in the branch worktree, unsandboxed.

- `node --test scripts/review/*.test.mjs` — passed: 406 tests, 406 pass, 0 fail
  (54.8 s).
- `pnpm lint:scripts` — passed.
- `pnpm docs:index --check` — passed.
- `pnpm adr:check --base origin/main` — passed.
- `./tools/trunk fmt`, then `./tools/trunk check --ci` on the eleven changed
  files — passed: 10 checked, no issues (`docs/evals/review-skill-fixtures.json`
  and `docs/README.md` are prettier-ignored by `trunk.yaml`). The tree was clean
  after formatting.
- `pnpm agent:context-check` — passed (175 managed files).
  `pnpm agent:context-budget --strict` — passed (exit 0).
  `pnpm agent:context-budget:test` — passed: 17 tests, 17 pass.
- `pnpm review:eval -- --check-fixtures --offline` — passed: `ok`, 9 PRs, 51
  scorable, 16 P1, 0 problems.
- `pnpm review:eval -- --check-ledger` — passed: `ok`, 6 rows, 0 problems.
- `CI=true pnpm install --frozen-lockfile` — passed; the lockfile change arrived
  with the base merge.
- `pnpm agent:quality-gate --run --base origin/main` — not run: it produced no
  output within a 16-minute foreground budget and was stopped. The mapped author
  checks above were run directly in its place.
- Dashboard, size-limit and supply-chain rows selected by the base merge — not
  run: the diff of `ui-dashboard`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
  `package.json` and `scripts/supply-chain` between `origin/main` and this head
  is empty, so those paths are byte-identical to `origin/main` and this branch
  contributes no change to them.

Negative control, run before the fix: a probe driving the real `verdict()`
against the committed contract gave `no threshold -> PROMOTE ["pipeline gained a
net 6 defects against the baseline (b=0, c=6)"]` where the unmodified contract
gave GREEN. That is the case the new test now asserts is refused.

Independent closeout review — `pnpm agent:closeout-review --no-fetch --base
origin/main --timeout-seconds 900`, codex-cli 0.153.4, gpt-5.6-sol, high — ran
twice.

- Round 1 on `83ebe204` plus working-tree fixes: exit 1, one P2, "Preserve
  verdicts from archived pre-corroboration contracts". Confirmed against
  `docs/evals/review-skill.md` and `comparabilityKey`, then fixed in `a566bec5`.
  Report: `.reviews/closeout-review-20260909T150904-83ebe20-70042.md`.
- Round 2 on `a566bec5`: exit 1, one P2, the file-size drift rule. Declined with
  the reason under Details. It also noted its own broader test run was limited
  by a read-only sandbox (EPERM on tests that create temp directories); the full
  unsandboxed suite above covers that gap. Report:
  `.reviews/closeout-review-20260909T152107-a566bec-36953.md`.

The nearest stronger claim this evidence does not support: the tests prove the
gate refuses the constructed uncorroborated shapes (`replay` absent on either
side, below the shared-defect floor, below the threshold, an unreadable rule
value) and preserves archived-contract verdicts. They do not show that 3 net
`replay` flips is the empirically right threshold. No canonical run has
exercised the gate on live data yet, and the first run after this merge
re-anchors with no baseline, so the first live measurement of the rule comes
later.

## Deferrals

- https://github.com/mento-protocol/monitoring-monorepo/issues/2333 — scaling
  the control-drift waiver threshold to control's 39-defect scope. The
  `controlMoved` comment now points there instead of at 2324.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #2324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyXYSWFBZaJu9vxdWjQrei



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline-based promotion decisions now require replay corroboration with at least three net replay gains.
  * Uncorroborated or insufficient evidence produces a GREEN result without re-anchoring the baseline.
  * Replay-headline and RED verdict behavior remains unchanged.

* **Documentation**
  * Added and updated guidance describing promotion corroboration, baseline re-anchoring, and evaluation thresholds.

* **Tests**
  * Added coverage for missing, invalid, and insufficient corroboration evidence, including baseline protection and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->