### PR TITLE
ci(deps): batch npm version updates through Dependabot on Mondays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,14 @@ version: 2
 #
 # The npm entry batches routine workspace updates into Monday group PRs so
 # they arrive as a handful of themed PRs instead of one PR per package.
-# `minimumReleaseAge: 4320` in pnpm-workspace.yaml still applies at install
-# time and is the harder of the two floors for young releases. GitHub-issued
-# security advisories on pnpm-lock.yaml arrive whenever the advisory publishes;
-# no schedule here can move them. Both npm lanes use the normal CI and
-# operator-approved merge gates because the auto-merge lane accepts only
-# GitHub-owned `actions/*` minor and patch updates in the named group below.
+# `minimumReleaseAge: 4320` in pnpm-workspace.yaml is a separate three-day
+# install-time guard for versions not listed in `minimumReleaseAgeExclude`;
+# the Dependabot cooldown below is the longer floor for version-update PRs.
+# GitHub-issued security advisories on pnpm-lock.yaml arrive whenever the
+# advisory publishes; no schedule here can move them. Both npm lanes use the
+# normal CI and operator-approved merge gates because the auto-merge lane
+# accepts only GitHub-owned `actions/*` minor and patch updates in the named
+# group below.
 updates:
   # npm / pnpm workspace dependencies. The root directory covers every
   # workspace member through pnpm-lock.yaml. governance-watchdog and the two
@@ -249,6 +251,9 @@ updates:
           - "@next/*"
           - react
           - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
 
       envio-runtime-security:
         applies-to: security-updates
@@ -279,6 +284,39 @@ updates:
           - "@noble/*"
           - "@scure/*"
 
+      test-toolchain-security:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - vite
+          - jest
+          - ts-jest
+          - "@types/jest"
+          - "@stryker-mutator/*"
+          - fast-check
+          - jsdom
+          - axe-core
+          - vitest-axe
+
+      lint-toolchain-security:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - eslint
+          - "@eslint/*"
+          - "@eslint-react/*"
+          - eslint-plugin-*
+          - eslint-config-*
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - prettier
+          - knip
+          - dependency-cruiser
+          - jscpd
+          - react-doctor
+
       security-runtime:
         applies-to: security-updates
         dependency-type: production
@@ -289,6 +327,9 @@ updates:
           - "@next/*"
           - react
           - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
           - envio
           - envio-cloud
           - "@envio-dev/*"
@@ -302,6 +343,29 @@ updates:
           - "@mento-protocol/*"
           - "@noble/*"
           - "@scure/*"
+          - vitest
+          - "@vitest/*"
+          - vite
+          - jest
+          - ts-jest
+          - "@types/jest"
+          - "@stryker-mutator/*"
+          - fast-check
+          - jsdom
+          - axe-core
+          - vitest-axe
+          - eslint
+          - "@eslint/*"
+          - "@eslint-react/*"
+          - eslint-plugin-*
+          - eslint-config-*
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - prettier
+          - knip
+          - dependency-cruiser
+          - jscpd
+          - react-doctor
 
       security-tooling:
         applies-to: security-updates
@@ -313,6 +377,9 @@ updates:
           - "@next/*"
           - react
           - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
           - envio
           - envio-cloud
           - "@envio-dev/*"
@@ -326,6 +393,29 @@ updates:
           - "@mento-protocol/*"
           - "@noble/*"
           - "@scure/*"
+          - vitest
+          - "@vitest/*"
+          - vite
+          - jest
+          - ts-jest
+          - "@types/jest"
+          - "@stryker-mutator/*"
+          - fast-check
+          - jsdom
+          - axe-core
+          - vitest-axe
+          - eslint
+          - "@eslint/*"
+          - "@eslint-react/*"
+          - eslint-plugin-*
+          - eslint-config-*
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - prettier
+          - knip
+          - dependency-cruiser
+          - jscpd
+          - react-doctor
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,10 @@ version: 2
 updates:
   # npm / pnpm workspace dependencies. The root directory covers every
   # workspace member through pnpm-lock.yaml. governance-watchdog and the two
