### PR TITLE
Export complete bridge transfer snapshots for alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Real-time monitoring infrastructure for Mento v3 on-chain pools — a multichain
 | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | [`indexer-envio`](./indexer-envio/)                                     | Envio HyperIndex indexer — Celo, Monad, Polygon, and Ethereum reserve-yield data                            |
 | [`ui-dashboard`](./ui-dashboard/)                                       | Next.js 16 + Plotly.js multi-chain dashboard — all chains shown together, network derived from the pool URL |
-| [`metrics-bridge`](./metrics-bridge/)                                   | Hasura state + isolated CEX/RPC peg observations → Prometheus metrics and current peg decisions             |
+| [`metrics-bridge`](./metrics-bridge/)                                   | Hasura state, isolated NTT transfer observations and CEX/RPC peg observations → Prometheus metrics          |
 | [`shared-config`](./shared-config/)                                     | Public `@mento-protocol/config` package for protocol metadata, thresholds, and shared ABIs                  |
 | [`aegis`](./aegis/)                                                     | App Engine v2 alerting service + Aegis Grafana dashboards                                                   |
 | [`integration-probes`](./integration-probes/)                           | Read-only DEX aggregator and cross-chain router probes → Upstash and dashboard                              |

--- a/docs/README.md
+++ b/docs/README.md
@@ -221,6 +221,7 @@ Authority: canonical
 - [`adr/0092-dependabot-npm-version-updates.md`](adr/0092-dependabot-npm-version-updates.md) — Dependabot batches npm version updates into Monday groups
 - [`adr/0093-opt-in-native-stacked-pull-requests.md`](adr/0093-opt-in-native-stacked-pull-requests.md) — Adopt native stacked pull requests through an opt-in pilot
 - [`adr/0094-grid-waiver.md`](adr/0094-grid-waiver.md) — Scale the control waiver to grid scope
+- [`adr/0094-isolated-bridge-transfer-observations.md`](adr/0094-isolated-bridge-transfer-observations.md) — Bridge transfers use isolated complete observations
 
 Authority: non-canonical
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -221,7 +221,7 @@ Authority: canonical
 - [`adr/0092-dependabot-npm-version-updates.md`](adr/0092-dependabot-npm-version-updates.md) — Dependabot batches npm version updates into Monday groups
 - [`adr/0093-opt-in-native-stacked-pull-requests.md`](adr/0093-opt-in-native-stacked-pull-requests.md) — Adopt native stacked pull requests through an opt-in pilot
 - [`adr/0094-grid-waiver.md`](adr/0094-grid-waiver.md) — Scale the control waiver to grid scope
-- [`adr/0094-isolated-bridge-transfer-observations.md`](adr/0094-isolated-bridge-transfer-observations.md) — Bridge transfers use isolated complete observations
+- [`adr/0095-isolated-bridge-transfer-observations.md`](adr/0095-isolated-bridge-transfer-observations.md) — Bridge transfers use isolated complete observations
 
 Authority: non-canonical
 

--- a/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
+++ b/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
@@ -16,7 +16,8 @@ garden_lane: adrs-architecture
 **Status:** Accepted (Apr 2026), in force. Scope extended by
 [ADR 0042](0042-metrics-bridge-external-price-poller.md) (Jul 2026): the
 bridge additionally hosts an isolated external market-price peg-polling
-lifecycle.
+lifecycle. [ADR 0094](0094-isolated-bridge-transfer-observations.md) adds an
+isolated bridge-transfer observation lifecycle.
 **Scope:** metrics-bridge
 
 ## Context
@@ -28,9 +29,10 @@ threshold data it can't scrape.
 
 ## Decision
 
-Run a small **`metrics-bridge`** service with two isolated polling lifecycles:
+Run a small **`metrics-bridge`** service with isolated polling lifecycles:
 the primary loop reads Hasura/Envio data plus bounded RPC rebalance probes; the
-peg loop reads protected policy plus external market sources. Both expose
+peg loop reads protected policy plus external market sources; the bridge-transfer
+loop reads complete bounded transfer observations. All expose
 **Prometheus gauges** for Grafana alert rules. Prometheus labels must have
 **bounded cardinality** — never tx hashes, user addresses, or pool-specific
 free text.

--- a/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
+++ b/docs/adr/0027-metrics-bridge-hasura-to-prometheus.md
@@ -16,7 +16,7 @@ garden_lane: adrs-architecture
 **Status:** Accepted (Apr 2026), in force. Scope extended by
 [ADR 0042](0042-metrics-bridge-external-price-poller.md) (Jul 2026): the
 bridge additionally hosts an isolated external market-price peg-polling
-lifecycle. [ADR 0094](0094-isolated-bridge-transfer-observations.md) adds an
+lifecycle. [ADR 0095](0095-isolated-bridge-transfer-observations.md) adds an
 isolated bridge-transfer observation lifecycle.
 **Scope:** metrics-bridge
 

--- a/docs/adr/0094-isolated-bridge-transfer-observations.md
+++ b/docs/adr/0094-isolated-bridge-transfer-observations.md
@@ -35,9 +35,12 @@ the previous snapshot and last-success time. Startup has no route samples and
 last-success zero. The separate observation-error signal starts at one.
 
 Wait 30 seconds after each attempt. Export a 45-second freshness limit from the
