### PR TITLE
Coordinate stack recovery and report stale merge bases

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -49,8 +49,8 @@ baseline, and the two-projection readiness contract.
 - **Codex sign-off is required here** — a 👍 reaction on the PR description at
   or after the current head. A "no major issues" comment is context, not the
   sign-off.
-- **Watch dependent PRs as a set.** Native membership, per-layer readiness, and
-  post-merge handling live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
+- **Watch dependent PRs as a set.** Native membership, stale-base diagnostics,
+  serial merge coordination and post-merge recovery live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
 - **Never force-push or amend while babysitting.** `git fetch` before every
   push; reviewers push mid-session.
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -51,8 +51,8 @@ bootstrap; setup has a separate [trust boundary](../../../docs/notes/worktree-an
 "$BASE_REMOTE/$baseRefName"` with the preflight-bound base. Hand its report to
   the `review` skill. Card step 4 owns base-integration axes, exit handling, and
   the limited single-source fallback.
-- **Native stacks are opt-in.** Selection, two-base binding, and verified linking
-  after per-PR publication live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
+- **Native stacks are opt-in.** Parent readiness, shared-path planning, two-base
+  binding, registration checks and coordinated recovery live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
 - **PRs open ready for review.** Drafts suppress the automated AI reviews this
   workflow depends on.
 - **`scripts/pr/check-pr-description.mjs` enforces `## The Problem` then

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -5,7 +5,7 @@ title: Babysit PR Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -49,8 +49,8 @@ baseline, and the two-projection readiness contract.
 - **Codex sign-off is required here** — a 👍 reaction on the PR description at
   or after the current head. A "no major issues" comment is context, not the
   sign-off.
-- **Watch dependent PRs as a set.** Native membership, per-layer readiness, and
-  post-merge handling live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
+- **Watch dependent PRs as a set.** Native membership, stale-base diagnostics,
+  serial merge coordination and post-merge recovery live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
 - **Never force-push or amend while babysitting.** `git fetch` before every
   push; reviewers push mid-session.
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -5,7 +5,7 @@ title: Ship Skill
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: skill
 scope: repo-wide
 review_interval_days: 90
@@ -51,8 +51,8 @@ bootstrap; setup has a separate [trust boundary](../../../docs/notes/worktree-an
 "$BASE_REMOTE/$baseRefName"` with the preflight-bound base. Hand its report to
   the `review` skill. Card step 4 owns base-integration axes, exit handling, and
   the limited single-source fallback.
-- **Native stacks are opt-in.** Selection, two-base binding, and verified linking
-  after per-PR publication live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
+- **Native stacks are opt-in.** Parent readiness, shared-path planning, two-base
+  binding, registration checks and coordinated recovery live in [stacked-pull-requests.md](../../../docs/notes/stacked-pull-requests.md).
 - **PRs open ready for review.** Drafts suppress the automated AI reviews this
   workflow depends on.
 - **`scripts/pr/check-pr-description.mjs` enforces `## The Problem` then

--- a/docs/adr/0093-opt-in-native-stacked-pull-requests.md
+++ b/docs/adr/0093-opt-in-native-stacked-pull-requests.md
@@ -3,7 +3,7 @@ title: Adopt native stacked pull requests through an opt-in pilot
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 scope: ci/process
 date: 2026-09
 doc_type: adr
@@ -13,7 +13,7 @@ garden_lane: adrs-architecture
 
 # ADR 0093 — Adopt native stacked pull requests through an opt-in pilot
 
-**Status:** Accepted (Sep 2026), rollout tooling in force; live pilot outstanding.
+**Status:** Accepted (Sep 2026), first feature pilot complete; broader adoption remains opt-in.
 **Scope:** ci/process
 
 ## Context
@@ -51,10 +51,19 @@ the terminal operation and PR merge record before reporting completion. The
 endpoint's selected-head SHA does not establish a binding for every layer of a
 group merge. No new unattended merge lane is introduced.
 
-Pilot the next authorized low-risk helper-and-consumer feature. Do not create
-synthetic pilot PRs. Keep the rollout issue open for actual CI, review,
-worktree, and parent-merge evidence. Broader adoption depends on reviewing
-that evidence; publishing the tooling alone does not complete the pilot.
+Retain opt-in adoption after the first feature pilot. Prepare descendants in
+parallel but wait for the bottom PR checks and feedback before publishing
+the initial descendant set and registering it. Coordinate
+merges and recovery through one owner. Recovery uses a local-only helper that
+pins inputs and creates a separate candidate; publication remains a reviewed,
+exact-leased coordinator action outside babysitting. Prefer this separation over
+an automatic sync-and-push tool because live membership and human edits can
+change while local replay runs. A confirmed GitHub `BEHIND` state blocks
+readiness even when Git reports no content conflict.
+
+Use a smaller helper-and-consumer feature for the next comparison. Do not create
+synthetic pilot PRs. Broader adoption still needs evidence of cost and reliability;
+completion of this feature batch alone does not establish a time saving.
 
 ## Alternatives considered
 
@@ -79,8 +88,21 @@ The pilot must record review turnaround, repeated checks, manual interventions,
 and agent mistakes. A comparison with a similar ordinary dependency has limits;
 no time saving is assumed before observation.
 
+## Pilot result — 2026-09-10
+
+Seven feature PRs merged across three stacks. Three initial parent transitions
+retargeted children without completing the rebase. A later #2366 to #2369
+transition succeeded with an identical child tree. Separate shared-catalog edits
+caused real conflicts across independent stacks. The final #2369 merge request
+waited behind main, then completed after base repair and required CI, without a
+replacement merge request. The cause of the failed automatic transitions remains
+unconfirmed. These incidents support explicit transition verification and isolated
+recovery, while preserving the existing merge and control-audit boundaries.
+
 ## Evidence
 
+- [Pilot follow-up #2376](https://github.com/mento-protocol/monitoring-monorepo/issues/2376).
+- [Bridge stack final PR #2369](https://github.com/mento-protocol/monitoring-monorepo/pull/2369).
 - [Rollout issue #2286](https://github.com/mento-protocol/monitoring-monorepo/issues/2286).
 - [PR #2292](https://github.com/mento-protocol/monitoring-monorepo/pull/2292)
   and [PR #1967](https://github.com/mento-protocol/monitoring-monorepo/pull/1967).

--- a/docs/notes/pr-operating-card.md
+++ b/docs/notes/pr-operating-card.md
@@ -3,7 +3,7 @@ title: PR Operating Card
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -132,9 +132,13 @@ If root `package.json` changed, first run
 
    Apply only the rows affected by a material fix before publishing the new
    head. Before a base integration, pin the fetched base as `base_oid` and the
-   existing branch head as `prior_head_oid`. Merge the exact `base_oid`. After
-   the resolution is committed, pin `final_head`, require a clean tree, and
-   require both pinned inputs to be ancestors of it. Derive changed paths for
+   existing branch head as `prior_head_oid`. For native linear-stack recovery,
+   use the isolated replay and both-axis evidence in
+   [stacked-pull-requests.md](stacked-pull-requests.md#recover-a-failed-child-transition);
+   a replay does not retain the old child as an ancestor. For ordinary merge
+   integration, merge the exact `base_oid` and require both pinned inputs to be
+   ancestors of the result. For either procedure, pin the committed `final_head`
+   and require a clean tree. Derive changed paths for
    both `base_oid..final_head` and `prior_head_oid..final_head`. Apply the union
    of the author-check rows selected by those ranges to `final_head`; record
    both axes that selected a check, and run a shared check once. Conflict

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -524,8 +524,9 @@ observed finding cannot be ignored while accepting that snapshot.
 Only complete, stable, ready results produce `PASS`; an unavailable, malformed,
 changed, or blocked result produces `PENDING`. The message identifies observed
 base updates, head/base transitions, required-check failures or pending checks,
-and feedback blockers. These diagnostics do not relax the PASS condition or
-turn a pending merge request into a terminal result. The helper adds no public
+and feedback blockers. Only a fully observed `AWAITING_USER_MERGE` or `MERGE_REQUESTED` result can
+complete the aggregate PASS path; unknown merge observations remain PENDING.
+These diagnostics never turn a pending merge request into a terminal result. The helper adds no public
 command; individual probe JSON remains layer-scoped.
 The native aggregate has a five-minute deadline that cancels active `gh` child
 requests and returns `PENDING` when reached.

--- a/docs/notes/pr-ready-state.md
+++ b/docs/notes/pr-ready-state.md
@@ -38,6 +38,10 @@ them required for the current PR.
 
 Required blockers:
 
+- GitHub `mergeStateStatus: BEHIND`, even when `mergeable` is `MERGEABLE`.
+  Integrate the current protection base and require fresh checks; a pending
+  merge setting does not waive this blocker.
+
 - Closed-unmerged PRs. Merged PRs are terminal-ready and short-circuit the
   expensive readiness sweep because there is nothing left to fix or wait on.
   Closed-unmerged PRs report only the terminal `state` blocker; review gates are
@@ -435,6 +439,11 @@ Field expectations:
   this before fetching comments, reactions, check sources, and branch
   protection so post-merge babysitting exits quickly and does not mistake
   GitHub's post-merge `mergeable: UNKNOWN` for a blocker.
+- `pr.mergeStateStatus`: GitHub's aggregate merge status. `BEHIND` is an
+  explicit base-update blocker; other aggregate states do not replace the
+  required-check and feedback projections.
+- `pr.autoMergeEnabledAt`: the observed pending auto-merge enable timestamp,
+  or null. It records intent and never proves merge completion.
 - `pr.mergedAt` / `pr.closedAt`: terminal timestamps when GitHub provides them.
 - Terminal closed PR summaries may use gate state `not_applicable` for gates
   that are normally required on open PRs. Agents should act on the terminal
@@ -513,8 +522,11 @@ matching stack snapshots, and performs a final selected-PR readiness read.
 Every later snapshot is checked for feedback as well as readiness, so a newly
 observed finding cannot be ignored while accepting that snapshot.
 Only complete, stable, ready results produce `PASS`; an unavailable, malformed,
-changed, or blocked result produces `PENDING`. It adds no public command and
-does not change the individual probes' layer-scoped JSON contract.
+changed, or blocked result produces `PENDING`. The message identifies observed
+base updates, head/base transitions, required-check failures or pending checks,
+and feedback blockers. These diagnostics do not relax the PASS condition or
+turn a pending merge request into a terminal result. The helper adds no public
+command; individual probe JSON remains layer-scoped.
 The native aggregate has a five-minute deadline that cancels active `gh` child
 requests and returns `PENDING` when reached.
 `scripts/pr/pr-ready-state-gh.mjs` owns GitHub CLI transport and scoped cancellation.

--- a/docs/notes/quick-commands.md
+++ b/docs/notes/quick-commands.md
@@ -84,6 +84,7 @@ pnpm agent:context-budget --strict # Enforce root, scoped-file, and aggregate-ro
 # /pr-ready-override gate=codex-description-approval head=<full-head-sha> reason=<why this is safe>
 pnpm --silent pr:feedback-state --pr 123 --json  # Normalize unresolved/reply-required feedback before all-clear
 pnpm pr:ready-state --pr 123 --json              # Final current-head required-readiness probe
+node scripts/pr/pr-stack-recover.mjs --help      # Prepare local native-stack recovery; never publishes or merges
 pnpm lockfile:lint                 # Fail-closed integrity/registry/override-floor check; no install
 pnpm skew:check                    # Fail on dependency skew vs pnpm catalog; no install
 pnpm sanitize:test                 # Fixture-test scripts/sanitize-terraform-output.sh secret redaction

--- a/docs/notes/stacked-pull-requests.md
+++ b/docs/notes/stacked-pull-requests.md
@@ -173,11 +173,20 @@ node scripts/pr/pr-stack-recover.mjs --old-parent <full-parent-sha> --old-head <
 The helper preserves pinned inputs, replays only the linear child range and
 writes a recovery receipt under `<worktree>.receipt`, including an isolated
 `comparison.git` reader that does not load source diff-driver configuration.
-It never fetches, publishes or merges a PR. Resolve any reported conflict in the
-candidate and preserve the conflict evidence. The receipt's `remaining` list
-starts with the failed commit: after resolving it with `git cherry-pick --continue`,
-replay the listed suffix explicitly. That command alone does not finish the range.
-Refresh both review diffs against the final clean candidate after manual work.
+It never fetches, publishes or merges a PR. Inspect a blocked receipt before
+choosing a continuation. For content conflicts, resolve and stage the candidate
+changes, then run `git cherry-pick --continue`. A combined squash in the new base
+can instead leave an empty cherry-pick that `git cherry` did not identify. An
+empty index alone is not equivalence proof: compare the original commit patch
+with the candidate and record why the intended change is already present.
+Then use `git cherry-pick --skip`, or retain the commit explicitly with
+`git commit --allow-empty --no-edit` when its history is needed. Do not repeatedly run
+`--continue` against an empty pick.
+
+The receipt's `remaining` list starts with the stopped commit. After resolving,
+skipping or retaining it, replay the listed suffix explicitly; a continuation
+command does not run that suffix. Preserve the original evidence and refresh
+both review diffs against the final clean candidate after manual work.
 A patch
 already present in the new base may be skipped only with recorded equivalence
 proof. Review the candidate against both the new base and the prior published

--- a/docs/notes/stacked-pull-requests.md
+++ b/docs/notes/stacked-pull-requests.md
@@ -3,7 +3,7 @@ title: Stacked pull request workflow
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-09-09
+last_verified: 2026-09-10
 doc_type: runbook
 scope: repo-wide
 review_interval_days: 90
@@ -13,7 +13,7 @@ garden_lane: operator-runbooks
 # Stacked pull request workflow
 
 Use a small native GitHub stack when one reviewable change depends on another.
-Native stacks are opt-in while the real-feature pilot is incomplete. Independent
+Native stacks remain opt-in after the first real-feature pilot. Independent
 work stays in independent PRs. The [operating card](pr-operating-card.md) owns
 author checks, reviews, publication, merge approval, and production closeout.
 This runbook adds dependency handling to those steps.
@@ -32,6 +32,23 @@ issue workflow's existing one-PR ownership binding; record related PR links in
 the issue instead of repeatedly rebinding ownership between layers. Do not
 create synthetic PRs to test stacking. Do not use review-control changes,
 production migrations, or a release requiring a soak as the first pilot.
+
+Keep one coordination receipt for the batch. Record each tracker, per-layer
+issue and full claim token, branch, worktree, published head, immediate parent
+head, protection base SHA, and original scope baseline. Preserve these SHAs
+after a parent merges or its branch disappears. Never refreeze a scope baseline
+to absorb recovery work.
+
+Before parallel implementation, compare shared paths across the planned layers
+and independent stacks. Reserve ADR numbers through the coordinator. Land a
+common generator or catalog-format repair once before dependent work branches;
+keep each feature's generated catalog changes limited to its own entries.
+Run trusted bootstrap before package-manager claim helpers, then claim before
+substantive edits. Inspect package artifact, Compose, documentation-navigation,
+and infrastructure-contract check requirements early. If new resources or CI
+graph changes need an independent control audit, prepare its exact input and
+owner handoff during planning. Reuse consent already given for that audit scope;
+do not widen a blocking control in the feature session.
 
 ## Bind two bases
 
@@ -60,7 +77,11 @@ fresh CI on the resulting current head and main base.
 
 ## Publish with ship
 
-1. Prepare, validate, review, and publish each PR through operating-card steps
+1. Prepare and review child layers locally in parallel. Publish the bottom PR
+   first and wait for its required CI and review feedback to settle. Then publish
+   the reviewed descendants and register the initial chain together. Do not wait
+   for main-filtered CI on an unregistered middle layer: registration must happen
+   first. This reduces replay work; later parent changes can still require recovery. Prepare, validate, review, and publish each PR through operating-card steps
    2–5. Use its bound diff base. Open each PR ready for review with the normal
    template and its own validation evidence.
 2. Re-read the repository, PR numbers, heads, and bases. Confirm the proposed
@@ -71,7 +92,15 @@ fresh CI on the resulting current head and main base.
 3. Read back the resulting native membership, order, and protection base.
    Record the stack and dependency links in the PR descriptions. Check that
    each layer has the expected required CI and automatic reviews.
-4. Hand the verified ordered set to babysit. A successful link request alone
+4. Verify workflow delivery after registration. A child opened before native
+   membership may not receive main-filtered CI retroactively. A body edit only
+   triggers workflows that subscribe to that event; it is not a CI repair.
+   When an owned child lacks required runs, a coordinated close/reopen can
+   deliver the supported lifecycle event. Before and after, verify the same
+   repository, head, base, native membership and claim binding. Preserve any
+   pending merge request; do not close a PR with one. Do not use dummy commits
+   or broaden CI triggers. Missing required runs remain blocking.
+5. Hand the verified ordered set to babysit. A successful link request alone
    does not establish readiness.
 
 Use the current [GitHub API reference](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests-apis-and-webhooks)
@@ -123,6 +152,47 @@ worktree before any edit or push. Preserve local changes and commits. If the
 remote rewrite cannot be reconciled without discarding work or rewriting
 published history, stop that mutation and report the exact conflict.
 
+## Recover a failed child transition
+
+After a parent merge, verify both the child's expected base and its head. A
+retarget alone does not prove GitHub replayed the child. Compare ancestry,
+mergeability and the published-parent boundary from the receipt. If GitHub
+rewrites the child successfully, compare trees and patches before reusing local
+validation. Fresh head-bound CI and review are still required.
+
+If the child retains obsolete parent ancestry or conflicts, leave the normal
+watch loop and give one coordinator ownership of recovery. The user's existing
+conflict-repair authorization covers routine preparation and scoped publication;
+it does not grant merge authority. Preserve the original worktrees and tips.
+Use the local-only helper to prepare a separate candidate:
+
+```bash
+node scripts/pr/pr-stack-recover.mjs --old-parent <full-parent-sha> --old-head <full-child-sha> --new-base <full-base-sha> --worktree <new-absolute-path> --branch <new-candidate-branch>
+```
+
+The helper preserves pinned inputs, replays only the linear child range and
+writes a recovery receipt under `<worktree>.receipt`, including an isolated
+`comparison.git` reader that does not load source diff-driver configuration.
+It never fetches, publishes or merges a PR. Resolve any reported conflict in the
+candidate and preserve the conflict evidence. The receipt's `remaining` list
+starts with the failed commit: after resolving it with `git cherry-pick --continue`,
+replay the listed suffix explicitly. That command alone does not finish the range.
+Refresh both review diffs against the final clean candidate after manual work.
+A patch
+already present in the new base may be skipped only with recorded equivalence
+proof. Review the candidate against both the new base and the prior published
+child. Distinguish ancestry repair from real shared-file integration. Regenerate
+generated files with their owner command rather than hand-merging rows.
+
+Run the union of affected checks once. Reuse evidence only when its reviewed
+inputs and scope remain identical; compare independent audit inputs separately
+from the unchanged control patch. Record any changed audit inputs honestly.
+Before publication, fetch and re-read the live PR state, head, base, membership,
+and protection branch. If they differ from the pinned recovery inputs, stop and
+recompute. Publish the reviewed candidate with an exact old-head lease; use one
+atomic push with an exact lease for each ref when rewriting dependent layers.
+Do not publish after the PR has merged. Resume the full stack watch afterward.
+
 ## Merge only an approved bottom layer
 
 The default handoff remains ALL_CLEAR. A user must explicitly approve the
@@ -144,22 +214,46 @@ merge record in the task evidence. Follow the current
 [API reference](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests-apis-and-webhooks)
 for the asynchronous endpoint and status response.
 
-After each merge, re-evaluate remaining layers before proposing the next
-merge. Keep any deployment or soak boundary. Approval for one PR never grants
+Coordinate batch merges one at a time, including independent stacks that touch
+shared files. Before handing over a merge order, check prospective shared-path
+conflicts. After each actual merge, integrate the resulting protection base and
+re-evaluate remaining layers before proposing the next merge. Keep any deployment or soak boundary. Approval for one PR never grants
 approval for another PR or production action. Ordinary PR merges continue to
 use operating-card step 8 and ADR 0084.
 
-## Complete the real-feature pilot
+Do not infer progress from a GitHub “merging” spinner. Read the PR state,
+current head, protection branch, `mergeStateStatus`, required checks and pending
+merge setting. `BEHIND` requires a base update, even when mergeability says
+`MERGEABLE`. A pending merge setting records intent, not completion. Preserve
+an existing request during authorized repair and verify its state afterward;
+do not cancel or resubmit it merely to discover an operation UUID. A head update
+may invalidate the request. Report that result rather than silently replacing it.
+When strict freshness repeatedly blocks the final PR, pause other batch merges
+until it lands. Confirm completion from the PR merge record and merged tree.
 
-Use the next authorized low-risk helper-and-consumer change. Record its actual
-PRs and evidence in the rollout issue. Capture required CI selection,
-automatic review delivery, local worktree behavior, a necessary parent fix if
-one occurs, and the child transition after a separately approved parent merge.
-Do not manufacture a fix or merge approval to satisfy the checklist. Mark
-unexercised cases explicitly.
+Cancelled duplicate CI runs are not source failures by themselves. Inspect the
+exact head, workflow, run, attempt and job state, then identify any replacement
+run. Keep required checks blocking until passing evidence satisfies the probe.
+Do not edit source or retry a cancelled duplicate merely to change its display.
 
-Record review turnaround, repeated check runs, manual rebase or reconciliation
-work, and agent mistakes. Compare with an ordinary dependent change of similar
-scope; report the limits of that comparison. Expand use only after reviewing
-that evidence. Until then, report tooling shipped and live pilot outstanding
-as separate results. Keep the rollout issue open when live acceptance remains.
+## Measure adoption after the pilot
+
+The 2026-09-10 pilot used seven PRs across three stacks: #2361/#2362,
+#2360/#2367 and #2358/#2366/#2369. Three initial parent merges retargeted
+children without completing their rebases; a later #2366 → #2369 transition
+rebased correctly with an identical tree. Independent stacks also conflicted in
+the generated documentation catalog. These are distinct failure classes.
+The #2369 pending merge completed after its stale base was repaired and new CI
+passed, without cancelling or replacing the user's request.
+
+The pilot proves grouping, ordering and a successful automatic transition. It
+does not establish a net time saving or the cause of the failed transitions.
+These observations sharpen the existing revalidation rule; they do not promise
+that native stacks eliminate squash-merge conflicts. Keep the next pilot small
+and compare it with an ordinary dependent change of similar scope.
+
+Record parent corrections, manual replays, shared-file repairs, workflow-delivery
+recoveries, repeated CI/review runs and setup failures separately. Successful
+automatic rebases also create new heads and repeat CI/review, so do not attribute
+all repeated checks to failed stacking. Preserve exact receipts rather than
+estimating total time. Keep merge, deployment and live acceptance separate.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -99,8 +99,9 @@ Move each pin class with its files.
   enforces two-way path equality with `findSentrySuites()`; moves fail closed.
 - **Babysit pin.** Move `pr/pr-stack-ready-state*.mjs` with
   `.claude/babysit-pr.sh`.
-- **PR probe pins.** `pr/pr-{ready,feedback}-state*.mjs` use
-  `pr:ready-state:test` and `pr:feedback-state:test` in scripts CI.
+- `pr:ready-state:test`: `pr/pr-ready-state*.mjs` and
+  `pr/pr-stack-{ready-state,recover}*.mjs`; `pr:feedback-state:test`:
+  `pr/pr-feedback-state*.mjs`.
 - **Workflow pins.** `check-ci-contract{,.test}.mjs` pins CI.
   `check-no-skip-audit{,.test}.mjs` pins admission, SHAs, caches, skips,
   `repo-health/dependency-cruiser-root-contract.test.mjs`, and the retained

--- a/scripts/pr/pr-ready-state-core.mjs
+++ b/scripts/pr/pr-ready-state-core.mjs
@@ -544,6 +544,8 @@ function summaryPr(pr, headUpdatedAt = currentHeadUpdatedAt(pr)) {
     headRefOid: pr.headRefOid,
     baseRefName: pr.baseRefName,
     mergeable: pr.mergeable ?? null,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    autoMergeEnabledAt: pr.autoMergeRequest?.enabledAt ?? null,
     reviewDecision: pr.reviewDecision ?? null,
     headUpdatedAt:
       headUpdatedAt === null ? null : new Date(headUpdatedAt).toISOString(),
@@ -733,6 +735,16 @@ export function summarizeReadyState({
       kind: "mergeability",
       name: "Pull request is not mergeable",
       state: pr.mergeable ?? "UNKNOWN",
+      required: true,
+      url: pr.url,
+    });
+  }
+
+  if (normalizeStatusValue(pr.mergeStateStatus) === "BEHIND") {
+    requiredBlockers.push({
+      kind: "base-update",
+      name: "Pull request must include the current base before merge",
+      state: "BEHIND",
       required: true,
       url: pr.url,
     });

--- a/scripts/pr/pr-ready-state.mjs
+++ b/scripts/pr/pr-ready-state.mjs
@@ -646,6 +646,7 @@ export async function fetchReadyState({
     "--json",
     [
       "author",
+      "autoMergeRequest",
       "baseRefName",
       "baseRefOid",
       "changedFiles",
@@ -653,6 +654,7 @@ export async function fetchReadyState({
       "headRefOid",
       "isDraft",
       "mergeable",
+      "mergeStateStatus",
       "mergedAt",
       "number",
       "reviewDecision",

--- a/scripts/pr/pr-ready-state.test.mjs
+++ b/scripts/pr/pr-ready-state.test.mjs
@@ -5,6 +5,7 @@
 
 import { readFileSync } from "node:fs";
 import "./pr-stack-ready-state.test.mjs";
+import "./pr-stack-recover.test.mjs";
 
 import {
   classifyCheck,
@@ -2262,6 +2263,41 @@ test("summarizes ready state when all blocking surfaces are clean", () => {
   assertEqual(summary.optional.ready, false);
   assertEqual(summary.optional.items[0].name, "jscpd");
   assertEqual(summary.statusChecks.skipped.length, 1);
+});
+
+test("blocks confirmed BEHIND even with mergeable head and green required checks", () => {
+  for (const mergeStateStatus of [
+    "BEHIND",
+    "CLEAN",
+    "BLOCKED",
+    "UNKNOWN",
+    undefined,
+  ]) {
+    const summary = summarizeReadyState({
+      pr: {
+        ...basePr,
+        mergeStateStatus,
+        autoMergeRequest: { enabledAt: "2026-05-21T13:24:00Z" },
+        statusCheckRollup: [
+          { name: "lint", conclusion: "SUCCESS", status: "COMPLETED" },
+        ],
+      },
+      reactions: [
+        {
+          content: "+1",
+          created_at: "2026-05-21T13:23:00Z",
+          user: { login: "chatgpt-codex-connector[bot]" },
+        },
+      ],
+    });
+    assertEqual(summary.ready, mergeStateStatus !== "BEHIND");
+    assertEqual(summary.pr.mergeStateStatus, mergeStateStatus ?? null);
+    assertEqual(summary.pr.autoMergeEnabledAt, "2026-05-21T13:24:00Z");
+    assertEqual(
+      summary.required.blockers.some((item) => item.kind === "base-update"),
+      mergeStateStatus === "BEHIND",
+    );
+  }
 });
 
 test("summarizes merged pull requests as terminal ready", () => {

--- a/scripts/pr/pr-stack-ready-state.mjs
+++ b/scripts/pr/pr-stack-ready-state.mjs
@@ -212,6 +212,15 @@ async function evaluateLayers(initial, repoArg, fetchState, feedback) {
           ready,
           `stack layer #${layer.number} readiness blocked`,
         );
+      if (
+        !["AWAITING_USER_MERGE", "MERGE_REQUESTED"].includes(
+          classifyStackObservation(ready).state,
+        )
+      )
+        return pendingObservation(
+          ready,
+          `stack layer #${layer.number} merge observation incomplete`,
+        );
     }
     const final = await fetchState({
       prArg: String(selected.number),
@@ -235,6 +244,8 @@ async function evaluateLayers(initial, repoArg, fetchState, feedback) {
         "readiness changed during final verification",
       );
     const observation = classifyStackObservation(final);
+    if (!["AWAITING_USER_MERGE", "MERGE_REQUESTED"].includes(observation.state))
+      return pendingObservation(final, "final merge observation incomplete");
     return `PASS stack #${stack.number}: every open layer passed both projections; ${observation.state}: ${observation.message}`;
   } catch {
     return "PENDING stack projections unavailable";

--- a/scripts/pr/pr-stack-ready-state.mjs
+++ b/scripts/pr/pr-stack-ready-state.mjs
@@ -3,6 +3,92 @@ import { fileURLToPath } from "node:url";
 import { fetchReadyState, withGhAbortSignal } from "./pr-ready-state.mjs";
 import { summarizeFeedbackState } from "./pr-feedback-state-core.mjs";
 
+// This describes an API observation. It never authorizes or performs a merge.
+export function classifyStackObservation(value, previous = null) {
+  const pr = value?.pr ?? {};
+  const prior = previous?.pr ?? previous;
+  const observation = {
+    prNumber: pr.number ?? null,
+    headRefOid: pr.headRefOid ?? null,
+    baseRefOid: pr.baseRefOid ?? null,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    autoMergeEnabledAt: pr.autoMergeEnabledAt ?? null,
+  };
+  const result = (state, message) => ({ ...observation, state, message });
+  if (pr.state === "MERGED")
+    return result(
+      "MERGED",
+      "GitHub confirms merged; rediscover remaining layers",
+    );
+  if (pr.state === "CLOSED")
+    return result("CLOSED", "GitHub confirms closed without merge");
+  if (pr.state !== "OPEN")
+    return result("UNKNOWN", "Pull request state is unavailable");
+  if (
+    prior &&
+    ["headRefOid", "baseRefOid", "headRefName", "baseRefName"].some(
+      (key) => prior[key] != null && pr[key] != null && prior[key] !== pr[key],
+    )
+  )
+    return result(
+      "HEAD_OR_BASE_CHANGED",
+      "Head or base changed; repeat verification",
+    );
+  if (
+    previous?.stack &&
+    value?.stack &&
+    fingerprint(previous.stack) !== fingerprint(value.stack)
+  )
+    return result(
+      "SNAPSHOT_CHANGED",
+      "Stack membership or another layer changed; repeat verification",
+    );
+  if (pr.mergeStateStatus === "BEHIND")
+    return result(
+      "BASE_UPDATE_REQUIRED",
+      "Head is behind the base; integrate the current base and recheck",
+    );
+  const blockers = value?.required?.blockers ?? [];
+  const checks = blockers.filter((item) => item.kind === "check");
+  if (checks.some((item) => item.state === "fail"))
+    return result(
+      "CHECKS_FAILED",
+      "Required checks failed or were canceled; pending replacements are not success",
+    );
+  if (checks.some((item) => item.state === "pending"))
+    return result("CHECKS_PENDING", "Required checks are pending");
+  if (value?.feedbackReady === false)
+    return result("FEEDBACK_BLOCKED", "Current-head feedback is blocked");
+  if (blockers.length > 0)
+    return result(
+      "READINESS_BLOCKED",
+      "Required feedback or readiness is blocked",
+    );
+  if (
+    value?.ready === true &&
+    pr.headRefOid &&
+    pr.baseRefOid &&
+    pr.mergeStateStatus != null &&
+    pr.mergeStateStatus !== "UNKNOWN"
+  ) {
+    if (pr.autoMergeEnabledAt)
+      return result(
+        "MERGE_REQUESTED",
+        "Auto-merge intent is recorded; wait for GitHub to confirm MERGED",
+      );
+    return result(
+      "AWAITING_USER_MERGE",
+      "Readiness passed; wait for an explicit user-approved merge and confirmed MERGED state",
+    );
+  }
+  return result("UNKNOWN", "Merge readiness is not fully observed");
+}
+
+function pendingObservation(value, context, previous = null) {
+  const observation = classifyStackObservation(value, previous);
+  return `PENDING ${context}; ${observation.state}: ${observation.message}`;
+}
+
 function fingerprint(stack) {
   return JSON.stringify([
     stack.number,
@@ -53,8 +139,10 @@ async function evaluateLayers(initial, repoArg, fetchState, feedback) {
   const selected = stack.layers.find(
     (layer) => layer.number === initial.pr?.number,
   );
-  if (!selected || selected.state !== "OPEN")
-    return "PENDING selected stack layer changed";
+  if (!selected || selected.state !== initial.pr?.state)
+    return "PENDING selected stack layer changed; SNAPSHOT_CHANGED: rediscover stack membership";
+  if (selected.state !== "OPEN")
+    return pendingObservation(initial, "selected stack layer is terminal");
   const observedBases = new Map();
   const matches = (value, layer) => {
     const baseOid = value?.pr?.baseRefOid;
@@ -78,7 +166,11 @@ async function evaluateLayers(initial, repoArg, fetchState, feedback) {
     );
   };
   if (!matches(initial, selected))
-    return "PENDING selected stack layer base unavailable or changed";
+    return pendingObservation(
+      initial,
+      "selected stack layer base unavailable or changed",
+      selected,
+    );
   try {
     for (const layer of stack.layers.filter(
       (entry) => entry.state === "OPEN",
@@ -88,32 +180,62 @@ async function evaluateLayers(initial, repoArg, fetchState, feedback) {
         repoArg,
         includeFeedbackDetails: true,
       });
-      if (!matches(detail, layer) || feedback(detail).ready !== true)
-        return `PENDING stack layer #${layer.number} feedback blocked or snapshot changed`;
+      if (!matches(detail, layer))
+        return pendingObservation(
+          detail,
+          `stack layer #${layer.number} snapshot changed`,
+          { pr: layer, stack },
+        );
+      if (feedback(detail).ready !== true)
+        return pendingObservation(
+          { ...detail, feedbackReady: false },
+          `stack layer #${layer.number} feedback blocked`,
+        );
       const ready = await fetchState({
         prArg: String(layer.number),
         repoArg,
         includeFeedbackDetails: true,
       });
-      if (
-        !matches(ready, layer) ||
-        ready.ready !== true ||
-        feedback(ready).ready !== true
-      )
-        return `PENDING stack layer #${layer.number} readiness blocked or snapshot changed`;
+      if (!matches(ready, layer))
+        return pendingObservation(
+          ready,
+          `stack layer #${layer.number} snapshot changed`,
+          { pr: layer, stack },
+        );
+      if (feedback(ready).ready !== true)
+        return pendingObservation(
+          { ...ready, feedbackReady: false },
+          `stack layer #${layer.number} feedback blocked`,
+        );
+      if (ready.ready !== true)
+        return pendingObservation(
+          ready,
+          `stack layer #${layer.number} readiness blocked`,
+        );
     }
     const final = await fetchState({
       prArg: String(selected.number),
       repoArg,
       includeFeedbackDetails: true,
     });
-    if (
-      !matches(final, selected) ||
-      final.ready !== true ||
-      feedback(final).ready !== true
-    )
-      return "PENDING stack changed during final verification";
-    return `PASS stack #${stack.number}: every open layer passed both projections`;
+    if (!matches(final, selected))
+      return pendingObservation(
+        final,
+        "stack changed during final verification",
+        { pr: selected, stack },
+      );
+    if (feedback(final).ready !== true)
+      return pendingObservation(
+        { ...final, feedbackReady: false },
+        "feedback changed during final verification",
+      );
+    if (final.ready !== true)
+      return pendingObservation(
+        final,
+        "readiness changed during final verification",
+      );
+    const observation = classifyStackObservation(final);
+    return `PASS stack #${stack.number}: every open layer passed both projections; ${observation.state}: ${observation.message}`;
   } catch {
     return "PENDING stack projections unavailable";
   }

--- a/scripts/pr/pr-stack-ready-state.test.mjs
+++ b/scripts/pr/pr-stack-ready-state.test.mjs
@@ -32,7 +32,7 @@ const stack = {
   layers,
 };
 const state = (number) => {
-  const pr = { ...layers[number - 1] };
+  const pr = { ...layers[number - 1], mergeStateStatus: "CLEAN" };
   return {
     ready: true,
     feedbackReady: true,
@@ -191,6 +191,53 @@ assert.equal(
   }).state,
   "UNKNOWN",
 );
+// Every other layer needs a complete observation, even when selected is clean.
+for (const mergeStateStatus of [null, "UNKNOWN", undefined]) {
+  let reads = 0;
+  const result = await evaluateStackGate(
+    state(1),
+    "owner/repo",
+    async (args) => {
+      reads++;
+      const value = state(Number(args.prArg));
+      if (args.prArg === "2") value.pr.mergeStateStatus = mergeStateStatus;
+      return value;
+    },
+    feedback,
+  );
+  assert.match(
+    result,
+    /^PENDING stack layer #2 merge observation incomplete; UNKNOWN:/,
+  );
+  assert.equal(reads, 4);
+}
+// Incomplete final observations must not pass otherwise green, stable layers.
+for (const patch of [
+  { mergeStateStatus: null },
+  { mergeStateStatus: "UNKNOWN" },
+  { mergeStateStatus: undefined },
+  { state: null },
+  { state: "UNKNOWN" },
+  { state: undefined },
+  { headRefOid: undefined },
+  { baseRefOid: undefined },
+]) {
+  let reads = 0;
+  const result = await evaluateStackGate(
+    state(2),
+    "owner/repo",
+    async (args) => {
+      const value = state(Number(args.prArg));
+      if (++reads === 5) Object.assign(value.pr, patch);
+      return value;
+    },
+    feedback,
+  );
+  assert.match(result, /^PENDING /, JSON.stringify(patch));
+  assert.equal(reads, 5);
+  if (Object.hasOwn(patch, "mergeStateStatus"))
+    assert.match(result, /final merge observation incomplete; UNKNOWN:/);
+}
 const calls = [];
 assert.match(
   await evaluateStackGate(
@@ -331,7 +378,7 @@ try {
   );
   writeFileSync(
     join(root, "scripts/pr/pr-ready-state.mjs"),
-    `import {readFileSync} from 'node:fs'; let calls=0; export function withGhAbortSignal(_signal,callback) { return callback(); } export async function fetchReadyState(args) { calls++; const value=JSON.parse(readFileSync('input.json')); value.pr={...value.stack.layers.find(layer=>String(layer.number)===args.prArg)}; if(process.env.SCENARIO==='blocked' && args.prArg==='1') value.feedbackReady=false; if(process.env.SCENARIO==='moved' && calls===5) value.stack.layers[0].headRefOid='b'.repeat(40); return value; }`,
+    `import {readFileSync} from 'node:fs'; let calls=0; export function withGhAbortSignal(_signal,callback) { return callback(); } export async function fetchReadyState(args) { calls++; const value=JSON.parse(readFileSync('input.json')); value.pr={...value.stack.layers.find(layer=>String(layer.number)===args.prArg),mergeStateStatus:'CLEAN'}; if(process.env.SCENARIO==='blocked' && args.prArg==='1') value.feedbackReady=false; if(process.env.SCENARIO==='moved' && calls===5) value.stack.layers[0].headRefOid='b'.repeat(40); return value; }`,
   );
   writeFileSync(
     join(root, "scripts/pr/pr-feedback-state-core.mjs"),

--- a/scripts/pr/pr-stack-ready-state.test.mjs
+++ b/scripts/pr/pr-stack-ready-state.test.mjs
@@ -11,7 +11,10 @@ import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { mock } from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
-import { evaluateStackGate } from "./pr-stack-ready-state.mjs";
+import {
+  classifyStackObservation,
+  evaluateStackGate,
+} from "./pr-stack-ready-state.mjs";
 
 const layers = [1, 2].map((number) => ({
   number,
@@ -38,6 +41,156 @@ const state = (number) => {
   };
 };
 const feedback = (value) => ({ ready: value.feedbackReady });
+// Report real API state, never a requested merge or a UI loading indicator.
+const observed = {
+  ...state(2),
+  pr: { ...state(2).pr, mergeStateStatus: "CLEAN" },
+  required: { blockers: [] },
+};
+assert.equal(classifyStackObservation(observed).state, "AWAITING_USER_MERGE");
+for (const terminal of ["MERGED", "CLOSED"])
+  assert.equal(
+    classifyStackObservation({
+      ...observed,
+      pr: { ...observed.pr, state: terminal },
+    }).state,
+    terminal,
+  );
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    pr: { ...observed.pr, autoMergeEnabledAt: "2026-09-10T12:00:00Z" },
+  }).state,
+  "MERGE_REQUESTED",
+);
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    pr: { ...observed.pr, state: null },
+    uiSpinner: false,
+  }).state,
+  "UNKNOWN",
+);
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    pr: { ...observed.pr, mergeStateStatus: null },
+  }).state,
+  "UNKNOWN",
+);
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    pr: { ...observed.pr, mergeStateStatus: "UNKNOWN" },
+  }).state,
+  "UNKNOWN",
+);
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    pr: { ...observed.pr, mergeStateStatus: "BEHIND" },
+  }).state,
+  "BASE_UPDATE_REQUIRED",
+);
+for (const key of ["headRefOid", "baseRefOid", "headRefName", "baseRefName"])
+  assert.equal(
+    classifyStackObservation(
+      { ...observed, pr: { ...observed.pr, [key]: "changed" } },
+      observed,
+    ).state,
+    "HEAD_OR_BASE_CHANGED",
+  );
+for (const [checkState, expected] of [
+  ["pending", "CHECKS_PENDING"],
+  ["fail", "CHECKS_FAILED"],
+]) {
+  const blocked = {
+    ...observed,
+    ready: false,
+    required: { blockers: [{ kind: "check", name: "ci", state: checkState }] },
+  };
+  assert.equal(classifyStackObservation(blocked).state, expected);
+}
+const canceledWithReplacement = {
+  ...observed,
+  ready: false,
+  required: {
+    blockers: [
+      { kind: "check", name: "ci", state: "fail" },
+      { kind: "check", name: "ci", state: "pending" },
+    ],
+  },
+};
+assert.equal(
+  classifyStackObservation(canceledWithReplacement).state,
+  "CHECKS_FAILED",
+);
+assert.match(
+  await evaluateStackGate(
+    observed,
+    "owner/repo",
+    async () => ({
+      ...canceledWithReplacement,
+      pr: { ...canceledWithReplacement.pr, ...layers[0] },
+    }),
+    feedback,
+  ),
+  /^PENDING /,
+);
+
+assert.equal(
+  classifyStackObservation({ ...observed, feedbackReady: false }).state,
+  "FEEDBACK_BLOCKED",
+);
+const changedMembership = structuredClone(observed);
+changedMembership.stack.layers[0].headRefOid = "c".repeat(40);
+assert.equal(
+  classifyStackObservation(changedMembership, observed).state,
+  "SNAPSHOT_CHANGED",
+);
+const mergeRequested = (number) => ({
+  ...state(number),
+  pr: {
+    ...state(number).pr,
+    mergeStateStatus: "CLEAN",
+    autoMergeEnabledAt: "2026-09-10T12:00:00Z",
+  },
+});
+assert.match(
+  await evaluateStackGate(
+    mergeRequested(2),
+    "owner/repo",
+    async (args) => mergeRequested(Number(args.prArg)),
+    feedback,
+  ),
+  /^PASS .*MERGE_REQUESTED:/,
+);
+assert.match(
+  await evaluateStackGate(
+    observed,
+    "owner/repo",
+    async (args) => ({ ...state(Number(args.prArg)), feedbackReady: false }),
+    feedback,
+  ),
+  /^PENDING .*FEEDBACK_BLOCKED:/,
+);
+for (const missing of ["headRefOid", "baseRefOid"])
+  assert.equal(
+    classifyStackObservation({
+      ...observed,
+      pr: { ...observed.pr, [missing]: null },
+    }).state,
+    "UNKNOWN",
+  );
+assert.equal(
+  classifyStackObservation({
+    ...observed,
+    ready: false,
+    uiSpinner: false,
+    pr: { ...observed.pr, autoMergeEnabledAt: "2026-09-10T12:00:00Z" },
+  }).state,
+  "UNKNOWN",
+);
 const calls = [];
 assert.match(
   await evaluateStackGate(

--- a/scripts/pr/pr-stack-recover.mjs
+++ b/scripts/pr/pr-stack-recover.mjs
@@ -22,7 +22,8 @@ Replays a linear child-only range, recording git cherry proof for skipped patche
 Writes review receipts to NEW_ABSOLUTE_PATH.receipt (must not exist).
 Its comparison.git reads source objects through alternates without source config.
 Conflicts leave the candidate and cherry-pick state intact for inspection.
-After --continue, explicitly replay remaining after its first (failed) commit.
+Inspect failure.kind first: empty-cherry-pick needs explicit proof and skip/keep.
+After resolving the stopped commit, replay remaining after its first commit.
 --continue completes one commit here, not the unattempted suffix.
 Never publishes, merges, resets, aborts, deletes, or changes pre-existing refs.
 Review both axes and validate the candidate before a separately authorized push.
@@ -121,6 +122,29 @@ function newPath(path, roots) {
   throw new Error(`Destination already exists: ${resolved}`);
 }
 
+function worktreeRoots(repo) {
+  const records = git(repo, [
+    "worktree",
+    "list",
+    "--porcelain",
+    "-z",
+  ]).stdout.split("\0\0");
+  return records.flatMap((record) => {
+    const fields = record.split("\0");
+    const field = fields.find((value) => value.startsWith("worktree "));
+    if (!field) return [];
+    try {
+      return [realpathSync(field.slice(9))];
+    } catch (error) {
+      const prunable = fields.some(
+        (value) => value === "prunable" || value.startsWith("prunable "),
+      );
+      if (error.code === "ENOENT" && prunable) return [];
+      throw error;
+    }
+  });
+}
+
 function validate(options) {
   const repo = realpathSync(
     output(resolve(options.repo ?? "."), ["rev-parse", "--show-toplevel"]),
@@ -169,10 +193,7 @@ function validate(options) {
     }).status === 0
   )
     throw new Error("Candidate branch already exists");
-  const roots = git(repo, ["worktree", "list", "--porcelain", "-z"])
-    .stdout.split("\0")
-    .filter((field) => field.startsWith("worktree "))
-    .map((field) => realpathSync(field.slice(9)));
+  const roots = worktreeRoots(repo);
   const worktree = newPath(options.worktree, roots);
   const receiptDir = newPath(`${worktree}.receipt`, roots);
   const cherryProof = output(repo, [
@@ -306,6 +327,69 @@ function writeReceipts(plan, receipt) {
   );
 }
 
+function cherryPickFailure(worktree, commit, conflicts) {
+  const cherryPick = git(
+    worktree,
+    ["rev-parse", "--verify", "CHERRY_PICK_HEAD"],
+    { allowFailure: true },
+  );
+  const headTree = output(worktree, ["rev-parse", "HEAD^{tree}"]);
+  const index = conflicts.length
+    ? null
+    : git(worktree, ["write-tree"], { allowFailure: true });
+  const indexTree = index?.status === 0 ? index.stdout.trim() : null;
+  const cherryPickHead =
+    cherryPick.status === 0 ? cherryPick.stdout.trim() : null;
+  const empty =
+    !conflicts.length && cherryPickHead === commit && indexTree === headTree;
+  const kind = conflicts.length
+    ? "conflict"
+    : empty
+      ? "empty-cherry-pick"
+      : "cherry-pick-failed";
+  return {
+    kind,
+    commit,
+    cherryPickHead,
+    headTree,
+    indexTree,
+    ...(empty
+      ? {
+          explanation:
+            "The index equals HEAD, but git cherry did not prove this individual patch equivalent. Do not run --continue alone or skip without reviewing the original patch and current tree.",
+          proofCommands: [
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            ["git", "rev-parse", "CHERRY_PICK_HEAD", "HEAD^{tree}"],
+            ["git", "write-tree"],
+            [
+              "git",
+              "diff",
+              "--no-ext-diff",
+              "--no-textconv",
+              "--binary",
+              "--cached",
+              "HEAD",
+            ],
+            [
+              "git",
+              "diff",
+              "--no-ext-diff",
+              "--no-textconv",
+              "--binary",
+              `${commit}^`,
+              commit,
+            ],
+          ],
+          operatorOptions: [
+            "After proving the original patch is already represented in the current tree, explicitly run git cherry-pick --skip.",
+            "If preserving the empty commit is intended, explicitly run git commit --allow-empty --no-edit.",
+            "Then verify CHERRY_PICK_HEAD is absent and explicitly replay remaining after its first (failed) commit. No option is run automatically.",
+          ],
+        }
+      : {}),
+  };
+}
+
 export function prepareRecovery(options) {
   const plan = validate(options);
   const backupPrefix = `refs/stack-recovery/${randomUUID()}`;
@@ -337,6 +421,7 @@ export function prepareRecovery(options) {
     candidateTree: null,
     candidateStatus: null,
     conflicts: [],
+    failure: null,
     artifactErrors: [],
   };
   try {
@@ -372,6 +457,11 @@ export function prepareRecovery(options) {
           ])
             .split("\n")
             .filter(Boolean);
+          receipt.failure = cherryPickFailure(
+            plan.worktree,
+            commit,
+            receipt.conflicts,
+          );
           break;
         }
         receipt.replayed.push({

--- a/scripts/pr/pr-stack-recover.mjs
+++ b/scripts/pr/pr-stack-recover.mjs
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { lstatSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const HELP = `Usage: node scripts/pr/pr-stack-recover.mjs
+  --old-parent FULL_SHA --old-head FULL_SHA --new-base FULL_SHA
+  --worktree NEW_ABSOLUTE_PATH --branch NEW_BRANCH [--repo PATH]
+
+Local-only candidate preparation. Fetch and verify remote ownership separately.
+Preserves pinned commits in new backup refs and creates an isolated worktree.
+Replays a linear child-only range, recording git cherry proof for skipped patches.
+Writes review receipts to NEW_ABSOLUTE_PATH.receipt (must not exist).
+Its comparison.git reads source objects through alternates without source config.
+Conflicts leave the candidate and cherry-pick state intact for inspection.
+After --continue, explicitly replay remaining after its first (failed) commit.
+--continue completes one commit here, not the unattempted suffix.
+Never publishes, merges, resets, aborts, deletes, or changes pre-existing refs.
+Review both axes and validate the candidate before a separately authorized push.
+`;
+
+function git(
+  repo,
+  args,
+  { allowFailure = false, input, isolatedConfig = false } = {},
+) {
+  const env = { ...process.env };
+  for (const key of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_PREFIX",
+  ])
+    delete env[key];
+  if (isolatedConfig) {
+    for (const key of Object.keys(env)) {
+      if (
+        key.startsWith("GIT_CONFIG") ||
+        ["GIT_TEMPLATE_DIR", "GIT_EXTERNAL_DIFF", "GIT_DIFF_OPTS"].includes(key)
+      )
+        delete env[key];
+    }
+    env.GIT_CONFIG_NOSYSTEM = "1";
+    env.GIT_CONFIG_SYSTEM = "/dev/null";
+    env.GIT_CONFIG_GLOBAL = "/dev/null";
+    env.GIT_ATTR_NOSYSTEM = "1";
+  }
+  const result = spawnSync("git", args, {
+    env,
+    cwd: repo,
+    encoding: "utf8",
+    input,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !allowFailure)
+    throw new Error(`git ${args[0]} failed: ${result.stderr.trim()}`);
+  return result;
+}
+const output = (repo, args) => git(repo, args).stdout.trim();
+const ancestor = (repo, older, newer) => {
+  const result = git(repo, ["merge-base", "--is-ancestor", older, newer], {
+    allowFailure: true,
+  });
+  if (result.status > 1) throw new Error(result.stderr);
+  return result.status === 0;
+};
+
+export function parseRecoveryArgs(args) {
+  const names = new Map([
+    ["--old-parent", "oldParent"],
+    ["--old-head", "oldHead"],
+    ["--new-base", "newBase"],
+    ["--worktree", "worktree"],
+    ["--branch", "branch"],
+    ["--repo", "repo"],
+  ]);
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = names.get(args[index]);
+    const value = args[index + 1];
+    if (!key || !value || value.startsWith("--") || key in options)
+      throw new Error(`Invalid or duplicate argument: ${args[index]}`);
+    options[key] = value;
+  }
+  return options;
+}
+
+function newPath(path, roots) {
+  if (!path || !isAbsolute(path))
+    throw new Error("Worktree path must be absolute");
+  const normalized = resolve(path);
+  const resolved = join(
+    realpathSync(dirname(normalized)),
+    basename(normalized),
+  );
+  for (const root of roots) {
+    const inside = relative(root, resolved);
+    if (!inside || (!inside.startsWith("../") && !isAbsolute(inside)))
+      throw new Error("Destination must be outside existing worktrees");
+  }
+  try {
+    lstatSync(resolved);
+  } catch (error) {
+    if (error.code === "ENOENT") return resolved;
+    throw error;
+  }
+  throw new Error(`Destination already exists: ${resolved}`);
+}
+
+function validate(options) {
+  const repo = realpathSync(
+    output(resolve(options.repo ?? "."), ["rev-parse", "--show-toplevel"]),
+  );
+  for (const key of ["oldParent", "oldHead", "newBase"]) {
+    const sha = options[key];
+    if (
+      !/^[0-9a-f]{40}$/.test(sha ?? "") ||
+      output(repo, ["cat-file", "-t", sha]) !== "commit"
+    )
+      throw new Error(`${key} must be a full commit SHA`);
+  }
+  if (!ancestor(repo, options.oldParent, options.oldHead))
+    throw new Error("Old parent must be an ancestor of old head");
+  if (ancestor(repo, options.oldHead, options.newBase))
+    throw new Error("New base already contains the old child head");
+  if (
+    ancestor(repo, options.newBase, options.oldHead) &&
+    !ancestor(repo, options.newBase, options.oldParent)
+  )
+    throw new Error("New base lies inside the child range");
+  output(repo, ["merge-base", options.oldParent, options.newBase]);
+  const range = `${options.oldParent}..${options.oldHead}`;
+  const commits = output(repo, ["rev-list", "--reverse", range])
+    .split("\n")
+    .filter(Boolean);
+  if (
+    !commits.length ||
+    commits.length > 100 ||
+    output(repo, ["rev-list", "--merges", range])
+  )
+    throw new Error(
+      "Require a nonempty linear child range of at most 100 commits",
+    );
+  if (
+    !options.branch ||
+    options.branch.startsWith("-") ||
+    git(repo, ["check-ref-format", `refs/heads/${options.branch}`], {
+      allowFailure: true,
+    }).status !== 0
+  )
+    throw new Error("Require a valid new branch name");
+  if (
+    git(repo, ["show-ref", "--verify", `refs/heads/${options.branch}`], {
+      allowFailure: true,
+    }).status === 0
+  )
+    throw new Error("Candidate branch already exists");
+  const roots = git(repo, ["worktree", "list", "--porcelain", "-z"])
+    .stdout.split("\0")
+    .filter((field) => field.startsWith("worktree "))
+    .map((field) => realpathSync(field.slice(9)));
+  const worktree = newPath(options.worktree, roots);
+  const receiptDir = newPath(`${worktree}.receipt`, roots);
+  const cherryProof = output(repo, [
+    "cherry",
+    options.newBase,
+    options.oldHead,
+    options.oldParent,
+  ]);
+  const equivalent = new Set(
+    cherryProof
+      .split("\n")
+      .filter((line) => line.startsWith("- "))
+      .map((line) => line.slice(2)),
+  );
+  if (
+    commits.every(
+      (commit) =>
+        equivalent.has(commit) || ancestor(repo, commit, options.newBase),
+    )
+  )
+    throw new Error("All child commits are already represented in new base");
+  return {
+    ...options,
+    repo,
+    worktree,
+    receiptDir,
+    commits,
+    cherryProof,
+    equivalent,
+  };
+}
+
+function comparisonRepository(plan) {
+  // range-diff invokes log internally without forwarding --no-textconv.
+  // A bare reader with no source config prevents drivers from executing there.
+  const repo = join(plan.receiptDir, "comparison.git");
+  git(plan.receiptDir, ["init", "--bare", "--template=", repo], {
+    isolatedConfig: true,
+  });
+  const objects = resolve(
+    plan.repo,
+    output(plan.repo, ["rev-parse", "--git-common-dir"]),
+    "objects",
+  );
+  if (objects.includes("\n"))
+    throw new Error("Object directory cannot contain a newline");
+  writeFileSync(join(repo, "objects", "info", "alternates"), `${objects}\n`);
+  return repo;
+}
+
+function writeReceipts(plan, receipt) {
+  const comparison = comparisonRepository(plan);
+  const artifacts = [
+    [
+      "old-child.patch",
+      [
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--binary",
+        plan.oldHead,
+        receipt.candidateHead,
+      ],
+    ],
+    [
+      "new-base.patch",
+      [
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--binary",
+        plan.newBase,
+        receipt.candidateHead,
+      ],
+    ],
+    [
+      "range-diff.txt",
+      [
+        "range-diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        `${plan.oldParent}..${plan.oldHead}`,
+        `${plan.newBase}..${receipt.candidateHead}`,
+      ],
+      comparison,
+      true,
+    ],
+  ];
+  if (receipt.candidateTree) {
+    artifacts.push(
+      [
+        "working-tree.patch",
+        ["diff", "--no-ext-diff", "--no-textconv", "--no-color", "--binary"],
+        plan.worktree,
+      ],
+      [
+        "index.patch",
+        [
+          "diff",
+          "--no-ext-diff",
+          "--no-textconv",
+          "--no-color",
+          "--binary",
+          "--cached",
+        ],
+        plan.worktree,
+      ],
+    );
+  }
+  receipt.artifactScope =
+    receipt.status === "prepared"
+      ? "complete-candidate"
+      : "committed-prefix-only; inspect working-tree.patch, index.patch, and candidateStatus for unresolved state";
+  for (const [
+    name,
+    args,
+    repo = plan.repo,
+    isolatedConfig = false,
+  ] of artifacts) {
+    const result = git(repo, args, { allowFailure: true, isolatedConfig });
+    writeFileSync(join(plan.receiptDir, name), result.stdout);
+    if (result.status !== 0)
+      receipt.artifactErrors.push({ name, error: result.stderr });
+  }
+  writeFileSync(
+    join(plan.receiptDir, "receipt.json"),
+    `${JSON.stringify(receipt, null, 2)}\n`,
+  );
+}
+
+export function prepareRecovery(options) {
+  const plan = validate(options);
+  const backupPrefix = `refs/stack-recovery/${randomUUID()}`;
+  const backups = Object.fromEntries(
+    ["oldParent", "oldHead", "newBase"].map((key) => [
+      key,
+      `${backupPrefix}/${key}`,
+    ]),
+  );
+  mkdirSync(plan.receiptDir);
+  git(plan.repo, ["update-ref", "--stdin"], {
+    input: `start\n${Object.entries(backups)
+      .map(([key, ref]) => `create ${ref} ${plan[key]}`)
+      .join("\n")}\nprepare\ncommit\n`,
+  });
+  const receipt = {
+    status: "prepared",
+    oldParent: plan.oldParent,
+    oldHead: plan.oldHead,
+    newBase: plan.newBase,
+    branch: plan.branch,
+    worktree: plan.worktree,
+    backupRefs: backups,
+    cherryProof: plan.cherryProof,
+    replayed: [],
+    skipped: [],
+    remaining: [...plan.commits],
+    candidateHead: plan.newBase,
+    candidateTree: null,
+    candidateStatus: null,
+    conflicts: [],
+    artifactErrors: [],
+  };
+  try {
+    mkdirSync(plan.worktree);
+    git(plan.repo, [
+      "worktree",
+      "add",
+      "-b",
+      plan.branch,
+      plan.worktree,
+      plan.newBase,
+    ]);
+    for (const commit of plan.commits) {
+      const reachable = ancestor(plan.repo, commit, plan.newBase);
+      if (plan.equivalent.has(commit) || reachable) {
+        receipt.skipped.push({
+          commit,
+          proof: reachable ? "ancestor-of-new-base" : "git-cherry-equivalent",
+        });
+      } else {
+        const result = git(plan.worktree, ["cherry-pick", commit], {
+          allowFailure: true,
+        });
+        if (result.status !== 0) {
+          receipt.status = "blocked";
+          receipt.error = result.stderr;
+          receipt.conflicts = output(plan.worktree, [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--name-only",
+            "--diff-filter=U",
+          ])
+            .split("\n")
+            .filter(Boolean);
+          break;
+        }
+        receipt.replayed.push({
+          old: commit,
+          new: output(plan.worktree, ["rev-parse", "HEAD"]),
+        });
+      }
+      receipt.remaining.shift();
+    }
+    receipt.candidateHead = output(plan.worktree, ["rev-parse", "HEAD"]);
+    receipt.candidateTree = output(plan.worktree, ["rev-parse", "HEAD^{tree}"]);
+    receipt.candidateStatus = git(plan.worktree, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+    ]).stdout;
+    if (receipt.status === "prepared" && receipt.candidateStatus) {
+      receipt.status = "blocked";
+      receipt.error =
+        "Candidate has uncommitted changes; preserve and inspect them before review";
+    }
+  } catch (error) {
+    receipt.status = "blocked";
+    receipt.error = error.message;
+  }
+  writeReceipts(plan, receipt);
+  return receipt;
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    if (process.argv.slice(2).includes("--help")) process.stdout.write(HELP);
+    else {
+      const receipt = prepareRecovery(parseRecoveryArgs(process.argv.slice(2)));
+      process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+      if (receipt.status !== "prepared" || receipt.artifactErrors.length)
+        process.exitCode = 2;
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/pr/pr-stack-recover.test.mjs
+++ b/scripts/pr/pr-stack-recover.test.mjs
@@ -121,6 +121,7 @@ fixture(({ git, commit, options, oldParent }) => {
   const receipt = prepareRecovery(options);
   assert.equal(receipt.status, "blocked");
   assert.deepEqual(receipt.conflicts, ["parent.txt"]);
+  assert.equal(receipt.failure.kind, "conflict");
   assert.match(receipt.artifactScope, /committed-prefix-only/);
   assert.match(receipt.candidateStatus, /UU parent.txt/);
   assert.match(
@@ -309,6 +310,73 @@ fixture(({ git, commit, options }) => {
       encoding: "utf8",
     }).stdout.trim(),
     failed,
+  );
+});
+
+fixture(({ root, repo, git, options }) => {
+  const stale = join(root, "stale");
+  git("worktree", "add", "--detach", stale, options.oldParent);
+  const metadata = join(repo, ".git", "worktrees", "stale", "gitdir");
+  const before = readFileSync(metadata, "utf8");
+  rmSync(stale, { recursive: true });
+  assert.match(git("worktree", "list", "--porcelain"), /prunable/);
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "prepared");
+  assert.equal(readFileSync(metadata, "utf8"), before);
+  assert.match(git("worktree", "list", "--porcelain"), /prunable/);
+  assert.equal(existsSync(stale), false);
+});
+
+fixture(({ root, git, options }) => {
+  const missing = join(root, "locked");
+  git("worktree", "add", "--detach", missing, options.oldParent);
+  git("worktree", "lock", missing);
+  rmSync(missing, { recursive: true });
+  const refs = git("show-ref");
+  assert.throws(() => prepareRecovery(options), /ENOENT/);
+  assert.equal(git("show-ref"), refs);
+  assert.equal(existsSync(options.worktree), false);
+});
+
+fixture(({ git, commit, options }) => {
+  const first = options.oldHead;
+  const combinedEnd = commit("second.txt", "combined second patch\n");
+  options.oldHead = commit("suffix.txt", "not applied upstream\n");
+  git("switch", "-c", "combined-base", options.oldParent);
+  git("merge", "--squash", combinedEnd);
+  git("commit", "-m", "combine first two patches");
+  options.newBase = git("rev-parse", "HEAD");
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "blocked");
+  assert.equal(receipt.failure.kind, "empty-cherry-pick");
+  assert.equal(receipt.failure.cherryPickHead, first);
+  assert.equal(receipt.failure.indexTree, receipt.failure.headTree);
+  assert.deepEqual(receipt.remaining, [first, combinedEnd, options.oldHead]);
+  assert.deepEqual(receipt.skipped, []);
+  assert.deepEqual(receipt.conflicts, []);
+  assert.equal(receipt.candidateStatus, "");
+  assert.match(receipt.cherryProof, new RegExp(`\\+ ${first}`));
+  assert.equal(receipt.candidateHead, options.newBase);
+  assert.equal(existsSync(join(options.worktree, "suffix.txt")), false);
+  assert.equal(
+    spawnSync("git", ["rev-parse", "CHERRY_PICK_HEAD"], {
+      cwd: options.worktree,
+      encoding: "utf8",
+    }).stdout.trim(),
+    first,
+  );
+  assert.ok(
+    receipt.failure.proofCommands.some(
+      (args) => args.includes(`${first}^`) && args.includes(first),
+    ),
+  );
+  assert.ok(
+    receipt.failure.operatorOptions.some((option) => option.includes("--skip")),
+  );
+  assert.ok(
+    receipt.failure.operatorOptions.some((option) =>
+      option.includes("--allow-empty"),
+    ),
   );
 });
 

--- a/scripts/pr/pr-stack-recover.test.mjs
+++ b/scripts/pr/pr-stack-recover.test.mjs
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  symlinkSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { prepareRecovery, parseRecoveryArgs } from "./pr-stack-recover.mjs";
+
+function fixture(run) {
+  const root = mkdtempSync(join(tmpdir(), "stack-recovery-test-"));
+  const repo = join(root, "source");
+  mkdirSync(repo);
+  const git = (...args) => {
+    const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout.trim();
+  };
+  const commit = (file, text, message = file) => {
+    writeFileSync(join(repo, file), text);
+    git("add", file);
+    git("commit", "-m", message);
+    return git("rev-parse", "HEAD");
+  };
+  try {
+    git("init", "-b", "main");
+    git("config", "user.email", "fixture@example.invalid");
+    git("config", "user.name", "Recovery fixture");
+    git("config", "commit.gpgsign", "false");
+    const base = commit("base.txt", "base\n");
+    git("switch", "-c", "parent");
+    const oldParent = commit("parent.txt", "producer\n");
+    git("switch", "-c", "child");
+    const oldHead = commit("child.txt", "consumer\n");
+    const options = {
+      repo,
+      oldParent,
+      oldHead,
+      newBase: base,
+      branch: "candidate",
+      worktree: join(root, "candidate"),
+    };
+    run({ root, repo, git, commit, base, oldParent, oldHead, options });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+fixture(({ repo, git, base, options }) => {
+  git("switch", "main");
+  git("merge", "--squash", "parent");
+  git("commit", "-m", "squashed producer");
+  options.newBase = git("rev-parse", "HEAD");
+  git("switch", "child");
+  writeFileSync(join(repo, "untracked.txt"), "keep me\n");
+  writeFileSync(join(repo, "base.txt"), "dirty source\n");
+  const before = git("show-ref");
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "prepared");
+  assert.equal(receipt.replayed.length, 1);
+  assert.deepEqual(receipt.remaining, []);
+  assert.equal(git("rev-parse", "HEAD"), options.oldHead);
+  assert.equal(readFileSync(join(repo, "base.txt"), "utf8"), "dirty source\n");
+  assert.equal(readFileSync(join(repo, "untracked.txt"), "utf8"), "keep me\n");
+  assert.equal(
+    readFileSync(join(options.worktree, "parent.txt"), "utf8"),
+    "producer\n",
+  );
+  assert.equal(
+    readFileSync(join(options.worktree, "child.txt"), "utf8"),
+    "consumer\n",
+  );
+  for (const line of before.split("\n"))
+    assert.ok(git("show-ref").includes(line));
+  for (const [key, ref] of Object.entries(receipt.backupRefs))
+    assert.equal(git("rev-parse", ref), options[key]);
+  assert.match(
+    readFileSync(`${options.worktree}.receipt/range-diff.txt`, "utf8"),
+    / = /,
+  );
+  assert.deepEqual(receipt.artifactErrors, []);
+  assert.equal(git("rev-parse", "main"), options.newBase);
+  assert.notEqual(base, options.newBase);
+});
+
+fixture(({ git, commit, options, oldParent }) => {
+  const first = options.oldHead;
+  const second = commit("second.txt", "second\n");
+  options.oldHead = second;
+  git("switch", "-c", "fixed-parent", oldParent);
+  commit("parent-fix.txt", "fix\n");
+  git("cherry-pick", first);
+  options.newBase = git("rev-parse", "HEAD");
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "prepared");
+  assert.equal(receipt.skipped[0].commit, first);
+  assert.equal(receipt.skipped[0].proof, "git-cherry-equivalent");
+  assert.match(receipt.cherryProof, new RegExp(`- ${first}`));
+  assert.equal(receipt.replayed.length, 1);
+  assert.equal(
+    readFileSync(join(options.worktree, "second.txt"), "utf8"),
+    "second\n",
+  );
+  assert.equal(
+    readFileSync(join(options.worktree, "parent-fix.txt"), "utf8"),
+    "fix\n",
+  );
+});
+
+fixture(({ git, commit, options, oldParent }) => {
+  options.oldHead = commit("parent.txt", "child changes parent\n");
+  git("switch", "-c", "conflicting-parent", oldParent);
+  options.newBase = commit("parent.txt", "parent fix\n");
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "blocked");
+  assert.deepEqual(receipt.conflicts, ["parent.txt"]);
+  assert.match(receipt.artifactScope, /committed-prefix-only/);
+  assert.match(receipt.candidateStatus, /UU parent.txt/);
+  assert.match(
+    readFileSync(`${options.worktree}.receipt/working-tree.patch`, "utf8"),
+    /parent.txt/,
+  );
+  assert.match(
+    readFileSync(`${options.worktree}.receipt/index.patch`, "utf8"),
+    /parent.txt/,
+  );
+  assert.deepEqual(receipt.remaining, [options.oldHead]);
+  assert.equal(receipt.replayed.length, 1);
+  assert.equal(git("rev-parse", "child"), options.oldHead);
+  assert.equal(
+    spawnSync("git", ["rev-parse", "CHERRY_PICK_HEAD"], {
+      cwd: options.worktree,
+    }).status,
+    0,
+  );
+  assert.equal(
+    JSON.parse(readFileSync(`${options.worktree}.receipt/receipt.json`, "utf8"))
+      .status,
+    "blocked",
+  );
+});
+
+fixture(({ git, commit, options, base, oldParent }) => {
+  const assertRefused = (changes, pattern) => {
+    const refs = git("show-ref");
+    assert.throws(() => prepareRecovery({ ...options, ...changes }), pattern);
+    assert.equal(git("show-ref"), refs);
+    assert.equal(existsSync(options.worktree), false);
+    assert.equal(existsSync(`${options.worktree}.receipt`), false);
+  };
+  assertRefused({ oldParent: "main" }, /full commit SHA/);
+  assertRefused({ oldParent: options.oldHead, oldHead: oldParent }, /ancestor/);
+  assertRefused({ oldHead: oldParent }, /nonempty linear/);
+  assertRefused({ newBase: options.oldHead }, /already contains/);
+  assertRefused({ branch: "child" }, /already exists/);
+  assertRefused({ branch: "--bad" }, /valid new branch/);
+  assertRefused({ worktree: join(options.repo, "nested") }, /outside/);
+  options.oldHead = commit("second.txt", "second\n");
+  assertRefused(
+    { newBase: git("rev-parse", "HEAD^") },
+    /inside the child range/,
+  );
+  git("switch", "-c", "side", base);
+  commit("side.txt", "side\n");
+  git("switch", "child");
+  git("merge", "--no-ff", "side", "-m", "merge side");
+  assertRefused({ oldHead: git("rev-parse", "HEAD") }, /linear/);
+});
+
+fixture(({ options, git }) => {
+  mkdirSync(`${options.worktree}.receipt`);
+  writeFileSync(`${options.worktree}.receipt/keep.txt`, "preserve");
+  const before = git("show-ref");
+  assert.throws(() => prepareRecovery(options), /already exists/);
+  assert.equal(git("show-ref"), before);
+  assert.equal(
+    readFileSync(`${options.worktree}.receipt/keep.txt`, "utf8"),
+    "preserve",
+  );
+});
+
+fixture(({ git, commit, options, oldParent }) => {
+  git("switch", "-c", "equivalent-base", oldParent);
+  commit("other.txt", "base change\n");
+  git("cherry-pick", options.oldHead);
+  options.newBase = git("rev-parse", "HEAD");
+  assert.throws(() => prepareRecovery(options), /already represented/);
+  assert.equal(existsSync(options.worktree), false);
+});
+
+fixture(({ root, git, options }) => {
+  const other = join(root, "other-worktree");
+  git("worktree", "add", "--detach", other, options.oldParent);
+  assert.throws(
+    () => prepareRecovery({ ...options, worktree: join(other, "nested") }),
+    /outside/,
+  );
+  symlinkSync(join(root, "missing"), options.worktree);
+  assert.throws(() => prepareRecovery(options), /already exists/);
+});
+
+fixture(({ root, repo, git, options }) => {
+  const prior = process.env.GIT_INDEX_FILE;
+  const poisoned = join(root, "foreign-index");
+  process.env.GIT_INDEX_FILE = poisoned;
+  try {
+    const receipt = prepareRecovery(options);
+    assert.equal(receipt.status, "prepared");
+    assert.equal(existsSync(poisoned), false);
+  } finally {
+    if (prior === undefined) delete process.env.GIT_INDEX_FILE;
+    else process.env.GIT_INDEX_FILE = prior;
+  }
+  assert.equal(git("rev-parse", "HEAD"), options.oldHead);
+  assert.equal(readFileSync(join(repo, "child.txt"), "utf8"), "consumer\n");
+});
+
+fixture(({ root, git, options }) => {
+  const marker = join(root, "external-executed");
+  const command = join(root, "external-diff");
+  writeFileSync(
+    command,
+    `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(${JSON.stringify(marker)}, JSON.stringify(process.argv));\nprocess.stdout.write("NOT A PATCH");\n`,
+  );
+  chmodSync(command, 0o755);
+  git("config", "diff.external", command);
+  git("config", "diff.trap.textconv", command);
+  writeFileSync(
+    join(options.repo, ".git", "info", "attributes"),
+    "*.txt diff=trap\n",
+  );
+  const injected = {
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "diff.external",
+    GIT_CONFIG_VALUE_0: command,
+    GIT_CONFIG_KEY_1: "diff.trap.textconv",
+    GIT_CONFIG_VALUE_1: command,
+  };
+  const previous = Object.fromEntries(
+    Object.keys(injected).map((key) => [key, process.env[key]]),
+  );
+  let receipt;
+  try {
+    Object.assign(process.env, injected);
+    receipt = prepareRecovery(options);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+  assert.equal(receipt.status, "prepared");
+  assert.equal(
+    existsSync(marker),
+    false,
+    existsSync(marker) ? readFileSync(marker, "utf8") : "",
+  );
+  assert.match(
+    readFileSync(`${options.worktree}.receipt/new-base.patch`, "utf8"),
+    /^diff --git /,
+  );
+  assert.match(
+    readFileSync(`${options.worktree}.receipt/range-diff.txt`, "utf8"),
+    / = /,
+  );
+  assert.deepEqual(receipt.artifactErrors, []);
+  assert.match(receipt.candidateTree, /^[0-9a-f]{40}$/);
+  assert.equal(receipt.candidateStatus, "");
+});
+
+fixture(({ root, git, options }) => {
+  const hooks = join(root, "hooks");
+  mkdirSync(hooks);
+  const hook = join(hooks, "post-checkout");
+  writeFileSync(hook, '#!/bin/sh\nprintf "hook output" > hook-output.txt\n');
+  chmodSync(hook, 0o755);
+  git("config", "core.hooksPath", hooks);
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "blocked");
+  assert.match(receipt.error, /uncommitted changes/);
+  assert.match(receipt.candidateStatus, /\?\? hook-output.txt/);
+  assert.equal(
+    readFileSync(join(options.worktree, "hook-output.txt"), "utf8"),
+    "hook output",
+  );
+});
+
+fixture(({ git, commit, options }) => {
+  options.oldParent = options.oldHead;
+  const failed = commit("parent.txt", "child conflict\n");
+  options.oldHead = commit("suffix.txt", "unattempted\n");
+  git("switch", "-c", "new-parent", options.oldParent);
+  options.newBase = commit("parent.txt", "parent correction\n");
+  const receipt = prepareRecovery(options);
+  assert.equal(receipt.status, "blocked");
+  assert.deepEqual(receipt.remaining, [failed, options.oldHead]);
+  assert.deepEqual(receipt.replayed, []);
+  assert.equal(existsSync(join(options.worktree, "suffix.txt")), false);
+  assert.equal(
+    spawnSync("git", ["rev-parse", "CHERRY_PICK_HEAD"], {
+      cwd: options.worktree,
+      encoding: "utf8",
+    }).stdout.trim(),
+    failed,
+  );
+});
+
+assert.throws(() => parseRecoveryArgs(["--push", "yes"]), /Invalid/);
+assert.throws(
+  () => parseRecoveryArgs(["--branch", "a", "--branch", "b"]),
+  /duplicate/,
+);
+assert.throws(() => parseRecoveryArgs(["--old-head"]), /Invalid/);
+console.log("stack recovery disposable Git fixtures passed");


### PR DESCRIPTION
## The Problem

The first native-stack feature batch needed repeated child-branch repairs and manual diagnosis of a merge that displayed progress while it was behind main. Our readiness probe did not expose that stale-base blocker, and recovery depended on commands reconstructed during each repair.

## The Solution

Report a confirmed stale base as a readiness blocker, explain pending stack states, and provide a local recovery command that preserves the original commits and prepares an isolated candidate with review evidence. Ship and babysit now use a coordinated publication and merge sequence informed by the pilot.

The helper does not publish or merge. Native stacks remain opt-in, and specific-PR merge approval and independent control audits remain required.

## Details

- The recovery helper takes three explicit commit SHAs and a new branch/worktree, preserves backup refs, and records child-only replay, conflicts, skipped-patch proof, and both review axes.
- Stack diagnostics distinguish changed snapshots, stale bases, required checks, feedback, terminal state and pending merge intent. Cancelled required checks remain blocking until valid passing evidence exists.
- Canonical instructions and skill mirrors cover initial registration, shared catalog coordination, early audit planning, isolated recovery and one-at-a-time merge handoffs. ADR 0093 records the mixed pilot results without claiming a measured time saving.

Refs #2376. Refs #2286.

## Validation

- `pnpm pr:ready-state:test`: passed 112 readiness tests plus imported stack-state tests and 14 disposable Git recovery fixtures. Covers replay, conflicts, preserved refs/worktrees, dirty candidates, external-diff isolation, stale bases and pending merge intent; it does not prove future GitHub cascade reliability.
- `pnpm pr:feedback-state:test` and `pnpm lint:scripts`: passed. Live read-only `gh` checks confirmed the added PR fields are supported.
- `pnpm docs:index --check`, `pnpm agent:context-check`, `pnpm agent:context-budget:test`, `pnpm agent:context-budget --strict`, documentation-navigation tests, skill-mirror checks/tests, guardrail-prose checks/tests and `pnpm adr:check`: passed. These checks establish local instruction consistency, not operator adoption.
- `pnpm agent:closeout-review --base origin/main`: exit 2 because nested Codex execution is unavailable. Used the operating card's permitted single-source review fallback, with coordinator integration review and scoped worker reviews. No remaining findings. GitHub review is still required on the published head.
- Original scope baseline: 17 files, 659 non-test added lines, base `bf978ee595f8b154a10f246e2a340514e89f164f`, tree `8072d9c204eb9fec4562151f2056af4e5c8d7552`. Current scope: 861 non-test added lines; original stop threshold 1,318.
- Review fixes: incomplete merge observations now keep every native layer pending; stale prunable worktrees no longer block unrelated recovery; empty cherry-picks preserve proof and provide explicit continuation choices. Targeted regressions, the full readiness entrypoint, root lint and affected docs checks passed.
- Browser verification: not applicable; no rendered UI or browser behavior changed. Claude Security scan: skipped (not available in Codex).

## Deferrals

- None