-  # alert function roots keep their own lockfiles for standalone deploys, so
-  # they need their own directories; one entry keeps a shared dependency such
-  # as viem in one grouped PR across all four roots, which is what
+  # alert function roots keep their own lockfiles for standalone deploys, and
+  # sentry-ingest-watcher is a lockfile-less Cloud Function manifest outside
+  # the workspace; they need their own directories. One entry keeps a shared
+  # dependency such as viem in one grouped PR across all roots, which is what
   # scripts/supply-chain/version-skew-check.mjs requires of the catalog.
   - package-ecosystem: npm
     directories:
@@ -27,6 +28,7 @@ updates:
       - /governance-watchdog
       - /alerts/infra/onchain-event-handler
       - /alerts/infra/oncall-announcer
+      - /alerts/infra/sentry-ingest-watcher
     schedule:
       interval: weekly
       day: monday
@@ -41,7 +43,10 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 7
 
-    # Worst case per Monday: nine version groups plus a few ungrouped majors.
+    # Worst case per Monday: nine version groups plus one PR per ungrouped
+    # major (chain-stack majors and any production major outside the named
+    # runtime groups). Dependabot defers further PRs until the count drops,
+    # so a busy week queues rather than fails.
     open-pull-requests-limit: 12
 
     labels:
@@ -160,8 +165,10 @@ updates:
           - minor
           - patch
 
-      # Catch-all so ungrouped production stragglers arrive as one weekly PR.
-      # Exclusions mirror the named groups above so group order never matters.
+      # Catch-all so ungrouped production minor and patch stragglers arrive as
+      # one weekly PR. Production majors stay individual so each gets its own
+      # review. Exclusions mirror the named groups above so group order never
+      # matters.
       production-misc:
         applies-to: version-updates
         dependency-type: production
@@ -286,7 +293,6 @@ updates:
 
       test-toolchain-security:
         applies-to: security-updates
-        dependency-type: development
         patterns:
           - vitest
           - "@vitest/*"
@@ -302,7 +308,6 @@ updates:
 
       lint-toolchain-security:
         applies-to: security-updates
-        dependency-type: development
         patterns:
           - eslint
           - "@eslint/*"
@@ -317,9 +322,9 @@ updates:
           - jscpd
           - react-doctor
 
-      security-runtime:
+      security-tooling:
         applies-to: security-updates
-        dependency-type: production
+        dependency-type: development
         patterns:
           - "*"
         exclude-patterns:
@@ -367,9 +372,10 @@ updates:
           - jscpd
           - react-doctor
 
-      security-tooling:
+      # Final catch-all with no dependency-type filter so production and
+      # indirect (transitive) advisories both land here instead of nowhere.
+      security-runtime:
         applies-to: security-updates
-        dependency-type: development
         patterns:
           - "*"
         exclude-patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -257,6 +257,19 @@ updates:
           - envio-cloud
           - "@envio-dev/*"
 
+      nest-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+
+      playwright-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - "@playwright/test"
+
       chain-stack-security:
         applies-to: security-updates
         patterns:
@@ -279,6 +292,11 @@ updates:
           - envio
           - envio-cloud
           - "@envio-dev/*"
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+          - "@playwright/test"
           - viem
           - abitype
           - "@mento-protocol/*"
@@ -298,6 +316,11 @@ updates:
           - envio
           - envio-cloud
           - "@envio-dev/*"
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+          - "@playwright/test"
           - viem
           - abitype
           - "@mento-protocol/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,309 @@
 version: 2
 