-30-second cadence plus 15-second timeout. Consumers must require error zero,
-last-success greater than zero, and observation age at most this limit. Pool
-health and peg freshness cannot establish bridge-transfer freshness.
+30-second cadence plus 15-second timeout. Direct consumers must require error zero, last-success greater than zero,
+and observation age at most this runtime limit. Prometheus consumers must also
+allow for the configured scrape interval: the current 30-second Alloy scrape
+adds 30 seconds, for a 75-second sampled-data limit. Alert tooling must check
+that allowance against the scrape configuration. Pool health and peg freshness
+cannot establish bridge-transfer freshness.
 
 Share status thresholds and timestamp precedence through
 `@mento-protocol/config/bridge-status`. Labels use only chain IDs 137, 143 and

--- a/docs/adr/0094-isolated-bridge-transfer-observations.md
+++ b/docs/adr/0094-isolated-bridge-transfer-observations.md
@@ -1,0 +1,79 @@
+---
+title: Bridge transfers use isolated complete observations
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-09-10
+scope: metrics-bridge
+date: 2026-09
+doc_type: adr
+review_interval_days: 90
+garden_lane: adrs-architecture
+---
+
+# ADR 0094 — Bridge transfers use isolated complete observations
+
+**Status:** Accepted. Extends [ADR 0027](0027-metrics-bridge-hasura-to-prometheus.md).
+
+## Context
+
+Bridge alerts need every relevant non-terminal transfer. Dashboard windows are
+capped. Reusing a capped window can report a healthy queue while an older
+transfer is stuck. A failed page must not clear an active incident. The existing
+pool and peg observations must continue when this domain fails.
+
+## Decision
+
+Use an independent sequential polling loop in Metrics Bridge. Read Hasura with
+ID keyset pagination. Bound each observation to 20 pages, 500 rows per page,
+10,000 rows and 15 seconds. A full last page does not prove completeness;
+exhausting any budget fails the observation. Deduplicate IDs within one traversal.
+
+Publish all route gauges synchronously only after a complete observation.
+Successful empty observations write zero to every finite bucket. Failure retains
+the previous snapshot and last-success time. Startup has no route samples and
+last-success zero. The separate observation-error signal starts at one.
+
+Wait 30 seconds after each attempt. Export a 45-second freshness limit from the
+30-second cadence plus 15-second timeout. Consumers must require error zero,
+last-success greater than zero, and observation age at most this limit. Pool
+health and peg freshness cannot establish bridge-transfer freshness.
+
+Share status thresholds and timestamp precedence through
+`@mento-protocol/config/bridge-status`. Labels use only chain IDs 137, 143 and
+42220, canonical USDm/EURm token identities, canonical non-terminal statuses,
+and `unknown`. Include partially known routes because destination-first rows
+can precede source evidence. Unknown labels and missing/future ages increment a
+separate invalid-row signal. Negative epochs retain the shared contract's
+existing age semantics. No address, hash, transfer ID or raw symbol is a label.
+
+## Alternatives considered
+
+- Reuse the dashboard transfer window: incomplete coverage cannot support alerts.
+- Add bridge pages to the primary pool loop: timeout and retry delays would couple
+  unrelated domain freshness.
+- Clear gauges when a request fails: missing evidence would resolve real incidents.
+- Add a transactional server aggregate: stronger consistency, but it requires a
+  new indexed data contract and rollout. This change uses existing schema fields.
+
+## Consequences
+
+Pagination is a bounded traversal, not a database transaction. Concurrent inserts
+behind the cursor can appear on the next poll. A row that progresses after it was
+read can remain in that observation. Stable ID order avoids offset skips, and
+repeated IDs count once. This does not prove a simultaneous database snapshot.
+The two-minute alert pending period limits transient notifications; it cannot
+make an incomplete observation authoritative.
+
+There are 180 route/token/status buckets and three gauges per bucket, plus four
+domain gauges: at most 544 series. No route samples exist before first success.
+Unknown-route alerts must use broader dashboard filters instead of fabricated
+chain IDs. Exporter rollout and alert activation remain separate approved steps.
+
+## Evidence
+
+- Tracker #1362 and exporter layer #2356; parent shared contract PR #2358.
+- `metrics-bridge/src/bridge/observation.ts`: traversal and timeout budgets.
+- `metrics-bridge/src/bridge/metrics.ts`: finite snapshots and failure signals.
+- `metrics-bridge/src/bridge/runtime.ts`: isolated cadence.
+- `metrics-bridge/src/bridge/bridge.test.ts`: pagination and state transitions.

--- a/docs/adr/0095-isolated-bridge-transfer-observations.md
+++ b/docs/adr/0095-isolated-bridge-transfer-observations.md
@@ -11,7 +11,7 @@ review_interval_days: 90
 garden_lane: adrs-architecture
 ---
 
-# ADR 0094 — Bridge transfers use isolated complete observations
+# ADR 0095 — Bridge transfers use isolated complete observations
 
 **Status:** Accepted. Extends [ADR 0027](0027-metrics-bridge-hasura-to-prometheus.md).
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -155,22 +155,21 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 
 ### metrics-bridge
 
