### PR TITLE
fix(ci): include repository in Slack failure alerts

### DIFF
--- a/.github/workflows/notify-slack-on-main-failure.yml
+++ b/.github/workflows/notify-slack-on-main-failure.yml
@@ -106,6 +106,7 @@ jobs:
           COMMIT_MSG: ${{ github.event.workflow_run.display_title }}
           ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
           EVENT: ${{ github.event.workflow_run.event }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
 
@@ -152,13 +153,14 @@ jobs:
               --arg msg "$COMMIT_MSG" \
               --arg actor "$ACTOR" \
               --arg event "$EVENT" \
+              --arg repo "$REPOSITORY_NAME" \
               '($msg | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) as $safe_msg
                | (if $actor != "" and $actor != "null" then "\n*Triggered by:* " + $actor elif $event == "schedule" then "\n*Triggered by:* scheduled cron" else "" end) as $actor_line
                | {
                 channel: $ch,
-                text: ("❌ " + $wf + " failed on main (" + $sha + ")"),
+                text: ("❌ " + $wf + " failed on main in " + $repo + " (" + $sha + ")"),
                 blocks: [
-                  {type: "section", text: {type: "mrkdwn", text: ("❌ *<" + $url + "|" + $wf + ">* failed on `main`")}},
+                  {type: "section", text: {type: "mrkdwn", text: ("❌ *<" + $url + "|" + $wf + "> failed on* `main` *in " + $repo + "*")}},
                   {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `" + $sha + "` — " + $safe_msg + $actor_line + "\n\n<" + $url + "|View failed run →>")}}
                 ]
               }')


### PR DESCRIPTION
## The Problem

> **TL;DR:** Failure alerts in the shared CI channel identified the workflow and branch but omitted the source repository. This made similarly named workflows ambiguous until someone opened the run link.

- Operators could not identify the failing repository from the alert headline or notification preview.

## The Solution

Add the repository name to both the visible Slack headline and the plain-text notification fallback. The existing manual wiring-test message and failure details remain unchanged.

## Details

- Read the repository name from GitHub's event metadata.
- Pass it to `jq` through `--arg`, preserving the workflow's existing shell-injection boundary.
- Render production alerts as ``❌ *<run URL|workflow> failed on* `main` *in repository*``.

## Validation

- `pnpm agent:quality-gate --run` — all 7 mapped commands passed, including targeted Trunk/actionlint, action pinning, autofix trust, Terraform identity contracts, Sentry CI wiring, and docs navigation fixtures. This proves the workflow passes the repository's static and contract checks; it does not prove Slack's live rendering.
- Representative `jq` payload render — produced ``❌ *<https://github.com/mento-protocol/monitoring-monorepo/actions/runs/34449921384|Trunk> failed on* `main` *in monitoring-monorepo*``. This proves the local payload string matches the requested format; it does not post to Slack.
- `git diff --check origin/main...HEAD` — passed with no whitespace errors.
- `pnpm agent:closeout-review --base origin/main --no-fetch` — clean at `eaa19334` against `f9fa63aa`; the follow-up review-skill pass also found no defects. These are source reviews and do not prove live delivery.
- The Claude security scan was not run because it would send the committed diff to Anthropic and this task did not authorize that egress. Local security review confirmed the workflow keeps `contents: read`, adds no third-party action, and passes the repository name through `env` and `jq --arg`; this does not replace a specialized external security scan.

## Deferrals

- None

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] Architecture decision? Not applicable; this changes alert copy only.