-# Keep GitHub Actions pinned to commit SHAs (not floating tags). This file is
-# scoped to github-actions only so Dependabot opens a PR whenever an action
-# we use tags a new release, letting us refresh the pinned SHA under review.
-# npm updates for this monorepo are handled out-of-band (pnpm workspace,
-# `minimumReleaseAge: 4320` in pnpm-workspace.yaml). GitHub-issued security
-# advisories on pnpm-lock.yaml still come through as Dependabot PRs even
-# without an `npm` entry here. Those PRs use the normal CI and operator-approved
-# gates because the auto-merge lane accepts only GitHub-owned `actions/*`
-# minor and patch updates in the named group below.
+# Keep GitHub Actions pinned to commit SHAs (not floating tags). The
+# github-actions entry opens a PR whenever an action we use tags a new release,
+# letting us refresh the pinned SHA under review.
+#
+# The npm entry batches routine workspace updates into Monday group PRs so
+# they arrive as a handful of themed PRs instead of one PR per package.
+# `minimumReleaseAge: 4320` in pnpm-workspace.yaml still applies at install
+# time and is the harder of the two floors for young releases. GitHub-issued
+# security advisories on pnpm-lock.yaml arrive whenever the advisory publishes;
+# no schedule here can move them. Both npm lanes use the normal CI and
+# operator-approved merge gates because the auto-merge lane accepts only
+# GitHub-owned `actions/*` minor and patch updates in the named group below.
 updates:
+  # npm / pnpm workspace dependencies. The root directory covers every
+  # workspace member through pnpm-lock.yaml. governance-watchdog and the two
+  # alert function roots keep their own lockfiles for standalone deploys, so
+  # they need their own directories; one entry keeps a shared dependency such
+  # as viem in one grouped PR across all four roots, which is what
+  # scripts/supply-chain/version-skew-check.mjs requires of the catalog.
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /governance-watchdog
+      - /alerts/infra/onchain-event-handler
+      - /alerts/infra/oncall-announcer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00" # trunk-ignore(yamllint/quoted-strings)
+      timezone: UTC
+
+    # Security updates bypass cooldown. Version updates wait so a malicious
+    # release that gets yanked days after publication never reaches a PR.
+    cooldown:
+      default-days: 7
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 7
+
+    # Worst case per Monday: nine version groups plus a few ungrouped majors.
+    open-pull-requests-limit: 12
+
+    labels:
+      - dependencies
+
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+
+    groups:
+      # Next.js and React are coupled to the Vercel deployment contract and the
+      # React Compiler pin. Isolate every level for focused verification.
+      next-runtime:
+        applies-to: version-updates
+        patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
+        update-types:
+          - major
+          - minor
+          - patch
+
+      # Envio CLI and hosted-service tooling gate the indexer build and deploy.
+      envio-runtime:
+        applies-to: version-updates
+        patterns:
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+        update-types:
+          - major
+          - minor
+          - patch
+
+      # Aegis runtime framework. NestJS packages move together.
+      nest-runtime:
+        applies-to: version-updates
+        patterns:
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+        update-types:
+          - major
+          - minor
+          - patch
+
+      # Playwright updates can require a matching browser cache key in ci.yml.
+      playwright-runtime:
+        applies-to: version-updates
+        patterns:
+          - "@playwright/test"
+        update-types:
+          - major
+          - minor
+          - patch
+
+      # Chain, signing, and protocol packages: the highest-value supply-chain
+      # target in this repo. Routine minor/patch stay in one reviewed PR;
+      # majors arrive individually.
+      chain-stack:
+        applies-to: version-updates
+        patterns:
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+        update-types:
+          - minor
+          - patch
+
+      test-toolchain:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - vite
+          - jest
+          - ts-jest
+          - "@types/jest"
+          - "@stryker-mutator/*"
+          - fast-check
+          - jsdom
+          - axe-core
+          - vitest-axe
+        update-types:
+          - major
+          - minor
+          - patch
+
+      lint-toolchain:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - eslint
+          - "@eslint/*"
+          - "@eslint-react/*"
+          - eslint-plugin-*
+          - eslint-config-*
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - prettier
+          - knip
+          - dependency-cruiser
+          - jscpd
+          - react-doctor
+        update-types:
+          - major
+          - minor
+          - patch
+
+      # Catch-all so ungrouped production stragglers arrive as one weekly PR.
+      # Exclusions mirror the named groups above so group order never matters.
+      production-misc:
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - "*"
+        exclude-patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+          - "@playwright/test"
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+        update-types:
+          - minor
+          - patch
+
+      tooling:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+          - babel-plugin-react-compiler
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+          - "@nestjs/*"
+          - "@willsoto/nestjs-prometheus"
+          - reflect-metadata
+          - rxjs
+          - "@playwright/test"
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+          - vitest
+          - "@vitest/*"
+          - vite
+          - jest
+          - ts-jest
+          - "@types/jest"
+          - "@stryker-mutator/*"
+          - fast-check
+          - jsdom
+          - axe-core
+          - vitest-axe
+          - eslint
+          - "@eslint/*"
+          - "@eslint-react/*"
+          - eslint-plugin-*
+          - eslint-config-*
+          - typescript-eslint
+          - "@typescript-eslint/*"
+          - prettier
+          - knip
+          - dependency-cruiser
+          - jscpd
+          - react-doctor
+
+      # Security updates keep the same boundaries so a chain-stack advisory
+      # never shares a PR with an unrelated tooling fix.
+      next-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+
+      envio-runtime-security:
+        applies-to: security-updates
+        patterns:
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+
+      chain-stack-security:
+        applies-to: security-updates
+        patterns:
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+
+      security-runtime:
+        applies-to: security-updates
+        dependency-type: production
+        patterns:
+          - "*"
+        exclude-patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+
+      security-tooling:
+        applies-to: security-updates
+        dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - next
+          - "@next/*"
+          - react
+          - react-dom
+          - envio
+          - envio-cloud
+          - "@envio-dev/*"
+          - viem
+          - abitype
+          - "@mento-protocol/*"
+          - "@noble/*"
+          - "@scure/*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/docs/README.md
+++ b/docs/README.md
@@ -217,6 +217,7 @@ Authority: canonical
 - [`docs/adr/0088-temporary-m6-canary-collection.md`](adr/0088-temporary-m6-canary-collection.md) — Temporary event-driven M6 canary collection
 - [`docs/adr/0089-review-eval-canonical-matrix-pr-groups.md`](adr/0089-review-eval-canonical-matrix-pr-groups.md) — The canonical review-eval matrix runs PR groups concurrently
 - [`docs/adr/0090-canonical-eval-matrix-freshness-floor.md`](adr/0090-canonical-eval-matrix-freshness-floor.md) — The canonical review-eval matrix is a freshness floor