-| ADR                                                           | Decision                                                                      |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [0027](0027-metrics-bridge-hasura-to-prometheus.md)           | A Hasura→Prometheus bridge exists so v3 DB data can drive Grafana alerts      |
-| [0039](0039-multistrategy-pools-historical-fx-volume.md)      | Pool blockage requires every active indexed strategy to be confirmed blocked  |
-| [0042](0042-metrics-bridge-external-price-poller.md)          | The bridge hosts an isolated external market-price peg-polling lifecycle      |
-| [0043](0043-peg-registry-service-local.md)                    | The peg-monitor registry is service-local config, not published shared-config |
-| [0045](0045-peg-paging-semantics.md)                          | Peg paging measures executable sell price; the deep venue pages alone         |
-| [0048](0048-private-gcs-peg-policy-artifact.md)               | Archived: private GCS artifact with superseded dedicated-project hosting      |
-| [0049](0049-peg-decision-package-read-model.md)               | Peg decisions use a bounded Metrics Bridge read model                         |
-| [0052](0052-envio-logs-prometheus-grafana-alerting.md)        | Envio logs diagnose; Prometheus metrics and Grafana rules alert               |
-| [0054](0054-same-project-peg-policy-artifact.md)              | Peg policy stays private and generation-pinned in the monitoring project      |
-| [0055](0055-peg-policy-bucket-controller-recovery.md)         | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery   |
-| [0057](0057-peg-observation-advancement.md)                   | Repeated provider observations retain bounded health, never sample authority  |
-| [0058](0058-metrics-bridge-dedicated-cloud-build-executor.md) | Metrics Bridge uses a dedicated Cloud Build executor                          |
-
-| [0094](0094-isolated-bridge-transfer-observations.md) | Bridge transfers publish only complete bounded observations in an isolated loop |
+| ADR                                                           | Decision                                                                        |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [0027](0027-metrics-bridge-hasura-to-prometheus.md)           | A Hasura→Prometheus bridge exists so v3 DB data can drive Grafana alerts        |
+| [0039](0039-multistrategy-pools-historical-fx-volume.md)      | Pool blockage requires every active indexed strategy to be confirmed blocked    |
+| [0042](0042-metrics-bridge-external-price-poller.md)          | The bridge hosts an isolated external market-price peg-polling lifecycle        |
+| [0043](0043-peg-registry-service-local.md)                    | The peg-monitor registry is service-local config, not published shared-config   |
+| [0045](0045-peg-paging-semantics.md)                          | Peg paging measures executable sell price; the deep venue pages alone           |
+| [0048](0048-private-gcs-peg-policy-artifact.md)               | Archived: private GCS artifact with superseded dedicated-project hosting        |
+| [0049](0049-peg-decision-package-read-model.md)               | Peg decisions use a bounded Metrics Bridge read model                           |
+| [0052](0052-envio-logs-prometheus-grafana-alerting.md)        | Envio logs diagnose; Prometheus metrics and Grafana rules alert                 |
+| [0054](0054-same-project-peg-policy-artifact.md)              | Peg policy stays private and generation-pinned in the monitoring project        |
+| [0055](0055-peg-policy-bucket-controller-recovery.md)         | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery     |
+| [0057](0057-peg-observation-advancement.md)                   | Repeated provider observations retain bounded health, never sample authority    |
+| [0058](0058-metrics-bridge-dedicated-cloud-build-executor.md) | Metrics Bridge uses a dedicated Cloud Build executor                            |
+| [0094](0094-isolated-bridge-transfer-observations.md)         | Bridge transfers publish only complete bounded observations in an isolated loop |
 
 ### terraform / infra
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -169,7 +169,7 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0055](0055-peg-policy-bucket-controller-recovery.md)         | Peg bucket IAM reconciliation uses a narrow controller and bounded recovery     |
 | [0057](0057-peg-observation-advancement.md)                   | Repeated provider observations retain bounded health, never sample authority    |
 | [0058](0058-metrics-bridge-dedicated-cloud-build-executor.md) | Metrics Bridge uses a dedicated Cloud Build executor                            |
-| [0094](0094-isolated-bridge-transfer-observations.md)         | Bridge transfers publish only complete bounded observations in an isolated loop |
+| [0095](0095-isolated-bridge-transfer-observations.md)         | Bridge transfers publish only complete bounded observations in an isolated loop |
 
 ### terraform / infra
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -170,6 +170,8 @@ workflow without an ADR (see [ADR 0033](0033-adr-process-and-gate.md)).
 | [0057](0057-peg-observation-advancement.md)                   | Repeated provider observations retain bounded health, never sample authority  |
 | [0058](0058-metrics-bridge-dedicated-cloud-build-executor.md) | Metrics Bridge uses a dedicated Cloud Build executor                          |
 
+| [0094](0094-isolated-bridge-transfer-observations.md) | Bridge transfers publish only complete bounded observations in an isolated loop |
+
 ### terraform / infra
 
 | ADR                                                           | Decision                                                                                                          |

