### PR TITLE
Persist numeric log indexes for trove operation ordering

### DIFF
--- a/docs/notes/liquity-monitoring-invariants.md
+++ b/docs/notes/liquity-monitoring-invariants.md
@@ -102,3 +102,41 @@ handler bug. Use Blockscout or an RPC log query to count event topic hashes over
 the contract's complete relevant history. If the event is absent, select a
 different emitted signal, maintain a transition delta, or use a bounded
 `eth_call`; changing handler code cannot manufacture a missing event.
+
+## Operation ordering rollout
+
+`TroveOperationEvent.logIndex` stores the original numeric event ordinal.
+Its ID remains `eventId(chainId, blockNumber, logIndex)`. User-operation
+inclusion and batch snapshot semantics remain unchanged. Numeric readers order
+by `timestamp`, `blockNumber`, and `logIndex` before applying a row limit.
+Legacy readers remain compatible with the additive field. The separate
+`TroveLedgerEvent` contract in ADR 0074 remains unchanged.
+
+A new field in introspection proves compatibility, not historical completeness.
+Use the `deploy-indexer` workflow for candidate replay and promotion. Before
+promotion, record this evidence in the rollout tracker:
+
+1. Record the candidate SHA, resolved configuration, endpoint, and effective
+   start blocks. Mainnet currently configures the three Celo TroveManagers
+   (GBPm, CHFm, JPYm) from block `60664500`; the other mainnet chains have no
+   configured TroveManagers. Celo Sepolia defaults to `18946570`. Verify the
+   candidate configuration and environment overrides; do not move these
+   starts forward to shorten replay.
+2. Wait for the full configured history to replay. For every configured
+   market, query its earliest and recent operation rows. Match `chainId`,
+   `blockNumber`, and `logIndex` to the three numeric ID components and to
+   representative canonical `TroveOperation` logs. Record the covered block
+   range and row counts. Never fill absent ordinals with a default value.
+3. Query a trove with same-timestamp operations using descending numeric
+   `timestamp`, `blockNumber`, and `logIndex`. Confirm the server applies this
+   order before `limit: 1000`. Pair limited live history with the consumer's
+   reproducible Hasura cap-boundary fixture; do not claim live cap coverage
+   when the selected trove has fewer than 1,001 operations.
+4. After separately approved promotion, repeat the field and historical-row
+   checks on the static endpoint. Keep the dashboard's old-schema query
+   available for schema lag and rollback. A capped legacy response cannot
+   guarantee the newest 999 operations, even after client sorting.
+
+A caught-up status, successful deployment job, or new-event sample alone does
+not satisfy the historical replay requirement. Keep rollout issue #2103 open
+until producer promotion and consumer deployment evidence are complete.

--- a/indexer-envio/schema.graphql
+++ b/indexer-envio/schema.graphql
@@ -1918,6 +1918,7 @@ type TroveOperationEvent
   debtIncreaseFromUpfrontFee: BigInt!
   timestamp: BigInt! @index
   blockNumber: BigInt!
+  logIndex: Int!
   txHash: String!
 }
 

--- a/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
+++ b/indexer-envio/src/handlers/liquity/troveOperationSnapshot.ts
@@ -193,6 +193,7 @@ export function maybeRecordTroveOperation(args: {
     debtIncreaseFromUpfrontFee: event.params._debtIncreaseFromUpfrontFee,
     timestamp: args.blockTimestamp,
     blockNumber: args.blockNumber,
+    logIndex: event.logIndex,
     txHash: event.transaction.hash,
   });
 }

--- a/indexer-envio/test/troveOperationSnapshot.test.ts
+++ b/indexer-envio/test/troveOperationSnapshot.test.ts
@@ -186,6 +186,7 @@ describe("TroveOperationEvent before/after snapshot (issue #2080)", () => {
       0n,
       "regression: open row's collBefore is 0, not the post-open coll",
     );
+    assert.equal(row?.logIndex, 2);
     assert.equal(row?.debtAfter, 1_000n * 10n ** 18n);
     assert.equal(row?.collAfter, 500n * 10n ** 18n);
   });