+- [`docs/adr/0092-dependabot-npm-version-updates.md`](adr/0092-dependabot-npm-version-updates.md) — Dependabot batches npm version updates into Monday groups
 
 Authority: non-canonical
 

--- a/docs/adr/0092-dependabot-npm-version-updates.md
+++ b/docs/adr/0092-dependabot-npm-version-updates.md
@@ -50,16 +50,19 @@ Add an `npm` update entry to `.github/dependabot.yml`:
   development tooling; `production-misc` and `tooling` catch the rest.
 - Security-update groups mirror the same boundaries (`next-runtime-security`,
   `envio-runtime-security`, `nest-runtime-security`,
-  `playwright-runtime-security`, `chain-stack-security`, `security-runtime`,
+  `playwright-runtime-security`, `chain-stack-security`,
+  `test-toolchain-security`, `lint-toolchain-security`, `security-runtime`,
   `security-tooling`).
 - Every npm PR stays on the operator-authorized merge path. The
   [ADR 0081](0081-narrow-dependabot-auto-merge-exception.md) lane requires the
   `github_actions` ecosystem and the exact `actions-minor-patch` group, so no
   npm PR can enter it.
 
-`minimumReleaseAge` remains in force; Dependabot's cooldown is a second,
-earlier floor for version updates, and the install-time gate still applies to
-the resulting lockfile.
+The two floors are separate. Dependabot's cooldown decides when a version
+update may become a PR: seven days for minor and patch, 21 for major, none
+for security updates. pnpm's `minimumReleaseAge` is a three-day install-time
+guard on every lockfile entry not listed in `minimumReleaseAgeExclude`; it
+still applies to the lockfile a Dependabot PR produces.
 
 ## Alternatives considered
 