--- a/metrics-bridge/src/bridge/bridge.test.ts
+++ b/metrics-bridge/src/bridge/bridge.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Registry } from "prom-client";
+import { aggregateBridgeTransfers, createBridgeMetrics } from "./metrics.js";
+import {
+  observeBridgeTransfers,
+  BRIDGE_TRANSFERS_QUERY,
+  type BridgeRow,
+} from "./observation.js";
+import { pollBridgeTransfers } from "./runtime.js";
+import { BRIDGE_FRESHNESS_SECONDS } from "./config.js";
+
+const row = (patch: Partial<BridgeRow> = {}): BridgeRow => ({
+  id: "a",
+  status: "SENT",
+  sourceChainId: 137,
+  destChainId: 143,
+  tokenAddress: "0xbc69212b8e4d445b2307c9d32dd68e2a4df00115",
+  sentTimestamp: "100",
+  firstSeenAt: "100",
+  lastUpdatedAt: "100",
+  lastAttestedTimestamp: null,
+  ...patch,
+});
+const response = (rows: BridgeRow[]) => ({ BridgeTransfer: rows });
+const value = async (
+  registry: Registry,
+  name: string,
+  labels?: Record<string, string>,
+) => {
+  const metric = (await registry.getMetricsAsJSON()).find(
+    (metric) => metric.name === `mento_ntt_bridge_${name}`,
+  );
+  return metric?.values.find(
+    (sample) =>
+      !labels ||
+      Object.entries(labels).every(([key, val]) => sample.labels[key] === val),
+  )?.value;
+};
+const labels = {
+  source_chain: "137",
+  destination_chain: "143",
+  token: "USDm",
+  status: "SENT",
+};
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("complete bridge observation", () => {
+  it("queries by stable ID and retains unknown endpoints", () => {
+    expect(BRIDGE_TRANSFERS_QUERY).toContain("order_by: { id: asc }");
+    expect(BRIDGE_TRANSFERS_QUERY).toContain("_is_null: true");
+    expect(BRIDGE_TRANSFERS_QUERY).toContain(
+      'status: { _nin: ["DELIVERED", "CANCELLED", "FAILED"] }',
+    );
+  });
+  it("reads multiple pages, deduplicates IDs and keeps later row evidence", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(response([row(), row({ id: "b" })]))
+      .mockResolvedValueOnce(
+        response([row({ id: "b", status: "ATTESTED" }), row({ id: "c" })]),
+      )
+      .mockResolvedValueOnce(response([]));
+    const result = await observeBridgeTransfers({ fetchPage, pageSize: 2 });
+    expect(result.map((item) => item.id)).toEqual(["a", "b", "c"]);
+    expect(result[1]?.status).toBe("ATTESTED");
+    expect(fetchPage.mock.calls.map((call) => call[0])).toEqual(["", "b", "c"]);
+  });
+  it("fails the whole observation when a later page fails", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(response([row()]))
+      .mockRejectedValueOnce(new Error("offline"));
+    await expect(
+      observeBridgeTransfers({ fetchPage, pageSize: 1 }),
+    ).rejects.toThrow("offline");
+  });
+  it("does not treat a full final page as complete", async () => {
+    await expect(
+      observeBridgeTransfers({
+        fetchPage: async () => response([row()]),
+        pageSize: 1,
+        maxPages: 1,
+      }),
+    ).rejects.toThrow("page budget");
+  });
+  it("bounds rows including duplicate records", async () => {
+    await expect(
+      observeBridgeTransfers({
+        fetchPage: async () => response([row(), row({ id: "b" })]),
+        pageSize: 2,
+        maxRows: 1,
+      }),
+    ).rejects.toThrow("row budget");
+  });
+  it("rejects oversized and malformed responses", async () => {
+    await expect(
+      observeBridgeTransfers({
+        fetchPage: async () => response([row(), row()]),
+        pageSize: 1,
+      }),
+    ).rejects.toThrow("requested limit");
+    await expect(
+      observeBridgeTransfers({
+        fetchPage: async () => ({ BridgeTransfer: [{}] }),
+      }),
+    ).rejects.toThrow();
+  });
+  it("rejects a cursor that does not advance", async () => {
+    await expect(
+      observeBridgeTransfers({
+        fetchPage: async () => response([row()]),
+        pageSize: 1,
+      }),
+    ).rejects.toThrow("did not advance");
+  });
+  it("times out even if a request ignores its abort signal", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const pending = observeBridgeTransfers({
+      timeoutMs: 10,
+      fetchPage: async (_after, _limit, inputSignal) => {
+        signal = inputSignal;
+        return new Promise(() => {});
+      },
+    });
+    const rejected = expect(pending).rejects.toThrow("timeout");
+    await vi.advanceTimersByTimeAsync(10);
+    await rejected;
+    expect(signal?.aborted).toBe(true);
+  });
+});
+
+describe("bounded bridge aggregation", () => {
+  it("separates healthy count from stuck count at the exact boundary", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row(),
+        row({ id: "b", lastUpdatedAt: "99" }),
+        row({ id: "c", lastUpdatedAt: "200" }),
+      ],
+      3700,
+    );
+    expect(
+      snapshot.buckets.find(
+        (bucket) =>
+          bucket.labels.token === "USDm" &&
+          bucket.labels.status === "SENT" &&
+          bucket.labels.source_chain === "137" &&
+          bucket.labels.destination_chain === "143",
+      ),
+    ).toMatchObject({ count: 3, stuck: 1, oldest: 3601 });
+    expect(snapshot.invalidRows).toBe(0);
+  });
+  it("retains destination-first rows and bounded unknown labels", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row({
+          sourceChainId: null,
+          destChainId: 137,
+          tokenAddress: "untrusted-address",
+          status: "NEW_STATUS",
+          sentTimestamp: null,
+          firstSeenAt: null,
+          lastUpdatedAt: null,
+        }),
+      ],
+      5000,
+    );
+    expect(snapshot.buckets.find((bucket) => bucket.count === 1)).toMatchObject(
+      {
+        labels: {
+          source_chain: "unknown",
+          destination_chain: "137",
+          token: "unknown",
+          status: "unknown",
+        },
+        oldest: 0,
+        stuck: 0,
+      },
+    );
+    expect(snapshot.invalidRows).toBe(1);
+    expect(JSON.stringify(snapshot.buckets)).not.toContain("untrusted-address");
+    expect(JSON.stringify(snapshot.buckets)).not.toContain("NEW_STATUS");
+  });
+  it("uses attestation rather than backdated source progress", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row({
+          status: "ATTESTED",
+          lastAttestedTimestamp: "4999",
+          lastUpdatedAt: "1",
+        }),
+      ],
+      5000,
+    );
+    expect(snapshot.buckets.find((bucket) => bucket.count === 1)).toMatchObject(
+      { stuck: 0, oldest: 1 },
+    );
+  });
+  it("supports EURm and destination-first canonical token lookup", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row({
+          tokenAddress: "0x4d502d735b4c574b487ed641ae87ceae884731c7",
+          sourceChainId: null,
+          destChainId: 137,
+        }),
+      ],
+      100,
+    );
+    expect(
+      snapshot.buckets.find((bucket) => bucket.count === 1)?.labels.token,
+    ).toBe("EURm");
+  });
+  it("keeps missing and future time visible without false age", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row({ sentTimestamp: "0", firstSeenAt: "NaN", lastUpdatedAt: null }),
+        row({ id: "b", lastUpdatedAt: "10000" }),
+      ],
+      5000,
+    );
+    expect(snapshot.invalidRows).toBe(2);
+    expect(snapshot.buckets.find((bucket) => bucket.count === 2)).toMatchObject(
+      { oldest: 0, stuck: 0 },
+    );
+  });
+  it("excludes terminal and unrelated known routes, deduplicates rows", () => {
+    const snapshot = aggregateBridgeTransfers(
+      [
+        row(),
+        row(),
+        row({ id: "b", status: "DELIVERED" }),
+        row({ id: "c", sourceChainId: 42220, destChainId: 143 }),
+      ],
+      5000,
+    );
+    expect(
+      snapshot.buckets.reduce((sum, bucket) => sum + bucket.count, 0),
+    ).toBe(1);
+  });
+});
+
+describe("snapshot lifecycle", () => {
+  it("distinguishes startup, success, failure, empty success and resumed work", async () => {
+    const registry = new Registry();
+    const metrics = createBridgeMetrics(registry);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await value(registry, "observation_error")).toBe(1);
+    expect(await value(registry, "last_success_timestamp_seconds")).toBe(0);
+    expect(await value(registry, "transfers", labels)).toBeUndefined();
+    expect(await value(registry, "freshness_limit_seconds")).toBe(
+      BRIDGE_FRESHNESS_SECONDS,
+    );
+    await pollBridgeTransfers(
+      metrics,
+      async () => [row()],
+      () => 5_000_000,
+    );
+    expect(await value(registry, "transfers", labels)).toBe(1);
+    expect(await value(registry, "stuck_transfers", labels)).toBe(1);
+    expect(await value(registry, "oldest_state_age_seconds", labels)).toBe(
+      4900,
+    );
+    expect(await value(registry, "last_success_timestamp_seconds")).toBe(5000);
+    expect(await value(registry, "observation_error")).toBe(0);
+    await pollBridgeTransfers(
+      metrics,
+      async () => {
+        throw new Error("later page failed");
+      },
+      () => 6_000_000,
+    );
+    expect(await value(registry, "transfers", labels)).toBe(1);
+    expect(await value(registry, "stuck_transfers", labels)).toBe(1);
+    expect(await value(registry, "last_success_timestamp_seconds")).toBe(5000);
+    expect(await value(registry, "observation_error")).toBe(1);
+    await pollBridgeTransfers(
+      metrics,
+      async () => [],
+      () => 7_000_000,
+    );
+    expect(await value(registry, "transfers", labels)).toBe(0);
+    expect(await value(registry, "stuck_transfers", labels)).toBe(0);
+    expect(await value(registry, "oldest_state_age_seconds", labels)).toBe(0);
+    expect(await value(registry, "last_success_timestamp_seconds")).toBe(7000);
+    expect(await value(registry, "observation_error")).toBe(0);
+    await pollBridgeTransfers(
+      metrics,
+      async () => [row()],
+      () => 8_000_000,
+    );
+    expect(await value(registry, "transfers", labels)).toBe(1);
+    const restarted = new Registry();
+    createBridgeMetrics(restarted);
+    expect(await value(restarted, "last_success_timestamp_seconds")).toBe(0);
+    expect(await value(restarted, "transfers", labels)).toBeUndefined();
+  });
+});