@@ -403,6 +404,7 @@ describe("TroveOperationEvent before/after snapshot (issue #2080)", () => {
       row,
       "TroveOperationEvent row is written for OPEN_TROVE_AND_JOIN_BATCH",
     );
+    assert.equal(row.logIndex, 2);
     assert.equal(
       row?.debtBefore,
       undefined,
@@ -484,6 +486,31 @@ describe("troveOperationSnapshot unit edges", () => {
     assert.equal(rows[0]!.collBefore, 0n, "950 - 1000 floors at zero");
     assert.equal(rows[0]!.debtAfter, 700n);
     assert.equal(rows[0]!.collAfter, 950n);
+  });
+
+  it("preserves numeric log indexes and distinct IDs within one block", () => {
+    const rows: TroveOperationEvent[] = [];
+    for (const logIndex of [0, 9, 10, 101]) {
+      maybeRecordTroveOperation({
+        context: { TroveOperationEvent: { set: (row) => rows.push(row) } },
+        op: OP.ADJUST_TROVE,
+        event: { ...makeEvent(), logIndex },
+        instanceId: "instance-1",
+        troveId: "0x1",
+        snapshotState: { owner: "0xaa", debtAfter: 1n, collAfter: 1n },
+        pendingBatchedTroveUpdate: undefined,
+        blockNumber: 42n,
+        blockTimestamp: 1_000n,
+      });
+    }
+    assert.deepEqual(
+      rows.map((row) => row.logIndex),
+      [0, 9, 10, 101],
+    );
+    assert.deepEqual(
+      rows.map((row) => row.id),
+      [0, 9, 10, 101].map((ordinal) => `${market.chainId}_42_${ordinal}`),
+    );
   });
 
   it("writes no row for ops that own dedicated event entities or are protocol-forced", () => {

--- a/ui-dashboard/src/lib/__generated__/graphql.ts
+++ b/ui-dashboard/src/lib/__generated__/graphql.ts
@@ -5410,6 +5410,7 @@ export type TroveOperationEventSelectColumn =
   | "debtIncreaseFromUpfrontFee"
   | "id"
   | "instanceId"
+  | "logIndex"
   | "operation"
   | "owner"
   | "timestamp"
@@ -5429,6 +5430,7 @@ export type TroveOperationEventOrderBy = {
   readonly debtIncreaseFromUpfrontFee?: OrderBy;
   readonly id?: OrderBy;
   readonly instanceId?: OrderBy;
+  readonly logIndex?: OrderBy;
   readonly operation?: OrderBy;
   readonly owner?: OrderBy;
   readonly timestamp?: OrderBy;
@@ -5456,6 +5458,7 @@ export type TroveOperationEventBoolExp = {
   readonly debtIncreaseFromUpfrontFee?: ComparisonExp<string>;
   readonly id?: ComparisonExp<string>;
   readonly instanceId?: ComparisonExp<string>;
+  readonly logIndex?: ComparisonExp<number>;
   readonly operation?: ComparisonExp<number>;
   readonly owner?: ComparisonExp<string>;
   readonly timestamp?: ComparisonExp<string>;


### PR DESCRIPTION
## The Problem

Trove operation IDs contain unpadded block and log numbers. Hasura cannot use those strings to select the newest operations reliably before its row cap. Client sorting cannot recover rows omitted by that cap.

## The Solution

Persist each operation's numeric log index. This additive producer change lets a separate dashboard child PR order by timestamp, block number and log index on the server. Existing readers, IDs, user-operation selection and batch snapshots keep their behavior. Full historical replay and separately approved promotion remain required.

## Details

Native stack #2368: [producer #2360](https://github.com/mento-protocol/monitoring-monorepo/pull/2360) → [consumer #2367](https://github.com/mento-protocol/monitoring-monorepo/pull/2367). Protection base: `main`. Membership verified through GitHub stacks API; each layer needs its own current-head readiness.

### Invariants

- Persist the event ordinal directly, including zero. Never synthesize an ordinal for missing historical data.
- Keep operation IDs and excluded protocol operation classes unchanged.
- Keep the complete TroveLedgerEvent contract separate.

### Degraded behavior

The existing dashboard query remains compatible. This parent does not switch the reader. Schema presence alone does not prove historical completeness; the replay checklist requires earliest and recent rows across all configured markets.

### Intentional non-goals

Consumer query selection, Recent Transactions ordering, deployment, promotion and merge are outside this parent.

## Validation

- Passed: testnet, bridge-only and final mainnet indexer code generation.
- Passed: indexer lint and typecheck; full unit suite 1,193 passed, 44 skipped across 85 files (139.25 seconds).
- Passed: producer assertions for individual and batch-managed operations, unchanged exclusions, and same-block ordinals 0, 9, 10 and 101.
- Passed: dashboard codegen; generated diff contains only the three new logIndex select/order/filter type fields.
- Passed: dashboard full unit suite, 5,114 tests across 333 files (32.31 seconds).
- Passed: metrics-bridge full unit suite, 618 tests (2.52 seconds).
- Passed: Trunk formatting, diff whitespace check, docs index and agent context check (178 managed files).
- Closeout review: command refused nested Codex execution (exit 2). Used the operating card's permitted single-source fallback. Independent root source review found no findings against base a746e1c5a45938318303633fa7cddc009f92d0ef and tree 1e7a73e0737d378323eea3871fcb29b236592b71. Commit 44d662d5387f615e5181f6319299101f3b5d233f preserves that tree.
- Browser: not required for this additive producer and generated contract change; consumer browser and actual Hasura cap-boundary proof belong to #2354.
- Claude Security scan: skipped (Codex surface).

Scope baseline: 5 changed files, 43 non-test added lines, 70 total added lines, 0 deleted. Diff base a746e1c5a45938318303633fa7cddc009f92d0ef; protection base main. Parent of the planned native #2103 stack; child #2354 will target this branch.

## Deferrals

Refs #2353. Refs #2103. Consumer implementation and Hasura cap-boundary proof are tracked in #2354. Historical replay, promotion, deployment and production acceptance remain in #2103 and require separate authorization. Native stack transition evidence is tracked in #2286.

## Checklist

- [x] The opening explains old behavior, new behavior, benefit and limits.
- [x] Validation records commands and source review. Offline tests do not prove hosted historical replay or production behavior.
- [x] Deferrals have linked issues.
- [x] Architecture decision: not applicable; additive field follows the existing numeric ledger ordering contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trove operation events now include a log index to preserve event ordering and distinguish multiple events within the same block.

- **Bug Fixes**
  - Improved accuracy for replaying and identifying same-block trove operations.

- **Tests**
  - Added coverage for numeric log indexes, event ordering, and unique event identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->