--- a/docs/adr/0092-dependabot-npm-version-updates.md
+++ b/docs/adr/0092-dependabot-npm-version-updates.md
@@ -1,0 +1,87 @@
+---
+title: Dependabot batches npm version updates into Monday groups
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-09-10
+scope: ci/process
+date: 2026-09
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0092 — Dependabot batches npm version updates into Monday groups
+
+**Status:** Accepted (Sep 2026), in force.
+**Scope:** ci/process
+
+## Context
+
+Since [ADR 0009](0009-supply-chain-hardening.md) the repository limited
+Dependabot to the `github-actions` ecosystem. Routine npm bumps were manual
+work behind `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`. Security
+advisories on `pnpm-lock.yaml` still arrived as Dependabot PRs under GitHub's
+default `npm_and_yarn` group, on whatever day the advisory published.
+
+Two costs grew with the workspace. Manual bumps landed in irregular batches
+(for example PRs 2334, 2335, 2336, 2339 in one week) and depended on someone
+remembering to run them. Security PRs carried no group boundary, so a
+wallet-adjacent advisory and a lint-plugin advisory could share one PR.
+`frontend-monorepo` already runs an `npm` Dependabot entry with themed groups
+on the same Monday cadence, so the two repositories diverged in process for no
+protocol reason.
+
+## Decision
+
+Add an `npm` update entry to `.github/dependabot.yml`:
+
+- Weekly on Monday 06:00 UTC across the workspace root and the three
+  standalone lockfile roots (`governance-watchdog`, the two alert function
+  roots) in one entry, so a shared dependency lands in one grouped PR and
+  `pnpm skew:check` keeps the catalog aligned.
+- Cooldown of 7 days for minor and patch and 21 days for major. Security
+  updates bypass cooldown by GitHub design.
+- Version-update groups by blast radius: `next-runtime`, `envio-runtime`,
+  `nest-runtime`, and `playwright-runtime` isolate deployment-coupled
+  runtimes at every level; `chain-stack` keeps viem, abitype, `@noble/*`,
+  `@scure/*`, and `@mento-protocol/*` minor and patch in one reviewed PR with
+  majors arriving alone; `test-toolchain` and `lint-toolchain` batch
+  development tooling; `production-misc` and `tooling` catch the rest.
+- Security-update groups mirror the same boundaries (`chain-stack-security`,
+  `next-runtime-security`, `envio-runtime-security`, `security-runtime`,
+  `security-tooling`).
+- Every npm PR stays on the operator-authorized merge path. The
+  [ADR 0081](0081-narrow-dependabot-auto-merge-exception.md) lane requires the
+  `github_actions` ecosystem and the exact `actions-minor-patch` group, so no
+  npm PR can enter it.
+
+`minimumReleaseAge` remains in force; Dependabot's cooldown is a second,
+earlier floor for version updates, and the install-time gate still applies to
+the resulting lockfile.
+
+## Alternatives considered
+
+- **Keep npm manual.** Rejected: the work was already happening, just
+  irregularly and without a boundary between risk tiers.
+- **One catch-all npm group.** Rejected: a Next.js or Envio runtime bump needs
+  its own verification and would block the rest of the batch.
+- **Disable Dependabot security updates to stop off-Monday PRs.** Rejected:
+  security PRs are the only lane that bypasses the 3-day release-age hold.
+  Their timing is set by advisory publication and cannot be scheduled.
+
+## Consequences
+
+- Expect up to nine grouped PRs on a Monday, plus ungrouped chain-stack majors.
+  `open-pull-requests-limit: 12` leaves headroom.
+- Adding a package that belongs to a runtime or chain group means editing the
+  group patterns and the mirrored `exclude-patterns` in the same change.
+- ADR 0081's context sentence that Dependabot is limited to GitHub Actions is
+  historical as of this record; its decision and lane boundary are unchanged.
+
+## Evidence
+
+- `.github/dependabot.yml`, `scripts/production-infra-identity-contract/workflow.test.mjs`
+  (pins the unchanged `github-actions` entry),
+  [`docs/pr-checklists/ci-workflow-gates.md`](../pr-checklists/ci-workflow-gates.md) §7.
+- Reference setup: `mento-protocol/frontend-monorepo` `.github/dependabot.yml`.