--- a/metrics-bridge/src/bridge/config.ts
+++ b/metrics-bridge/src/bridge/config.ts
@@ -1,0 +1,11 @@
+// Fixed independent cadence; exported alongside the snapshot so alert freshness
+// follows the actual runtime rather than a separately hard-coded rule value.
+export const BRIDGE_POLL_INTERVAL_MS = 30_000;
+export const BRIDGE_OBSERVATION_TIMEOUT_MS = 15_000;
+export const BRIDGE_FRESHNESS_SECONDS =
+  (BRIDGE_POLL_INTERVAL_MS + BRIDGE_OBSERVATION_TIMEOUT_MS) / 1000;
+export const BRIDGE_PAGE_SIZE = 500;
+export const BRIDGE_MAX_PAGES = 20;
+export const BRIDGE_MAX_ROWS = 10_000;
+export const BRIDGE_CHAIN_LABELS = ["137", "143", "42220", "unknown"] as const;
+export const BRIDGE_TOKEN_LABELS = ["USDm", "EURm", "unknown"] as const;

--- a/metrics-bridge/src/bridge/metrics.ts
+++ b/metrics-bridge/src/bridge/metrics.ts
@@ -1,0 +1,190 @@
+import { Gauge, type Registry } from "prom-client";
+import { tokenSymbol } from "@mento-protocol/config/tokens";
+import {
+  bridgeStateAgeSeconds,
+  deriveBridgeStatus,
+  isBridgeInFlight,
+  type BridgeProgression,
+} from "@mento-protocol/config/bridge-status";
+import {
+  BRIDGE_CHAIN_LABELS,
+  BRIDGE_FRESHNESS_SECONDS,
+  BRIDGE_TOKEN_LABELS,
+} from "./config.js";
+import type { BridgeRow } from "./observation.js";
+
+const statuses = [
+  "PENDING",
+  "SENT",
+  "ATTESTED",
+  "QUEUED_INBOUND",
+  "unknown",
+] as const;
+const labelNames = [
+  "source_chain",
+  "destination_chain",
+  "token",
+  "status",
+] as const;
+type Labels = Record<(typeof labelNames)[number], string>;
+interface Bucket {
+  labels: Labels;
+  count: number;
+  stuck: number;
+  oldest: number;
+}
+
+function chainLabel(chain: number | null): string {
+  return (
+    BRIDGE_CHAIN_LABELS.find((label) => label === String(chain)) ?? "unknown"
+  );
+}
+function tokenLabel(row: BridgeRow): string {
+  if (row.tokenAddress === null) return "unknown";
+  const symbols = [row.sourceChainId, row.destChainId].flatMap((chain) => {
+    if (chain === null || chainLabel(chain) === "unknown") return [];
+    const symbol = tokenSymbol(chain, row.tokenAddress!);
+    return symbol === "USDm" || symbol === "EURm" ? [symbol] : [];
+  });
+  return symbols.length > 0 && symbols.every((symbol) => symbol === symbols[0])
+    ? symbols[0]!
+    : "unknown";
+}
+function key(labels: Labels): string {
+  return labelNames.map((name) => labels[name]).join(":");
+}
+function emptyBuckets(): Map<string, Bucket> {
+  const buckets = new Map<string, Bucket>();
+  const routes = BRIDGE_CHAIN_LABELS.flatMap((source_chain) =>
+    BRIDGE_CHAIN_LABELS.map((destination_chain) => ({
+      source_chain,
+      destination_chain,
+    })),
+  );
+  for (const route of routes) {
+    if (
+      ![route.source_chain, route.destination_chain].some(
+        (chain) => chain === "137" || chain === "unknown",
+      )
+    )
+      continue;
+    for (const token of BRIDGE_TOKEN_LABELS)
+      for (const status of statuses) {
+        const labels = { ...route, token, status };
+        buckets.set(key(labels), { labels, count: 0, stuck: 0, oldest: 0 });
+      }
+  }
+  return buckets;
+}
+
+function addRow(bucket: Bucket, row: BridgeRow, nowSeconds: number): boolean {
+  bucket.count++;
+  const age = isBridgeInFlight(row.status)
+    ? bridgeStateAgeSeconds(row as BridgeProgression, nowSeconds)
+    : null;
+  if (age !== null) {
+    bucket.oldest = Math.max(bucket.oldest, age);
+    if (deriveBridgeStatus(row as BridgeProgression, nowSeconds) === "STUCK")
+      bucket.stuck++;
+  }
+  return (
+    Object.values(bucket.labels).includes("unknown") || age === null || age < 0
+  );
+}
+
+export function aggregateBridgeTransfers(
+  rows: BridgeRow[],
+  nowSeconds: number,
+): { buckets: Bucket[]; invalidRows: number } {
+  const buckets = emptyBuckets();
+  let invalidRows = 0;
+  for (const row of new Map(rows.map((row) => [row.id, row])).values()) {
+    if (["DELIVERED", "CANCELLED", "FAILED"].includes(row.status)) continue;
+    const labels = {
+      source_chain: chainLabel(row.sourceChainId),
+      destination_chain: chainLabel(row.destChainId),
+      token: tokenLabel(row),
+      status: isBridgeInFlight(row.status) ? row.status : "unknown",
+    };
+    const bucket = buckets.get(key(labels));
+    if (bucket && addRow(bucket, row, nowSeconds)) invalidRows++;
+  }
+  return { buckets: [...buckets.values()], invalidRows };
+}
+
+function registerBridgeGauges(register: Registry) {
+  const gauge = (
+    definition: { name: string; help: string },
+    labels: readonly string[] = [],
+  ) =>
+    new Gauge({
+      ...definition,
+      labelNames: [...labels],
+      registers: [register],
+    });
+  const count = gauge(
+    {
+      name: "mento_ntt_bridge_transfers",
+      help: "Last complete non-terminal bridge transfer count",
+    },
+    labelNames,
+  );
+  const stuck = gauge(
+    {
+      name: "mento_ntt_bridge_stuck_transfers",
+      help: "Last complete count strictly beyond the status threshold",
+    },
+    labelNames,
+  );
+  const oldest = gauge(
+    {
+      name: "mento_ntt_bridge_oldest_state_age_seconds",
+      help: "Oldest known state age at the last complete observation",
+    },
+    labelNames,
+  );
+  const invalid = gauge({
+    name: "mento_ntt_bridge_invalid_rows",
+    help: "Rows with unknown route, token, status or unusable time at last success",
+  });
+  const lastSuccess = gauge({
+    name: "mento_ntt_bridge_last_success_timestamp_seconds",
+    help: "Unix time of last complete observation; zero means never observed",
+  });
+  const error = gauge({
+    name: "mento_ntt_bridge_observation_error",
+    help: "One before first success or after an incomplete or failed observation",
+  });
+  const freshness = gauge({
+    name: "mento_ntt_bridge_freshness_limit_seconds",
+    help: "Maximum complete-observation age from cadence plus timeout",
+  });
+  return { count, stuck, oldest, invalid, lastSuccess, error, freshness };
+}
+
+/** Gauge updates are synchronous: a scrape cannot interleave a complete snapshot commit. */
+export function createBridgeMetrics(register: Registry) {
+  const { count, stuck, oldest, invalid, lastSuccess, error, freshness } =
+    registerBridgeGauges(register);
+  lastSuccess.set(0);
+  error.set(1);
+  freshness.set(BRIDGE_FRESHNESS_SECONDS);
+  // No route samples before success: startup cannot masquerade as known empty.
+  return {
+    fail() {
+      error.set(1);
+    },
+    publish(rows: BridgeRow[], nowSeconds: number) {
+      const snapshot = aggregateBridgeTransfers(rows, nowSeconds);
+      for (const bucket of snapshot.buckets) {
+        count.set(bucket.labels, bucket.count);
+        stuck.set(bucket.labels, bucket.stuck);
+        oldest.set(bucket.labels, bucket.oldest);
+      }
+      invalid.set(snapshot.invalidRows);
+      lastSuccess.set(nowSeconds);
+      error.set(0);
+    },
+  };
+}
+export type BridgeMetrics = ReturnType<typeof createBridgeMetrics>;

