### PR TITLE
fix(review-eval): signal a worker interrupted before it is recorded

### DIFF
--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -378,9 +378,9 @@ signals both the workers it recorded and its own direct children, so a worker
 interrupted between its fork and the command that records it is ended too. A
 cell's log lines are buffered and emitted as one write, which is indivisible on
 the regular file the launchd job redirects to and guaranteed only to `PIPE_BUF`
-through a pipe, so `run-eval.sh | tee` can still interleave two failing cells. Every cell's outcome
-is written to its own status file and summed by the parent, so
-`matrix: D done, F failed, of T` counts each cell exactly once and `T` is the
+through a pipe, so `run-eval.sh | tee` can still interleave two failing cells.
+Every cell's outcome is written to its own status file and summed by the parent,
+so `matrix: D done, F failed, of T` counts each cell exactly once and `T` is the
 whole planned matrix.
 
 A PR whose draw-2 cell never ran is scored on draw 1 alone: the defect's bit

--- a/docs/evals/review-skill.md
+++ b/docs/evals/review-skill.md
@@ -373,10 +373,12 @@ run and replace the `hours TBD` above with what it took. Each group is its own
 process group, and the TERM and EXIT paths take every one of them down before
 the run returns; because `run_bounded` puts each cell's bounded child in a
 process group of its own, a signalled worker forwards to that group as well