--- a/docs/adr/0092-dependabot-npm-version-updates.md
+++ b/docs/adr/0092-dependabot-npm-version-updates.md
@@ -48,8 +48,9 @@ Add an `npm` update entry to `.github/dependabot.yml`:
   `@scure/*`, and `@mento-protocol/*` minor and patch in one reviewed PR with
   majors arriving alone; `test-toolchain` and `lint-toolchain` batch
   development tooling; `production-misc` and `tooling` catch the rest.
-- Security-update groups mirror the same boundaries (`chain-stack-security`,
-  `next-runtime-security`, `envio-runtime-security`, `security-runtime`,
+- Security-update groups mirror the same boundaries (`next-runtime-security`,
+  `envio-runtime-security`, `nest-runtime-security`,
+  `playwright-runtime-security`, `chain-stack-security`, `security-runtime`,
   `security-tooling`).
 - Every npm PR stays on the operator-authorized merge path. The
   [ADR 0081](0081-narrow-dependabot-auto-merge-exception.md) lane requires the

--- a/docs/adr/0092-dependabot-npm-version-updates.md
+++ b/docs/adr/0092-dependabot-npm-version-updates.md
@@ -36,9 +36,10 @@ protocol reason.
 
 Add an `npm` update entry to `.github/dependabot.yml`:
 
-- Weekly on Monday 06:00 UTC across the workspace root and the three
+- Weekly on Monday 06:00 UTC across the workspace root, the three
   standalone lockfile roots (`governance-watchdog`, the two alert function
-  roots) in one entry, so a shared dependency lands in one grouped PR and
+  roots), and the lockfile-less `sentry-ingest-watcher` Cloud Function
+  manifest, in one entry, so a shared dependency lands in one grouped PR and
   `pnpm skew:check` keeps the catalog aligned.
 - Cooldown of 7 days for minor and patch and 21 days for major. Security
   updates bypass cooldown by GitHub design.
@@ -47,12 +48,18 @@ Add an `npm` update entry to `.github/dependabot.yml`:
   runtimes at every level; `chain-stack` keeps viem, abitype, `@noble/*`,
   `@scure/*`, and `@mento-protocol/*` minor and patch in one reviewed PR with
   majors arriving alone; `test-toolchain` and `lint-toolchain` batch
-  development tooling; `production-misc` and `tooling` catch the rest.
+  development tooling at every level; `production-misc` catches remaining
+  production minor and patch updates, and `tooling` catches remaining
+  development updates. Production majors outside the named groups arrive as
+  individual PRs so each gets its own review.
 - Security-update groups mirror the same boundaries (`next-runtime-security`,
   `envio-runtime-security`, `nest-runtime-security`,
   `playwright-runtime-security`, `chain-stack-security`,
-  `test-toolchain-security`, `lint-toolchain-security`, `security-runtime`,
-  `security-tooling`).
+  `test-toolchain-security`, `lint-toolchain-security`, `security-tooling`,
+  and a final untyped `security-runtime` catch-all). The named security
+  groups carry no `dependency-type` filter, so an advisory on an indirect
+  (transitive) dependency still lands in its themed group instead of falling
+  through every typed group.
 - Every npm PR stays on the operator-authorized merge path. The
   [ADR 0081](0081-narrow-dependabot-auto-merge-exception.md) lane requires the
   `github_actions` ecosystem and the exact `actions-minor-patch` group, so no
@@ -62,7 +69,11 @@ The two floors are separate. Dependabot's cooldown decides when a version
 update may become a PR: seven days for minor and patch, 21 for major, none
 for security updates. pnpm's `minimumReleaseAge` is a three-day install-time
 guard on every lockfile entry not listed in `minimumReleaseAgeExclude`; it
-still applies to the lockfile a Dependabot PR produces.
+still applies to the lockfile a Dependabot PR produces. A security PR whose
+patched release is younger than three days therefore opens immediately but
+fails the frozen install until that version is added to
+`minimumReleaseAgeExclude`, which is the existing procedure for security
+override floors.
 
 ## Alternatives considered
 
@@ -71,13 +82,16 @@ still applies to the lockfile a Dependabot PR produces.
 - **One catch-all npm group.** Rejected: a Next.js or Envio runtime bump needs
   its own verification and would block the rest of the batch.
 - **Disable Dependabot security updates to stop off-Monday PRs.** Rejected:
-  security PRs are the only lane that bypasses the 3-day release-age hold.
-  Their timing is set by advisory publication and cannot be scheduled.
+  security PRs are the only lane that skips Dependabot's cooldown, so they
+  are the earliest signal that a patched release exists. Their timing is set
+  by advisory publication and cannot be scheduled.
 
 ## Consequences
 
-- Expect up to nine grouped PRs on a Monday, plus ungrouped chain-stack majors.
-  `open-pull-requests-limit: 12` leaves headroom.
+- Expect up to nine grouped PRs on a Monday, plus one PR per ungrouped major
+  (chain-stack majors and production majors outside the named runtime groups).
+  `open-pull-requests-limit: 12` covers the common week; in a heavier week
+  Dependabot defers the remainder until open PRs drop below the limit.
 - Adding a package that belongs to a runtime or chain group means editing the
   group patterns and the mirrored `exclude-patterns` in the same change.
 - ADR 0081's context sentence that Dependabot is limited to GitHub Actions is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,6 +100,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0088](0088-temporary-m6-canary-collection.md)              | Collect temporary M6 canary evidence after CI without per-PR operator requests       |
 | [0089](0089-review-eval-canonical-matrix-pr-groups.md)      | The canonical review-eval matrix runs PR groups concurrently                         |
 | [0090](0090-canonical-eval-matrix-freshness-floor.md)       | Canonical full run drops to 27 cells; repeat draws live in the experiment lane       |
+| [0092](0092-dependabot-npm-version-updates.md)              | Dependabot batches npm version updates into Monday groups; npm stays operator-merged |
 
 ### shared-config
 

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -260,8 +260,9 @@ and `npm`. Both run weekly on Monday. The npm entry batches routine workspace
 updates into themed groups (`next-runtime`, `envio-runtime`, `nest-runtime`,
 `playwright-runtime`, `chain-stack`, `test-toolchain`, `lint-toolchain`, plus
 `production-misc` and `tooling` catch-alls) and mirrors those boundaries for
-security updates. `minimumReleaseAge: 4320` in `pnpm-workspace.yaml` still
-gates every install. GitHub-issued security advisories on `pnpm-lock.yaml` open
+security updates. `minimumReleaseAge: 4320` in `pnpm-workspace.yaml` is a
+separate three-day install-time guard for versions not listed in
+`minimumReleaseAgeExclude`. GitHub-issued security advisories on `pnpm-lock.yaml` open
 as soon as the advisory publishes; the schedule does not apply to them. See
 [ADR 0092](../adr/0092-dependabot-npm-version-updates.md).
 

--- a/docs/pr-checklists/ci-workflow-gates.md
+++ b/docs/pr-checklists/ci-workflow-gates.md
@@ -255,7 +255,15 @@ Audit workflows that "tolerate transient errors" become attack surface — an at
 
 ## 7. Dependabot policy
 
-Dependabot is scoped to the `github-actions` ecosystem (`.github/dependabot.yml`). npm is handled by pnpm with `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`; GitHub-issued security advisories on `pnpm-lock.yaml` still come through as Dependabot PRs without an `npm` entry.
+Dependabot covers two ecosystems in `.github/dependabot.yml`: `github-actions`
+and `npm`. Both run weekly on Monday. The npm entry batches routine workspace
+updates into themed groups (`next-runtime`, `envio-runtime`, `nest-runtime`,
+`playwright-runtime`, `chain-stack`, `test-toolchain`, `lint-toolchain`, plus
+`production-misc` and `tooling` catch-alls) and mirrors those boundaries for
+security updates. `minimumReleaseAge: 4320` in `pnpm-workspace.yaml` still
+gates every install. GitHub-issued security advisories on `pnpm-lock.yaml` open
+as soon as the advisory publishes; the schedule does not apply to them. See
+[ADR 0092](../adr/0092-dependabot-npm-version-updates.md).
 
 Dependabot groups routine updates. One exact group can auto-merge through
 `.github/workflows/dependabot-auto-merge.yml`.