--- a/metrics-bridge/src/bridge/observation.ts
+++ b/metrics-bridge/src/bridge/observation.ts
@@ -1,0 +1,123 @@
+import { GraphQLClient, gql } from "graphql-request";
+import { z } from "zod";
+import { HASURA_URL } from "../config.js";
+import {
+  BRIDGE_MAX_PAGES,
+  BRIDGE_MAX_ROWS,
+  BRIDGE_OBSERVATION_TIMEOUT_MS,
+  BRIDGE_PAGE_SIZE,
+} from "./config.js";
+
+const rowSchema = z.object({
+  id: z.string().min(1),
+  status: z.string(),
+  sourceChainId: z.number().int().nullable(),
+  destChainId: z.number().int().nullable(),
+  tokenAddress: z.string().nullable(),
+  sentTimestamp: z.string().nullable(),
+  firstSeenAt: z.string().nullable(),
+  lastUpdatedAt: z.string().nullable(),
+  lastAttestedTimestamp: z.string().nullable(),
+});
+export type BridgeRow = z.infer<typeof rowSchema>;
+const responseSchema = z.object({ BridgeTransfer: z.array(rowSchema) });
+
+// Unknown endpoints might involve Polygon. Keep them visible in bounded unknown
+// buckets. Known routes with neither endpoint Polygon are outside this domain.
+export const BRIDGE_TRANSFERS_QUERY = gql`
+  query BridgeTransferObservation($after: String!, $limit: Int!) {
+    BridgeTransfer(
+      limit: $limit
+      order_by: { id: asc }
+      where: {
+        id: { _gt: $after }
+        status: { _nin: ["DELIVERED", "CANCELLED", "FAILED"] }
+        _or: [
+          { sourceChainId: { _eq: 137 } }
+          { destChainId: { _eq: 137 } }
+          { sourceChainId: { _is_null: true } }
+          { destChainId: { _is_null: true } }
+        ]
+      }
+    ) {
+      id
+      status
+      sourceChainId
+      destChainId
+      tokenAddress
+      sentTimestamp
+      firstSeenAt
+      lastUpdatedAt
+      lastAttestedTimestamp
+    }
+  }
+`;
+export type FetchBridgePage = (
+  after: string,
+  limit: number,
+  signal: AbortSignal,
+) => Promise<unknown>;
+const client = new GraphQLClient(HASURA_URL);
+const fetchPage: FetchBridgePage = (after, limit, signal) =>
+  client.request({
+    document: BRIDGE_TRANSFERS_QUERY,
+    variables: { after, limit },
+    signal,
+  });
+
+/** Keyset traversal is bounded, not a transaction: rows can progress between pages. */
+export async function observeBridgeTransfers(
+  options: {
+    fetchPage?: FetchBridgePage;
+    pageSize?: number;
+    maxPages?: number;
+    maxRows?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<BridgeRow[]> {
+  const pageSize = options.pageSize ?? BRIDGE_PAGE_SIZE;
+  const maxPages = options.maxPages ?? BRIDGE_MAX_PAGES;
+  const maxRows = options.maxRows ?? BRIDGE_MAX_ROWS;
+  const timeoutMs = options.timeoutMs ?? BRIDGE_OBSERVATION_TIMEOUT_MS;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout>;
+  const timedOut = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error("Bridge observation timeout"));
+    }, timeoutMs);
+  });
+  const collect = async () => {
+    const rows = new Map<string, BridgeRow>();
+    let after = "";
+    let readRows = 0;
+    for (let page = 0; page < maxPages; page++) {
+      controller.signal.throwIfAborted();
+      const response = responseSchema.parse(
+        await (options.fetchPage ?? fetchPage)(
+          after,
+          pageSize,
+          controller.signal,
+        ),
+      );
+      const batch = response.BridgeTransfer;
+      if (batch.length > pageSize)
+        throw new Error("Bridge page exceeds requested limit");
+      readRows += batch.length;
+      if (readRows > maxRows) throw new Error("Bridge row budget exhausted");
+      for (const row of batch) rows.set(row.id, row);
+      if (batch.length < pageSize) return [...rows.values()];
+      // Use server ordering: PostgreSQL collation is not JavaScript lexical order.
+      const next = batch.at(-1)!.id;
+      if (next === after) throw new Error("Bridge pagination did not advance");
+      after = next;
+    }
+    throw new Error("Bridge page budget exhausted");
+  };
+  try {
+    return await Promise.race([collect(), timedOut]);
+  } finally {
+    clearTimeout(timer!);
+    controller.abort();
+  }
+}