-rather than leaving a finder or a contestant orphaned. A cell's log lines are
-buffered and emitted as one write, which is indivisible on the regular file the
-launchd job redirects to and guaranteed only to `PIPE_BUF` through a pipe, so
-`run-eval.sh | tee` can still interleave two failing cells. Every cell's outcome
+rather than leaving a finder or a contestant orphaned. On TERM or INT the run
+signals both the workers it recorded and its own direct children, so a worker
+interrupted between its fork and the command that records it is ended too. A
+cell's log lines are buffered and emitted as one write, which is indivisible on
+the regular file the launchd job redirects to and guaranteed only to `PIPE_BUF`
+through a pipe, so `run-eval.sh | tee` can still interleave two failing cells. Every cell's outcome
 is written to its own status file and summed by the parent, so
 `matrix: D done, F failed, of T` counts each cell exactly once and `T` is the
 whole planned matrix.

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -883,7 +883,7 @@ test("comparabilityKey moves with the contract, the prompts, and the scorer", ()
 
 test("orchestratorSourceDigest binds the shell and the cell modules", () => {
   const expected =
-    "e7fe24ecf42652e8b4403dce78869bdecf278997796f72e123ca691587101200";
+    "d460aa3fefe45e964e71b6490898ed69e69b1d6e2f99781d7eff2c8252bff61f";
   assert.equal(orchestratorSourceDigest(), expected);
   // The cell writer and the stream parser are in the digest for the same
   // reason the shell is: the writer decides what a paid cell records and the
@@ -2555,6 +2555,117 @@ test("TERM takes every group worker's process group down with the run", async ()
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("TERM ends a group worker interrupted before the parent recorded it", async () => {
+  const dir = mkdtempSync(
+    path.join(tmpdir(), "review-eval-matrix-unrecorded-"),
+  );
+  let workerChild = "";
+  let workerGroup = "";
+  try {
+    const rowsFile = path.join(dir, "rows.tsv");
+    writeFileSync(
+      rowsFile,
+      [
+        "pr-1990-control-draw1",
+        "1990",
+        "control",
+        "1",
+        "opus",
+        "high",
+        "",
+        "",
+        "request",
+      ].join("\t") + "\n",
+    );
+    const marker = path.join(dir, "survivor");
+    const childFile = path.join(dir, "worker-child");
+    // `matrix_start_group` forks the worker and records it in the next command,
+    // and a pending trap runs between two commands. A `printf` function shadows
+    // the builtin the parent writes the pid file with, which holds the parent
+    // inside exactly that gap while the worker signals it, so the run's TERM
+    // trap finds `MATRIX_WORKER_PIDS` empty and has to discover the worker to
+    // signal it at all.
+    const harness = [
+      "set -euo pipefail",
+      "TMPROOT=" + JSON.stringify(dir),
+      "STARTED=$(date +%s)",
+      "MATRIX_DEADLINE=3600",
+      'STATUS_NOTE=""',
+      "DONE=0",
+      "FAILED=0",
+      "TOTAL=0",
+      "MARKER=" + JSON.stringify(marker),
+      "CHILD_FILE=" + JSON.stringify(childFile),
+      // Read here, not from `$PPID` inside the worker: the worker is a subshell,
+      // where `$PPID` is still this shell's own parent rather than this shell.
+      "ORCHESTRATOR=$$",
+      `log() { builtin printf '%s\\n' "$*"; }`,
+      `fail() { builtin printf 'FATAL: %s\\n' "$*" >&2; exit 1; }`,
+      "cell_rows() { cat " + JSON.stringify(rowsFile) + "; }",
+      "source " + JSON.stringify(matrixSourcePath),
+      'printf() { sleep 2; builtin printf "$@"; }',
+      // The worker records a child of its own, interrupts the run, and waits.
+      // Nothing writes the marker unless the worker outlives the run that never
+      // recorded it.
+      "matrix_group_worker() {",
+      "  sleep 20 &",
+      `  builtin printf '%s\\n' "$!" >"$CHILD_FILE"`,
+      '  kill -TERM "$ORCHESTRATOR"',
+      "  wait",
+      `  builtin printf 'survived\\n' >"$MARKER"`,
+      "}",
+      "run_matrix",
+    ].join("\n");
+    // `/bin/bash` for the same reason the pass above uses it: that is what the
+    // launchd job execs, and on macOS it is 3.2.
+    const child = spawn("/bin/bash", ["-c", harness], {
+      stdio: "ignore",
+      env: { ...process.env, REVIEW_EVAL_PR_CONCURRENCY: "3" },
+    });
+    const exited = new Promise((resolve) => {
+      child.on("exit", (code) => resolve(code));
+    });
+    assert.equal(await exited, 143);
+    workerChild = readFileSync(childFile, "utf8").trim();
+    assert.match(workerChild, /^\d+$/, "the worker never started its child");
+    // The worker leads its group, so its child's parent is the group id this
+    // teardown needs. Read it while the child can still name it: on the fixed
+    // scheduler the child is already gone, and there is nothing to end.
+    workerGroup = String(
+      spawnSync("ps", ["-o", "ppid=", "-p", workerChild], {
+        encoding: "utf8",
+      }).stdout ?? "",
+    ).trim();
+    // Gone or reaped-late, the same poll the pass above uses: the worker's group
+    // outliving the run is the orphan that keeps spending quota.
+    let ended = false;
+    for (let attempt = 0; attempt < 40 && !ended; attempt += 1) {
+      const state = spawnSync("ps", ["-o", "state=", "-p", workerChild], {
+        encoding: "utf8",
+      });
+      ended =
+        spawnSync("kill", ["-0", workerChild]).status !== 0 ||
+        state.status !== 0 ||
+        state.stdout.trim() === "" ||
+        state.stdout.trim().startsWith("Z");
+      if (!ended) await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.ok(
+      ended,
+      `unrecorded worker's group ${workerChild} outlived the run`,
+    );
+    assert.equal(existsSync(marker), false, "the unrecorded worker ran on");
+  } finally {
+    // A worker that outlived the run writes into this directory while it is
+    // being removed, so end its whole group before the removal, not after.
+    if (/^\d+$/.test(workerGroup)) {
+      spawnSync("kill", ["-KILL", `-${workerGroup}`]);
+    }
+    if (/^\d+$/.test(workerChild)) spawnSync("kill", ["-KILL", workerChild]);
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5 });
   }
 });
 

--- a/scripts/review/review-eval.test.mjs
+++ b/scripts/review/review-eval.test.mjs
@@ -2631,14 +2631,25 @@ test("TERM ends a group worker interrupted before the parent recorded it", async
     assert.equal(await exited, 143);
     workerChild = readFileSync(childFile, "utf8").trim();
     assert.match(workerChild, /^\d+$/, "the worker never started its child");
-    // The worker leads its group, so its child's parent is the group id this
-    // teardown needs. Read it while the child can still name it: on the fixed
-    // scheduler the child is already gone, and there is nothing to end.
+    // Read the group id itself, not the child's parent: once the worker dies
+    // its child reparents to pid 1, and a teardown that group-killed that
+    // answer would signal every process this user owns.
     workerGroup = String(
-      spawnSync("ps", ["-o", "ppid=", "-p", workerChild], {
+      spawnSync("ps", ["-o", "pgid=", "-p", workerChild], {
         encoding: "utf8",
       }).stdout ?? "",
     ).trim();
+    // A runner that cannot inspect processes must fail this test, not pass it:
+    // every probe below reads as "gone" when `ps` is denied, which is also the
+    // answer the fixed scheduler gives. Prove `ps` works on this process first.
+    const selfState = spawnSync(
+      "ps",
+      ["-o", "state=", "-p", String(process.pid)],
+      { encoding: "utf8" },
+    );
+    assert.equal(selfState.error, undefined, "ps cannot run here");
+    assert.equal(selfState.status, 0, "ps cannot read process state here");
+    assert.notEqual(selfState.stdout.trim(), "", "ps reported no state here");
     // Gone or reaped-late, the same poll the pass above uses: the worker's group
     // outliving the run is the orphan that keeps spending quota.
     let ended = false;
@@ -2646,8 +2657,8 @@ test("TERM ends a group worker interrupted before the parent recorded it", async
       const state = spawnSync("ps", ["-o", "state=", "-p", workerChild], {
         encoding: "utf8",
       });
+      assert.equal(state.error, undefined, "ps stopped running mid-poll");
       ended =
-        spawnSync("kill", ["-0", workerChild]).status !== 0 ||
         state.status !== 0 ||
         state.stdout.trim() === "" ||
         state.stdout.trim().startsWith("Z");
@@ -2655,14 +2666,17 @@ test("TERM ends a group worker interrupted before the parent recorded it", async
     }
     assert.ok(
       ended,
-      `unrecorded worker's group ${workerChild} outlived the run`,
+      `the unrecorded worker's group member ${workerChild} outlived the run`,
     );
     assert.equal(existsSync(marker), false, "the unrecorded worker ran on");
   } finally {
     // A worker that outlived the run writes into this directory while it is
     // being removed, so end its whole group before the removal, not after.
-    if (/^\d+$/.test(workerGroup)) {
-      spawnSync("kill", ["-KILL", `-${workerGroup}`]);
+    // Never group-kill 0 or 1: neither names this worker's group, and
+    // signalling them reaches every process this user owns.
+    const group = Number(workerGroup);
+    if (Number.isInteger(group) && group > 1) {
+      spawnSync("kill", ["-KILL", `-${group}`]);
     }
     if (/^\d+$/.test(workerChild)) spawnSync("kill", ["-KILL", workerChild]);
     rmSync(dir, { recursive: true, force: true, maxRetries: 5 });

--- a/scripts/review/run-eval-matrix.sh
+++ b/scripts/review/run-eval-matrix.sh
@@ -88,15 +88,51 @@ matrix_worker_kill_children() {
 # TERM first, then KILL for whatever ignored it. The grace between them is what
 # gives each worker's own handler time to forward the signal to the bounded
 # child it started, which leads a group of its own.
+#
+# The recorded array is the primary source, so the pass still ends the workers
+# where `pgrep` is missing. Asked to discover, it adds the orchestrator's direct
+# children to that list. `matrix_start_group` records a worker in the command
+# after the one that forked it, and Bash runs a pending trap between two
+# commands, so a signal delivered in that gap arrives here with the array not
+# yet naming a live worker — the parent-side twin of the window the worker's own
+# handler waits out. The fork already made that worker a child, so `pgrep` names
+# it even there.
+#
+# Only the TERM and INT trap asks for discovery. `matrix_cleanup` reaches this
+# on the EXIT path, after `run_matrix` returned, where a live direct child is a
+# later stage's `run_bounded` leader rather than a group worker, and ending
+# those is not this function's job.
+#
+# The list is collected once and both passes reuse it, for the same reason the
+# worker-side pass collects its groups once: a leader that dies on TERM leaves
+# `pgrep` while a member of its group is still alive. A child that leads no
+# group answers to its own leader's signal instead, and the failed `kill` is
+# discarded.
 # shellcheck disable=SC2329  # invoked by the TERM trap and by matrix_cleanup
 matrix_kill_workers() {
-  local pid
-  ((${#MATRIX_WORKER_PIDS[@]} > 0)) || return 0
+  local discover="${1:-}" pid candidate known
+  local -a targets=()
   for pid in ${MATRIX_WORKER_PIDS[@]+"${MATRIX_WORKER_PIDS[@]}"}; do
+    targets+=("$pid")
+  done
+  if [[ $discover == discover ]]; then
+    for candidate in $(pgrep -P "$$" 2>/dev/null || true); do
+      known=0
+      for pid in ${targets[@]+"${targets[@]}"}; do
+        if [[ $pid == "$candidate" ]]; then
+          known=1
+          break
+        fi
+      done
+      ((known)) || targets+=("$candidate")
+    done
+  fi
+  ((${#targets[@]} > 0)) || return 0
+  for pid in "${targets[@]}"; do
     kill -TERM "-$pid" 2>/dev/null || true
   done
   sleep 3
-  for pid in ${MATRIX_WORKER_PIDS[@]+"${MATRIX_WORKER_PIDS[@]}"}; do
+  for pid in "${targets[@]}"; do
     kill -KILL "-$pid" 2>/dev/null || true
   done
   MATRIX_WORKER_PIDS=()
@@ -274,7 +310,7 @@ run_matrix() {
     fail "could not create the matrix status directory"
   log "scheduling ${#group_prs[@]} PR groups, up to $MATRIX_PR_CONCURRENCY at once"
 
-  trap 'matrix_kill_workers; exit 143' TERM INT
+  trap 'matrix_kill_workers discover; exit 143' TERM INT
   count=${#group_prs[@]}
   for ((next = 0; next < count; next++)); do
     matrix_wait_for_capacity "$MATRIX_STATUS_DIR" "$MATRIX_PR_CONCURRENCY"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- On TERM or INT, the review-eval matrix run signalled only the workers listed
  in `MATRIX_WORKER_PIDS`. `matrix_start_group` appends to that array in the
  command _after_ the one that forks the worker, and Bash runs a pending trap
  between two commands.
- An interrupt delivered in that gap reached the kill pass while the array did
  not yet name the freshly forked worker, so that worker was never signalled at
  all. Its own handler never ran, so the pid file from #2323 did not help: that
  file closes the worker-side window, not the parent-side one.
- The run exited 143 and released its locks while the orphan kept running its
  group's cells and spending model quota, bounded only by `MATRIX_DEADLINE` —
  up to 4.5 hours by default — and able to overlap a later run.

## The Solution

`matrix_kill_workers` now takes an optional `discover` argument. Asked to
discover, it adds the orchestrator's direct children from `pgrep -P "$$"` to the
recorded pids, deduplicates, and signals that one list by process group for both
the TERM and the KILL pass. The fork itself makes a worker a child before any
Bash statement runs, so the window closes: an operator interrupt can no longer
leave a paid worker running after the run has reported failure.

Limits. The recorded array stays the primary source, so where `pgrep` is missing
the pass behaves exactly as before. Discovery is off on the EXIT path:
`matrix_cleanup` calls the function unchanged, because it runs after `run_matrix`
returned, when a live direct child is a later stage's `run_bounded` leader
(scoring, judging) rather than a group worker.

## Details

**Why only the TERM/INT trap asks for discovery.** I could not show the EXIT
path cannot reach a live `run_bounded` leader — `abort`/`fail` during scoring
exits with a bounded child alive — so the issue's default stands and the code
comment states it in three sentences.

**Why the union is collected once.** The TERM pass and the KILL pass reuse one
list, for the same reason the worker-side pass collects its groups once: a leader
that dies on TERM leaves `pgrep` while a member of its group is still alive, and
a process group outlives its leader.

**Signalling stays by process group** (`kill -TERM "-$pid"`), matching the
existing pass. A discovered child that leads no group — for instance the
command-substitution subshell that runs `pgrep` itself — fails the group kill
with ESRCH, which is discarded. Its pid cannot alias a live group id, because a
pgid stays reserved while any member holds it. The recorded array is copied into
the target list first and discovered pids are appended only when absent, so no
worker is signalled twice.

**The orchestrator digest moves, and every cached cell is invalidated by
design.** `scripts/review/run-eval-matrix.sh` is listed in `ORCHESTRATOR_FILES`,
so its bytes are length-framed into `orchestrator_digest`; the pin at
`scripts/review/review-eval.test.mjs:886` moves from
`e7fe24ecf42652e8b4403dce78869bdecf278997796f72e123ca691587101200` to
`d460aa3fefe45e964e71b6490898ed69e69b1d6e2f99781d7eff2c8252bff61f`. That digest
is what keeps a cell recorded under one orchestrator out of a run made by
another, so re-running the cells is the intended outcome. `ORCHESTRATOR_FILES`
itself needed no change, and no entry was added to
`ORCHESTRATOR_REUSE_TRANSITIONS`: that map is marked CLOSED in its own comment.
The review round changed no shell file, so the digest does not move a second
time.

**The test forces the timing without a production seam.** A shell function named
`printf` shadows the builtin the parent writes the pid file with and sleeps 2 s,
holding the parent between the fork and the array append. A stubbed
`matrix_group_worker` records a child of its own, sends TERM to the orchestrator
pid (read as `ORCHESTRATOR=$$` before anything forks, never `$PPID` inside the
worker), and waits. The test asserts the parent exits 143, that the worker's
process group is gone within a bound, and that no survivor marker was written.
Its teardown kills the worker's whole group before removing the temp directory,
so a pre-fix run reports the real assertion instead of an `ENOTEMPTY` from an
orphan still writing into that directory.

**Review-driven fixes (second commit, tests and docs only).** Two defects were in
the new regression test itself. Its teardown derived the worker's group from the
child's parent, which becomes pid 1 once the worker dies, so on the very
regression the test catches it could have run `kill -KILL -1` and signalled every
process the user owns; it now reads `pgid` directly and refuses 0 and 1. Its
survival poll treated a failed `ps` or `kill` as proof the worker was gone, so on
a runner that cannot inspect processes the test reported green against the
unfixed scheduler; it now proves `ps` works on its own process before trusting
any probe and fails loudly when `ps` stops running. The failure message named the
worker's child as the group id and now calls it the group member. One
documentation line left at 99 columns was re-wrapped at 80.

**Declined review finding.** The independent closeout review returned one [P1],
"Discover detached cell groups before killing workers": a worker interrupted in
the window may already have started a `run_bounded` child in its own process
group, which the parent's group kill would miss. Declined as unreachable — the
scenario needs both halves at once and they exclude each other. The parent-side
window discovery covers is fork → `worker=$!` → `printf … >"$pid_file"`
(`run-eval-matrix.sh:222-226`): one assignment and one builtin write, and Bash
runs a pending trap only between commands. For the worker to own a separate
`run_bounded` group by then it must first run `node "$CELL_WRITER" --preflight`
(a whole node process), `fixture_path`, `purge_skill` and `reset_fixture` (git
operations) — `run-eval-runtime.sh:398-419` — hundreds of milliseconds to seconds
before the first `run_bounded` call at line 437. The pid-file gap the finding
rests on is pre-existing and documented at `run-eval-matrix.sh:63-68`; this
change neither opens nor widens it. Both suggested remedies (block the worker on
its pid file before it starts work, or discover grandchild groups from the
parent) change worker startup or the EXIT-path blast radius, which is outside
issue 2329.

**Docs.** `docs/evals/review-skill.md` gained one sentence describing the two
sources on the TERM/INT path. ADR 0089 is unchanged and no ADR is added: nothing
in it claimed the parent read only the recorded array.

Branch size against the merge base: 58 non-test changed lines.

## Validation

- **Pre-fix failure, re-established after the changes.** `git show
  origin/main:scripts/review/run-eval-matrix.sh` was written to a scratch file,
  `matrixSourcePath` (`review-eval.test.mjs:2145`) was pointed at it for one run,
  then restored: `node --test --test-name-pattern="interrupted before the parent
  recorded it" scripts/review/review-eval.test.mjs` → ✖ 1 fail, 0 pass,
  `AssertionError: the unrecorded worker's group member 86241 outlived the run`.
  Post-fix, same command against the live file → ✔ pass, 5101.2 ms.
- **Denied-inspection guard.** With a stub `ps` first on PATH that prints to
  stderr and exits 1, against the fixed source: ✖ 1 fail, `AssertionError: ps
  cannot read process state here`. That is the case the review showed passing
  green before. The denial is real on this machine, not hypothetical: `ps -o
  pgid=,ppid= -p $$` in the agent sandbox returns `operation not permitted: ps`
  (exit 127), which is why the suite below was run unsandboxed.
- **Full suite at the pushed head** (`facc02cb`, after merging `origin/main`):
  `node --test scripts/review/*.test.mjs` → tests 402, pass 402, fail 0,
  duration 61.5 s, exit 0. That run includes the `orchestratorSourceDigest` pin
  test.
- **`pnpm agent:quality-gate --run --base origin/main`: not run to completion.**
  It produced no output for 26 minutes and its scratch state stopped advancing
  after the Darwin process-identity helper was built, which matches the sandbox
  denying process inspection (`pgrep` returns `Cannot get process list` here). I
  stopped it and ran the mapped author checks directly instead, all at
  `facc02cb`: `./tools/trunk fmt` on the three changed files → "Checked 2 files
  ✔ No issues"; `./tools/trunk check --ci` on the same three → "Checked 3 files
  ✔ No issues"; `pnpm lint:scripts` → exit 0; `pnpm docs:index --check` → exit 0;
  `shellcheck -x scripts/review/run-eval-matrix.sh` → exit 0; `bash -n` on the
  same file → exit 0.
- **Independent review.** `pnpm agent:closeout-review --no-fetch --base
  origin/main --timeout-seconds 900` (codex-cli 0.153.4, gpt-5.6-sol, high,
  read-only) exited 1 with the single [P1] declined above. Report:
  `.reviews/closeout-review-20260909T151358-a5eb4bc-6538.md`. It ran at
  `a5eb4bc` with the review fixes in the working tree, before the clean merge of
  `origin/main`. It was **not** re-run on either reconciliation axis after that
  merge: the merge resolved without conflicts and changed none of this branch's
  three files (`git diff a201da98 HEAD -- scripts/review docs/evals` is empty),
  it brought only the dependency bumps in #2334 and #2335, and no code changed in
  response to the finding.
- **Nearest stronger claims the evidence does not support.** The test proves that
  one forced interrupt inside the fork-to-append gap ends the worker's group; it
  does not prove every interrupt ordering, nor that a worker's own detached
  `run_bounded` group would be reached — that case is the declined finding. The
  passing suite covers the branch's own behavior at `facc02cb`; it is not the
  repository gate, which did not run to completion here and remains required CI's
  job.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyXYSWFBZaJu9vxdWjQrei


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interruption handling for evaluation runs. When a run is stopped, both registered workers and newly started child processes are now terminated, including workers interrupted before they are fully tracked.
  - Helps prevent orphaned processes and ensures cleaner shutdowns when stopping runs with `TERM` or `INT`.

- **Tests**
  - Added regression coverage for interrupted workers and child-process cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->