@@ -279,7 +287,9 @@ Dependabot groups routine updates. One exact group can auto-merge through
 - **`dependabot/*`:** require an operator-authorized merge. `dependabot/fetch-metadata`
   classifies this auto-merge lane, so it cannot update itself through the lane.
   Dependabot-owned actions remain separate from other third-party groups.
-- **Every non-GitHub-Actions ecosystem:** require an operator-authorized merge.
+- **Every npm group, version or security:** require an operator-authorized merge.
+  The auto-merge classifier requires the `github_actions` ecosystem, so no
+  npm PR can enter the lane.
 
 All version-update tiers use `default-days: 7`; the `github-actions` ecosystem
 has no per-tier cooldown. GitHub skips cooldown for security updates. Requiring


### PR DESCRIPTION
## The Problem

- Dependabot only covered `github-actions`. Routine npm bumps were manual and landed irregularly (2334, 2335, 2336, 2339 in one week) or not at all.
- Security PRs on `pnpm-lock.yaml` arrived under GitHub's default `npm_and_yarn` group, so a chain-stack advisory and a lint-plugin advisory could share one PR.
- `frontend-monorepo` already batches npm through themed Monday groups, so the two repos diverged in process for no protocol reason.

## The Solution

Add an `npm` Dependabot entry that runs weekly on Monday 06:00 UTC across the workspace root, the three standalone lockfile roots, and the lockfile-less sentry-ingest-watcher Cloud Function manifest. Routine updates arrive as up to nine themed group PRs (`next-runtime`, `envio-runtime`, `nest-runtime`, `playwright-runtime`, `chain-stack`, `test-toolchain`, `lint-toolchain`, `production-misc`, `tooling`) instead of one PR per package; majors outside the named runtime groups still arrive individually for their own review. Security updates use the same boundaries, with a final untyped catch-all so indirect advisories land somewhere. Every npm PR stays on the operator-authorized merge path.

Limits: security PRs still open whenever GitHub publishes the advisory. No Dependabot schedule applies to them, so a Thursday security PR like 2344 will still happen. `minimumReleaseAge: 4320` in `pnpm-workspace.yaml` still gates every install.

## Details

- Cooldown 7 days for minor and patch, 21 days for major. Security updates bypass cooldown by GitHub design.
- Deployment-coupled runtimes (Next.js and React, Envio, NestJS, Playwright) group at every semver level so each gets its own verification. `chain-stack` (viem, abitype, `@noble/*`, `@scure/*`, `@mento-protocol/*`) groups minor and patch; majors arrive individually.
- One entry with five `directories` keeps a shared dependency in one grouped PR across all lockfile roots, which `pnpm skew:check` requires of the viem catalog pin.
- `open-pull-requests-limit: 12` leaves headroom above the nine groups.
- The `github-actions` entry is byte-identical. The ADR 0081 classifier requires the `github_actions` ecosystem and the exact `actions-minor-patch` group, so no npm PR can enter the auto-merge lane.
- ADR 0092 records the decision. `docs/pr-checklists/ci-workflow-gates.md` §7 and both ADR indexes are updated. ADR 0081's context sentence about the actions-only scope is now historical; its decision is unchanged.
- Merging this file triggers an immediate Dependabot run, so expect the first npm group PRs shortly after merge rather than next Monday.

## Validation

- `node scripts/production-infra-identity-contract/workflow.test.mjs` passes: the pinned `github-actions` entry shape is unchanged. It does not validate the npm entry.
- `trunk check` on `.github/dependabot.yml` and the four docs files: no issues. YAML parses with two `updates` entries and 14 npm groups. This proves the file is well-formed, not that Dependabot accepts every key; the schema mirrors the frontend-monorepo entry that is live and producing group PRs.
- `pnpm adr:check`, `pnpm agent:context-check`, `pnpm docs:index` pass.
- Not verified: actual group assignment. That evidence arrives with the first Dependabot run after merge.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? If this makes one, an ADR is added under `docs/adr/` (see `docs/pr-checklists/architecture-decisions.md`); otherwise not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fs67umu8dDRKWvTFYbVfFz