--- a/metrics-bridge/src/bridge/runtime.ts
+++ b/metrics-bridge/src/bridge/runtime.ts
@@ -1,0 +1,28 @@
+import { register } from "../metrics.js";
+import { BRIDGE_POLL_INTERVAL_MS } from "./config.js";
+import { createBridgeMetrics, type BridgeMetrics } from "./metrics.js";
+import { observeBridgeTransfers, type BridgeRow } from "./observation.js";
+
+export async function pollBridgeTransfers(
+  metrics: BridgeMetrics,
+  observe: () => Promise<BridgeRow[]> = observeBridgeTransfers,
+  now: () => number = Date.now,
+): Promise<void> {
+  try {
+    metrics.publish(await observe(), Math.floor(now() / 1000));
+  } catch {
+    metrics.fail();
+    console.error(
+      "Bridge transfer observation incomplete; retaining last complete snapshot",
+    );
+  }
+}
+
+export function startBridgePolling(): void {
+  const metrics = createBridgeMetrics(register);
+  const loop = async () => {
+    await pollBridgeTransfers(metrics);
+    setTimeout(() => void loop(), BRIDGE_POLL_INTERVAL_MS);
+  };
+  void loop();
+}

--- a/metrics-bridge/src/main.ts
+++ b/metrics-bridge/src/main.ts
@@ -2,6 +2,9 @@ import { startServer } from "./server.js";
 import { startPolling } from "./poller.js";
 import { startPegPolling } from "./peg/runtime.js";
 
+import { startBridgePolling } from "./bridge/runtime.js";
+
 startServer();
 startPolling();
 startPegPolling();
+startBridgePolling();


### PR DESCRIPTION
## The Problem

Operators can see stuck bridge transfers on the dashboard, but the exporter has no complete transfer observation for alerting. A capped query or a failed page could otherwise report a healthy queue while transfers remain stuck.

## The Solution

Add an isolated bridge-transfer poller that publishes only complete observations. It retains the last successful values on failure and reports error and freshness separately. This supplies the alert layer with bounded counts, stuck counts and ages; production deployment and alert activation remain separate steps.

## Details

- Native stack [#2370](https://api.github.com/repos/mento-protocol/monitoring-monorepo/stacks/2370): #2358 → #2366 → #2369. Protection target: `main`; each PR keeps its immediate-parent diff base.

- Shared contract #2358 is merged into `main`; this exporter now targets `main`. This layer implements #2356 within #1362; #2357 adds alert rules and routing.
- Read existing Hasura fields with deterministic ID keyset pagination: 500 rows/page, 20 pages, 10,000 rows, 15-second observation deadline. A full final page or any failure is incomplete. Repeated IDs count once.
- Pagination is not transactional: concurrent inserts behind the cursor and progression after a row is read can appear on the next poll. No simultaneous-database-snapshot claim is made.
- Publish a complete snapshot synchronously. Successful empty clears every finite bucket. Failure retains values and last-success; startup exports error one and last-success zero, with no route samples.
- Independent 30-second retry cadence; exported runtime freshness limit is 45 seconds. Prometheus consumers add the configured 30-second scrape allowance (75 seconds total), require error zero and a positive last-success timestamp.
- At most 544 series: 180 route/token/status buckets × three gauges, plus four domain gauges. Labels contain allowlisted chain IDs, canonical USDm/EURm, statuses, or bounded unknowns. Unknown endpoints remain visible for destination-first transfers. No address or ID is a metric label.
- ADR 0095 records isolation and observation consistency. No indexer schema or dashboard behavior changes.

Refs #2356
Refs #1362

## Validation

- Current head `86c922a5a698004d126a3eb95bee12a7e6f856dc` targets main `cc27bdcd`. The only replay conflicts were in the generated catalog. Regenerating with the current generator preserved all entries and ADR 0095; final catalog and generator bytes are identical to the prior bridge head. The coordinator reviewed both the layer and inherited-base diffs.
- Fresh checks pass: 166 focused inherited ordering/query tests, 30 catalog tests, 34 navigation tests, catalog drift, context and ADR checks. The inherited ordering implementation is identical to the independently reviewed merged PR tree.
- Exporter runtime, shared configuration, scripts and CI bytes are unchanged from the prior validated bridge head. Reused evidence: 633 exporter tests in 28 files, lint/typecheck/build, shared build, and original coverage of 91.61% statements, 87.05% branches, 95.26% functions and 92.91% lines. These fixture-based tests do not prove production rollout.
- Original baseline: 11 files, 424 non-test added lines, stop threshold 848. Current scope: 11 files, 459 non-test added lines. Reviewed tree: `0686f8b7f3b734922b981b080c790af2a9171475`.
- The current closeout CLI refused active nested Codex execution (exit 2). The coordinator supplied independent review of both axes. This is not a second-model CLI report. Claude Security scan: skipped (Codex surface). Hosted checks and reviews are evaluated against this published head.

## Deferrals

- Separately approved exporter deployment and multi-poll live proof remain in #2356.
- Transfer and infrastructure alert rules, channel wiring, approved apply and delivery verification: #2357.
- Native stack transition evidence after separately approved parent merges: #2286.

## Checklist

- [x] The Problem has no more than three bullets.
- [x] The opening explains the old behavior, new behavior, and concrete benefit.
- [x] The opening states any material limit or non-goal that applies.
- [x] A reader can understand the opening without reading the diff.
- [x] Deeper implementation details come after the opening two sections.
- [x] Each Validation claim names its evidence and the nearest stronger claim that evidence does not support.
- [x] Every knowing deferral is listed under Deferrals with a GitHub issue link.
- [x] ADR 0095 records the isolated complete-observation contract.






